### PR TITLE
fix: plural of date picker

### DIFF
--- a/webapp/javascript/util/formatDate.spec.ts
+++ b/webapp/javascript/util/formatDate.spec.ts
@@ -42,7 +42,7 @@ describe('FormatDate', () => {
     it('works with "now"', () => {
       // TODO
       // not entirely sure this case is even possible to happen in the code
-      expect(formatAsOBject('now')).toEqual(mockDate);
+      expect(formatAsOBject('now')).toEqual(mockDate.getTime());
     });
 
     it('works with "now-1h"', () => {
@@ -58,12 +58,12 @@ describe('FormatDate', () => {
     });
 
     it('works with "now-1m"', () => {
-      expect(formatAsOBject('now-1m')).toBe(1640090641741);
+      expect(formatAsOBject('now-1m')).toBe(1640090581741);
     });
 
     it('works with absolute timestamps', () => {
       expect(formatAsOBject('1624192489')).toEqual(
-        new Date('2021-06-20T12:34:49.000Z')
+        new Date('2021-06-20T12:34:49.000Z').getTime()
       );
     });
   });

--- a/webapp/javascript/util/formatDate.spec.ts
+++ b/webapp/javascript/util/formatDate.spec.ts
@@ -45,7 +45,7 @@ describe('FormatDate', () => {
       expect(formatAsOBject('now')).toEqual(mockDate);
     });
 
-    it.only('works with "now-1h"', () => {
+    it('works with "now-1h"', () => {
       const got = formatAsOBject('now-1h');
 
       expect(got).toBe(1640087041741);

--- a/webapp/javascript/util/formatDate.ts
+++ b/webapp/javascript/util/formatDate.ts
@@ -44,7 +44,9 @@ export function readableRange(from: string, until: string) {
   const dateFormat = 'yyyy-MM-dd hh:mm a';
   if (/^now-/.test(from) && until === 'now') {
     const { number, _multiplier } = convertPresetsToDate(from);
-    return `Last ${number} ${_multiplier}`;
+    const multiplier =
+      parseInt(number, 10) >= 2 ? _multiplier : _multiplier.slice(0, -1);
+    return `Last ${number} ${multiplier}`;
   }
 
   const d1 = new Date(Math.round(parseInt(from, 10) * 1000));


### PR DESCRIPTION
- [x] fix plural of datepicker (Last 1 hours -> Last 1 hour, Last 1 years -> Last 1 year)

Please take a look at the preview screenshots and let me know if there is other issues.
Thanks!

![image](https://user-images.githubusercontent.com/72560298/153807359-b775dd6b-e45b-47c0-9399-1140647a8e42.png)
![image](https://user-images.githubusercontent.com/72560298/153807389-4da25ee9-34ec-4e11-b453-18e3b727036e.png)
