### PR TITLE
chore: fixes the logic in convertJaegerTraceToProfile function

### DIFF
--- a/packages/pyroscope-flamegraph/src/convert/convertJaegerTraceToProfile.ts
+++ b/packages/pyroscope-flamegraph/src/convert/convertJaegerTraceToProfile.ts
@@ -46,12 +46,12 @@ export function convertJaegerTraceToProfile(trace: Trace): Profile {
     span.children = map(groups, (group) => {
       const res = group[0];
       for (let i = 1; i < group.length; i += 1) {
-        res.duration += group[i].duration;
+        res.total += group[i].total;
       }
-      childrenDur += res.duration;
+      childrenDur += res.total;
       return res;
     });
-    span.total = span.duration || childrenDur;
+    span.total = Math.max(span.duration, childrenDur);
     span.self = Math.max(0, span.total - childrenDur);
   }
   groupSpans(root, 0);


### PR DESCRIPTION
Addresses #1671 / https://github.com/jaegertracing/jaeger-ui/issues/1012

## Trace 
![Screen Shot 2022-11-04 at 3 15 57 PM](https://user-images.githubusercontent.com/662636/200082850-9242810d-6470-464c-8179-9d94f76b3e68.png)

## Flamegraph Before


![before](https://user-images.githubusercontent.com/662636/200081804-a045e5ef-17f7-45a5-a572-20980c0dbf9d.png)


## Flamegraph After

![after](https://user-images.githubusercontent.com/662636/200081801-e1f5d028-4679-4099-bf95-f002ee0d9df6.png)


## Notes

One of the characteristics of the trace from the original issue was that it had parallel executions, particularly in `logic-proxy: upstream` node. That's why it looked so strange before.

This PR makes it so that in such cases when the sum of children nodes' duration is above parent duration, parent duration is set to the sum of children nodes' duration.

One unfortunate consequence of this is that now durations of the top nodes are inflated and don't always match the durations in span, e.g look at the top `eyeball-facing-service: request`. While this is correct in a sense that that's how much wall time was spent processing a request, it might be confusing to some.

@bobrik What do you think about this? 

