### PR TITLE
fix: segment node truncation

### DIFF
--- a/pkg/storage/retention.go
+++ b/pkg/storage/retention.go
@@ -116,6 +116,12 @@ func (s *Storage) deleteSegmentData(ctx context.Context, k *segment.Key, rp *seg
 	}
 
 	_, err = seg.DeleteNodesBefore(rp)
+	// We call put here to explicitly invalidate the cached item:
+	// there is a big chance that the segment is not in use, which
+	// means that the modified segment would never be written to disk.
+	// Thus, the next time storage is opened, we would need to remove
+	// these nodes again, unless the entire segment is removed.
+	s.segments.Put(sk, seg)
 	return err
 }
 


### PR DESCRIPTION
Currently, when segment nodes are removed because of the retention policy, the change is not persistent: unless the segment is modified at write, it won't be written to the disk. Thus, the segment is only deleted when all of its nodes have expired. In most cases, this is not a big problem: after the first truncation (run of the retention task) nodes are removed again.

The change makes it so that the segment is marked as modified after removing expired nodes, so that the write-back thread flushes it to the disk next time.
