### PR TITLE
chore: adds clarifications RE Apache 2 packages to LICENSING.md

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -8,7 +8,9 @@ The default license for this project is [AGPL-3.0-only](LICENSE).
 
 The following directories and their subdirectories are licensed under Apache-2.0:
 ```
-pkg/agent/profiles
+pkg/agent/profiler
+packages/pyroscope-flamegraph
+packages/pyroscope-models
 ```
 
 ## Vendored code


### PR DESCRIPTION
Adds clarifications that our frontend packages are Apache 2:
* `@pyroscope/flamegraph`
* `@pyroscope/models`