### PR TITLE
fix(pyroscope-flamegraph): use map in sandwich conversion to not conflict with properties from the prototype

### DIFF
--- a/packages/pyroscope-flamegraph/src/convert/sandwichViewProfiles.ts
+++ b/packages/pyroscope-flamegraph/src/convert/sandwichViewProfiles.ts
@@ -52,14 +52,17 @@ const arrayToTree = (nodesArray: TreeNode[], total: number): TreeNode => {
 };
 
 function dedupTree(node: TreeNode) {
-  const childrenMap: { [key: string]: TreeNode } = {};
+  const childrenMap = new Map<string, TreeNode>();
   for (let i = 0; i < node.children.length; i += 1) {
-    childrenMap[node.children[i].name] ||= node.children[i];
+    if (!childrenMap.has(node.children[i].name)) {
+      childrenMap.set(node.children[i].name, node.children[i]);
+    }
   }
+
   for (let i = 0; i < node.children.length; i += 1) {
     const currentNode = node.children[i];
-    const existingNode = childrenMap[node.children[i].name];
-    if (existingNode !== currentNode) {
+    const existingNode = childrenMap.get(node.children[i].name);
+    if (existingNode && existingNode !== currentNode) {
       existingNode.total[0] += currentNode.total[0];
       existingNode.self[0] += currentNode.self[0];
       existingNode.children = existingNode.children.concat(

--- a/packages/pyroscope-flamegraph/src/convert/sandwichViewProfiles.ts
+++ b/packages/pyroscope-flamegraph/src/convert/sandwichViewProfiles.ts
@@ -70,7 +70,7 @@ function dedupTree(node: TreeNode) {
       );
     }
   }
-  node.children = Object.values(childrenMap);
+  node.children = Array.from(childrenMap.values());
   for (let i = 0; i < node.children.length; i += 1) {
     dedupTree(node.children[i]);
   }


### PR DESCRIPTION
If the node name is part of a property from the prototype chain (like `toString`), `childrenMap[node.children[i].name] ||= node.children[i];` won't set up the correct value, since there's already a property there! Long story short, it crashes the calculation and therefore the flamegraph.

By using a `map` it correctly ignores these default properties.

A full list of function names this should fix is below:
<details>

`"toString, toLocaleString, valueOf, hasOwnProperty, isPrototypeOf, propertyIsEnumerable, __defineGetter__, __defineSetter__, __lookupGetter__, __lookupSetter__, __proto__, constructor" `
</details>

Also a reproducible flamebearer:
<details>

```json
{
  "version": 1,
  "flamebearer": {
    "names": [
      "total",
      "runtime.main",
      "toString",
      "main.work",
      "main.main",
      "main.fastFunction"
    ],
    "levels": [
      [0, 988, 0, 0],
      [0, 988, 0, 1],
      [0, 214, 0, 5, 0, 3, 2, 4, 0, 771, 0, 2],
      [0, 214, 214, 3, 2, 1, 1, 5, 0, 771, 771, 3]
    ],
    "numTicks": 988,
    "maxSelf": 771,
    "spyName": "gospy",
    "sampleRate": 100,
    "units": "samples",
    "format": "single"
  },
  "metadata": {
    "format": "single",
    "sampleRate": 100,
    "spyName": "gospy",
    "units": "samples"
  },
  "timeline": {
    "startTime": 1632335270,
    "samples": [989],
    "durationDelta": 10
  },
  "groups": {}
}
```
</details>