### PR TITLE
fix(webapp): fix heatmap y axis

### DIFF
--- a/webapp/javascript/components/Heatmap/index.tsx
+++ b/webapp/javascript/components/Heatmap/index.tsx
@@ -260,13 +260,19 @@ interface AxisProps {
 
 function Axis({ axis, max, min, ticksCount, timezone, sampleRate }: AxisProps) {
   const yAxisformatter = sampleRate && getFormatter(max, sampleRate, 'samples');
+  let ticks: string[];
 
-  const ticks = getTicks(
+  ticks = getTicks(
     min,
     max,
     { timezone, formatter: yAxisformatter, ticksCount },
     sampleRate
   );
+
+  // There's not enough data to construct the Y axis
+  if (axis === 'y' && min === 0 && max === 0) {
+    ticks = ['0'];
+  }
 
   return (
     <div


### PR DESCRIPTION
When querying exemplars and there's no data, the backend will return `minValue: 0, maxValue: 0`, which breaks the y axis calculation. Worse, it will generate duplicate values (a bunch of `0.0`s), which are used as the [`key`](https://react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key) in the React component. This confuses React, which upon querying exemplars that exist, will not be aware that the items must be removed (since the key is duplicated).

It's better exemplified in the following screenshots:
![image](https://user-images.githubusercontent.com/6951209/228238075-2fe242b0-334e-46c4-add1-b627564b300c.png)
![image](https://user-images.githubusercontent.com/6951209/228238118-e9ba3cc2-4db0-4e97-9c9c-fe14e7596525.png)

To fix this I just make it very clear that the Y axis can not be constructed, and default to a single value: 0.
