### PR TITLE
fix(phpspy): update phpspy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ WORKDIR /opt/pyroscope
 
 
 COPY third_party/phpspy/phpspy.h /opt/pyroscope/third_party/phpspy/phpspy.h
-COPY --from=phpspy-builder /var/www/html/third_party/phpspy/libphpspy.a /opt/pyroscope/third_party/phpspy/libphpspy.a
+COPY --from=phpspy-builder /third_party/phpspy/libphpspy.a /opt/pyroscope/third_party/phpspy/libphpspy.a
 COPY --from=js-builder /opt/pyroscope/webapp/public ./webapp/public
 COPY --from=ebpf-builder /build/bcc/lib third_party/bcc/lib
 COPY --from=ebpf-builder /build/libbpf/lib third_party/libbpf/lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # | |         | |       | |     __/ |
 # |_|         |_|       |_|    |___/
 
-FROM php:7.4-fpm-alpine3.16 as phpspy-builder
+FROM alpine:3.16 as phpspy-builder
 RUN apk update && apk upgrade \
     && apk add --update alpine-sdk
 COPY Makefile Makefile

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ OS ?= $(shell uname)
 
 
 # if you change the name of this variable please change it in generate-git-info.sh file
-PHPSPY_VERSION ?= be3abd72e8e2dd5dd4e61008fcd702f90c6eb238
+PHPSPY_VERSION ?= c7d2b542812ef3c8ca30280266fb3d57a91d001d
 
 ifeq ("$(OS)", "Darwin")
 	ifeq ("$(ARCH)", "arm64")
@@ -116,8 +116,9 @@ build-panel:
 build-phpspy-dependencies: ## Builds the PHP dependency
 	cd third_party && cd phpspy_src || (git clone https://github.com/pyroscope-io/phpspy.git phpspy_src && cd phpspy_src)
 	cd third_party/phpspy_src && git checkout $(PHPSPY_VERSION)
-	cd third_party/phpspy_src && USE_ZEND=1 make CFLAGS="-DUSE_DIRECT" || $(MAKE) print-deps-error-message
+	cd third_party/phpspy_src && make clean static
 	cp third_party/phpspy_src/libphpspy.a third_party/phpspy/libphpspy.a
+	cp third_party/phpspy_src/phpspy.h third_party/phpspy/phpspy.h
 
 .PHONY: build-libbpf
 build-libbpf:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ OS ?= $(shell uname)
 
 
 # if you change the name of this variable please change it in generate-git-info.sh file
-PHPSPY_VERSION ?= c7d2b542812ef3c8ca30280266fb3d57a91d001d
+PHPSPY_VERSION ?= 66b6fdb2f9da1d87912b46b7faf68796d471c209
 
 ifeq ("$(OS)", "Darwin")
 	ifeq ("$(ARCH)", "arm64")

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,6 @@ build-phpspy-dependencies: ## Builds the PHP dependency
 	cd third_party/phpspy_src && git checkout $(PHPSPY_VERSION)
 	cd third_party/phpspy_src && make clean static
 	cp third_party/phpspy_src/libphpspy.a third_party/phpspy/libphpspy.a
-	cp third_party/phpspy_src/phpspy.h third_party/phpspy/phpspy.h
 
 .PHONY: build-libbpf
 build-libbpf:

--- a/pkg/adhoc/connect.go
+++ b/pkg/adhoc/connect.go
@@ -41,5 +41,6 @@ func newConnect(cfg *config.Adhoc, st *storage.Storage, logger *logrus.Logger) (
 		SampleRate:         sampleRate,
 		DetectSubprocesses: cfg.DetectSubprocesses,
 		Pid:                cfg.Pid,
+		PHPSpyArgs:         cfg.PHPSpyArgs,
 	}, nil
 }

--- a/pkg/adhoc/exec.go
+++ b/pkg/adhoc/exec.go
@@ -43,5 +43,6 @@ func newExec(cfg *config.Adhoc, args []string, st *storage.Storage, logger *logr
 		ApplicationName:    exec.CheckApplicationName(logger, cfg.ApplicationName, spyName, args),
 		SampleRate:         sampleRate,
 		DetectSubprocesses: cfg.DetectSubprocesses,
+		PHPSpyArgs:         cfg.PHPSpyArgs,
 	}, nil
 }

--- a/pkg/agent/session.go
+++ b/pkg/agent/session.go
@@ -104,6 +104,7 @@ type SessionConfig struct {
 	Pid              int
 	WithSubprocesses bool
 	ClibIntegration  bool
+	PHPSpyArgs       string
 }
 
 func NewSession(c SessionConfig) (*ProfileSession, error) {
@@ -159,6 +160,7 @@ func NewGenericSpyFactory(c SessionConfig) SpyFactory {
 				SampleRate:    c.SampleRate,
 				DisableGCRuns: c.DisableGCRuns,
 				Logger:        c.Logger,
+				PHPSpyArgs:    c.PHPSpyArgs,
 			}
 			s, err := sf(params)
 

--- a/pkg/agent/spy/spy.go
+++ b/pkg/agent/spy/spy.go
@@ -62,6 +62,7 @@ type InitParams struct {
 	SampleRate    uint32
 	DisableGCRuns bool
 	Logger        log.Logger
+	PHPSpyArgs    string
 }
 type SpyIntitializer func(InitParams) (Spy, error)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -291,6 +291,7 @@ type Exec struct {
 	SampleRate         uint   `def:"100" desc:"sample rate for the profiler in Hz. 100 means reading 100 times per second" mapstructure:"sample-rate"`
 	SpyName            string `def:"auto" desc:"name of the profiler you want to use. Supported ones are: <supportedProfilers>" mapstructure:"spy-name"`
 	DetectSubprocesses bool   `def:"true" desc:"makes pyroscope keep track of and profile subprocesses of the main process" mapstructure:"detect-subprocesses"`
+	PHPSpyArgs         string `def:"" desc:"todo" mapstructure:"php-spy-args"`
 
 	// Remote upstream configuration
 	ServerAddress          string        `def:"http://localhost:4040" desc:"address of the pyroscope server" mapstructure:"server-address"`
@@ -314,6 +315,7 @@ type Connect struct {
 	SampleRate         uint   `def:"100" desc:"sample rate for the profiler in Hz. 100 means reading 100 times per second" mapstructure:"sample-rate"`
 	SpyName            string `def:"" desc:"name of the profiler you want to use. Supported ones are: <supportedProfilers>" mapstructure:"spy-name"`
 	DetectSubprocesses bool   `def:"true" desc:"makes pyroscope keep track of and profile subprocesses of the main process" mapstructure:"detect-subprocesses"`
+	PHPSpyArgs         string `def:"" desc:"todo" mapstructure:"php-spy-args"`
 
 	// Remote upstream configuration
 	ServerAddress          string        `def:"http://localhost:4040" desc:"address of the pyroscope server" mapstructure:"server-address"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,6 +50,7 @@ type Adhoc struct {
 	SampleRate         uint   `def:"100" desc:"sample rate for the profiler in Hz. 100 means reading 100 times per second" mapstructure:"sample-rate"`
 	SpyName            string `def:"auto" desc:"name of the profiler you want to use. Supported ones are: <supportedProfilers>" mapstructure:"spy-name"`
 	DetectSubprocesses bool   `def:"true" desc:"makes pyroscope keep track of and profile subprocesses of the main process" mapstructure:"detect-subprocesses"`
+	PHPSpyArgs         string `def:"" desc:"comma separated list of phpspy's argument. direct_mem=true/false,php_awk_pattern=libphp'" mapstructure:"php-spy-args"`
 
 	// Connect mode configuration
 	Pid int `def:"0" desc:"PID of the process you want to profile. Pass -1 to profile the whole system (only supported by ebpfspy)" mapstructure:"pid"`
@@ -291,7 +292,7 @@ type Exec struct {
 	SampleRate         uint   `def:"100" desc:"sample rate for the profiler in Hz. 100 means reading 100 times per second" mapstructure:"sample-rate"`
 	SpyName            string `def:"auto" desc:"name of the profiler you want to use. Supported ones are: <supportedProfilers>" mapstructure:"spy-name"`
 	DetectSubprocesses bool   `def:"true" desc:"makes pyroscope keep track of and profile subprocesses of the main process" mapstructure:"detect-subprocesses"`
-	PHPSpyArgs         string `def:"" desc:"todo" mapstructure:"php-spy-args"`
+	PHPSpyArgs         string `def:"" desc:"comma separated list of phpspy's argument. direct_mem=true/false,php_awk_pattern=libphp'" mapstructure:"php-spy-args"`
 
 	// Remote upstream configuration
 	ServerAddress          string        `def:"http://localhost:4040" desc:"address of the pyroscope server" mapstructure:"server-address"`
@@ -315,7 +316,7 @@ type Connect struct {
 	SampleRate         uint   `def:"100" desc:"sample rate for the profiler in Hz. 100 means reading 100 times per second" mapstructure:"sample-rate"`
 	SpyName            string `def:"" desc:"name of the profiler you want to use. Supported ones are: <supportedProfilers>" mapstructure:"spy-name"`
 	DetectSubprocesses bool   `def:"true" desc:"makes pyroscope keep track of and profile subprocesses of the main process" mapstructure:"detect-subprocesses"`
-	PHPSpyArgs         string `def:"" desc:"todo" mapstructure:"php-spy-args"`
+	PHPSpyArgs         string `def:"" desc:"comma separated list of phpspy's argument. direct_mem=true/false,php_awk_pattern=libphp'" mapstructure:"php-spy-args"`
 
 	// Remote upstream configuration
 	ServerAddress          string        `def:"http://localhost:4040" desc:"address of the pyroscope server" mapstructure:"server-address"`

--- a/pkg/exec/connect.go
+++ b/pkg/exec/connect.go
@@ -27,6 +27,7 @@ type Connect struct {
 	DetectSubprocesses bool
 	Tags               map[string]string
 	Pid                int
+	PHPSpyArgs         string
 }
 
 func NewConnect(cfg *config.Connect) (*Connect, error) {
@@ -69,6 +70,7 @@ func NewConnect(cfg *config.Connect) (*Connect, error) {
 		DetectSubprocesses: cfg.DetectSubprocesses,
 		Tags:               cfg.Tags,
 		Pid:                cfg.Pid,
+		PHPSpyArgs:         cfg.PHPSpyArgs,
 	}, nil
 }
 
@@ -96,6 +98,7 @@ func (c *Connect) Run() error {
 		Pid:              c.Pid,
 		WithSubprocesses: c.DetectSubprocesses,
 		Logger:           c.Logger,
+		PHPSpyArgs:       c.PHPSpyArgs,
 	}
 	session, err := agent.NewSession(sc)
 	if err != nil {

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -31,6 +31,7 @@ type Exec struct {
 	NoRootDrop         bool
 	UserName           string
 	GroupName          string
+	PHPSpyArgs         string
 }
 
 func NewExec(cfg *config.Exec, args []string) (*Exec, error) {
@@ -81,6 +82,7 @@ func NewExec(cfg *config.Exec, args []string) (*Exec, error) {
 		NoRootDrop:         cfg.NoRootDrop,
 		UserName:           cfg.UserName,
 		GroupName:          cfg.GroupName,
+		PHPSpyArgs:         cfg.PHPSpyArgs,
 	}, nil
 }
 
@@ -123,6 +125,7 @@ func (e *Exec) Run() error {
 		Pid:              cmd.Process.Pid,
 		WithSubprocesses: e.DetectSubprocesses,
 		Logger:           e.Logger,
+		PHPSpyArgs:       e.PHPSpyArgs,
 	}
 	session, err := agent.NewSession(sc)
 	if err != nil {

--- a/third_party/phpspy/phpspy.h
+++ b/third_party/phpspy/phpspy.h
@@ -1,5 +1,11 @@
+#ifndef __PYROSCOPE_API_H
+#define __PYROSCOPE_API_H
+
 #include <sys/types.h>
 
-int phpspy_init(pid_t pid, void* err_ptr, int err_len);
-int phpspy_cleanup(pid_t pid, void* err_ptr, int err_len);
-int phpspy_snapshot(pid_t pid, void* ptr, int len, void* err_ptr, int err_len);
+void phpspy_init_spy(const char *args);
+int phpspy_init_pid(int pid_i, void *err_ptr, int err_len);
+int phpspy_cleanup(int pid_i, void *err_ptr, int err_len);
+int phpspy_snapshot(int pid_i, void *ptr, int len, void *err_ptr, int err_len);
+
+#endif


### PR DESCRIPTION
update phpspy

what's changed:
- do not use USE_ZEND=1 (allow profiling all php versions other then 7.3 and simillar)
- fix bug when reading from /proc/pid/mem and process is dead and we did not notice it and was sampling the dead process forever
- add a new api to pass args to php_spy via phpspy_init_spy - it accepts comma separated list of arguments, for now only two args are supported direct_mem=true/false (default is false), libphp_awk_pattern=foobar(default is "libphp[78]?")
- allow selecting direct_mem/proc_vm_read at runtime
- allow overriding libphp awk pattern 

