### PR TITLE
fix(webapp): only load timelines when both queries are set

### DIFF
--- a/webapp/javascript/hooks/timeline.hook.ts
+++ b/webapp/javascript/hooks/timeline.hook.ts
@@ -29,7 +29,9 @@ export default function useTimelines() {
 
   // Only reload timelines when an item that affects a timeline has changed
   useEffect(() => {
-    dispatch(fetchSideTimelines(null));
+    if (leftQuery && rightQuery) {
+      dispatch(fetchSideTimelines(null));
+    }
   }, [from, until, refreshToken, maxNodes, leftQuery, rightQuery]);
 
   const leftTimeline = {


### PR DESCRIPTION
When queries are not set and trying to load the timelines, the backend will return an error:
![image](https://user-images.githubusercontent.com/6951209/232057681-9e80d753-e473-4a9a-a021-2232e45c1f24.png)

Here we just skip loading the timelines, unless both queries are set.

This has the side effect of requiring BOTH queries to be set, which is fine for now, since we auto set the query automatically (based on application name). But could be a problem in the future if we ever decide to allow using different queries.

