### PR TITLE
chore: allow overwriting app selector label

### DIFF
--- a/webapp/javascript/components/AppSelector/AppSelector.module.scss
+++ b/webapp/javascript/components/AppSelector/AppSelector.module.scss
@@ -15,6 +15,7 @@
   }
 
   .headerTitle {
+    text-transform: uppercase;
     margin-left: 10px;
     color: var(--ps-select-modal-title);
     font-weight: 700;

--- a/webapp/javascript/components/AppSelector/Label.tsx
+++ b/webapp/javascript/components/AppSelector/Label.tsx
@@ -3,3 +3,5 @@ import React from 'react';
 export function Label() {
   return <>Application:&nbsp;</>;
 }
+
+export const LabelString = 'Select Application';

--- a/webapp/javascript/components/AppSelector/Label.tsx
+++ b/webapp/javascript/components/AppSelector/Label.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export function Label() {
+  return <>Application:&nbsp;</>;
+}

--- a/webapp/javascript/components/AppSelector/index.tsx
+++ b/webapp/javascript/components/AppSelector/index.tsx
@@ -3,7 +3,7 @@ import ModalWithToggle from '@webapp/ui/Modals/ModalWithToggle';
 import Input from '@webapp/ui/Input';
 import { App } from '@webapp/models/app';
 import SelectButton from '@webapp/components/AppSelector/SelectButton';
-import { Label } from '@webapp/components/AppSelector/Label';
+import { Label, LabelString } from '@webapp/components/AppSelector/Label';
 import styles from './AppSelector.module.scss';
 
 interface AppSelectorProps {
@@ -174,10 +174,10 @@ export const SelectorModalWithToggler = ({
           </div>
         ) : null
       }
-      toggleText={appName || 'Select application'}
+      toggleText={appName || LabelString}
       headerEl={
         <>
-          <div className={styles.headerTitle}>SELECT APPLICATION</div>
+          <div className={styles.headerTitle}>{LabelString}</div>
           <Input
             name="application seach"
             type="text"

--- a/webapp/javascript/components/AppSelector/index.tsx
+++ b/webapp/javascript/components/AppSelector/index.tsx
@@ -2,7 +2,8 @@ import React, { useState, useEffect, useMemo } from 'react';
 import ModalWithToggle from '@webapp/ui/Modals/ModalWithToggle';
 import Input from '@webapp/ui/Input';
 import { App } from '@webapp/models/app';
-import SelectButton from './SelectButton';
+import SelectButton from '@webapp/components/AppSelector/SelectButton';
+import { Label } from '@webapp/components/AppSelector/Label';
 import styles from './AppSelector.module.scss';
 
 interface AppSelectorProps {
@@ -28,7 +29,7 @@ const AppSelector = ({
 
   return (
     <div className={styles.container}>
-      Application:&nbsp;
+      <Label />
       <SelectorModalWithToggler
         selectAppName={selectAppName}
         appNames={appNames}

--- a/webapp/javascript/components/Toolbar.tsx
+++ b/webapp/javascript/components/Toolbar.tsx
@@ -12,9 +12,9 @@ import {
 import { faSyncAlt } from '@fortawesome/free-solid-svg-icons/faSyncAlt';
 import Button from '@webapp/ui/Button';
 import LoadingSpinner from '@webapp/ui/LoadingSpinner';
-import DateRangePicker from './DateRangePicker';
-import RefreshButton from './RefreshButton';
-import AppSelector from './AppSelector';
+import DateRangePicker from '@webapp/components/DateRangePicker';
+import RefreshButton from '@webapp/components/RefreshButton';
+import AppSelector from '@webapp/components/AppSelector';
 import styles from './Toolbar.module.css';
 
 interface ToolbarProps {


### PR DESCRIPTION
Follow up from https://github.com/grafana/pyroscope/pull/1923 because I didn't notice same string was used in other places (┛ಠ_ಠ)┛彡┻━┻