### PR TITLE
chore(webapp): use aliased imports and do type assertion

### DIFF
--- a/webapp/javascript/components/TimelineChart/TimelineChart.tsx
+++ b/webapp/javascript/components/TimelineChart/TimelineChart.tsx
@@ -4,13 +4,13 @@ import React from 'react';
 
 import ReactFlot from 'react-flot';
 import 'react-flot/flot/jquery.flot.time.min';
-import './Selection.plugin';
+import '@webapp/components/TimelineChart/Selection.plugin';
 import 'react-flot/flot/jquery.flot.crosshair';
-import './TimelineChartPlugin';
-import './Tooltip.plugin';
-import './Annotations.plugin';
-import './ContextMenu.plugin';
-import './CrosshairSync.plugin';
+import '@webapp/components/TimelineChart/TimelineChartPlugin';
+import '@webapp/components/TimelineChart/Tooltip.plugin';
+import '@webapp/components/TimelineChart/Annotations.plugin';
+import '@webapp/components/TimelineChart/ContextMenu.plugin';
+import '@webapp/components/TimelineChart/CrosshairSync.plugin';
 
 interface TimelineChartProps {
   onSelect: (from: string, until: string) => void;
@@ -32,6 +32,7 @@ class TimelineChart extends ReactFlot<TimelineChartProps> {
   }
 
   componentDidUpdate() {
+    console.log('data', this.props.data);
     this.draw();
   }
 

--- a/webapp/javascript/components/TimelineChart/TimelineChartWrapper.tsx
+++ b/webapp/javascript/components/TimelineChart/TimelineChartWrapper.tsx
@@ -8,13 +8,16 @@ import type { Timeline } from '@webapp/models/timeline';
 import { Annotation } from '@webapp/models/annotation';
 import Legend from '@webapp/pages/tagExplorer/components/Legend';
 import type { TooltipCallbackProps } from '@webapp/components/TimelineChart/Tooltip.plugin';
-import type { ITooltipWrapperProps } from './TooltipWrapper';
-import TooltipWrapper from './TooltipWrapper';
-import TimelineChart from './TimelineChart';
+import TooltipWrapper from '@webapp/components/TimelineChart/TooltipWrapper';
+import type { ITooltipWrapperProps } from '@webapp/components/TimelineChart/TooltipWrapper';
+import TimelineChart from '@webapp/components/TimelineChart/TimelineChart';
+import { ContextMenuProps } from '@webapp/components/TimelineChart/ContextMenu.plugin';
+import {
+  markingsFromSelection,
+  ANNOTATION_COLOR,
+} from '@webapp/components/TimelineChart/markings';
+import { centerTimelineData } from '@webapp/components/TimelineChart/centerTimelineData';
 import styles from './TimelineChartWrapper.module.css';
-import { markingsFromSelection, ANNOTATION_COLOR } from './markings';
-import { ContextMenuProps } from './ContextMenu.plugin';
-import { centerTimelineData } from './centerTimelineData';
 
 export interface TimelineGroupData {
   data: Group;

--- a/webapp/javascript/components/TimelineChart/Tooltip.plugin.tsx
+++ b/webapp/javascript/components/TimelineChart/Tooltip.plugin.tsx
@@ -130,7 +130,8 @@ export interface TooltipCallbackProps {
           coordsToCanvasPos: plot.p2c.bind(plot),
         });
 
-        ReactDOM.render(Tooltip, exploreTooltip?.[0]);
+        // Type checking will be wrong if a React 18 app tries to use this code
+        ReactDOM.render(Tooltip as ShamefulAny, exploreTooltip?.[0]);
       }
     });
 


### PR DESCRIPTION
So that we can 1) override most timeline code downstream and 2) it type checks with react 18