### PR TITLE
benchmark: use the more efficient strings.Builder

### DIFF
--- a/benchmark/internal/cireport/imagereport.go
+++ b/benchmark/internal/cireport/imagereport.go
@@ -1,7 +1,6 @@
 package cireport
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"path"
@@ -132,7 +131,7 @@ func normalizeWord(s string) string {
 }
 
 func (*ImageReporter) tpl(panels []screenshotPanel) (string, error) {
-	var tpl bytes.Buffer
+	var tpl strings.Builder
 
 	data := struct {
 		Panels []screenshotPanel

--- a/benchmark/internal/cireport/metareport.go
+++ b/benchmark/internal/cireport/metareport.go
@@ -1,7 +1,6 @@
 package cireport
 
 import (
-	"bytes"
 	"fmt"
 	"strings"
 	"text/template"
@@ -94,7 +93,7 @@ func (mr *MetaReport) validate(m []meta) error {
 }
 
 func (*MetaReport) tpl(title string, m []meta) (string, error) {
-	var tpl bytes.Buffer
+	var tpl strings.Builder
 
 	data := struct {
 		Title string

--- a/benchmark/internal/cireport/tablereport.go
+++ b/benchmark/internal/cireport/tablereport.go
@@ -1,12 +1,12 @@
 package cireport
 
 import (
-	"bytes"
 	"context"
 	"embed"
 	"fmt"
 	"math"
 	"os"
+	"strings"
 	"sync"
 	"text/template"
 	"time"
@@ -113,7 +113,7 @@ func (r *TableReport) Report(ctx context.Context, qCfg *QueriesConfig) (string, 
 		return "", err
 	}
 
-	var tpl bytes.Buffer
+	var tpl strings.Builder
 
 	data := struct {
 		QC *QueriesConfig


### PR DESCRIPTION
strings.Builder uses *(*string)(unsafe.Pointer(&b.buf)) to save the application memory operation when converting to a string