### PR TITLE
perf(flamegraph): improve performance

### DIFF
--- a/packages/pyroscope-flamegraph/src/FlameGraph/decode.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/decode.ts
@@ -62,14 +62,17 @@ export function deltaDiffWrapper(
   return mutableLevels;
 }
 
-export default function decodeFlamebearer(fb: Profile): Profile {
-  // Make a copy since we will modify the undelying data structure
-  const copy = JSON.parse(JSON.stringify(fb));
-
-  copy.flamebearer.levels = deltaDiffWrapper(
-    copy.metadata.format,
-    copy.flamebearer.levels
+/*
+ * decodeLevels decodes an unecoded
+ * It:
+ * - expects input data to be not decoded (ie. not idempotent)
+ * - mutates the 'flamebearer.levels' field in place
+ */
+export function decodeFlamebearer(fb: Profile) {
+  fb.flamebearer.levels = deltaDiffWrapper(
+    fb.metadata.format,
+    fb.flamebearer.levels
   );
 
-  return copy;
+  return fb;
 }

--- a/packages/pyroscope-flamegraph/src/FlameGraph/normalize.spec.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/normalize.spec.ts
@@ -1,0 +1,65 @@
+import { normalize } from './normalize';
+import { Flamebearer } from '@pyroscope/models/src';
+
+describe('normalize', () => {
+  it('accepts a flamebearer', () => {
+    const flame: Flamebearer = {
+      format: 'single',
+      names: ['foo'],
+      units: 'unknown',
+      levels: [[99]],
+      spyName: 'unknown',
+      numTicks: 10,
+      sampleRate: 100,
+      maxSelf: 1,
+    };
+
+    expect(normalize({ flamebearer: flame })).toStrictEqual(flame);
+  });
+
+  it('accepts a profile', () => {
+    const flame = normalize({
+      profile: {
+        metadata: {
+          spyName: 'unknown',
+          format: 'single',
+          sampleRate: 100,
+          units: 'unknown',
+        },
+        flamebearer: {
+          levels: [[99]],
+          maxSelf: 1,
+          names: ['foo'],
+          numTicks: 10,
+        },
+      },
+    });
+
+    expect(flame).toStrictEqual({
+      format: 'single',
+      names: ['foo'],
+      units: 'unknown',
+      levels: [[99]],
+      spyName: 'unknown',
+      numTicks: 10,
+      sampleRate: 100,
+      maxSelf: 1,
+      rightTicks: undefined,
+      leftTicks: undefined,
+    });
+  });
+
+  it('accepts nothing', () => {
+    const flame = normalize({});
+    expect(flame).toStrictEqual({
+      format: 'single',
+      names: [],
+      units: 'unknown',
+      levels: [[]],
+      spyName: 'unknown',
+      numTicks: 0,
+      sampleRate: 0,
+      maxSelf: 0,
+    });
+  });
+});

--- a/packages/pyroscope-flamegraph/src/FlameGraph/normalize.spec.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/normalize.spec.ts
@@ -1,5 +1,5 @@
 import { normalize } from './normalize';
-import { Flamebearer } from '@pyroscope/models/src';
+import { Flamebearer, Profile } from '@pyroscope/models/src';
 
 describe('normalize', () => {
   it('accepts a flamebearer', () => {
@@ -18,7 +18,7 @@ describe('normalize', () => {
   });
 
   it('accepts a profile', () => {
-    const flame = normalize({
+    const input: { profile: Profile } = {
       profile: {
         metadata: {
           spyName: 'unknown',
@@ -27,26 +27,37 @@ describe('normalize', () => {
           units: 'unknown',
         },
         flamebearer: {
-          levels: [[99]],
+          levels: [
+            [0, 609, 0, 0],
+            [0, 606, 0, 13, 0, 3, 0, 1],
+          ],
           maxSelf: 1,
-          names: ['foo'],
+          names: ['total', 'foo'],
           numTicks: 10,
         },
       },
-    });
+    };
+    const snapshot = JSON.parse(JSON.stringify(input));
+
+    const flame = normalize(input);
 
     expect(flame).toStrictEqual({
       format: 'single',
-      names: ['foo'],
+      names: ['total', 'foo'],
       units: 'unknown',
-      levels: [[99]],
+      levels: [
+        [0, 609, 0, 0],
+        [0, 606, 0, 13, 606, 3, 0, 1],
+      ],
       spyName: 'unknown',
       numTicks: 10,
       sampleRate: 100,
       maxSelf: 1,
-      rightTicks: undefined,
-      leftTicks: undefined,
     });
+
+    // It should not modify the original object
+    // Since it's stored in the redux store
+    expect(input).toStrictEqual(snapshot);
   });
 
   it('accepts nothing', () => {

--- a/packages/pyroscope-flamegraph/src/FlameGraph/normalize.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/normalize.ts
@@ -3,7 +3,10 @@ import { decodeFlamebearer } from './decode';
 
 // normalize receives either a Profile or a Flamebearer
 // then generates an usable 'Flamebearer', the expected format downstream
-export function normalize(p: { profile?: Profile; flamebearer?: Flamebearer }) {
+export function normalize(p: {
+  profile?: Profile;
+  flamebearer?: Flamebearer;
+}): Flamebearer {
   if (p.profile && p.flamebearer) {
     console.warn(
       "'profile' and 'flamebearer' properties are mutually exclusive. Please use profile if possible."
@@ -34,7 +37,7 @@ export function normalize(p: { profile?: Profile; flamebearer?: Flamebearer }) {
 
     delete p2.flamebearer;
     delete p2.metadata;
-    return p2;
+    return p2 as Flamebearer;
   }
 
   if (p.flamebearer) {

--- a/packages/pyroscope-flamegraph/src/FlameGraph/normalize.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/normalize.ts
@@ -1,0 +1,44 @@
+import { Flamebearer, Profile } from '@pyroscope/models/src';
+import decode from './decode';
+
+// normalize receives either a Profile or a Flamebearer
+// then generates an usable 'Flamebearer', the expected format downstream
+export function normalize(p: { profile?: Profile; flamebearer?: Flamebearer }) {
+  if (p.profile && p.flamebearer) {
+    console.warn(
+      "'profile' and 'flamebearer' properties are mutually exclusive. Please use profile if possible."
+    );
+  }
+
+  if (p.profile) {
+    // TODO: copy levels, since that's modified by decode
+    const copy = JSON.parse(JSON.stringify(p.profile));
+    const profile = decode(copy);
+
+    // TODO: clean this
+    return {
+      leftTicks: profile.leftTicks,
+      rightTicks: profile.rightTicks,
+      ...profile.flamebearer,
+      ...profile.metadata,
+    } as Flamebearer;
+  }
+
+  if (p.flamebearer) {
+    return p.flamebearer;
+  }
+
+  // people may send us both values as undefined
+  // but we still have to render something
+  const noop: Flamebearer = {
+    format: 'single',
+    names: [],
+    units: 'unknown',
+    levels: [[]],
+    spyName: 'unknown',
+    numTicks: 0,
+    sampleRate: 0,
+    maxSelf: 0,
+  };
+  return noop;
+}

--- a/packages/pyroscope-flamegraph/src/FlameGraph/uniqueness.spec.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/uniqueness.spec.ts
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import path from 'path';
+import { isSameFlamebearer } from './uniqueness';
+import { normalize } from './normalize';
+
+// Just to make it easier to import "heavy" data
+const testData = JSON.parse(
+  fs.readFileSync(path.join(__dirname, './testData.json'), 'utf-8')
+);
+const flame = normalize({ profile: testData });
+
+describe('uniqueness', () => {
+  it('works', () => {
+    expect(isSameFlamebearer(flame, flame)).toBe(true);
+  });
+});

--- a/packages/pyroscope-flamegraph/src/FlameGraph/uniqueness.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/uniqueness.ts
@@ -1,0 +1,84 @@
+import { Flamebearer } from '@pyroscope/models/src';
+
+export function isSameFlamebearer(
+  prevFlame: Flamebearer,
+  currFlame: Flamebearer
+) {
+  // We first compare simple fields, since they are faster
+  if (prevFlame.format !== currFlame.format) {
+    return false;
+  }
+
+  if (prevFlame.numTicks !== currFlame.numTicks) {
+    return false;
+  }
+
+  if (prevFlame.sampleRate !== currFlame.sampleRate) {
+    return false;
+  }
+
+  if (prevFlame.units !== currFlame.units) {
+    return false;
+  }
+
+  if (prevFlame.names?.length !== currFlame?.names.length) {
+    return false;
+  }
+
+  if (prevFlame.levels.length !== currFlame.levels.length) {
+    return false;
+  }
+
+  // Most likely names is smaller, so let's start with it
+  // Are all names the same?
+  if (
+    !prevFlame.names.every((a, i) => {
+      return a === currFlame.names[i];
+    })
+  ) {
+    return false;
+  }
+
+  if (!areLevelsTheSame(prevFlame.levels, currFlame.levels)) {
+    return false;
+  }
+
+  // Fallback in case new fields are added
+  return (
+    JSON.stringify({
+      ...prevFlame,
+      levels: undefined,
+      names: undefined,
+    }) ===
+    JSON.stringify({
+      ...currFlame,
+      levels: undefined,
+      names: undefined,
+    })
+  );
+}
+
+function areLevelsTheSame(
+  l1: Flamebearer['levels'],
+  l2: Flamebearer['levels']
+) {
+  if (l1.length !== l2.length) {
+    return false;
+  }
+
+  // eslint-disable-next-line no-plusplus
+  for (let i = 0; i < l1.length; i++) {
+    if (l1[i].length !== l2[i].length) {
+      return false;
+    }
+
+    // eslint-disable-next-line no-plusplus
+    for (let j = 0; j < l1[i].length; j++) {
+      if (l1[i][j] !== l2[i][j]) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}

--- a/packages/pyroscope-flamegraph/src/ProfilerTable.tsx
+++ b/packages/pyroscope-flamegraph/src/ProfilerTable.tsx
@@ -420,7 +420,7 @@ const getTableBody = ({
 
       return isMatch(highlightQuery, x.name);
     })
-    .reduce((acc, x) => {
+    .map((x) => {
       const pn = getPackageNameFromStackTrace(spyName, x.name);
       const color = isDoubles
         ? defaultColor
@@ -430,13 +430,11 @@ const getTableBody = ({
       };
 
       if (x.type === 'double') {
-        acc.push(getDoubleRow(x, style));
-        return acc;
+        return getDoubleRow(x, style);
       }
 
-      acc.push(getSingleRow(x, color, style));
-      return acc;
-    }, [] as BodyRow[]);
+      return getSingleRow(x, color, style);
+    });
 
   return rows.length > 0
     ? { bodyRows: rows, type: 'filled' as const }

--- a/packages/pyroscope-flamegraph/src/ProfilerTable.tsx
+++ b/packages/pyroscope-flamegraph/src/ProfilerTable.tsx
@@ -457,7 +457,7 @@ export interface ProfilerTableProps {
   tableBodyRef: RefObject<HTMLTableSectionElement>;
 }
 
-export default function ProfilerTable({
+const ProfilerTable = React.memo(function ProfilerTable({
   flamebearer,
   fitMode,
   handleTableItemClick,
@@ -488,4 +488,6 @@ export default function ProfilerTable({
       />
     </div>
   );
-}
+});
+
+export default ProfilerTable;

--- a/packages/pyroscope-flamegraph/src/convert/subtract.ts
+++ b/packages/pyroscope-flamegraph/src/convert/subtract.ts
@@ -1,5 +1,6 @@
 import type { Profile } from '@pyroscope/models/src';
-import decodeFlamebearer, {
+import {
+  decodeFlamebearer,
   deltaDiffWrapperReverse,
 } from '../FlameGraph/decode';
 import { flamebearersToTree, TreeNode } from './flamebearersToTree';


### PR DESCRIPTION
we were naively deep copying the profile by serializing to/parsing from json, which in big cases (>5 MB) is very slow.

Also memoize the `ProfilerTable`.

I've investigated it a little bit more and found that great part of the slowness with a huge flamegraph comes from 
https://github.com/grafana/pyroscope/blob/72e54ccfcbb4812f87f8fc6840545079096c5462/packages/pyroscope-flamegraph/src/ProfilerTable.tsx#L415-L439

Which in turn creates n handlers
https://github.com/grafana/pyroscope/blob/72e54ccfcbb4812f87f8fc6840545079096c5462/packages/pyroscope-flamegraph/src/ProfilerTable.tsx#L354

So yeah there's room for more improvement.