### PR TITLE
fix(server): set `Content-Type` to JSON in label handlers

### DIFF
--- a/pkg/server/labels.go
+++ b/pkg/server/labels.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/pyroscope-io/pyroscope/pkg/server/httputils"
@@ -39,11 +38,6 @@ func NewLabelsHandler(s storage.LabelsGetter, httpUtils httputils.Utils) http.Ha
 			})
 		}
 
-		b, err := json.Marshal(keys)
-		if err != nil {
-			httpUtils.WriteJSONEncodeError(r, w, err)
-			return
-		}
-		_, _ = w.Write(b)
+		httpUtils.WriteResponseJSON(r, w, keys)
 	}
 }

--- a/pkg/server/labelvalues.go
+++ b/pkg/server/labelvalues.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/pyroscope-io/pyroscope/pkg/server/httputils"
@@ -45,11 +44,6 @@ func NewLabelValuesHandler(s storage.LabelValuesGetter, httpUtils httputils.Util
 			})
 		}
 
-		b, err := json.Marshal(values)
-		if err != nil {
-			httpUtils.WriteJSONEncodeError(r, w, err)
-			return
-		}
-		_, _ = w.Write(b)
+		httpUtils.WriteResponseJSON(r, w, values)
 	}
 }


### PR DESCRIPTION
For now,  `/labels` and `/label-values` handlers do not set `Content-Type` explictly, so `net/http` wrongly sets it to `text/plain`.

This PR fixes the problem by using `httpUtils.WriteResponseJSON` function.

