### PR TITLE
fix(sec): upgrade Django to 

### DIFF
--- a/examples/python/rideshare/django/app/requirements.txt
+++ b/examples/python/rideshare/django/app/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.2.13
+Django==4.2.1
 djangorestframework==3.12.4
 gunicorn==20.1.0
 psycopg2-binary==2.9.1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in Django 3.2.13
- [CVE-2022-34265](https://www.oscs1024.com/hd/CVE-2022-34265)


### What did I do？
Upgrade Django from 3.2.13 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS