### PR TITLE
Update adhoc readme for more adhoc modes

### DIFF
--- a/examples/adhoc/README.md
+++ b/examples/adhoc/README.md
@@ -1,6 +1,6 @@
 ## Adhoc mode examples
 
-Pyroscope provides two options for using the "adhoc" mode, depending on whether you have the Pyroscope SDK installed or not. Choose the appropriate method based on your setup.
+Pyroscope provides three options for using the "adhoc" mode, depending on whether you have the Pyroscope SDK installed or not. Choose the appropriate method based on your setup.
 
 ### Option 1: Push mode (with SDK installed)
 If your application already uses an agent or has integration with the Pyroscope HTTP API, you can use push mode 
@@ -47,7 +47,7 @@ Using docker:
  docker run --rm -ti --privileged --pid=host pyroscope/pyroscope-rs-cli:0.2.7-457bb15 connect --pid=369936 --spy-name=pyspy --server-address="http://localhost:4100"
 ```
 
-### Pull mode
+### Option 2: Pull Mode
 
 If the application to profile supports pull-mode, that is, it's already running a HTTP server
 and serving profiling data in a supported format, like `pprof`,

--- a/examples/adhoc/README.md
+++ b/examples/adhoc/README.md
@@ -40,7 +40,6 @@ Attach to and profile a process using adhoc
 sudo ./pyroscope-cli connect --pid=[369936] --spy-name=pyspy --server-address="http://localhost:4100"
 ```
 
-Using docker:
 ```
  docker run --rm -ti --privileged --pid=host pyroscope/pyroscope-rs-cli:0.2.7-457bb15 connect --pid=369936 --spy-name=pyspy --server-address="http://localhost:4100"
 ```

--- a/examples/adhoc/README.md
+++ b/examples/adhoc/README.md
@@ -32,7 +32,6 @@ For example, this method will work for python or ruby _without_ the pip/gem inst
 
 Profile a script using adhoc
 ```
-# Run with spy-name autodetected.
 pyroscope adhoc --push pyroscope-cli exec --spy-name=pyspy main.py  
 ```
 

--- a/examples/adhoc/README.md
+++ b/examples/adhoc/README.md
@@ -1,19 +1,20 @@
 ## Adhoc mode examples
 
-These examples showcase the different running modes of `pyroscope adhoc`.
-Check [adhoc documentation](https://pyroscope.io/docs/agent-configuration-adhoc) for complete information about what modes are supported by each language.
+Pyroscope provides two options for using the "adhoc" mode, depending on whether you have the Pyroscope SDK installed or not. Choose the appropriate method based on your setup.
 
-Note: The example programs are toy examples but they share some interesting properties: their running time should take around 1 minute, and their profiling data should change slightly from run to run (making them good examples for comparison / diff mode visualizations).
+### Option 1: Push mode (with SDK installed)
+If your application already uses an agent or has integration with the Pyroscope HTTP API, you can use push mode 
+to profile the application without any additional configuration changes.
 
-### Push Mode
+#### Golang Adhoc (Push Mode)
 If the application to profile is already using an agent or has some integration with the HTTP API,
 push mode can be used to profile the application without any configuration change.
 
-#### Golang adhoc (push)
 ```
 # no spy is supported, --push is not needed (but can still be provided):
 pyroscope adhoc go run adhoc-push.go
 ```
+
 #### Python adhoc (using pip package)
 ```
 # pyspy is autodetected, --push is mandatory.
@@ -21,32 +22,29 @@ pyroscope adhoc go run adhoc-push.go
 pyroscope adhoc --push python adhoc-push.py
 ```
 
+### Option 2: Push Mode (no SDK installed -- Pyroscope sidecar)
 
-### Exec mode
+If you don't have the Pyroscope SDK installed and want to profile a Python or Ruby application, you can still push data
+to the Pyroscope server using the adhoc mode as a sidecar.
+
+#### Python adhoc (no pip package -- Pyroscope sidecar)
 For languages with a supported spy and no other pyroscope integration, this is the easiest way to get profiling data.
 For example, this method will work for python or ruby _without_ the pip/gem instrumented in the code.
 
+Profile a script using adhoc
 ```
 # Run with spy-name autodetected.
-pyroscope adhoc python adhoc-spy.py
-
-# Alternatively, specify the spy-name if it cannot be autodetected.
-pyroscope adhoc --spy-name pyspy ./adhoc-spy.py
+./bin/pyroscope adhoc --push   ~/Downloads/pyroscope-cli exec --spy-name=pyspy   examples/python/simple/main.py  
 ```
 
-### Connect mode
-#### Profile a process that is already running
-
-If the profiled process is already running, it's possible to attach to it instead, indicating its PID through the `--pid` flag:
-
+Attach to and profile a process using adhoc
 ```
-# Run the program normally, in the background. It should give the PID as output.
-python adhoc-spy.py &
-# => [1] 841690
-# Use adhoc to attach to the running command.
-# Note that the --spy-name is now mandatory as it cannot be inferred.
-# Also, pyroscope needs to be launched as root to be able to trace the running process.
-sudo pyroscope adhoc --spy-name pyspy --pid 841690
+sudo ./pyroscope-cli connect --pid=[369936] --spy-name=pyspy --server-address="http://localhost:4100"
+```
+
+Using docker:
+```
+ docker run --rm -ti --privileged --pid=host pyroscope/pyroscope-rs-cli:0.2.7-457bb15 connect --pid=369936 --spy-name=pyspy --server-address="http://localhost:4100"
 ```
 
 ### Pull mode

--- a/examples/adhoc/README.md
+++ b/examples/adhoc/README.md
@@ -33,7 +33,7 @@ For example, this method will work for python or ruby _without_ the pip/gem inst
 Profile a script using adhoc
 ```
 # Run with spy-name autodetected.
-./bin/pyroscope adhoc --push   ~/Downloads/pyroscope-cli exec --spy-name=pyspy   examples/python/simple/main.py  
+pyroscope adhoc --push pyroscope-cli exec --spy-name=pyspy main.py  
 ```
 
 Attach to and profile a process using adhoc

--- a/examples/adhoc/README.md
+++ b/examples/adhoc/README.md
@@ -44,7 +44,6 @@ sudo ./pyroscope-cli connect --pid=[369936] --spy-name=pyspy --server-address="h
 ```
 
 ```
- docker run --rm -ti --privileged --pid=host pyroscope/pyroscope-rs-cli:0.2.7-457bb15 connect --pid=369936 --spy-name=pyspy --server-address="http://localhost:4100"
 ```
 
 ### Option 3: Pull Mode

--- a/examples/adhoc/README.md
+++ b/examples/adhoc/README.md
@@ -29,13 +29,16 @@ to the Pyroscope server using the adhoc mode as a sidecar.
 #### Python adhoc (no pip package -- Pyroscope sidecar)
 For languages with a supported spy and no other pyroscope integration, this is the easiest way to get profiling data.
 For example, this method will work for python or ruby _without_ the pip/gem instrumented in the code.
+For this you will need to use the `pyroscope-cli` from the [pyroscope-rs](https://github.com/grafana/pyroscope-rs/releases/tag/cli-0.2.7) project.
+
+**Note: this is different than using the pyroscope binary, `./pyroscope`, itself.**
 
 Profile a script using adhoc
 ```
 pyroscope adhoc --push pyroscope-cli exec --spy-name=pyspy main.py
 ```
 
-Attach to and profile a process using adhoc
+Attach to a process and profile it using `pyroscope-cli`
 ```
 sudo ./pyroscope-cli connect --pid=[369936] --spy-name=pyspy --server-address="http://localhost:4100"
 ```

--- a/examples/adhoc/README.md
+++ b/examples/adhoc/README.md
@@ -40,7 +40,7 @@ pyroscope adhoc --push pyroscope-cli exec --spy-name=pyspy main.py
 
 Attach to a process and profile it using `pyroscope-cli`
 ```
-sudo ./pyroscope-cli connect --pid=[369936] --spy-name=pyspy --server-address="http://localhost:4100"
+sudo pyroscope adhoc --push pyroscope-cli connect --spy-name=pyspy --pid=<pid>
 ```
 
 ```

--- a/examples/adhoc/README.md
+++ b/examples/adhoc/README.md
@@ -3,7 +3,7 @@
 Pyroscope provides three options for using the "adhoc" mode, depending on whether you have the Pyroscope SDK installed or not. Choose the appropriate method based on your setup.
 
 ### Option 1: Push mode (with SDK installed)
-If your application already uses an agent or has integration with the Pyroscope HTTP API, you can use push mode 
+If your application already uses an agent or has integration with the Pyroscope HTTP API, you can use push mode
 to profile the application without any additional configuration changes.
 
 #### Golang Adhoc (Push Mode)
@@ -32,7 +32,7 @@ For example, this method will work for python or ruby _without_ the pip/gem inst
 
 Profile a script using adhoc
 ```
-pyroscope adhoc --push pyroscope-cli exec --spy-name=pyspy main.py  
+pyroscope adhoc --push pyroscope-cli exec --spy-name=pyspy main.py
 ```
 
 Attach to and profile a process using adhoc

--- a/examples/adhoc/README.md
+++ b/examples/adhoc/README.md
@@ -18,7 +18,6 @@ pyroscope adhoc go run adhoc-push.go
 #### Python adhoc (using pip package)
 ```
 # pyspy is autodetected, --push is mandatory.
-# Note that you need pyroscope-io >= 0.6.0 for this to work.
 pyroscope adhoc --push python adhoc-push.py
 ```
 

--- a/examples/adhoc/README.md
+++ b/examples/adhoc/README.md
@@ -46,7 +46,7 @@ Using docker:
  docker run --rm -ti --privileged --pid=host pyroscope/pyroscope-rs-cli:0.2.7-457bb15 connect --pid=369936 --spy-name=pyspy --server-address="http://localhost:4100"
 ```
 
-### Option 2: Pull Mode
+### Option 3: Pull Mode
 
 If the application to profile supports pull-mode, that is, it's already running a HTTP server
 and serving profiling data in a supported format, like `pprof`,


### PR DESCRIPTION
@korniltsev can you please help me make the docs more generic / make sense to run from scratch in our examples folder?
i.e. pyroscope-cli vs ./bin/pyroscope which one should I use? Should I already have both downloaded, etc.