### PR TITLE
fix: limit time picker presets

### DIFF
--- a/webapp/javascript/components/DateRangePicker.tsx
+++ b/webapp/javascript/components/DateRangePicker.tsx
@@ -31,10 +31,6 @@ const defaultPresets = [
     { label: 'Last 7 days', from: 'now-7d', until: 'now' },
     { label: 'Last 30 days', from: 'now-30d', until: 'now' },
     { label: 'Last 90 days', from: 'now-90d', until: 'now' },
-    { label: 'Last 6 months', from: 'now-6M', until: 'now' },
-    { label: 'Last 1 year', from: 'now-1y', until: 'now' },
-    { label: 'Last 2 years', from: 'now-2y', until: 'now' },
-    { label: 'Last 5 years', from: 'now-5y', until: 'now' },
   ],
 ];
 


### PR DESCRIPTION
- Progress toward #1999

The new maximum time range preset if 90 days.

![image](https://github.com/grafana/pyroscope/assets/38694490/44e92f53-7ff7-453a-bbd5-a5865cf097b7)
