### PR TITLE
Compact symdb

### DIFF
--- a/pkg/iter/iter.go
+++ b/pkg/iter/iter.go
@@ -101,6 +101,20 @@ func NewSliceSeekIterator[A constraints.Ordered](s []A) SeekIterator[A, A] {
 	}
 }
 
+type slicePositionIterator[T constraints.Integer, M any] struct {
+	i Iterator[T]
+	s []M
+}
+
+func NewSliceIndexIterator[T constraints.Integer, M any](s []M, i Iterator[T]) Iterator[M] {
+	return slicePositionIterator[T, M]{s: s, i: i}
+}
+
+func (i slicePositionIterator[T, M]) Next() bool   { return i.i.Next() }
+func (i slicePositionIterator[T, M]) At() M        { return i.s[i.i.At()] }
+func (i slicePositionIterator[T, M]) Err() error   { return i.i.Err() }
+func (i slicePositionIterator[T, M]) Close() error { return i.i.Close() }
+
 type sliceSeekIterator[A constraints.Ordered] struct {
 	*sliceIterator[A]
 }

--- a/pkg/iter/tree.go
+++ b/pkg/iter/tree.go
@@ -1,11 +1,7 @@
 package iter
 
 import (
-<<<<<<< HEAD
 	"github.com/grafana/pyroscope/pkg/util/loser"
-=======
-	"github.com/grafana/phlare/pkg/util/loser"
->>>>>>> ee8a92e04 (Add first draft of block compaction)
 )
 
 var _ Iterator[interface{}] = &TreeIterator[interface{}]{}

--- a/pkg/phlaredb/block_querier.go
+++ b/pkg/phlaredb/block_querier.go
@@ -435,6 +435,11 @@ func (b *singleBlockQuerier) Index() IndexReader {
 	return b.index
 }
 
+func (b *singleBlockQuerier) Symbols() SymbolsReader {
+	// TODO(kolesnikovae)
+	return nil
+}
+
 func (b *singleBlockQuerier) Meta() block.Meta {
 	if b.meta == nil {
 		return block.Meta{}

--- a/pkg/phlaredb/block_querier.go
+++ b/pkg/phlaredb/block_querier.go
@@ -388,11 +388,9 @@ func (r *stacktraceResolverV2) Load(ctx context.Context) error {
 
 func (r *stacktraceResolverV2) WriteStats(partition uint64, s *symdb.Stats) {
 	mr, ok := r.reader.SymbolsResolver(partition)
-	if !ok {
-		return
+	if ok {
+		mr.WriteStats(s)
 	}
-	mr.WriteStats(s)
-	return
 }
 
 func NewSingleBlockQuerierFromMeta(phlarectx context.Context, bucketReader phlareobj.Bucket, meta *block.Meta) *singleBlockQuerier {

--- a/pkg/phlaredb/block_querier.go
+++ b/pkg/phlaredb/block_querier.go
@@ -464,6 +464,8 @@ func (b *singleBlockQuerier) Index() IndexReader {
 
 func (b *singleBlockQuerier) Symbols() SymbolsReader {
 	return &inMemorySymbolsReader{
+		partitions: make(map[uint64]*inMemorySymbolsResolver),
+
 		strings:     b.strings,
 		functions:   b.functions,
 		locations:   b.locations,
@@ -1224,6 +1226,7 @@ type inMemoryparquetReader[M Models, P schemav1.Persister[M]] struct {
 	persister P
 	file      *parquet.File
 	size      int64
+	numRows   int64
 	reader    phlareobj.ReaderAtCloser
 	cache     []M
 }

--- a/pkg/phlaredb/block_querier.go
+++ b/pkg/phlaredb/block_querier.go
@@ -449,8 +449,14 @@ func (b *singleBlockQuerier) Index() IndexReader {
 }
 
 func (b *singleBlockQuerier) Symbols() SymbolsReader {
-	// TODO(kolesnikovae)
-	return nil
+	return &inMemorySymbolsReader{
+		// TODO
+		//	strings:     b.strings,
+		functions:   b.functions,
+		locations:   b.locations,
+		mappings:    b.mappings,
+		stacktraces: b.stacktraces,
+	}
 }
 
 func (b *singleBlockQuerier) Meta() block.Meta {

--- a/pkg/phlaredb/block_querier.go
+++ b/pkg/phlaredb/block_querier.go
@@ -1226,7 +1226,6 @@ type inMemoryparquetReader[M Models, P schemav1.Persister[M]] struct {
 	persister P
 	file      *parquet.File
 	size      int64
-	numRows   int64
 	reader    phlareobj.ReaderAtCloser
 	cache     []M
 }

--- a/pkg/phlaredb/block_symbols_appender.go
+++ b/pkg/phlaredb/block_symbols_appender.go
@@ -1,0 +1,19 @@
+package phlaredb
+
+import schemav1 "github.com/grafana/phlare/pkg/phlaredb/schemas/v1"
+
+// TODO(kolesnikovae): Refactor to symdb.
+
+type SymbolsWriter interface {
+	SymbolsAppender(partition uint64) (SymbolsAppender, error)
+}
+
+type SymbolsAppender interface {
+	AppendStacktrace([]int32) uint32
+	AppendLocation(*schemav1.InMemoryLocation) uint32
+	AppendMapping(*schemav1.InMemoryMapping) uint32
+	AppendFunction(*schemav1.InMemoryFunction) uint32
+	AppendString(string) uint32
+
+	Flush() error
+}

--- a/pkg/phlaredb/block_symbols_reader.go
+++ b/pkg/phlaredb/block_symbols_reader.go
@@ -1,0 +1,92 @@
+package phlaredb
+
+import (
+	"context"
+
+	"github.com/grafana/phlare/pkg/iter"
+	schemav1 "github.com/grafana/phlare/pkg/phlaredb/schemas/v1"
+	"github.com/grafana/phlare/pkg/phlaredb/symdb"
+)
+
+// TODO(kolesnikovae): Refactor to symdb.
+
+type SymbolsReader interface {
+	SymbolsResolver(partition uint64) (SymbolsResolver, error)
+}
+
+type SymbolsResolver interface {
+	ResolveStacktraces(ctx context.Context, dst symdb.StacktraceInserter, stacktraces []uint32) error
+
+	Locations(iter.Iterator[uint32]) iter.Iterator[*schemav1.InMemoryLocation]
+	Mappings(iter.Iterator[uint32]) iter.Iterator[*schemav1.InMemoryMapping]
+	Functions(iter.Iterator[uint32]) iter.Iterator[*schemav1.InMemoryFunction]
+	Strings(iter.Iterator[uint32]) iter.Iterator[string]
+
+	WriteStats(*SymbolStats)
+}
+
+type SymbolStats struct {
+	StacktracesTotal int
+	LocationsTotal   int
+	MappingsTotal    int
+	FunctionsTotal   int
+	StringsTotal     int
+}
+
+type inMemorySymbolsReader struct {
+	partitions map[uint64]*inMemorySymbolsResolver
+
+	// TODO(kolesnikovae): Split into partitions.
+	strings     inMemoryparquetReader[string, *schemav1.StringPersister]
+	functions   inMemoryparquetReader[*schemav1.InMemoryFunction, *schemav1.FunctionPersister]
+	locations   inMemoryparquetReader[*schemav1.InMemoryLocation, *schemav1.LocationPersister]
+	mappings    inMemoryparquetReader[*schemav1.InMemoryMapping, *schemav1.MappingPersister]
+	stacktraces StacktraceDB
+}
+
+func (r *inMemorySymbolsReader) Symbols(partition uint64) SymbolsResolver {
+	p, ok := r.partitions[partition]
+	if !ok {
+		p = &inMemorySymbolsResolver{
+			partition: 0,
+			ctx:       nil,
+			reader:    nil,
+		}
+		r.partitions[partition] = p
+	}
+	return p
+}
+
+type inMemorySymbolsResolver struct {
+	partition uint64
+	ctx       context.Context
+	reader    *inMemorySymbolsReader
+}
+
+func (s inMemorySymbolsResolver) ResolveStacktraces(ctx context.Context, dst symdb.StacktraceInserter, stacktraces []uint32) error {
+	return s.reader.stacktraces.Resolve(ctx, s.partition, dst, stacktraces)
+}
+
+func (s inMemorySymbolsResolver) Locations(i iter.Iterator[uint32]) iter.Iterator[*schemav1.InMemoryLocation] {
+	return iter.NewSliceIndexIterator(s.reader.locations.cache, i)
+}
+
+func (s inMemorySymbolsResolver) Mappings(i iter.Iterator[uint32]) iter.Iterator[*schemav1.InMemoryMapping] {
+	return iter.NewSliceIndexIterator(s.reader.mappings.cache, i)
+}
+
+func (s inMemorySymbolsResolver) Functions(i iter.Iterator[uint32]) iter.Iterator[*schemav1.InMemoryFunction] {
+	return iter.NewSliceIndexIterator(s.reader.functions.cache, i)
+}
+
+func (s inMemorySymbolsResolver) Strings(i iter.Iterator[uint32]) iter.Iterator[string] {
+	return iter.NewSliceIndexIterator(s.reader.strings.cache, i)
+}
+
+func (s inMemorySymbolsResolver) WriteStats(stats *SymbolStats) {
+	stats.StacktracesTotal = 0 // TODO
+	stats.LocationsTotal = int(s.reader.locations.NumRows())
+	stats.MappingsTotal = int(s.reader.mappings.NumRows())
+	stats.FunctionsTotal = int(s.reader.functions.NumRows())
+	stats.StringsTotal = int(s.reader.strings.NumRows())
+}

--- a/pkg/phlaredb/block_symbols_reader.go
+++ b/pkg/phlaredb/block_symbols_reader.go
@@ -75,8 +75,8 @@ func (s inMemorySymbolsResolver) Strings(i iter.Iterator[uint32]) iter.Iterator[
 
 func (s inMemorySymbolsResolver) WriteStats(stats *symdb.Stats) {
 	s.reader.stacktraces.WriteStats(s.partition, stats)
-	stats.LocationsTotal = int(s.reader.locations.file.NumRows())
-	stats.MappingsTotal = int(s.reader.mappings.file.NumRows())
-	stats.FunctionsTotal = int(s.reader.functions.file.NumRows())
-	stats.StringsTotal = int(s.reader.strings.file.NumRows())
+	stats.LocationsTotal = len(s.reader.locations.cache)
+	stats.MappingsTotal = len(s.reader.mappings.cache)
+	stats.FunctionsTotal = len(s.reader.functions.cache)
+	stats.StringsTotal = len(s.reader.strings.cache)
 }

--- a/pkg/phlaredb/block_symbols_reader.go
+++ b/pkg/phlaredb/block_symbols_reader.go
@@ -3,9 +3,9 @@ package phlaredb
 import (
 	"context"
 
-	"github.com/grafana/phlare/pkg/iter"
-	schemav1 "github.com/grafana/phlare/pkg/phlaredb/schemas/v1"
-	"github.com/grafana/phlare/pkg/phlaredb/symdb"
+	"github.com/grafana/pyroscope/pkg/iter"
+	schemav1 "github.com/grafana/pyroscope/pkg/phlaredb/schemas/v1"
+	"github.com/grafana/pyroscope/pkg/phlaredb/symdb"
 )
 
 // TODO(kolesnikovae): Refactor to symdb.
@@ -75,8 +75,8 @@ func (s inMemorySymbolsResolver) Strings(i iter.Iterator[uint32]) iter.Iterator[
 
 func (s inMemorySymbolsResolver) WriteStats(stats *symdb.Stats) {
 	s.reader.stacktraces.WriteStats(s.partition, stats)
-	stats.LocationsTotal = int(s.reader.locations.NumRows())
-	stats.MappingsTotal = int(s.reader.mappings.NumRows())
-	stats.FunctionsTotal = int(s.reader.functions.NumRows())
-	stats.StringsTotal = int(s.reader.strings.NumRows())
+	stats.LocationsTotal = int(s.reader.locations.file.NumRows())
+	stats.MappingsTotal = int(s.reader.mappings.file.NumRows())
+	stats.FunctionsTotal = int(s.reader.functions.file.NumRows())
+	stats.StringsTotal = int(s.reader.strings.file.NumRows())
 }

--- a/pkg/phlaredb/block_symbols_writer.go
+++ b/pkg/phlaredb/block_symbols_writer.go
@@ -1,6 +1,13 @@
 package phlaredb
 
-import schemav1 "github.com/grafana/phlare/pkg/phlaredb/schemas/v1"
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	schemav1 "github.com/grafana/phlare/pkg/phlaredb/schemas/v1"
+	"github.com/grafana/phlare/pkg/phlaredb/symdb"
+)
 
 // TODO(kolesnikovae): Refactor to symdb.
 
@@ -9,21 +16,102 @@ type SymbolsWriter interface {
 }
 
 type SymbolsAppender interface {
-	AppendStacktrace([]int32) uint32
-	AppendLocation(*schemav1.InMemoryLocation) uint32
-	AppendMapping(*schemav1.InMemoryMapping) uint32
-	AppendFunction(*schemav1.InMemoryFunction) uint32
-	AppendString(string) uint32
+	AppendStacktraces([]uint32, [][]int32)
+	AppendLocations([]uint32, []*schemav1.InMemoryLocation)
+	AppendMappings([]uint32, []*schemav1.InMemoryMapping)
+	AppendFunctions([]uint32, []*schemav1.InMemoryFunction)
+	AppendStrings([]uint32, []string)
 
 	Flush() error
 }
 
-type symbolsWriter struct{}
+type symbolsWriter struct {
+	partitions map[uint64]*symbolsAppender
 
-func newSymbolsWriter(dst string) (*symbolsWriter, error) {
-	return &symbolsWriter{}, nil
+	locations deduplicatingSlice[*schemav1.InMemoryLocation, locationsKey, *locationsHelper, *schemav1.LocationPersister]
+	mappings  deduplicatingSlice[*schemav1.InMemoryMapping, mappingsKey, *mappingsHelper, *schemav1.MappingPersister]
+	functions deduplicatingSlice[*schemav1.InMemoryFunction, functionsKey, *functionsHelper, *schemav1.FunctionPersister]
+	strings   deduplicatingSlice[string, string, *stringsHelper, *schemav1.StringPersister]
+	tables    []Table
+
+	symdb *symdb.SymDB
+}
+
+func newSymbolsWriter(dst string, cfg *ParquetConfig) (*symbolsWriter, error) {
+	w := symbolsWriter{
+		partitions: make(map[uint64]*symbolsAppender),
+	}
+	dir := filepath.Join(dst, symdb.DefaultDirName)
+	w.symdb = symdb.NewSymDB(symdb.DefaultConfig().WithDirectory(dir))
+	w.tables = []Table{
+		&w.locations,
+		&w.mappings,
+		&w.functions,
+		&w.strings,
+	}
+	for _, t := range w.tables {
+		if err := t.Init(dst, cfg, contextHeadMetrics(context.Background())); err != nil {
+			return nil, err
+		}
+	}
+	return &w, nil
 }
 
 func (w *symbolsWriter) SymbolsAppender(partition uint64) (SymbolsAppender, error) {
-	return nil, nil
+	p, ok := w.partitions[partition]
+	if !ok {
+		appender := w.symdb.SymbolsAppender(partition)
+		x := &symbolsAppender{
+			stacktraces: appender.StacktraceAppender(),
+			writer:      w,
+		}
+		w.partitions[partition] = x
+		p = x
+	}
+	return p, nil
+}
+
+func (w *symbolsWriter) Close() error {
+	for _, t := range w.tables {
+		_, _, err := t.Flush(context.Background())
+		if err != nil {
+			return fmt.Errorf("flushing table %s: %w", t.Name(), err)
+		}
+	}
+	if err := w.symdb.Flush(); err != nil {
+		return fmt.Errorf("flushing symbol database: %w", err)
+	}
+	return nil
+}
+
+type symbolsAppender struct {
+	stacktraces symdb.StacktraceAppender
+	writer      *symbolsWriter
+}
+
+func (s symbolsAppender) AppendStacktraces(dst []uint32, stacktraces [][]int32) {
+	// TODO: []*schemav1.Stacktrace -> [][]uint32.
+	s.stacktraces.AppendStacktrace(dst, stacktraces)
+}
+
+func (s symbolsAppender) AppendLocations(dst []uint32, locations []*schemav1.InMemoryLocation) {
+	// TODO: rewriter -> dst.
+	_ = s.writer.locations.ingest(context.Background(), locations, nil)
+}
+
+func (s symbolsAppender) AppendMappings(dst []uint32, mappings []*schemav1.InMemoryMapping) {
+	_ = s.writer.mappings.ingest(context.Background(), mappings, nil)
+}
+
+func (s symbolsAppender) AppendFunctions(dst []uint32, functions []*schemav1.InMemoryFunction) {
+	_ = s.writer.functions.ingest(context.Background(), functions, nil)
+}
+
+func (s symbolsAppender) AppendStrings(dst []uint32, strings []string) {
+	_ = s.writer.strings.ingest(context.Background(), strings, nil)
+}
+
+func (s symbolsAppender) Flush() error {
+	// TODO: Reset state (e.g. rewriter).
+	return nil
 }

--- a/pkg/phlaredb/block_symbols_writer.go
+++ b/pkg/phlaredb/block_symbols_writer.go
@@ -75,6 +75,9 @@ func (w *symbolsWriter) Close() error {
 		if err != nil {
 			return fmt.Errorf("flushing table %s: %w", t.Name(), err)
 		}
+		if err = t.Close(); err != nil {
+			return fmt.Errorf("closing table %s: %w", t.Name(), err)
+		}
 	}
 	if err := w.symdb.Flush(); err != nil {
 		return fmt.Errorf("flushing symbol database: %w", err)

--- a/pkg/phlaredb/block_symbols_writer.go
+++ b/pkg/phlaredb/block_symbols_writer.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"path/filepath"
 
-	schemav1 "github.com/grafana/phlare/pkg/phlaredb/schemas/v1"
-	"github.com/grafana/phlare/pkg/phlaredb/symdb"
+	schemav1 "github.com/grafana/pyroscope/pkg/phlaredb/schemas/v1"
+	"github.com/grafana/pyroscope/pkg/phlaredb/symdb"
 )
 
 // TODO(kolesnikovae): Refactor to symdb.

--- a/pkg/phlaredb/block_symbols_writer.go
+++ b/pkg/phlaredb/block_symbols_writer.go
@@ -16,13 +16,11 @@ type SymbolsWriter interface {
 }
 
 type SymbolsAppender interface {
-	AppendStacktraces([]uint32, [][]int32)
+	AppendStacktraces([]uint32, []*schemav1.Stacktrace)
 	AppendLocations([]uint32, []*schemav1.InMemoryLocation)
 	AppendMappings([]uint32, []*schemav1.InMemoryMapping)
 	AppendFunctions([]uint32, []*schemav1.InMemoryFunction)
 	AppendStrings([]uint32, []string)
-
-	Flush() error
 }
 
 type symbolsWriter struct {
@@ -89,8 +87,7 @@ type symbolsAppender struct {
 	writer      *symbolsWriter
 }
 
-func (s symbolsAppender) AppendStacktraces(dst []uint32, stacktraces [][]int32) {
-	// TODO: []*schemav1.Stacktrace -> [][]uint32.
+func (s symbolsAppender) AppendStacktraces(dst []uint32, stacktraces []*schemav1.Stacktrace) {
 	s.stacktraces.AppendStacktrace(dst, stacktraces)
 }
 
@@ -108,9 +105,4 @@ func (s symbolsAppender) AppendFunctions(dst []uint32, functions []*schemav1.InM
 
 func (s symbolsAppender) AppendStrings(dst []uint32, strings []string) {
 	s.writer.strings.append(dst, strings)
-}
-
-func (s symbolsAppender) Flush() error {
-	// TODO: Reset state (e.g. rewriter).
-	return nil
 }

--- a/pkg/phlaredb/block_symbols_writer.go
+++ b/pkg/phlaredb/block_symbols_writer.go
@@ -95,20 +95,19 @@ func (s symbolsAppender) AppendStacktraces(dst []uint32, stacktraces [][]int32) 
 }
 
 func (s symbolsAppender) AppendLocations(dst []uint32, locations []*schemav1.InMemoryLocation) {
-	// TODO: rewriter -> dst.
-	_ = s.writer.locations.ingest(context.Background(), locations, nil)
+	s.writer.locations.append(dst, locations)
 }
 
 func (s symbolsAppender) AppendMappings(dst []uint32, mappings []*schemav1.InMemoryMapping) {
-	_ = s.writer.mappings.ingest(context.Background(), mappings, nil)
+	s.writer.mappings.append(dst, mappings)
 }
 
 func (s symbolsAppender) AppendFunctions(dst []uint32, functions []*schemav1.InMemoryFunction) {
-	_ = s.writer.functions.ingest(context.Background(), functions, nil)
+	s.writer.functions.append(dst, functions)
 }
 
 func (s symbolsAppender) AppendStrings(dst []uint32, strings []string) {
-	_ = s.writer.strings.ingest(context.Background(), strings, nil)
+	s.writer.strings.append(dst, strings)
 }
 
 func (s symbolsAppender) Flush() error {

--- a/pkg/phlaredb/block_symbols_writer.go
+++ b/pkg/phlaredb/block_symbols_writer.go
@@ -17,3 +17,13 @@ type SymbolsAppender interface {
 
 	Flush() error
 }
+
+type symbolsWriter struct{}
+
+func newSymbolsWriter(dst string) (*symbolsWriter, error) {
+	return &symbolsWriter{}, nil
+}
+
+func (w *symbolsWriter) SymbolsAppender(partition uint64) (SymbolsAppender, error) {
+	return nil, nil
+}

--- a/pkg/phlaredb/compact.go
+++ b/pkg/phlaredb/compact.go
@@ -784,7 +784,6 @@ func (p *symPartitionRewriter) stacktracesFromResolvedValues() []*schemav1.Stack
 type stacktraceInserter struct {
 	stacktraces *lookupTable[[]int32]
 	locations   *lookupTable[*schemav1.InMemoryLocation]
-	c           int
 }
 
 func (i *stacktraceInserter) InsertStacktrace(stacktrace uint32, locations []int32) {
@@ -794,12 +793,12 @@ func (i *stacktraceInserter) InsertStacktrace(stacktrace uint32, locations []int
 	}
 	// stacktrace points to resolved which should
 	// be a marked pointer to unresolved value.
-	v := &i.stacktraces.values[stacktrace&markerMask]
+	idx := i.stacktraces.resolved[stacktrace] & markerMask
+	v := &i.stacktraces.values[idx]
 	n := grow(*v, len(locations))
 	copy(n, locations)
 	// Preserve allocated capacity.
-	v = &n
-	i.c++
+	i.stacktraces.values[idx] = n
 }
 
 const (

--- a/pkg/phlaredb/compact.go
+++ b/pkg/phlaredb/compact.go
@@ -110,7 +110,7 @@ func Compact(ctx context.Context, src []BlockReader, dst string) (meta block.Met
 	meta.Files = metaFiles
 	meta.Stats.NumProfiles = total
 	meta.Stats.NumSeries = seriesRewriter.NumSeries()
-	meta.Stats.NumSamples = symbolsRewriter.NumSamples()
+	meta.Stats.NumSamples = symRewriter.NumSamples()
 	if _, err := meta.WriteToFile(util.Logger, blockPath); err != nil {
 		return block.Meta{}, err
 	}

--- a/pkg/phlaredb/compact.go
+++ b/pkg/phlaredb/compact.go
@@ -125,13 +125,6 @@ func metaFilesFromDir(dir string) ([]block.File, error) {
 			return err
 		}
 		if info.IsDir() {
-			if info.Name() == symdb.DefaultDirName {
-				f, err := symdbMetaFiles(dir)
-				if err != nil {
-					return err
-				}
-				files = append(files, f...)
-			}
 			return nil
 		}
 		var f block.File
@@ -146,8 +139,6 @@ func metaFilesFromDir(dir string) ([]block.File, error) {
 			if err != nil {
 				return err
 			}
-		default:
-			return nil
 		}
 		f.RelPath, err = filepath.Rel(dir, path)
 		if err != nil {

--- a/pkg/phlaredb/compact.go
+++ b/pkg/phlaredb/compact.go
@@ -746,7 +746,7 @@ func (p *symPartitionRewriter) appendRewrite(stacktraces []uint32) error {
 		stacktraces[i] = p.stacktraces.lookupResolved(v)
 	}
 
-	return p.appender.Flush()
+	return nil
 }
 
 func (p *symPartitionRewriter) resolveStacktraces(stacktraceIDs []uint32) error {

--- a/pkg/phlaredb/compact.go
+++ b/pkg/phlaredb/compact.go
@@ -21,6 +21,7 @@ import (
 	phlareparquet "github.com/grafana/pyroscope/pkg/parquet"
 	"github.com/grafana/pyroscope/pkg/phlaredb/block"
 	schemav1 "github.com/grafana/pyroscope/pkg/phlaredb/schemas/v1"
+	"github.com/grafana/pyroscope/pkg/phlaredb/symdb"
 	"github.com/grafana/pyroscope/pkg/phlaredb/tsdb/index"
 	"github.com/grafana/pyroscope/pkg/util"
 	"github.com/grafana/pyroscope/pkg/util/loser"
@@ -124,6 +125,13 @@ func metaFilesFromDir(dir string) ([]block.File, error) {
 			return err
 		}
 		if info.IsDir() {
+			if info.Name() == symdb.DefaultDirName {
+				f, err := symdbMetaFiles(dir)
+				if err != nil {
+					return err
+				}
+				files = append(files, f...)
+			}
 			return nil
 		}
 		var f block.File
@@ -138,6 +146,8 @@ func metaFilesFromDir(dir string) ([]block.File, error) {
 			if err != nil {
 				return err
 			}
+		default:
+			return nil
 		}
 		f.RelPath, err = filepath.Rel(dir, path)
 		if err != nil {

--- a/pkg/phlaredb/compact.go
+++ b/pkg/phlaredb/compact.go
@@ -29,7 +29,37 @@ type BlockReader interface {
 	Meta() block.Meta
 	Profiles() []parquet.RowGroup
 	Index() IndexReader
-	// todo symbdb
+	Symbols() SymbolsResolver
+}
+
+// TODO(kolesnikovae): Refactor to symdb.
+
+// ProfileSymbols represents symbolic information associated with a profile.
+type ProfileSymbols struct {
+	StacktracePartition uint64
+	StacktraceIDs       []uint32
+
+	Stacktraces []*schemav1.Stacktrace
+	Locations   []*schemav1.InMemoryLocation
+	Mappings    []*schemav1.InMemoryMapping
+	Functions   []*schemav1.InMemoryFunction
+	Strings     []string
+}
+
+type SymbolsResolver interface {
+	Stacktraces(iter.Iterator[uint32]) iter.Iterator[*schemav1.Stacktrace]
+	Locations(iter.Iterator[uint32]) iter.Iterator[*schemav1.InMemoryLocation]
+	Mappings(iter.Iterator[uint32]) iter.Iterator[*schemav1.InMemoryMapping]
+	Functions(iter.Iterator[uint32]) iter.Iterator[*schemav1.InMemoryFunction]
+	Strings(iter.Iterator[uint32]) iter.Iterator[string]
+}
+
+type SymbolsAppender interface {
+	AppendStacktrace(*schemav1.Stacktrace) uint32
+	AppendLocation(*schemav1.InMemoryLocation) uint32
+	AppendMapping(*schemav1.InMemoryMapping) uint32
+	AppendFunction(*schemav1.InMemoryFunction) uint32
+	AppendString(string) uint32
 }
 
 func Compact(ctx context.Context, src []BlockReader, dst string) (meta block.Meta, err error) {
@@ -74,16 +104,18 @@ func Compact(ctx context.Context, src []BlockReader, dst string) (meta block.Met
 		return block.Meta{}, err
 	}
 	profileWriter := newProfileWriter(profileFile)
-
-	// todo new symbdb
+	symw, err := newSymbolsWriter(dst)
+	if err != nil {
+		return block.Meta{}, err
+	}
 
 	rowsIt, err := newMergeRowProfileIterator(src)
 	if err != nil {
 		return block.Meta{}, err
 	}
 	seriesRewriter := newSeriesRewriter(rowsIt, indexw)
-	symbolsRewriter := newSymbolsRewriter(seriesRewriter)
-	reader := phlareparquet.NewIteratorRowReader(newRowsIterator(symbolsRewriter))
+	symRewriter := newSymbolsRewriter(seriesRewriter, src, symw)
+	reader := phlareparquet.NewIteratorRowReader(newRowsIterator(symRewriter))
 
 	total, _, err := phlareparquet.CopyAsRowGroups(profileWriter, reader, defaultParquetConfig.MaxBufferRowCount)
 	if err != nil {
@@ -229,10 +261,13 @@ type profileRow struct {
 	labels    phlaremodel.Labels
 	fp        model.Fingerprint
 	row       schemav1.ProfileRow
+
+	blockReader BlockReader
 }
 
 type profileRowIterator struct {
 	profiles    iter.Iterator[parquet.Row]
+	blockReader BlockReader
 	index       IndexReader
 	allPostings index.Postings
 	err         error
@@ -241,15 +276,16 @@ type profileRowIterator struct {
 	chunks     []index.ChunkMeta
 }
 
-func newProfileRowIterator(reader parquet.RowReader, idx IndexReader) (*profileRowIterator, error) {
+func newProfileRowIterator(reader parquet.RowReader, s BlockReader) (*profileRowIterator, error) {
 	k, v := index.AllPostingsKey()
-	allPostings, err := idx.Postings(k, nil, v)
+	allPostings, err := s.Index().Postings(k, nil, v)
 	if err != nil {
 		return nil, err
 	}
 	return &profileRowIterator{
 		profiles:    phlareparquet.NewBufferedRowReaderIterator(reader, 1024),
-		index:       idx,
+		blockReader: s,
+		index:       s.Index(),
 		allPostings: allPostings,
 		currentRow: profileRow{
 			seriesRef: math.MaxUint32,
@@ -266,6 +302,7 @@ func (p *profileRowIterator) Next() bool {
 	if !p.profiles.Next() {
 		return false
 	}
+	p.currentRow.blockReader = p.blockReader
 	p.currentRow.row = schemav1.ProfileRow(p.profiles.At())
 	seriesIndex := p.currentRow.row.SeriesIndex()
 	p.currentRow.timeNanos = p.currentRow.row.TimeNanos()
@@ -308,10 +345,7 @@ func newMergeRowProfileIterator(src []BlockReader) (iter.Iterator[profileRow], e
 	for i, s := range src {
 		// todo: may be we could merge rowgroups in parallel but that requires locking.
 		reader := parquet.MultiRowGroup(s.Profiles()...).Rows()
-		it, err := newProfileRowIterator(
-			reader,
-			s.Index(),
-		)
+		it, err := newProfileRowIterator(reader, s)
 		if err != nil {
 			return nil, err
 		}
@@ -341,80 +375,6 @@ func newMergeRowProfileIterator(src []BlockReader) (iter.Iterator[profileRow], e
 			func(it iter.Iterator[profileRow]) { _ = it.Close() },
 		)),
 	}, nil
-}
-
-type noopStacktraceRewriter struct{}
-
-func (noopStacktraceRewriter) RewriteStacktraces(src, dst []uint32) error {
-	copy(dst, src)
-	return nil
-}
-
-type StacktraceRewriter interface {
-	RewriteStacktraces(src, dst []uint32) error
-}
-
-type symbolsRewriter struct {
-	iter.Iterator[profileRow]
-	err error
-
-	rewriter   StacktraceRewriter
-	src, dst   []uint32
-	numSamples uint64
-}
-
-// todo remap symbols & ingest symbols
-func newSymbolsRewriter(it iter.Iterator[profileRow]) *symbolsRewriter {
-	return &symbolsRewriter{
-		Iterator: it,
-		rewriter: noopStacktraceRewriter{},
-	}
-}
-
-func (s *symbolsRewriter) NumSamples() uint64 {
-	return s.numSamples
-}
-
-func (s *symbolsRewriter) Next() bool {
-	if !s.Iterator.Next() {
-		return false
-	}
-	var err error
-	s.Iterator.At().row.ForStacktraceIDsValues(func(values []parquet.Value) {
-		s.numSamples += uint64(len(values))
-		s.loadStacktracesID(values)
-		err = s.rewriter.RewriteStacktraces(s.src, s.dst)
-		if err != nil {
-			return
-		}
-		for i, v := range values {
-			values[i] = parquet.Int64Value(int64(s.dst[i])).Level(v.RepetitionLevel(), v.DefinitionLevel(), v.Column())
-		}
-	})
-	if err != nil {
-		s.err = err
-		return false
-	}
-	return true
-}
-
-func (s *symbolsRewriter) Err() error {
-	if s.err != nil {
-		return s.err
-	}
-	return s.Iterator.Err()
-}
-
-func (s *symbolsRewriter) loadStacktracesID(values []parquet.Value) {
-	if cap(s.src) < len(values) {
-		s.src = make([]uint32, len(values)*2)
-		s.dst = make([]uint32, len(values)*2)
-	}
-	s.src = s.src[:len(values)]
-	s.dst = s.dst[:len(values)]
-	for i := range values {
-		s.src[i] = values[i].Uint32()
-	}
 }
 
 type seriesRewriter struct {
@@ -534,3 +494,292 @@ func prepareIndexWriter(ctx context.Context, path string, readers []BlockReader)
 
 	return indexw, nil
 }
+
+type symbolsRewriter struct {
+	profiles         iter.Iterator[profileRow]
+	stacktraces, dst []uint32
+	err              error
+
+	rewriters map[BlockReader]*stacktraceRewriter
+
+	numSamples uint64
+}
+
+func newSymbolsRewriter(it iter.Iterator[profileRow], blocks []BlockReader, a SymbolsAppender) *symbolsRewriter {
+	sr := symbolsRewriter{
+		profiles:  it,
+		rewriters: make(map[BlockReader]*stacktraceRewriter, len(blocks)),
+	}
+	for _, b := range blocks {
+		sr.rewriters[b] = newStacktraceRewriter()
+	}
+	return &sr
+}
+
+func (s *symbolsRewriter) NumSamples() uint64 { return s.numSamples }
+
+func (s *symbolsRewriter) At() profileRow { return s.profiles.At() }
+
+func (s *symbolsRewriter) Close() error { return s.profiles.Close() }
+
+func (s *symbolsRewriter) Err() error {
+	if s.err != nil {
+		return s.err
+	}
+	return s.profiles.Err()
+}
+
+func (s *symbolsRewriter) Next() bool {
+	if !s.profiles.Next() {
+		return false
+	}
+	var err error
+	profile := s.profiles.At()
+	profile.row.ForStacktraceIDsValues(func(values []parquet.Value) {
+		s.loadStacktracesID(values)
+		r := s.rewriters[profile.blockReader]
+		if err = r.rewriteStacktraces(profile.row.StacktracePartitionID(), s.stacktraces); err != nil {
+			return
+		}
+		s.numSamples += uint64(len(values))
+		for i, v := range values {
+			values[i] = parquet.Int64Value(int64(s.dst[i])).Level(v.RepetitionLevel(), v.DefinitionLevel(), v.Column())
+		}
+	})
+	if err != nil {
+		s.err = err
+		return false
+	}
+	return true
+}
+
+func (s *symbolsRewriter) loadStacktracesID(values []parquet.Value) {
+	if cap(s.stacktraces) < len(values) {
+		s.stacktraces = make([]uint32, len(values)*2)
+		s.dst = make([]uint32, len(values)*2)
+	}
+	s.stacktraces = s.stacktraces[:len(values)]
+	s.dst = s.dst[:len(values)]
+	for i := range values {
+		s.stacktraces[i] = values[i].Uint32()
+	}
+}
+
+type stacktraceRewriter struct {
+	partition   uint64
+	stacktraces map[uint64]*lookupTable[*schemav1.Stacktrace]
+
+	locations *lookupTable[*schemav1.InMemoryLocation]
+	mappings  *lookupTable[*schemav1.InMemoryMapping]
+	functions *lookupTable[*schemav1.InMemoryFunction]
+	strings   *lookupTable[string]
+}
+
+func newStacktraceRewriter() *stacktraceRewriter {
+	// TODO(kolesnikovae):
+	return new(stacktraceRewriter)
+}
+
+const (
+	marker     = 1 << 31
+	markedMask = math.MaxUint32 >> 1
+)
+
+type lookupTable[T any] struct {
+	// Index is source ID, and the value is the destination ID.
+	// If destination ID is not known, the element is index to 'unresolved' (marked).
+	resolved []uint32
+	// Source IDs.
+	unresolved []uint32
+	values     []T
+}
+
+func newLookupTable[T any](size int) *lookupTable[T] {
+	var t lookupTable[T]
+	t.init(size)
+	return &t
+}
+
+func (t *lookupTable[T]) init(size int) {
+	if cap(t.resolved) < size {
+		t.resolved = make([]uint32, size)
+		return
+	}
+	t.resolved = t.resolved[:size]
+	for i := range t.resolved {
+		t.resolved[i] = 0
+	}
+}
+
+func (t *lookupTable[T]) reset() { t.unresolved = t.unresolved[:0] }
+
+func (t *lookupTable[T]) tryLookup(x uint32) uint32 {
+	if v := t.resolved[x]; v != 0 {
+		return v - 1
+	}
+	v := uint32(len(t.unresolved)) | marker
+	t.unresolved = append(t.unresolved, x)
+	return v
+}
+
+func (t *lookupTable[T]) storeResolved(i, v uint32) { t.resolved[i] = v + 1 }
+
+func (t *lookupTable[T]) lookupUnresolved(x uint32) uint32 {
+	if x&marker == 0 {
+		// Already resolved.
+		return x
+	}
+	return t.unresolved[x&markedMask]
+}
+
+func (t *lookupTable[T]) iter() *lookupTableIterator[T] {
+	t.values = make([]T, len(t.resolved))
+	return &lookupTableIterator[T]{
+		values: t.values,
+	}
+}
+
+// TODO(kolesnikovae):
+type lookupTableIterator[T any] struct {
+	cur    uint32
+	values []T
+}
+
+func (t *lookupTableIterator[T]) set(v T) { t.values[t.cur] = v }
+
+func (r *stacktraceRewriter) symbolsResolver() SymbolsResolver {
+	// TODO(kolesnikovae):
+	return nil
+}
+
+func (r *stacktraceRewriter) symbolsAppender() SymbolsAppender {
+	// TODO(kolesnikovae):
+	return nil
+}
+
+func (r *stacktraceRewriter) reset(partition uint64) {
+	r.partition = partition
+	r.stacktraces[partition].reset()
+	r.locations.reset()
+	r.mappings.reset()
+	r.functions.reset()
+	r.strings.reset()
+}
+
+func (r *stacktraceRewriter) hasUnresolved() bool {
+	return len(r.stacktraces[r.partition].unresolved)+
+		len(r.locations.unresolved)+
+		len(r.mappings.unresolved)+
+		len(r.functions.unresolved)+
+		len(r.strings.unresolved) > 0
+}
+
+func (r *stacktraceRewriter) rewriteStacktraces(partition uint64, stacktraces []uint32) error {
+	r.reset(partition)
+	r.populateUnresolved(stacktraces)
+	if r.hasUnresolved() {
+		r.append(stacktraces)
+	}
+	return nil
+}
+
+func (r *stacktraceRewriter) populateUnresolved(stacktraces []uint32) {
+	// Filter out all stack traces that have been already resolved.
+	src := r.stacktraces[r.partition]
+	for i, v := range stacktraces {
+		stacktraces[i] = src.tryLookup(v)
+	}
+	if len(src.unresolved) == 0 {
+		return
+	}
+
+	// Resolve locations for new stack traces.
+	var stacktrace *schemav1.Stacktrace
+	unresolvedStacktraces := src.iter()
+	p := r.symbolsResolver()
+	for i := p.Stacktraces(unresolvedStacktraces); i.Next(); stacktrace = i.At() {
+		for i, loc := range stacktrace.LocationIDs {
+			stacktrace.LocationIDs[i] = uint64(r.locations.tryLookup(uint32(loc)))
+		}
+		unresolvedStacktraces.set(stacktrace)
+	}
+
+	// Resolve functions and mappings for new locations.
+	var location *schemav1.InMemoryLocation
+	unresolvedLocs := r.locations.iter()
+	for i := p.Locations(unresolvedLocs); i.Next(); location = i.At() {
+		location.MappingId = r.mappings.tryLookup(location.MappingId)
+		for j, line := range location.Line {
+			location.Line[j].FunctionId = r.functions.tryLookup(line.FunctionId)
+		}
+		unresolvedLocs.set(location)
+	}
+
+	// Resolve strings.
+	var mapping *schemav1.InMemoryMapping
+	unresolvedMappings := r.mappings.iter()
+	for i := p.Mappings(unresolvedMappings); i.Next(); mapping = i.At() {
+		mapping.BuildId = r.strings.tryLookup(mapping.BuildId)
+		mapping.Filename = r.strings.tryLookup(mapping.Filename)
+		unresolvedMappings.set(mapping)
+	}
+	var function *schemav1.InMemoryFunction
+	unresolvedFunctions := r.functions.iter()
+	for i := p.Functions(unresolvedFunctions); i.Next(); function = i.At() {
+		function.Name = r.strings.tryLookup(function.Name)
+		function.Filename = r.strings.tryLookup(function.Filename)
+		function.SystemName = r.strings.tryLookup(function.SystemName)
+		unresolvedFunctions.set(function)
+	}
+	var str string
+	unresolvedStrings := r.strings.iter()
+	for i := p.Strings(unresolvedStrings); i.Next(); str = i.At() {
+		unresolvedStrings.set(str)
+	}
+}
+
+func (r *stacktraceRewriter) append(stacktraces []uint32) {
+	a := r.symbolsAppender()
+	for _, str := range r.strings.values {
+		r.functions.storeResolved(0, a.AppendString(str))
+	}
+
+	for _, function := range r.functions.values {
+		function.Name = r.strings.lookupUnresolved(function.Name)
+		function.Filename = r.strings.lookupUnresolved(function.Filename)
+		function.SystemName = r.strings.lookupUnresolved(function.SystemName)
+		r.functions.storeResolved(0, a.AppendFunction(function))
+	}
+
+	for _, mapping := range r.mappings.values {
+		mapping.BuildId = r.strings.lookupUnresolved(mapping.BuildId)
+		mapping.Filename = r.strings.lookupUnresolved(mapping.Filename)
+		r.mappings.storeResolved(0, a.AppendMapping(mapping))
+	}
+
+	for _, location := range r.locations.values {
+		location.MappingId = r.mappings.lookupUnresolved(location.MappingId)
+		for j, line := range location.Line {
+			location.Line[j].FunctionId = r.functions.lookupUnresolved(line.FunctionId)
+		}
+		r.locations.storeResolved(0, a.AppendLocation(location))
+	}
+
+	src := r.stacktraces[r.partition]
+	for _, stacktrace := range src.values {
+		for j, v := range stacktrace.LocationIDs {
+			stacktrace.LocationIDs[j] = uint64(r.locations.lookupUnresolved(uint32(v)))
+		}
+		src.storeResolved(0, a.AppendStacktrace(stacktrace))
+	}
+	for i, v := range stacktraces {
+		stacktraces[i] = src.lookupUnresolved(v)
+	}
+}
+
+type symbolsWriter struct {
+	// TODO(kolesnikovae):
+	SymbolsAppender
+}
+
+func newSymbolsWriter(dst string) (*symbolsWriter, error) { return &symbolsWriter{}, nil }

--- a/pkg/phlaredb/compact_test.go
+++ b/pkg/phlaredb/compact_test.go
@@ -306,7 +306,7 @@ func generateParquetFile(t *testing.T, path string) {
 
 func Test_lookupTable(t *testing.T) {
 	// Given the source data set.
-	// Copy arbitrary subsets of those items to dst.
+	// Copy arbitrary subsets of items from src to dst.
 	var dst []string
 	src := []string{
 		"zero",

--- a/pkg/phlaredb/compact_test.go
+++ b/pkg/phlaredb/compact_test.go
@@ -136,6 +136,15 @@ func testCompact(t *testing.T, metas []*block.Meta, bkt phlareobj.Bucket, dst st
 		"numSamples", new.Stats.NumSamples)
 }
 
+type blockReaderMock struct {
+	BlockReader
+	idxr IndexReader
+}
+
+func (m *blockReaderMock) Index() IndexReader {
+	return m.idxr
+}
+
 func TestProfileRowIterator(t *testing.T) {
 	filePath := t.TempDir() + "/index.tsdb"
 	idxw, err := index.NewWriter(context.Background(), filePath)
@@ -162,7 +171,7 @@ func TestProfileRowIterator(t *testing.T) {
 			{SeriesIndex: 1, TimeNanos: 2},
 			{SeriesIndex: 2, TimeNanos: 3},
 		},
-	), idxr)
+	), &blockReaderMock{idxr: idxr})
 	require.NoError(t, err)
 
 	assert.True(t, it.Next())
@@ -293,4 +302,97 @@ func generateParquetFile(t *testing.T, path string) {
 		})
 		require.NoError(t, err)
 	}
+}
+
+func Test_lookupTable(t *testing.T) {
+	// Given the source data set.
+	// Copy arbitrary subsets of those items to dst.
+	var dst []string
+	src := []string{
+		"zero",
+		"one",
+		"two",
+		"three",
+		"four",
+		"five",
+		"six",
+		"seven",
+	}
+
+	type testCase struct {
+		description string
+		input       []uint32
+		expected    []string
+	}
+
+	testCases := []testCase{
+		{
+			description: "empty table",
+			input:       []uint32{5, 0, 3, 1, 2, 2, 4},
+			expected:    []string{"five", "zero", "three", "one", "two", "two", "four"},
+		},
+		{
+			description: "no new values",
+			input:       []uint32{2, 1, 2, 3},
+			expected:    []string{"two", "one", "two", "three"},
+		},
+		{
+			description: "new value mixed",
+			input:       []uint32{2, 1, 6, 2, 3},
+			expected:    []string{"two", "one", "six", "two", "three"},
+		},
+	}
+
+	// Try to lookup values in src lazily.
+	// Table size must be greater or equal
+	// to the source data set.
+	l := newLookupTable[string](10)
+
+	populate := func(t *testing.T, x []uint32) {
+		for i, v := range x {
+			x[i] = l.tryLookup(v)
+		}
+		// Resolve unknown yet values.
+		// Mind the order and deduplication.
+		p := -1
+		for it := l.iter(); it.Err() == nil && it.Next(); {
+			m := int(it.At())
+			if m <= p {
+				t.Fatal("iterator order invalid")
+			}
+			p = m
+			it.setValue(src[m])
+		}
+	}
+
+	resolveAppend := func() {
+		// Populate dst with the newly resolved values.
+		// Note that order in dst does not have to match src.
+		for _, n := range l.unresolved {
+			l.storeResolved(n.rid, uint32(len(dst)))
+			dst = append(dst, n.val)
+		}
+	}
+
+	resolve := func(x []uint32) []string {
+		// Lookup resolved values.
+		var resolved []string
+		for _, v := range x {
+			resolved = append(resolved, dst[l.lookupResolved(v)])
+		}
+		return resolved
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.description, func(t *testing.T) {
+			l.reset()
+			populate(t, tc.input)
+			resolveAppend()
+			assert.Equal(t, tc.expected, resolve(tc.input))
+		})
+	}
+
+	assert.Len(t, dst, 7)
+	assert.NotContains(t, dst, "seven")
 }

--- a/pkg/phlaredb/compact_test.go
+++ b/pkg/phlaredb/compact_test.go
@@ -368,9 +368,9 @@ func Test_lookupTable(t *testing.T) {
 	resolveAppend := func() {
 		// Populate dst with the newly resolved values.
 		// Note that order in dst does not have to match src.
-		for _, n := range l.unresolved {
-			l.storeResolved(n.rid, uint32(len(dst)))
-			dst = append(dst, n.val)
+		for i, v := range l.values {
+			l.storeResolved(i, uint32(len(dst)))
+			dst = append(dst, v)
 		}
 	}
 

--- a/pkg/phlaredb/compact_test.go
+++ b/pkg/phlaredb/compact_test.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"path/filepath"
 	"sort"
 	"sync"
 	"testing"
 	"time"
-
-	_ "net/http/pprof"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/storage"
@@ -119,9 +118,11 @@ func testCompact(t *testing.T, metas []*block.Meta, bkt phlareobj.Bucket, dst st
 			"numSamples", m.Stats.NumSamples)
 		b := NewSingleBlockQuerierFromMeta(ctx, bkt, m)
 		g.Go(func() error {
-			return b.Open(ctx)
+			if err := b.Open(ctx); err != nil {
+				return err
+			}
+			return b.stacktraces.Load(ctx)
 		})
-
 		src = append(src, b)
 	}
 

--- a/pkg/phlaredb/deduplicating_slice.go
+++ b/pkg/phlaredb/deduplicating_slice.go
@@ -244,13 +244,15 @@ func (s *deduplicatingSlice[M, K, H, P]) append(dst []uint32, elems []M) {
 		s.lock.RLock()
 		p := uint32(len(s.slice))
 		for _, i := range missing {
-			k := s.helper.key(elems[i])
+			e := elems[i]
+			k := s.helper.key(e)
 			x, ok := s.lookup[k]
-			if !ok {
+			if ok {
 				dst[i] = uint32(x)
 				continue
 			}
-			s.slice = append(s.slice, s.helper.clone(elems[i]))
+			s.size.Add(s.helper.size(e))
+			s.slice = append(s.slice, s.helper.clone(e))
 			s.lookup[k] = int64(p)
 			dst[i] = p
 			p++

--- a/pkg/phlaredb/head.go
+++ b/pkg/phlaredb/head.go
@@ -317,7 +317,7 @@ func (h *Head) convertSamples(_ context.Context, r *rewriter, stacktracePartitio
 			r.locations.rewriteUint64(&stacktraces[idxSample].LocationIDs[i])
 		}
 	}
-	appender := h.symbolDB.MappingWriter(stacktracePartition).StacktraceAppender()
+	appender := h.symbolDB.SymbolsAppender(stacktracePartition).StacktraceAppender()
 	defer appender.Release()
 
 	if cap(stacktracesIds) < len(stacktraces) {
@@ -609,7 +609,7 @@ func (h *Head) resolveStacktraces(ctx context.Context, stacktracesByMapping stac
 	sp.LogFields(otlog.String("msg", "building MergeProfilesStacktracesResult"))
 	_ = stacktracesByMapping.ForEach(
 		func(mapping uint64, stacktraceSamples stacktraceSampleMap) error {
-			mp, ok := h.symbolDB.MappingReader(mapping)
+			mp, ok := h.symbolDB.SymbolsResolver(mapping)
 			if !ok {
 				return nil
 			}
@@ -672,7 +672,7 @@ func (h *Head) resolvePprof(ctx context.Context, stacktracesByMapping profileSam
 	// now add locationIDs and stacktraces
 	_ = stacktracesByMapping.ForEach(
 		func(mapping uint64, stacktraceSamples profileSampleMap) error {
-			mp, ok := h.symbolDB.MappingReader(mapping)
+			mp, ok := h.symbolDB.SymbolsResolver(mapping)
 			if !ok {
 				return nil
 			}

--- a/pkg/phlaredb/head.go
+++ b/pkg/phlaredb/head.go
@@ -971,7 +971,7 @@ func (h *Head) flush(ctx context.Context) error {
 	}
 
 	// add total size symdb
-	symbDBFiles, err := h.SymDBFiles()
+	symbDBFiles, err := symdbMetaFiles(h.headPath)
 	if err != nil {
 		return err
 	}
@@ -1002,6 +1002,26 @@ func (h *Head) flush(ctx context.Context) error {
 // SymDBFiles lists files in symdb folder
 func (h *Head) SymDBFiles() ([]block.File, error) {
 	files, err := os.ReadDir(filepath.Join(h.headPath, symdb.DefaultDirName))
+	if err != nil {
+		return nil, err
+	}
+	result := make([]block.File, len(files))
+	for idx, f := range files {
+		if f.IsDir() {
+			continue
+		}
+		result[idx].RelPath = filepath.Join(symdb.DefaultDirName, f.Name())
+		info, err := f.Info()
+		if err != nil {
+			return nil, err
+		}
+		result[idx].SizeBytes = uint64(info.Size())
+	}
+	return result, nil
+}
+
+func symdbMetaFiles(dir string) ([]block.File, error) {
+	files, err := os.ReadDir(filepath.Join(dir, symdb.DefaultDirName))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/phlaredb/head.go
+++ b/pkg/phlaredb/head.go
@@ -971,9 +971,9 @@ func (h *Head) flush(ctx context.Context) error {
 	}
 
 	// add total size symdb
-	symbDBFiles, error := h.SymDBFiles()
-	if error != nil {
-		return error
+	symbDBFiles, err := h.SymDBFiles()
+	if err != nil {
+		return err
 	}
 
 	for _, file := range symbDBFiles {

--- a/pkg/phlaredb/sample_merge.go
+++ b/pkg/phlaredb/sample_merge.go
@@ -56,20 +56,12 @@ func newLocationsIdsByStacktraceID(size int) locationsIdsByStacktraceID {
 	}
 }
 
-func (l locationsIdsByStacktraceID) addFromParquet(stacktraceID int64, locs []parquet.Value) {
-	l.byStacktraceID[stacktraceID] = make([]int32, len(locs))
-	for i, locationID := range locs {
-		locID := locationID.Uint64()
-		l.ids[int64(locID)] = struct{}{}
-		l.byStacktraceID[stacktraceID][i] = int32(locID)
-	}
-}
-
-func (l locationsIdsByStacktraceID) add(stacktraceID int64, locs []int32) {
-	l.byStacktraceID[stacktraceID] = make([]int32, len(locs))
+func (l locationsIdsByStacktraceID) InsertStacktrace(stacktraceID uint32, locs []int32) {
+	s := make([]int32, len(locs))
+	l.byStacktraceID[int64(stacktraceID)] = s
 	for i, locationID := range locs {
 		l.ids[int64(locationID)] = struct{}{}
-		l.byStacktraceID[stacktraceID][i] = locationID
+		s[i] = locationID
 	}
 }
 

--- a/pkg/phlaredb/schemas/v1/profiles.go
+++ b/pkg/phlaredb/schemas/v1/profiles.go
@@ -42,10 +42,11 @@ var (
 		phlareparquet.NewGroupField("DefaultSampleType", parquet.Optional(parquet.Int(64))),
 	})
 
-	maxProfileRow        parquet.Row
-	seriesIndexColIndex  int
-	stacktraceIDColIndex int
-	timeNanoColIndex     int
+	maxProfileRow               parquet.Row
+	seriesIndexColIndex         int
+	stacktraceIDColIndex        int
+	timeNanoColIndex            int
+	stacktracePartitionColIndex int
 )
 
 func init() {
@@ -68,6 +69,11 @@ func init() {
 		panic(fmt.Errorf("StacktraceID column not found"))
 	}
 	stacktraceIDColIndex = stacktraceIDCol.ColumnIndex
+	stacktracePartitionCol, ok := profilesSchema.Lookup("StacktracePartition")
+	if !ok {
+		panic(fmt.Errorf("StacktracePartition column not found"))
+	}
+	stacktracePartitionColIndex = stacktracePartitionCol.ColumnIndex
 }
 
 type Sample struct {
@@ -469,6 +475,10 @@ type ProfileRow parquet.Row
 
 func (p ProfileRow) SeriesIndex() uint32 {
 	return p[seriesIndexColIndex].Uint32()
+}
+
+func (p ProfileRow) StacktracePartitionID() uint64 {
+	return p[stacktracePartitionColIndex].Uint64()
 }
 
 func (p ProfileRow) TimeNanos() int64 {

--- a/pkg/phlaredb/symdb/interfaces.go
+++ b/pkg/phlaredb/symdb/interfaces.go
@@ -10,6 +10,7 @@ import (
 // collection. https://github.com/google/pprof/blob/main/proto/README.md
 //
 // In the package, Mapping represents all the version of a binary.
+// TODO(kolesnikovae): Rename mapping to Partition
 
 type MappingWriter interface {
 	// StacktraceAppender provides exclusive write access

--- a/pkg/phlaredb/symdb/interfaces.go
+++ b/pkg/phlaredb/symdb/interfaces.go
@@ -10,26 +10,23 @@ import (
 // collection. https://github.com/google/pprof/blob/main/proto/README.md
 //
 // In the package, Mapping represents all the version of a binary.
-// TODO(kolesnikovae): Rename mapping to Partition
 
-type MappingWriter interface {
-	// StacktraceAppender provides exclusive write access
-	// to the stack traces of the mapping.
-	//
-	// StacktraceAppender.Release must be called in order
-	// to dispose the object and release the lock.
-	// Released resolver must not be used.
+type SymbolsAppender interface {
 	StacktraceAppender() StacktraceAppender
 }
 
-type MappingReader interface {
-	// StacktraceResolver provides non-exclusive read
-	// access to the stack traces of the mapping.
-	//
-	// StacktraceResolver.Release must be called in order
-	// to dispose the object and release the lock.
-	// Released resolver must not be used.
+type SymbolsResolver interface {
 	StacktraceResolver() StacktraceResolver
+	WriteStats(*Stats)
+}
+
+type Stats struct {
+	StacktracesTotal int
+	LocationsTotal   int
+	MappingsTotal    int
+	FunctionsTotal   int
+	StringsTotal     int
+	MaxStacktraceID  int
 }
 
 type StacktraceAppender interface {

--- a/pkg/phlaredb/symdb/stacktrace_tree_test.go
+++ b/pkg/phlaredb/symdb/stacktrace_tree_test.go
@@ -88,7 +88,7 @@ func Test_stacktrace_tree_encoding_group(t *testing.T) {
 }
 
 func Test_stacktrace_tree_encoding_rand(t *testing.T) {
-	// TODO: Fuzzing. With random data it's easy to hit overflow.
+	// TODO: Fuzzing.
 	nodes := make([]node, 1<<20)
 	for i := range nodes {
 		nodes[i] = node{

--- a/pkg/phlaredb/symdb/symbols_reader_file.go
+++ b/pkg/phlaredb/symdb/symbols_reader_file.go
@@ -92,6 +92,9 @@ func (r *Reader) SymbolsResolver(partition uint64) (SymbolsResolver, bool) {
 	return m, ok
 }
 
+// Load causes reader to load all contents into memory.
+func (r *Reader) Load() error { panic("implement me") }
+
 type partitionFileReader struct {
 	reader           *Reader
 	stacktraceChunks []*stacktraceChunkFileReader
@@ -135,6 +138,9 @@ func (r *stacktraceResolverFile) Release() {}
 var ErrInvalidStacktraceRange = fmt.Errorf("invalid range: stack traces can't be resolved")
 
 func (r *stacktraceResolverFile) ResolveStacktraces(ctx context.Context, dst StacktraceInserter, s []uint32) error {
+	if len(s) == 0 {
+		return nil
+	}
 	if len(r.partition.stacktraceChunks) == 0 {
 		return ErrInvalidStacktraceRange
 	}

--- a/pkg/phlaredb/symdb/symbols_reader_file_test.go
+++ b/pkg/phlaredb/symdb/symbols_reader_file_test.go
@@ -19,7 +19,7 @@ func Test_Reader_Open(t *testing.T) {
 	}
 
 	db := NewSymDB(cfg)
-	w := db.MappingWriter(1)
+	w := db.SymbolsAppender(1)
 	a := w.StacktraceAppender()
 	sids := make([]uint32, 5)
 	a.AppendStacktrace(sids, []*schemav1.Stacktrace{
@@ -37,7 +37,7 @@ func Test_Reader_Open(t *testing.T) {
 	require.NoError(t, err)
 	x, err := Open(context.Background(), b)
 	require.NoError(t, err)
-	mr, ok := x.MappingReader(1)
+	mr, ok := x.SymbolsResolver(1)
 	require.True(t, ok)
 
 	dst := new(mockStacktraceInserter)

--- a/pkg/phlaredb/symdb/symbols_writer_file.go
+++ b/pkg/phlaredb/symdb/symbols_writer_file.go
@@ -38,13 +38,13 @@ func (w *Writer) writeStacktraceChunk(ci int, c *stacktraceChunk) (err error) {
 	h := StacktraceChunkHeader{
 		Offset:             w.scd.w.offset,
 		Size:               0, // Set later.
-		MappingName:        c.mapping.name,
+		Partition:          c.parition.name,
 		ChunkIndex:         uint16(ci),
 		ChunkEncoding:      ChunkEncodingGroupVarint,
-		Stacktraces:        0, // TODO
+		Stacktraces:        c.stacks,
 		StacktraceNodes:    c.tree.len(),
 		StacktraceMaxDepth: 0, // TODO
-		StacktraceMaxNodes: c.mapping.maxNodesPerChunk,
+		StacktraceMaxNodes: c.parition.maxNodesPerChunk,
 		CRC:                0, // Set later.
 	}
 	crc := crc32.New(castagnoli)

--- a/pkg/phlaredb/symdb/symbols_writer_file_test.go
+++ b/pkg/phlaredb/symdb/symbols_writer_file_test.go
@@ -22,7 +22,7 @@ func Test_Writer_IndexFile(t *testing.T) {
 
 	sids := make([]uint32, 5)
 
-	w := db.MappingWriter(0)
+	w := db.SymbolsAppender(0)
 	a := w.StacktraceAppender()
 	a.AppendStacktrace(sids, []*schemav1.Stacktrace{
 		{LocationIDs: []uint64{3, 2, 1}},
@@ -34,7 +34,7 @@ func Test_Writer_IndexFile(t *testing.T) {
 	assert.Equal(t, []uint32{3, 2, 11, 16, 18}, sids)
 	a.Release()
 
-	w = db.MappingWriter(1)
+	w = db.SymbolsAppender(1)
 	a = w.StacktraceAppender()
 	a.AppendStacktrace(sids, []*schemav1.Stacktrace{
 		{LocationIDs: []uint64{3, 2, 1}},
@@ -46,9 +46,9 @@ func Test_Writer_IndexFile(t *testing.T) {
 	assert.Equal(t, []uint32{3, 2, 11, 16, 18}, sids)
 	a.Release()
 
-	require.Len(t, db.mappings, 2)
-	require.Len(t, db.mappings[0].stacktraceChunks, 3)
-	require.Len(t, db.mappings[1].stacktraceChunks, 3)
+	require.Len(t, db.partitions, 2)
+	require.Len(t, db.partitions[0].stacktraceChunks, 3)
+	require.Len(t, db.partitions[1].stacktraceChunks, 3)
 
 	require.NoError(t, db.Flush())
 
@@ -75,10 +75,10 @@ func Test_Writer_IndexFile(t *testing.T) {
 				{
 					Offset:             0,
 					Size:               10,
-					MappingName:        0x0,
+					Partition:          0x0,
 					ChunkIndex:         0x0,
 					ChunkEncoding:      0x1,
-					Stacktraces:        0x0,
+					Stacktraces:        0x2,
 					StacktraceNodes:    0x4,
 					StacktraceMaxDepth: 0x0,
 					StacktraceMaxNodes: 0x7,
@@ -87,10 +87,10 @@ func Test_Writer_IndexFile(t *testing.T) {
 				{
 					Offset:             10,
 					Size:               15,
-					MappingName:        0x0,
+					Partition:          0x0,
 					ChunkIndex:         0x1,
 					ChunkEncoding:      0x1,
-					Stacktraces:        0x0,
+					Stacktraces:        0x1,
 					StacktraceNodes:    0x5,
 					StacktraceMaxDepth: 0x0,
 					StacktraceMaxNodes: 0x7,
@@ -99,10 +99,10 @@ func Test_Writer_IndexFile(t *testing.T) {
 				{
 					Offset:             25,
 					Size:               15,
-					MappingName:        0x0,
+					Partition:          0x0,
 					ChunkIndex:         0x2,
 					ChunkEncoding:      0x1,
-					Stacktraces:        0x0,
+					Stacktraces:        0x3,
 					StacktraceNodes:    0x5,
 					StacktraceMaxDepth: 0x0,
 					StacktraceMaxNodes: 0x7,
@@ -111,10 +111,10 @@ func Test_Writer_IndexFile(t *testing.T) {
 				{
 					Offset:             40,
 					Size:               10,
-					MappingName:        0x1,
+					Partition:          0x1,
 					ChunkIndex:         0x0,
 					ChunkEncoding:      0x1,
-					Stacktraces:        0x0,
+					Stacktraces:        0x2,
 					StacktraceNodes:    0x4,
 					StacktraceMaxDepth: 0x0,
 					StacktraceMaxNodes: 0x7,
@@ -123,10 +123,10 @@ func Test_Writer_IndexFile(t *testing.T) {
 				{
 					Offset:             50,
 					Size:               15,
-					MappingName:        0x1,
+					Partition:          0x1,
 					ChunkIndex:         0x1,
 					ChunkEncoding:      0x1,
-					Stacktraces:        0x0,
+					Stacktraces:        0x1,
 					StacktraceNodes:    0x5,
 					StacktraceMaxDepth: 0x0,
 					StacktraceMaxNodes: 0x7,
@@ -135,10 +135,10 @@ func Test_Writer_IndexFile(t *testing.T) {
 				{
 					Offset:             65,
 					Size:               15,
-					MappingName:        0x1,
+					Partition:          0x1,
 					ChunkIndex:         0x2,
 					ChunkEncoding:      0x1,
-					Stacktraces:        0x0,
+					Stacktraces:        0x3,
 					StacktraceNodes:    0x5,
 					StacktraceMaxDepth: 0x0,
 					StacktraceMaxNodes: 0x7,
@@ -146,7 +146,7 @@ func Test_Writer_IndexFile(t *testing.T) {
 				},
 			},
 		},
-		CRC: 0x5bbecabf,
+		CRC: 0x6418eaed,
 	}
 
 	assert.Equal(t, expected, idx)


### PR DESCRIPTION
The PR contains implementation of the symbols rewriter which is used in compaction. The design of the implementation is heavily influenced by the following factors:
 - On compaction, we may want to get only a subrange of profiles from a source block. The range may be limited to a specific series set, time range, or both.
 - Symbolic information of a source block must be loaded into memory entirely, because there is no efficient way to load it in parts.

TODO:
 - [ ] Validity verification.
 - [ ] Performance tests.

Currently, the complete compaction flow is incomplete which complicates further testing. Specifically, I didn't manage to query any data from a storage with a compacted block: it either returns empty result, or fails with the error `panic: label hash conflict`.

Nevertheless, I think that we should pull this change into the main compaction branch and continue work there. Moreover, I'd like to get the compaction branch merged into main (`next`).
