### PR TITLE
Ensure we only query ingesters in active state

### DIFF
--- a/pkg/querier/ingester_querier.go
+++ b/pkg/querier/ingester_querier.go
@@ -42,9 +42,13 @@ func NewIngesterQuerier(pool *ring_client.Pool, ring ring.ReadRing) *IngesterQue
 	}
 }
 
+// readNoExtend is a ring.Operation that only selects instances marked as ring.ACTIVE.
+// This should mirror the operation used when choosing ingesters to write series to (ring.WriteNoExtend).
+var readNoExtend = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, nil)
+
 // forAllIngesters runs f, in parallel, for all ingesters
 func forAllIngesters[T any](ctx context.Context, ingesterQuerier *IngesterQuerier, f QueryReplicaFn[T, IngesterQueryClient]) ([]ResponseFromReplica[T], error) {
-	replicationSet, err := ingesterQuerier.ring.GetReplicationSetForOperation(ring.Read)
+	replicationSet, err := ingesterQuerier.ring.GetReplicationSetForOperation(readNoExtend)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
With ring.Read we query ingesters in any state. This change is taken
from Mimir and it will ensure to ignore not active ingesters.

https://github.com/grafana/mimir/blob/d99cb3c081022e0752ee3db8c2cc39af46d09ba8/pkg/distributor/query.go#L33-L35

This should improve the behaviour of Pyroscope during rollouts and
partial outages.
