### PR TITLE
Fix goroutine leak in BufferedIterator

### DIFF
--- a/pkg/iter/iter.go
+++ b/pkg/iter/iter.go
@@ -238,8 +238,8 @@ type BufferedIterator[T any] struct {
 }
 
 // NewBufferedIterator returns an iterator that reads asynchronously from the given iterator and buffers up to size elements.
-func NewBufferedIterator[T any](ctx context.Context, it Iterator[T], size int) Iterator[T] {
-	ctx, cancel := context.WithCancel(ctx)
+func NewBufferedIterator[T any](it Iterator[T], size int) Iterator[T] {
+	ctx, cancel := context.WithCancel(context.Background())
 	buffered := &BufferedIterator[T]{
 		Iterator: it,
 		buff:     make(chan T, size),

--- a/pkg/iter/iter.go
+++ b/pkg/iter/iter.go
@@ -1,7 +1,9 @@
 package iter
 
 import (
+	"context"
 	"sort"
+	"sync"
 
 	"github.com/samber/lo"
 	"golang.org/x/exp/constraints"
@@ -229,22 +231,38 @@ type BufferedIterator[T any] struct {
 	Iterator[T]
 	buff chan T
 	at   T
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
 }
 
 // NewBufferedIterator returns an iterator that reads asynchronously from the given iterator and buffers up to size elements.
-func NewBufferedIterator[T any](it Iterator[T], size int) Iterator[T] {
+func NewBufferedIterator[T any](ctx context.Context, it Iterator[T], size int) Iterator[T] {
+	ctx, cancel := context.WithCancel(ctx)
 	buffered := &BufferedIterator[T]{
 		Iterator: it,
 		buff:     make(chan T, size),
+		ctx:      ctx,
+		cancel:   cancel,
 	}
+
+	buffered.wg.Add(1)
 	go buffered.fill()
 	return buffered
 }
 
 func (it *BufferedIterator[T]) fill() {
+	defer it.wg.Done()
 	defer close(it.buff)
+
 	for it.Iterator.Next() {
-		it.buff <- it.Iterator.At()
+		select {
+		case <-it.ctx.Done():
+			return
+		case it.buff <- it.Iterator.At():
+			continue
+		}
 	}
 }
 
@@ -256,6 +274,20 @@ func (it *BufferedIterator[T]) Next() bool {
 	return ok
 }
 
+func (it *BufferedIterator[T]) Err() error {
+	if it.ctx.Err() != nil {
+		return it.ctx.Err()
+	}
+	return it.Iterator.Err()
+}
+
 func (it *BufferedIterator[T]) At() T {
 	return it.at
+}
+
+func (it *BufferedIterator[T]) Close() error {
+	err := it.Iterator.Close()
+	it.cancel()
+	it.wg.Wait()
+	return err
 }

--- a/pkg/iter/iter.go
+++ b/pkg/iter/iter.go
@@ -275,9 +275,6 @@ func (it *BufferedIterator[T]) Next() bool {
 }
 
 func (it *BufferedIterator[T]) Err() error {
-	if it.ctx.Err() != nil {
-		return it.ctx.Err()
-	}
 	return it.Iterator.Err()
 }
 

--- a/pkg/iter/profiles_test.go
+++ b/pkg/iter/profiles_test.go
@@ -1,7 +1,6 @@
 package iter
 
 import (
-	"context"
 	"math"
 	"testing"
 
@@ -164,7 +163,7 @@ func Test_BufferedIterator(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			actual, err := Slice(
-				NewBufferedIterator(context.Background(),
+				NewBufferedIterator(
 					NewSliceIterator(tc.in), tc.size),
 			)
 			require.NoError(t, err)

--- a/pkg/iter/profiles_test.go
+++ b/pkg/iter/profiles_test.go
@@ -176,7 +176,7 @@ func Test_BufferedIterator(t *testing.T) {
 func Test_BufferedIteratorClose(t *testing.T) {
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
-	it := NewBufferedIterator(context.Background(),
+	it := NewBufferedIterator(
 		NewSliceIterator(generatesProfiles(t, 100)), 10)
 	require.NoError(t, it.Close())
 }

--- a/pkg/phlaredb/block_querier.go
+++ b/pkg/phlaredb/block_querier.go
@@ -550,6 +550,11 @@ func SelectMatchingProfiles(ctx context.Context, request *ingestv1.SelectProfile
 	}
 
 	if err := g.Wait(); err != nil {
+		for _, it := range iters {
+			if it != nil {
+				it.Close()
+			}
+		}
 		return nil, err
 	}
 	return iters, nil
@@ -933,9 +938,7 @@ func (b *singleBlockQuerier) SelectMatchingProfiles(ctx context.Context, params 
 		}
 	}
 
-	var (
-		buf [][]parquet.Value
-	)
+	var buf [][]parquet.Value
 
 	pIt := query.NewBinaryJoinIterator(
 		0,

--- a/pkg/phlaredb/block_querier.go
+++ b/pkg/phlaredb/block_querier.go
@@ -544,7 +544,7 @@ func SelectMatchingProfiles(ctx context.Context, request *ingestv1.SelectProfile
 			if err != nil {
 				return err
 			}
-			iters[i] = iter.NewBufferedIterator(ctx, profiles, 1024)
+			iters[i] = iter.NewBufferedIterator(profiles, 1024)
 			return nil
 		}))
 	}
@@ -552,7 +552,7 @@ func SelectMatchingProfiles(ctx context.Context, request *ingestv1.SelectProfile
 	if err := g.Wait(); err != nil {
 		for _, it := range iters {
 			if it != nil {
-				it.Close()
+				runutil.CloseWithLogOnErr(util.Logger, it, "closing buffered iterator")
 			}
 		}
 		return nil, err

--- a/pkg/phlaredb/block_querier.go
+++ b/pkg/phlaredb/block_querier.go
@@ -544,7 +544,7 @@ func SelectMatchingProfiles(ctx context.Context, request *ingestv1.SelectProfile
 			if err != nil {
 				return err
 			}
-			iters[i] = iter.NewBufferedIterator(profiles, 1024)
+			iters[i] = iter.NewBufferedIterator(ctx, profiles, 1024)
 			return nil
 		}))
 	}


### PR DESCRIPTION
This PR fix a goroutine on the query path that can trigger if we don't call Close correctly or leave the buffer full (no calling next).

It adds changes:
- Close all iterator in case of failure when building them
- Add cancellation when pushing to channel.