### PR TITLE
Update workflows to publish to different website branch and new target directory

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -37,7 +37,7 @@ jobs:
       id: "publish-next"
       with:
         repository: "grafana/website"
-        branch: "master"
+        branch: "publish-to-pyroscope"
         host: "github.com"
         # PUBLISH_TO_WEBSITE_TOKEN is a fine-grained GitHub Personal Access Token that expires.
         # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
@@ -45,4 +45,4 @@ jobs:
         # The IT helpdesk can update the organization secret.
         github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_TOKEN }}"
         source_folder: "docs/sources"
-        target_folder: "content/docs/phlare/next"
+        target_folder: "content/docs/pyroscope/next"

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -68,7 +68,7 @@ jobs:
       id: "publish-release"
       with:
         repository: "grafana/website"
-        branch: "master"
+        branch: "publish-to-pyroscope"
         host: "github.com"
         # PUBLISH_TO_WEBSITE_TOKEN is a fine-grained GitHub Personal Access Token that expires.
         # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
@@ -77,4 +77,4 @@ jobs:
         github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_TOKEN }}"
         source_folder: "docs/sources"
         # Append ".x" to target to produce a v<major>.<minor>.x directory.
-        target_folder: "content/docs/phlare/${{ steps.target.outputs.target }}.x"
+        target_folder: "content/docs/pyroscope/${{ steps.target.outputs.target }}.x"


### PR DESCRIPTION
This lets us test out the new directory in the website repository preview builds.
Once we are happy with the preview of the `publish-to-pyroscope` branch in the website repository, we can merge that PR in the website repository, updating the production website.

Then we will need to update this workflow again to commit back to the primary website branch.