### PR TITLE
Correctly setup compaction sources in block meta files

### DIFF
--- a/pkg/phlaredb/compact_test.go
+++ b/pkg/phlaredb/compact_test.go
@@ -410,7 +410,8 @@ func TestCompactMetas(t *testing.T) {
 			MinTime: model.TimeFromUnix(0),
 			MaxTime: model.TimeFromUnix(100),
 			Compaction: tsdb.BlockMetaCompaction{
-				Level: 1,
+				Level:   1,
+				Sources: []ulid.ULID{ulid.MustParse("00000000000000000000000001")},
 			},
 			Labels: map[string]string{"foo": "bar"},
 		},
@@ -419,7 +420,8 @@ func TestCompactMetas(t *testing.T) {
 			MinTime: model.TimeFromUnix(50),
 			MaxTime: model.TimeFromUnix(100),
 			Compaction: tsdb.BlockMetaCompaction{
-				Level: 0,
+				Level:   0,
+				Sources: []ulid.ULID{ulid.MustParse("00000000000000000000000002")},
 			},
 			Labels: map[string]string{"bar": "buzz"},
 		},
@@ -428,10 +430,11 @@ func TestCompactMetas(t *testing.T) {
 			MinTime: model.TimeFromUnix(50),
 			MaxTime: model.TimeFromUnix(200),
 			Compaction: tsdb.BlockMetaCompaction{
-				Level: 3,
+				Level:   3,
+				Sources: []ulid.ULID{ulid.MustParse("00000000000000000000000003")},
 			},
 		},
-	})
+	}...)
 	labels := map[string]string{"foo": "bar", "bar": "buzz"}
 	if hostname, err := os.Hostname(); err == nil {
 		labels[block.HostnameLabel] = hostname

--- a/pkg/phlaredb/head.go
+++ b/pkg/phlaredb/head.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gogo/status"
 	"github.com/google/pprof/profile"
 	"github.com/google/uuid"
+	"github.com/oklog/ulid"
 	"github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
@@ -1003,6 +1004,7 @@ func (h *Head) flush(ctx context.Context) error {
 	h.meta.Files = files
 	h.meta.Stats.NumProfiles = uint64(h.profiles.index.totalProfiles.Load())
 	h.meta.Stats.NumSamples = h.totalSamples.Load()
+	h.meta.Compaction.Sources = []ulid.ULID{h.meta.ULID}
 	h.metrics.flushedBlockSamples.Observe(float64(h.meta.Stats.NumSamples))
 	h.metrics.flusehdBlockProfiles.Observe(float64(h.meta.Stats.NumProfiles))
 

--- a/pkg/phlaredb/head.go
+++ b/pkg/phlaredb/head.go
@@ -1005,6 +1005,7 @@ func (h *Head) flush(ctx context.Context) error {
 	h.meta.Stats.NumProfiles = uint64(h.profiles.index.totalProfiles.Load())
 	h.meta.Stats.NumSamples = h.totalSamples.Load()
 	h.meta.Compaction.Sources = []ulid.ULID{h.meta.ULID}
+	h.meta.Compaction.Level = 1
 	h.metrics.flushedBlockSamples.Observe(float64(h.meta.Stats.NumSamples))
 	h.metrics.flusehdBlockProfiles.Observe(float64(h.meta.Stats.NumProfiles))
 

--- a/pkg/phlaredb/head_test.go
+++ b/pkg/phlaredb/head_test.go
@@ -484,7 +484,7 @@ func TestFlushMeta(t *testing.T) {
 	})
 
 	require.Equal(t, []ulid.ULID{b.Meta().ULID}, b.Meta().Compaction.Sources)
-	require.Equal(t, 0, b.Meta().Compaction.Level)
+	require.Equal(t, 1, b.Meta().Compaction.Level)
 	require.Equal(t, false, b.Meta().Compaction.Deletable)
 	require.Equal(t, false, b.Meta().Compaction.Failed)
 	require.Equal(t, []string(nil), b.Meta().Compaction.Hints)


### PR DESCRIPTION
The original block should have all source IDS which is itself, then compacted should merge source of parents.

Also adds test for both case.