### PR TITLE
Use app auth for release/weekly-release/deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - run: make frontend/build
+      - name: Get github app token (valid for an hour)
+        id: app-goreleaser
+        uses: getsentry/action-github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: goreleaser/goreleaser-action@v4
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro':
@@ -53,7 +59,7 @@ jobs:
           version: latest
           args: release --rm-dist --timeout 60m
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-releaser.outputs.token }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro'
           # distribution:
           # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,9 +123,15 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+      - name: Get github app token (valid for an hour)
+        id: app-release
+        uses: getsentry/action-github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Deploy to fire-dev-001
         run: |
-          git config --global url."https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/deployment_tools".insteadOf "https://github.com/grafana/deployment_tools"
+          git config --global url."https://x-access-token:${{ steps.app-release.output.token }}@github.com/grafana/deployment_tools".insteadOf "https://github.com/grafana/deployment_tools"
           make docker-image/pyroscope/deploy-dev-001
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-release.outputs.token }}

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -43,6 +43,12 @@ jobs:
           node-version: lts/hydrogen
           cache: yarn
       - run: make frontend/build
+      - name: Get github app token (valid for an hour)
+        id: app-goreleaser
+        uses: getsentry/action-github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: goreleaser/goreleaser-action@v4
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro':
@@ -50,7 +56,7 @@ jobs:
           version: latest
           args: release --clean --skip-publish --timeout 60m
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-releaser.outputs.token }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro'
           # distribution:
           # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
@@ -70,5 +76,11 @@ jobs:
 
           docker manifest create "grafana/pyroscope:${WEEKLY_IMAGE_TAG}" "${IMAGE_AMMENDS[@]}"
           docker manifest push "grafana/pyroscope:${WEEKLY_IMAGE_TAG}"
+      - name: Get github app token (valid for an hour)
+        id: app-git-tag
+        uses: getsentry/action-github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Push git tag for weekly release
-        run: git push https://grafanabot:${{ secrets.GH_BOT_ACCESS_TOKEN }}@github.com/grafana/pyroscope.git "${WEEKLY_IMAGE_TAG}"
+        run: git push https://x-access-token:${{ steps.app-git-tag.output.token }}@github.com/grafana/pyroscope.git "${WEEKLY_IMAGE_TAG}"


### PR DESCRIPTION
This will avoid running into the rate limiting, which we hit on the bot account

