### PR TITLE
Fix timeline backfills

### DIFF
--- a/pkg/querier/timeline/timeline_test.go
+++ b/pkg/querier/timeline/timeline_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/pyroscope/pkg/querier/timeline"
 )
 
-const TimelineStepSec = 10
+const timelineStepSec = 10
 
 func Test_No_Backfill(t *testing.T) {
 	TestDate := time.Now()
@@ -20,12 +20,10 @@ func Test_No_Backfill(t *testing.T) {
 		},
 	}
 
-	timeline := timeline.New(points, TestDate.UnixMilli(), TestDate.UnixMilli(), TimelineStepSec)
+	timeline := timeline.New(points, TestDate.UnixMilli(), TestDate.UnixMilli(), timelineStepSec)
 
 	assert.Equal(t, TestDate.UnixMilli()/1000, timeline.StartTime)
-	assert.Equal(t, []uint64{
-		99,
-	}, timeline.Samples)
+	assert.Equal(t, []uint64{99}, timeline.Samples)
 }
 
 func Test_Backfill_Data_Start_End(t *testing.T) {
@@ -35,17 +33,38 @@ func Test_Backfill_Data_Start_End(t *testing.T) {
 
 	points := &typesv1.Series{
 		Points: []*typesv1.Point{
+			//      0 ms    -60000 ms
+			//  10000 ms    -50000 ms
+			//  20000 ms    -40000 ms
+			//  30000 ms    -30000 ms
+			//  40000 ms    -20000 ms
+			//  50000 ms    -10000 ms
 			{Timestamp: TestDate.UnixMilli(), Value: 99},
+			//  70000 ms    +10000 ms
+			//  80000 ms    +20000 ms
+			//  90000 ms    +30000 ms
+			// 100000 ms    +40000 ms
+			// 110000 ms    +50000 ms
+
 		},
 	}
 
-	timeline := timeline.New(points, startTime, endTime, TimelineStepSec)
+	timeline := timeline.New(points, startTime, endTime, timelineStepSec)
 
 	assert.Equal(t, startTime/1000, timeline.StartTime)
 	assert.Equal(t, []uint64{
-		0, 0, 0, 0, 0,
-		99,
-		0, 0, 0, 0, 0,
+		0,  //      0 ms    -60000 ms
+		0,  //  10000 ms    -50000 ms
+		0,  //  20000 ms    -40000 ms
+		0,  //  30000 ms    -30000 ms
+		0,  //  40000 ms    -20000 ms
+		0,  //  50000 ms    -10000 ms
+		99, //  60000 ms         0 ms (now)
+		0,  //  70000 ms    +10000 ms
+		0,  //  80000 ms    +20000 ms
+		0,  //  90000 ms    +30000 ms
+		0,  // 100000 ms    +40000 ms
+		0,  // 110000 ms    +50000 ms
 	}, timeline.Samples)
 }
 
@@ -56,20 +75,37 @@ func Test_Backfill_Data_Middle(t *testing.T) {
 
 	points := &typesv1.Series{
 		Points: []*typesv1.Point{
+			//      0 ms    -60000 ms
+			//  10000 ms    -50000 ms
+			//  20000 ms    -40000 ms
+			//  30000 ms    -30000 ms
+			//  40000 ms    -20000 ms
+			//  50000 ms    -10000 ms
 			{Timestamp: TestDate.UnixMilli(), Value: 99},
+			//  70000 ms    +10000 ms
 			{Timestamp: TestDate.Add(20 * time.Second).UnixMilli(), Value: 98},
+			//  90000 ms    +30000 ms
+			// 100000 ms    +40000 ms
+			// 110000 ms    +50000 ms
 		},
 	}
 
-	timeline := timeline.New(points, startTime, endTime, TimelineStepSec)
+	timeline := timeline.New(points, startTime, endTime, timelineStepSec)
 
 	assert.Equal(t, startTime/1000, timeline.StartTime)
 	assert.Equal(t, []uint64{
-		0, 0, 0, 0, 0,
-		99,
-		0,
-		98,
-		0, 0, 0, 0,
+		0,  //      0 ms    -60000 ms
+		0,  //  10000 ms    -50000 ms
+		0,  //  20000 ms    -40000 ms
+		0,  //  30000 ms    -30000 ms
+		0,  //  40000 ms    -20000 ms
+		0,  //  50000 ms    -10000 ms
+		99, //  60000 ms         0 ms (now)
+		0,  //  70000 ms    +10000 ms
+		98, //  80000 ms    +20000 ms
+		0,  //  90000 ms    +30000 ms
+		0,  // 100000 ms    +40000 ms
+		0,  // 110000 ms    +50000 ms
 	}, timeline.Samples)
 }
 
@@ -82,12 +118,57 @@ func Test_Backfill_All(t *testing.T) {
 		Points: []*typesv1.Point{},
 	}
 
-	timeline := timeline.New(points, startTime, endTime, TimelineStepSec)
+	timeline := timeline.New(points, startTime, endTime, timelineStepSec)
 
 	assert.Equal(t, startTime/1000, timeline.StartTime)
 	assert.Equal(t, []uint64{
-		0, 0, 0, 0, 0,
-		0, 0, 0, 0, 0,
-		0,
+		0, //      0 ms    -60000 ms
+		0, //  10000 ms    -50000 ms
+		0, //  20000 ms    -40000 ms
+		0, //  30000 ms    -30000 ms
+		0, //  40000 ms    -20000 ms
+		0, //  50000 ms    -10000 ms
+		0, //  60000 ms         0 ms (now)
+		0, //  70000 ms    +10000 ms
+		0, //  80000 ms    +20000 ms
+		0, //  90000 ms    +30000 ms
+		0, // 100000 ms    +40000 ms
+		0, // 110000 ms    +50000 ms
 	}, timeline.Samples)
+}
+
+func Test_Backfill_Arbitrary(t *testing.T) {
+	startMs := int64(0)
+	endMs := int64(10 * time.Second / time.Millisecond)
+	step := int64(1)
+	series := &typesv1.Series{
+		Points: []*typesv1.Point{
+			//    0 ms
+			// 1000 ms
+			{Timestamp: 2000, Value: 69},
+			{Timestamp: 3000, Value: 83},
+			// 4000 ms
+			// 5000 ms
+			{Timestamp: 6000, Value: 85},
+			// 7000 ms
+			{Timestamp: 8000, Value: 91},
+			// 9000 ms
+		},
+	}
+
+	tl := timeline.New(series, startMs, endMs, step)
+	assert.Equal(t, startMs/1000, tl.StartTime)
+
+	assert.Equal(t, []uint64{
+		0,  //    0 ms
+		0,  // 1000 ms
+		69, // 2000 ms
+		83, // 3000 ms
+		0,  // 4000 ms
+		0,  // 5000 ms
+		85, // 6000 ms
+		0,  // 7000 ms
+		91, // 8000 ms
+		0,  // 9000 ms
+	}, tl.Samples)
 }


### PR DESCRIPTION
closes https://github.com/grafana/pyroscope/issues/2147

This PR fixes the timeline bug where some timelines would have lots of 0 values towards the end. It also fixes some slice copy bugs, where slices would be copied incorrectly back on to other slices, adding erroneous values.

This also has fixes for small alignment issues in the timeline values, though these are unlikely to ever be noticed as it previously would only miss at most 2 padded values (one at the beginning and one at the end).