### PR TITLE
refactor: reduce allocs when building timeline

### DIFF
--- a/pkg/querier/timeline/timeline.go
+++ b/pkg/querier/timeline/timeline.go
@@ -16,7 +16,7 @@ func New(series *v1.Series, startMs int64, endMs int64, durationDeltaSec int64) 
 	// ms to seconds
 	startSec := startMs / 1000
 	points := series.GetPoints()
-	res := make([]uint64, 0, sizeToBackfill(startMs, endMs, durationDeltaSec))
+	samples := make([]uint64, 0, sizeToBackfill(startMs, endMs, durationDeltaSec))
 
 	timeline := &flamebearer.FlamebearerTimelineV1{
 		StartTime:     startSec,
@@ -26,7 +26,7 @@ func New(series *v1.Series, startMs int64, endMs int64, durationDeltaSec int64) 
 
 	if len(points) < 1 {
 		if n := sizeToBackfill(startMs, endMs, durationDeltaSec); n > 0 {
-			timeline.Samples = res[:n]
+			timeline.Samples = samples[:n]
 		}
 		return timeline
 	}
@@ -34,32 +34,29 @@ func New(series *v1.Series, startMs int64, endMs int64, durationDeltaSec int64) 
 	// Backfill before the first data point.
 	firstAvailableData := points[0]
 	if n := sizeToBackfill(startMs, firstAvailableData.Timestamp, durationDeltaSec); n > 0 {
-		res = res[:len(res)+int(n)]
+		samples = samples[:len(samples)+int(n)]
 	}
 
 	prev := points[0]
 	for _, curr := range points {
 		if n := sizeToBackfill(prev.Timestamp, curr.Timestamp, durationDeltaSec) - 1; n > 0 {
 			// Insert backfill.
-			res = res[:len(res)+int(n)]
+			samples = samples[:len(samples)+int(n)]
 		}
 
-		res = append(res, uint64(curr.Value))
+		samples = append(samples, uint64(curr.Value))
 		prev = curr
 	}
 
-	// Backfill after the last data point.
-	lastAvailableData := points[len(points)-1]
-	if n := sizeToBackfill(lastAvailableData.Timestamp, endMs, durationDeltaSec) - 1; n > 0 {
-		res = res[:len(res)+int(n)]
-	}
+	// Backfill to the end of the samples window.
+	samples = samples[:cap(samples)]
 
-	timeline.Samples = res
+	timeline.Samples = samples
 	return timeline
 }
 
-// sizeToBackfill indicates how many items are needed to backfill
-// if none are needed, a negative value is returned
+// sizeToBackfill indicates how many items are needed to backfill in the range
+// [startMs, endMs).
 func sizeToBackfill(startMs int64, endMs int64, stepSec int64) int64 {
 	startSec := startMs / 1000
 	endSec := endMs / 1000

--- a/pkg/querier/timeline/timeline.go
+++ b/pkg/querier/timeline/timeline.go
@@ -10,20 +10,24 @@ import (
 // backfilling any missing data with zeros
 // It assumes:
 // * Ordered
-// * startMs is earlier than the first series value
-// * endMs is after the last series value
+// * Series timestamps are within [startMs, endMs)
 func New(series *v1.Series, startMs int64, endMs int64, durationDeltaSec int64) *flamebearer.FlamebearerTimelineV1 {
 	// ms to seconds
 	startSec := startMs / 1000
 	points := series.GetPoints()
-	samples := make([]uint64, 0, sizeToBackfill(startMs, endMs, durationDeltaSec))
 
 	timeline := &flamebearer.FlamebearerTimelineV1{
 		StartTime:     startSec,
 		DurationDelta: durationDeltaSec,
 		Samples:       []uint64{},
 	}
+	if startMs >= endMs {
+		return timeline
+	}
+	samples := make([]uint64, 0, sizeToBackfill(startMs, endMs, durationDeltaSec))
 
+	// Ensure the points slice has only values in [startMs, endMs).
+	points = boundPointsToWindow(points, startMs, endMs)
 	if len(points) < 1 {
 		if n := sizeToBackfill(startMs, endMs, durationDeltaSec); n > 0 {
 			timeline.Samples = samples[:n]
@@ -62,4 +66,26 @@ func sizeToBackfill(startMs int64, endMs int64, stepSec int64) int64 {
 	endSec := endMs / 1000
 	size := (endSec - startSec) / stepSec
 	return size
+}
+
+// boundPointsToWindow will return a slice of points such that all the points
+// are constrained within [startMs, endMs).
+func boundPointsToWindow(points []*v1.Point, startMs int64, endMs int64) []*v1.Point {
+	start := 0
+	for ; start < len(points); start++ {
+		if points[start].Timestamp >= startMs {
+			break
+		}
+	}
+	points = points[start:]
+
+	end := len(points) - 1
+	for ; end >= 0; end-- {
+		if points[end].Timestamp < endMs {
+			break
+		}
+	}
+	points = points[:end+1]
+
+	return points
 }

--- a/pkg/querier/timeline/timeline_test.go
+++ b/pkg/querier/timeline/timeline_test.go
@@ -183,7 +183,7 @@ func Test_Backfill_LastSample(t *testing.T) {
 		},
 	}
 
-	t.Run("series value in last step bucket is included", func(t *testing.T) {
+	t.Run("series value in last step bucket is not included", func(t *testing.T) {
 		tl := timeline.New(series, startMs, int64(53000), step)
 		assert.Equal(t, startMs/1000, tl.StartTime)
 		assert.Equal(t, []uint64{
@@ -195,7 +195,7 @@ func Test_Backfill_LastSample(t *testing.T) {
 		}, tl.Samples)
 	})
 
-	t.Run("no series value in last step bucket doesn't get backfilled", func(t *testing.T) {
+	t.Run("last bucket does not get backfilled", func(t *testing.T) {
 		tl := timeline.New(series, startMs, int64(63000), step)
 		assert.Equal(t, startMs/1000, tl.StartTime)
 		assert.Equal(t, []uint64{
@@ -209,7 +209,7 @@ func Test_Backfill_LastSample(t *testing.T) {
 	})
 }
 
-func Test_Backfill_Bounds(t *testing.T) {
+func Test_Timeline_Bounds(t *testing.T) {
 	step := int64(1)
 	series := &typesv1.Series{
 		Points: []*typesv1.Point{
@@ -285,7 +285,7 @@ func Test_Backfill_Bounds(t *testing.T) {
 		}, tl.Samples)
 	})
 
-	t.Run("start and end are equal", func(t *testing.T) {
+	t.Run("start == end", func(t *testing.T) {
 		startMs := int64(1000)
 		endMs := startMs
 
@@ -295,7 +295,7 @@ func Test_Backfill_Bounds(t *testing.T) {
 		assert.Equal(t, []uint64{}, tl.Samples)
 	})
 
-	t.Run("start > end are equal", func(t *testing.T) {
+	t.Run("start > end", func(t *testing.T) {
 		startMs := int64(9000)
 		endMs := int64(1000)
 

--- a/pkg/querier/timeline/timeline_test.go
+++ b/pkg/querier/timeline/timeline_test.go
@@ -20,7 +20,7 @@ func Test_No_Backfill(t *testing.T) {
 		},
 	}
 
-	timeline := timeline.New(points, TestDate.UnixMilli(), TestDate.UnixMilli(), timelineStepSec)
+	timeline := timeline.New(points, TestDate.UnixMilli(), TestDate.UnixMilli()+timelineStepSec, timelineStepSec)
 
 	assert.Equal(t, TestDate.UnixMilli()/1000, timeline.StartTime)
 	assert.Equal(t, []uint64{99}, timeline.Samples)
@@ -192,7 +192,6 @@ func Test_Backfill_LastSample(t *testing.T) {
 			69, // 23000
 			0,  // 33000
 			0,  // 43000
-			91, // 53000
 		}, tl.Samples)
 	})
 
@@ -206,13 +205,124 @@ func Test_Backfill_LastSample(t *testing.T) {
 			0,  // 33000
 			0,  // 43000
 			91, // 53000
+		}, tl.Samples)
+	})
+}
 
-			// note(bryan) We current don't pad the last bucket, but we DO add
-			// a value to the last bucket if it's a series value. We need to
-			// decide some behaviors surrounding what range we want allow. For
-			// example, [start, end) vs [start, end] and do we truncate
-			// outliers?
-			// 0,  // 63000
+func Test_Backfill_Bounds(t *testing.T) {
+	step := int64(1)
+	series := &typesv1.Series{
+		Points: []*typesv1.Point{
+			//    0 ms
+			// 1000 ms
+			{Timestamp: 2000, Value: 69},
+			{Timestamp: 3000, Value: 83},
+			// 4000 ms
+			// 5000 ms
+			{Timestamp: 6000, Value: 85},
+			// 7000 ms
+			{Timestamp: 8000, Value: 91},
+			// 9000 ms
+		},
+	}
+
+	t.Run("start bounded", func(t *testing.T) {
+		startMs := int64(1000)
+		endMs := int64(10_000)
+
+		tl := timeline.New(series, startMs, endMs, step)
+		assert.Equal(t, startMs/1000, tl.StartTime)
+
+		assert.Equal(t, []uint64{
+			0,  // 1000 ms
+			69, // 2000 ms
+			83, // 3000 ms
+			0,  // 4000 ms
+			0,  // 5000 ms
+			85, // 6000 ms
+			0,  // 7000 ms
+			91, // 8000 ms
+			0,  // 9000 ms
+		}, tl.Samples)
+	})
+
+	t.Run("end bounded", func(t *testing.T) {
+		startMs := int64(0)
+		endMs := int64(9000)
+
+		tl := timeline.New(series, startMs, endMs, step)
+		assert.Equal(t, startMs/1000, tl.StartTime)
+
+		assert.Equal(t, []uint64{
+			0,  //    0 ms
+			0,  // 1000 ms
+			69, // 2000 ms
+			83, // 3000 ms
+			0,  // 4000 ms
+			0,  // 5000 ms
+			85, // 6000 ms
+			0,  // 7000 ms
+			91, // 8000 ms
+		}, tl.Samples)
+	})
+
+	t.Run("start and end bounded", func(t *testing.T) {
+		startMs := int64(1000)
+		endMs := int64(9000)
+
+		tl := timeline.New(series, startMs, endMs, step)
+		assert.Equal(t, startMs/1000, tl.StartTime)
+
+		assert.Equal(t, []uint64{
+			0,  // 1000 ms
+			69, // 2000 ms
+			83, // 3000 ms
+			0,  // 4000 ms
+			0,  // 5000 ms
+			85, // 6000 ms
+			0,  // 7000 ms
+			91, // 8000 ms
+		}, tl.Samples)
+	})
+
+	t.Run("start and end are equal", func(t *testing.T) {
+		startMs := int64(1000)
+		endMs := startMs
+
+		tl := timeline.New(series, startMs, endMs, step)
+		assert.Equal(t, startMs/1000, tl.StartTime)
+
+		assert.Equal(t, []uint64{}, tl.Samples)
+	})
+
+	t.Run("start > end are equal", func(t *testing.T) {
+		startMs := int64(9000)
+		endMs := int64(1000)
+
+		tl := timeline.New(series, startMs, endMs, step)
+		assert.Equal(t, startMs/1000, tl.StartTime)
+
+		assert.Equal(t, []uint64{}, tl.Samples)
+	})
+
+	t.Run("points are not contained within start and end", func(t *testing.T) {
+		startMs := int64(10_000)
+		endMs := int64(20_000)
+
+		tl := timeline.New(series, startMs, endMs, step)
+		assert.Equal(t, startMs/1000, tl.StartTime)
+
+		assert.Equal(t, []uint64{
+			0, // 10000 ms
+			0, // 11000 ms
+			0, // 12000 ms
+			0, // 13000 ms
+			0, // 14000 ms
+			0, // 15000 ms
+			0, // 16000 ms
+			0, // 17000 ms
+			0, // 18000 ms
+			0, // 19000 ms
 		}, tl.Samples)
 	})
 }


### PR DESCRIPTION
In https://github.com/grafana/pyroscope/pull/2200 ([comment](https://github.com/grafana/pyroscope/pull/2200#discussion_r1282708713)), it was noted that there could be a performance improvement when allocating slices. This PR changes how slices are allocated such that only one allocation is necessary at the beginning of the function.

Here's a quick benchmark that generally describes the performance change compared to the old method:

```
$ go test -bench=. -run=xxx -benchtime=5s -benchmem                                      
goos: darwin
goarch: arm64
pkg: github.com/grafana/pyroscope/pkg/querier/timeline
Benchmark_Backfill/New-12               5614            961086 ns/op         3942035 B/op          6 allocs/op
Benchmark_Backfill/Old-12                  1       72707588750 ns/op    953187418008 B/op     500043 allocs/op
PASS
ok      github.com/grafana/pyroscope/pkg/querier/timeline       79.087s
```

The benchmark mapped 3 different sizes of series data:
- short (~100 points)
- medium (~10,000 points)
- long (~100,000 points)

This benchmark probably doesn't precisely mimic a production workload, but in the synthetic workload there is massive improvements with the new approach.