### PR TITLE
Increase the default limit on number of samples per profile

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -892,7 +892,7 @@ Usage of ./pyroscope:
   -validation.max-profile-stacktrace-sample-labels int
     	Maximum number of labels in a profile sample. 0 to disable. (default 100)
   -validation.max-profile-stacktrace-samples int
-    	Maximum number of samples in a profile. 0 to disable. (default 4000)
+    	Maximum number of samples in a profile. 0 to disable. (default 16000)
   -validation.max-profile-symbol-value-length int
     	Maximum length of a profile symbol value (labels, function names and filenames, etc...). Profiles are not rejected instead symbol values are truncated. 0 to disable. (default 1024)
   -version

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -354,7 +354,7 @@ Usage of ./pyroscope:
   -validation.max-profile-stacktrace-sample-labels int
     	Maximum number of labels in a profile sample. 0 to disable. (default 100)
   -validation.max-profile-stacktrace-samples int
-    	Maximum number of samples in a profile. 0 to disable. (default 4000)
+    	Maximum number of samples in a profile. 0 to disable. (default 16000)
   -validation.max-profile-symbol-value-length int
     	Maximum length of a profile symbol value (labels, function names and filenames, etc...). Profiles are not rejected instead symbol values are truncated. 0 to disable. (default 1024)
   -version

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -225,7 +225,7 @@ limits:
 
   # Maximum number of samples in a profile. 0 to disable.
   # CLI flag: -validation.max-profile-stacktrace-samples
-  [max_profile_stacktrace_samples: <int> | default = 4000]
+  [max_profile_stacktrace_samples: <int> | default = 16000]
 
   # Maximum number of labels in a profile sample. 0 to disable.
   # CLI flag: -validation.max-profile-stacktrace-sample-labels

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -89,7 +89,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxQueryParallelism, "querier.max-query-parallelism", 0, "Maximum number of queries that will be scheduled in parallel by the frontend.")
 
 	f.IntVar(&l.MaxProfileSizeBytes, "validation.max-profile-size-bytes", 4*1024*1024, "Maximum size of a profile in bytes. This is based off the uncompressed size. 0 to disable.")
-	f.IntVar(&l.MaxProfileStacktraceSamples, "validation.max-profile-stacktrace-samples", 4000, "Maximum number of samples in a profile. 0 to disable.")
+	f.IntVar(&l.MaxProfileStacktraceSamples, "validation.max-profile-stacktrace-samples", 16000, "Maximum number of samples in a profile. 0 to disable.")
 	f.IntVar(&l.MaxProfileStacktraceSampleLabels, "validation.max-profile-stacktrace-sample-labels", 100, "Maximum number of labels in a profile sample. 0 to disable.")
 	f.IntVar(&l.MaxProfileStacktraceDepth, "validation.max-profile-stacktrace-depth", 1000, "Maximum depth of a profile stacktrace. Profiles are not rejected instead stacktraces are truncated. 0 to disable.")
 	f.IntVar(&l.MaxProfileSymbolValueLength, "validation.max-profile-symbol-value-length", 1024, "Maximum length of a profile symbol value (labels, function names and filenames, etc...). Profiles are not rejected instead symbol values are truncated. 0 to disable.")


### PR DESCRIPTION
The recently introduced limit on the number of samples per profile (of specific type) is overly conservative. This change increases the default value from 4K to 16K.