### PR TITLE
Skip image validation in doc-validator

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,4 +17,4 @@ test:
 
 .PHONY: validate
 validate:
-	docker run -v $(CURDIR)/sources:/docs/sources --rm grafana/doc-validator:v1.5.0 /docs/sources
+	docker run -v $(CURDIR)/sources:/docs/sources --rm grafana/doc-validator:v1.5.0 --skip-image-validation /docs/sources


### PR DESCRIPTION
The check is specific to storing assets in the repository as part of Hugo leaf bundles. Current advice is to instead store assets in the website asset uploader service following the instructions in https://grafana.com/docs/writers-toolkit/writing-guide/image-guidelines/#where-to-store-media-assets. This makes the check raise false errors.