### PR TITLE
Fix broken links after reorganizing docs structure

### DIFF
--- a/docs/sources/configure-client/_index.md
+++ b/docs/sources/configure-client/_index.md
@@ -45,10 +45,10 @@ The choice between using Grafana Agent (Auto-Instrumentation) or Pyroscope SDKs 
 To get started choose one of the integrations below:
 <table>
    <tr>
-      <td align="center"><a href="https://grafana.com/docs/pyroscope/next/configure-client/grafana-agent/"><img src="https://github-production-user-asset-6210df.s3.amazonaws.com/223048/257522425-48683963-91ae-4caf-8c52-ce131e25bd65.png" width="100px;" alt=""/><br />
+      <td align="center"><a href="https://grafana.com/docs/pyroscope/next/configure-client/grafana-agent/go_pull"><img src="https://github-production-user-asset-6210df.s3.amazonaws.com/223048/257522425-48683963-91ae-4caf-8c52-ce131e25bd65.png" width="100px;" alt=""/><br />
         <b>Grafana Agent</b></a><br />
           <a href="https://grafana.com/docs/pyroscope/next/configure-client/grafana-agent/go_pull/" title="Documentation">Documentation</a><br />
-          <a href="https://grafana.com/docs/pyroscope/next/configure-client/grafana-agent/go_pull/" title="examples">Examples</a>
+          <a href="https://github.com/grafana/pyroscope/tree/main/examples/grafana-agent" title="examples">Examples</a>
       </td>
       <td align="center"><a href="https://grafana.com/docs/pyroscope/next/configure-client/language-sdks/go_push/"><img src="https://user-images.githubusercontent.com/23323466/178160549-2d69a325-56ec-4e19-bca7-d460d400b163.png" width="100px;" alt=""/><br />
         <b>Golang</b></a><br />
@@ -60,10 +60,10 @@ To get started choose one of the integrations below:
           <a href="https://grafana.com/docs/pyroscope/next/configure-client/language-sdks/java/">Documentation</a><br />
           <a href="https://github.com/grafana/pyroscope/tree/main/examples/java-jfr/rideshare" title="java-examples">Examples</a>
       </td>
-      <td align="center"><a href="https://grafana.com/docs/pyroscope/next/configure-client/language-sdks/ebpf/"><img src="https://user-images.githubusercontent.com/23323466/178160548-e974c080-808d-4c5d-be9b-c983a319b037.png" width="100px;" alt=""/><br />
+      <td align="center"><a href="https://grafana.com/docs/pyroscope/next/configure-client/grafana-agent/ebpf"><img src="https://user-images.githubusercontent.com/23323466/178160548-e974c080-808d-4c5d-be9b-c983a319b037.png" width="100px;" alt=""/><br />
         <b>eBPF</b></a><br />
           <a href="https://grafana.com/docs/pyroscope/next/configure-client/grafana-agent/ebpf" title="Documentation">Documentation</a><br />
-          <a href="https://grafana.com/docs/pyroscope/next/configure-client/grafana-agent/ebpf" title="examples">Examples</a>
+          <a href="https://github.com/grafana/pyroscope/tree/main/examples/ebpf" title="examples">Examples</a>
       </td>
       <td align="center"><a href="https://grafana.com/docs/pyroscope/next/configure-client/language-sdks/python/"><img src="https://user-images.githubusercontent.com/23323466/178160553-c78b8c15-99b4-43f3-a2a0-252b6c4862b1.png" width="100px;" alt=""/><br />
         <b>Python</b></a><br />

--- a/docs/sources/configure-client/_index.md
+++ b/docs/sources/configure-client/_index.md
@@ -46,9 +46,9 @@ To get started choose one of the integrations below:
 <table>
    <tr>
       <td align="center"><a href="https://grafana.com/docs/pyroscope/next/configure-client/grafana-agent/"><img src="https://github-production-user-asset-6210df.s3.amazonaws.com/223048/257522425-48683963-91ae-4caf-8c52-ce131e25bd65.png" width="100px;" alt=""/><br />
-        <b>Grafana Agent<br />(Go Pull Mode)</b></a><br />
-          <a href="https://grafana.com/docs/pyroscope/next/configure-client/grafana-agent/" title="Documentation">Documentation</a><br />
-          <a href="https://github.com/grafana/pyroscope/tree/main/examples/grafana-agent" title="examples">Examples</a>
+        <b>Grafana Agent</b></a><br />
+          <a href="https://grafana.com/docs/pyroscope/next/configure-client/grafana-agent/go_pull/" title="Documentation">Documentation</a><br />
+          <a href="https://grafana.com/docs/pyroscope/next/configure-client/grafana-agent/go_pull/" title="examples">Examples</a>
       </td>
       <td align="center"><a href="https://grafana.com/docs/pyroscope/next/configure-client/language-sdks/go_push/"><img src="https://user-images.githubusercontent.com/23323466/178160549-2d69a325-56ec-4e19-bca7-d460d400b163.png" width="100px;" alt=""/><br />
         <b>Golang</b></a><br />
@@ -62,8 +62,8 @@ To get started choose one of the integrations below:
       </td>
       <td align="center"><a href="https://grafana.com/docs/pyroscope/next/configure-client/language-sdks/ebpf/"><img src="https://user-images.githubusercontent.com/23323466/178160548-e974c080-808d-4c5d-be9b-c983a319b037.png" width="100px;" alt=""/><br />
         <b>eBPF</b></a><br />
-          <a href="https://grafana.com/docs/pyroscope/next/configure-client/language-sdks/ebpf/" title="Documentation">Documentation</a><br />
-          <a href="https://github.com/grafana/pyroscope/tree/main/examples/ebpf" title="examples">Examples</a>
+          <a href="https://grafana.com/docs/pyroscope/next/configure-client/grafana-agent/ebpf" title="Documentation">Documentation</a><br />
+          <a href="https://grafana.com/docs/pyroscope/next/configure-client/grafana-agent/ebpf" title="examples">Examples</a>
       </td>
       <td align="center"><a href="https://grafana.com/docs/pyroscope/next/configure-client/language-sdks/python/"><img src="https://user-images.githubusercontent.com/23323466/178160553-c78b8c15-99b4-43f3-a2a0-252b6c4862b1.png" width="100px;" alt=""/><br />
         <b>Python</b></a><br />

--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -2,29 +2,32 @@
 aliases:
   - /docs/phlare/latest/operators-guide/getting-started/
   - /docs/phlare/latest/operators-guide/get-started/
-description: Learn how to get started with Grafana Phlare.
+  - /docs/phlare/latest/get-started/
+description: Learn how to get started with Grafana Pyroscope.
 menuTitle: Get started
-title: Get started with Grafana Phlare
+title: Get started with Grafana Pyroscope
 weight: 20
 ---
 
-# Get started with Grafana Phlare
+# Get started with Grafana Pyroscope
 
-Choose one of the following options to get started with Grafana Phlare:
+Note: Pyroscope 1.0 will be released in August 2023 -- you may see references to both Pyroscope and Phlare in the server documentation.
 
-- The **written tutorial** below provides a series of imperative commands to start a single Phlare process, or [monolith]({{< relref "../reference-phlare-architecture/deployment-modes/index.md#monolithic-mode" >}}), which is designed for users getting started with the project.
+Choose one of the following options to get started with Grafana Pyroscope:
+
+- The **written tutorial** below provides a series of imperative commands to start a single Pyroscope process, or [monolith]({{< relref "../reference-phlare-architecture/deployment-modes/index.md#monolithic-mode" >}}), which is designed for users getting started with the project.
 
 - The following **video tutorial** uses [`docker-compose`](https://github.com/grafana/pyroscope/tree/main/tools/docker-compose) to declaratively deploy Pyroscope and Grafana.
 
   {{< vimeo 766316030 >}}
 
-For more information on the different ways to deploy Phlare, see [Grafana Phlare deployment modes]({{< relref "../reference-phlare-architecture/deployment-modes/index.md" >}}).
+For more information on the different ways to deploy Pyroscope, see [Grafana Pyroscope deployment modes]({{< relref "../reference-phlare-architecture/deployment-modes/index.md" >}}).
 
 ## Before you begin
 
 Verify that you have installed [Docker](https://docs.docker.com/engine/install/).
 
-## Download and configure Phlare
+## Download and configure Phlare 
 
 1. Download Grafana Phlare.
 


### PR DESCRIPTION
Fixes broken links and I think _at least_ the top of our Getting Started page should say Pyroscope to not confuse people -- another pr in https://github.com/grafana/pyroscope/pull/2209