### PR TITLE
chore: moves UI to / from /ui, moves old / to /admin

### DIFF
--- a/cypress/ci-base-path.ts
+++ b/cypress/ci-base-path.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    baseUrl: 'http://localhost:8080/foobar/ui/',
+    baseUrl: 'http://localhost:8080/foobar/',
     env: {
       apiBasePath: '/foobar',
     },

--- a/cypress/e2e/smoke.cy.ts
+++ b/cypress/e2e/smoke.cy.ts
@@ -9,7 +9,7 @@ describe('smoke', () => {
   });
 
   it('loads admin page', () => {
-    cy.visit('../');
+    cy.visit('/admin');
   });
 
   it('loads single view (/)', () => {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -120,9 +120,9 @@ func (a *API) newRoute(path string, handler http.Handler, isPrefix, auth, gzip b
 	return route
 }
 
-// RegisterAPI registers the standard endpoints associated with a running Mimir.
+// RegisterAPI registers the standard endpoints associated with a running Pyroscope.
 func (a *API) RegisterAPI(statusService statusv1.StatusServiceServer) error {
-	// register index page
+	// register admin page
 	a.RegisterRoute("/admin", indexHandler("", a.indexPage), false, true, "GET")
 	// expose openapiv2 definition
 	openapiv2Handler, err := openapiv2.Handler()
@@ -145,21 +145,10 @@ func (a *API) RegisterAPI(statusService statusv1.StatusServiceServer) error {
 		return fmt.Errorf("unable to initialize the ui: %w", err)
 	}
 
-	uiIndexHandler, err := public.NewIndexHandler(a.cfg.BaseURL)
-	if err != nil {
-		return fmt.Errorf("unable to initialize the ui: %w", err)
-	}
-
 	// The UI used to be at /ui, but now it's at /.
 	a.RegisterRoutesWithPrefix("/ui", http.RedirectHandler("/", http.StatusFound), false, true, "GET")
 	// All assets are served as static files
 	a.RegisterRoutesWithPrefix("/assets/", http.FileServer(uiAssets), false, true, "GET")
-	// Serve index to all other pages
-	a.RegisterRoutesWithPrefix("/", uiIndexHandler, false, true, "GET")
-
-	a.indexPage.AddLinks(defaultWeight, "User interface", []IndexPageLink{
-		{Desc: "User interface", Path: "/"},
-	})
 
 	// register status service providing config and buildinfo at grpc gateway
 	if err := statusv1.RegisterStatusServiceHandlerServer(context.Background(), a.grpcGatewayMux, statusService); err != nil {
@@ -173,6 +162,21 @@ func (a *API) RegisterAPI(statusService statusv1.StatusServiceServer) error {
 		{Desc: "Only values that differ from the defaults", Path: "/api/v1/status/config/diff"},
 		{Desc: "Default values", Path: "/api/v1/status/config/default"},
 	})
+	return nil
+}
+
+func (a *API) RegisterCatchAll() error {
+	uiIndexHandler, err := public.NewIndexHandler(a.cfg.BaseURL)
+	if err != nil {
+		return fmt.Errorf("unable to initialize the ui: %w", err)
+	}
+	// Serve index to all other pages
+	a.RegisterRoutesWithPrefix("/", uiIndexHandler, false, true, "GET")
+
+	a.indexPage.AddLinks(defaultWeight, "User interface", []IndexPageLink{
+		{Desc: "User interface", Path: "/"},
+	})
+
 	return nil
 }
 

--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"runtime"
 	"sort"
+	"strings"
 
 	"github.com/bufbuild/connect-go"
 	"github.com/go-kit/log"
@@ -530,9 +531,16 @@ func levelFilter(l string) level.Option {
 
 func printRoutes(r *mux.Router) {
 	r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
-		tpl, err1 := route.GetPathTemplate()
-		met, err2 := route.GetMethods()
-		fmt.Println(tpl, err1, met, err2)
+		path, err := route.GetPathTemplate()
+		if err != nil {
+			fmt.Printf("failed to get path template %s\n", err)
+			return nil
+		}
+		method, err := route.GetMethods()
+		if err != nil {
+			method = []string{"*"}
+		}
+		fmt.Printf("%s %s\n", strings.Join(method, ","), path)
 		return nil
 	})
 }

--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -384,7 +384,7 @@ func (f *Phlare) Run() error {
 		}
 	}
 
-	if f.API.RegisterCatchAll(); err != nil {
+	if err = f.API.RegisterCatchAll(); err != nil {
 		return err
 	}
 
@@ -530,7 +530,7 @@ func levelFilter(l string) level.Option {
 }
 
 func printRoutes(r *mux.Router) {
-	r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+	err := r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
 		path, err := route.GetPathRegexp()
 		if err != nil {
 			fmt.Printf("failed to get path regexp %s\n", err)
@@ -543,4 +543,7 @@ func printRoutes(r *mux.Router) {
 		fmt.Printf("%s %s\n", strings.Join(method, ","), path)
 		return nil
 	})
+	if err != nil {
+		fmt.Printf("failed to walk routes %s\n", err)
+	}
 }

--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -531,9 +531,9 @@ func levelFilter(l string) level.Option {
 
 func printRoutes(r *mux.Router) {
 	r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
-		path, err := route.GetPathTemplate()
+		path, err := route.GetPathRegexp()
 		if err != nil {
-			fmt.Printf("failed to get path template %s\n", err)
+			fmt.Printf("failed to get path regexp %s\n", err)
 			return nil
 		}
 		method, err := route.GetMethods()

--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -320,7 +320,7 @@ func (f *Phlare) setupModuleManager() error {
 	mm.RegisterModule(UsageReport, f.initUsageReport)
 	mm.RegisterModule(QueryFrontend, f.initQueryFrontend)
 	mm.RegisterModule(QueryScheduler, f.initQueryScheduler)
-	mm.RegisterModule(All, nil)
+	mm.RegisterModule(All, f.initCatchAll)
 
 	// Add dependencies
 	deps := map[string][]string{
@@ -496,6 +496,14 @@ func (f *Phlare) initAPI() (services.Service, error) {
 	f.API = a
 
 	if err := f.API.RegisterAPI(f.statusService()); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (f *Phlare) initCatchAll() (services.Service, error) {
+	if err := f.API.RegisterCatchAll(); err != nil {
 		return nil, err
 	}
 

--- a/public/app/components/Sidebar.tsx
+++ b/public/app/components/Sidebar.tsx
@@ -112,11 +112,7 @@ export function Sidebar() {
       <SidebarFooter>
         <Menu iconShape="square">
           <MenuItem icon={<Icon icon={faInfoCircle} />}>
-            <a
-              href="/admin"
-            >
-              Admin Page
-            </a>
+            <a href="/admin">Admin Page</a>
           </MenuItem>
           <MenuItem icon={<Icon icon={faFileAlt} />}>
             <a

--- a/public/app/components/Sidebar.tsx
+++ b/public/app/components/Sidebar.tsx
@@ -4,6 +4,9 @@ import { faSearch } from '@fortawesome/free-solid-svg-icons/faSearch';
 import { faChartBar } from '@fortawesome/free-solid-svg-icons/faChartBar';
 import { faColumns } from '@fortawesome/free-solid-svg-icons/faColumns';
 import { faChevronLeft } from '@fortawesome/free-solid-svg-icons/faChevronLeft';
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons/faInfoCircle';
+import { faFileAlt } from '@fortawesome/free-solid-svg-icons/faFileAlt';
+import { faGithub } from '@fortawesome/free-brands-svg-icons/faGithub';
 
 import SidebarUI, {
   MenuItem,
@@ -108,6 +111,31 @@ export function Sidebar() {
       </SidebarContent>
       <SidebarFooter>
         <Menu iconShape="square">
+          <MenuItem icon={<Icon icon={faInfoCircle} />}>
+            <a
+              href="/admin"
+            >
+              Admin Page
+            </a>
+          </MenuItem>
+          <MenuItem icon={<Icon icon={faFileAlt} />}>
+            <a
+              rel="noreferrer"
+              target="_blank"
+              href="https://grafana.com/docs/pyroscope"
+            >
+              Documentation
+            </a>
+          </MenuItem>
+          <MenuItem icon={<Icon icon={faGithub} />}>
+            <a
+              rel="noreferrer"
+              target="_blank"
+              href="https://github.com/grafana/pyroscope"
+            >
+              Github
+            </a>
+          </MenuItem>
           <MenuItem
             data-testid="collapse-sidebar"
             className={clsx(

--- a/public/app/services/render.ts
+++ b/public/app/services/render.ts
@@ -50,7 +50,7 @@ export async function renderSingle(
 ): Promise<Result<RenderOutput, RequestError | ZodError>> {
   const url = buildRenderURL(props);
   // TODO
-  const response = await requestWithOrgID(`/pyroscope/${url}&format=json`, {
+  const response = await requestWithOrgID(`/pyroscope${url}&format=json`, {
     signal: controller?.signal,
   });
 

--- a/public/execute_template.go
+++ b/public/execute_template.go
@@ -43,6 +43,10 @@ func prepareBasePath(basepath string) (string, error) {
 
 	u.Path = strings.TrimSpace(u.Path)
 
+	if !strings.HasSuffix(u.Path, "/") {
+		u.Path = u.Path + "/"
+	}
+
 	if !strings.HasPrefix(u.Path, "/") {
 		u.Path = "/" + u.Path
 	}

--- a/public/execute_template.go
+++ b/public/execute_template.go
@@ -43,14 +43,6 @@ func prepareBasePath(basepath string) (string, error) {
 
 	u.Path = strings.TrimSpace(u.Path)
 
-	// ideally we would use https://pkg.go.dev/net/url#JoinPath
-	// but I found different results in darwin (it doesn't remove the leading slash)
-	u.Path = strings.Join(
-		// TODO: remove /ui/ once ui routes are moved to root
-		[]string{strings.TrimRight(u.Path, "/"), "ui/"},
-		"/",
-	)
-
 	if !strings.HasPrefix(u.Path, "/") {
 		u.Path = "/" + u.Path
 	}

--- a/public/execute_template_test.go
+++ b/public/execute_template_test.go
@@ -21,14 +21,14 @@ func TestInjectingBaseURL(t *testing.T) {
 		basePath string
 		expected string
 	}{
-		{basePath: "", expected: "/ui/"},
-		{basePath: "     ", expected: "/ui/"},
-		{basePath: "/foobar/", expected: "/foobar/ui/"},
-		{basePath: "/foobar", expected: "/foobar/ui/"},
-		{basePath: "foobar", expected: "/foobar/ui/"},
-		{basePath: "   foobar   ", expected: "/foobar/ui/"},
-		{basePath: "http://localhost:8080/foobar/", expected: "http://localhost:8080/foobar/ui/"},
-		{basePath: "http://localhost:8080/foobar", expected: "http://localhost:8080/foobar/ui/"},
+		{basePath: "", expected: "/"},
+		{basePath: "     ", expected: "/"},
+		{basePath: "/foobar/", expected: "/foobar/"},
+		{basePath: "/foobar", expected: "/foobar/"},
+		{basePath: "foobar", expected: "/foobar/"},
+		{basePath: "   foobar   ", expected: "/foobar/"},
+		{basePath: "http://localhost:8080/foobar/", expected: "http://localhost:8080/foobar/"},
+		{basePath: "http://localhost:8080/foobar", expected: "http://localhost:8080/foobar/"},
 	} {
 		tc := tc
 		t.Run(fmt.Sprintf("'%s' -> '%s'", tc.basePath, tc.expected), func(t *testing.T) {


### PR DESCRIPTION
I split it from [the old PR](https://github.com/grafana/pyroscope/pull/2190). 

The idea is to:
* move what's currently `/` to `/admin`
* move what's currently `/ui` to `/`

I fixed the issue Christian reported in the original PR. The issue was that when I changed the route from `/ui` to `/` it started matching everything, so I had to make sure `/` route is the very last we create.

Currently the routing table looks like this (I added `PYROSCOPE_PRINT_ROUTES=1` env variable to trigger a print of all routes):
```
* ^/metrics$
* ^/debug/pprof
GET ^/admin$
GET ^/api/swagger\.json$
GET,POST,PUT,DELETE,HEAD,OPTIONS ^/api
GET ^/debug/fgprof$
GET ^/static/
GET ^/ui
GET ^/assets/
GET ^/memberlist$
* ^/agent\.v1\.AgentService/GetTargets$
GET,POST ^/overrides-exporter/ring$
GET,POST ^/ring$
* ^/ingester\.v1\.IngesterService/Push$
* ^/ingester\.v1\.IngesterService/LabelValues$
* ^/ingester\.v1\.IngesterService/LabelNames$
* ^/ingester\.v1\.IngesterService/ProfileTypes$
* ^/ingester\.v1\.IngesterService/Series$
* ^/ingester\.v1\.IngesterService/Flush$
* ^/ingester\.v1\.IngesterService/MergeProfilesStacktraces$
* ^/ingester\.v1\.IngesterService/MergeProfilesLabels$
* ^/ingester\.v1\.IngesterService/MergeProfilesPprof$
GET ^/pyroscope/render$
GET ^/pyroscope/render-diff$
GET ^/pyroscope/label-values$
* ^/frontendpb\.FrontendForQuerier/QueryResult$
* ^/querier\.v1\.QuerierService/ProfileTypes$
* ^/querier\.v1\.QuerierService/LabelValues$
* ^/querier\.v1\.QuerierService/LabelNames$
* ^/querier\.v1\.QuerierService/Series$
* ^/querier\.v1\.QuerierService/SelectMergeStacktraces$
* ^/querier\.v1\.QuerierService/SelectMergeProfile$
* ^/querier\.v1\.QuerierService/SelectSeries$
* ^/querier\.v1\.QuerierService/Diff$
POST ^/ingest$
POST ^/pyroscope/ingest$
* ^/push\.v1\.PusherService/Push$
GET,POST ^/distributor/ring$
* ^/schedulerpb\.SchedulerForFrontend/FrontendLoop$
* ^/schedulerpb\.SchedulerForQuerier/QuerierLoop$
* ^/schedulerpb\.SchedulerForQuerier/NotifyQuerierShutdown$
GET ^/ready$
* ^/grpc\.health\.v1\.Health/
GET ^/
```

---

I also added a few links to the bottom of the sidebar
![Screenshot 2023-08-14 at 9 48 35 PM](https://github.com/grafana/pyroscope/assets/662636/31856e9a-727b-43a1-a27a-38fc51fadf00)


