### PR TITLE
Disable pools for locations, functions, and lines

### DIFF
--- a/api/buf.gen.yaml
+++ b/api/buf.gen.yaml
@@ -19,10 +19,7 @@ plugins:
       - pool=github.com/grafana/pyroscope/api/gen/proto/go/google/v1.Profile
       - pool=github.com/grafana/pyroscope/api/gen/proto/go/google/v1.Sample
       - pool=github.com/grafana/pyroscope/api/gen/proto/go/google/v1.Mapping
-      - pool=github.com/grafana/pyroscope/api/gen/proto/go/google/v1.Function
-      - pool=github.com/grafana/pyroscope/api/gen/proto/go/google/v1.Location
       - pool=github.com/grafana/pyroscope/api/gen/proto/go/google/v1.Label
-      - pool=github.com/grafana/pyroscope/api/gen/proto/go/google/v1.Line
 
   - name: connect-go
     out: gen/proto/go

--- a/api/gen/proto/go/google/v1/profile_vtproto.pb.go
+++ b/api/gen/proto/go/google/v1/profile_vtproto.pb.go
@@ -916,13 +916,13 @@ func (m *Profile) ResetVT() {
 	f2 := m.Mapping[:0]
 	for _, mm := range m.Location[:cap(m.Location)] {
 		if mm != nil {
-			mm.ResetVT()
+			mm.Reset()
 		}
 	}
 	f3 := m.Location[:0]
 	for _, mm := range m.Function[:cap(m.Function)] {
 		if mm != nil {
-			mm.ResetVT()
+			mm.Reset()
 		}
 	}
 	f4 := m.Function[:0]
@@ -1013,70 +1013,6 @@ func (m *Mapping) ReturnToVTPool() {
 }
 func MappingFromVTPool() *Mapping {
 	return vtprotoPool_Mapping.Get().(*Mapping)
-}
-
-var vtprotoPool_Location = sync.Pool{
-	New: func() interface{} {
-		return &Location{}
-	},
-}
-
-func (m *Location) ResetVT() {
-	for _, mm := range m.Line[:cap(m.Line)] {
-		if mm != nil {
-			mm.ResetVT()
-		}
-	}
-	f0 := m.Line[:0]
-	m.Reset()
-	m.Line = f0
-}
-func (m *Location) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Location.Put(m)
-	}
-}
-func LocationFromVTPool() *Location {
-	return vtprotoPool_Location.Get().(*Location)
-}
-
-var vtprotoPool_Line = sync.Pool{
-	New: func() interface{} {
-		return &Line{}
-	},
-}
-
-func (m *Line) ResetVT() {
-	m.Reset()
-}
-func (m *Line) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Line.Put(m)
-	}
-}
-func LineFromVTPool() *Line {
-	return vtprotoPool_Line.Get().(*Line)
-}
-
-var vtprotoPool_Function = sync.Pool{
-	New: func() interface{} {
-		return &Function{}
-	},
-}
-
-func (m *Function) ResetVT() {
-	m.Reset()
-}
-func (m *Function) ReturnToVTPool() {
-	if m != nil {
-		m.ResetVT()
-		vtprotoPool_Function.Put(m)
-	}
-}
-func FunctionFromVTPool() *Function {
-	return vtprotoPool_Function.Get().(*Function)
 }
 func (m *Profile) SizeVT() (n int) {
 	if m == nil {
@@ -2670,14 +2606,7 @@ func (m *Location) UnmarshalVT(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if len(m.Line) == cap(m.Line) {
-				m.Line = append(m.Line, &Line{})
-			} else {
-				m.Line = m.Line[:len(m.Line)+1]
-				if m.Line[len(m.Line)-1] == nil {
-					m.Line[len(m.Line)-1] = &Line{}
-				}
-			}
+			m.Line = append(m.Line, &Line{})
 			if err := m.Line[len(m.Line)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -1384,9 +1384,9 @@ backoff_config:
 [tls_min_version: <string> | default = ""]
 
 # The maximum amount of time to establish a connection. A value of 0 means
-# default gRPC connect timeout and backoff.
+# default gRPC client connect timeout and backoff.
 # CLI flag: -<prefix>.connect-timeout
-[connect_timeout: <duration> | default = 0s]
+[connect_timeout: <duration> | default = 5s]
 
 # Initial backoff delay after first connection failure. Only relevant if
 # ConnectTimeout > 0.


### PR DESCRIPTION
Reusing tiny pprof protobuf objects is more expensive than allocating new: `(*Profile).ReturnToVTPool` consumes 23% of total CPU time. It makes sense to revisit the decision to use pools for pprof proto.

<img width="1692" alt="image" src="https://github.com/grafana/pyroscope/assets/12090599/3dd15890-2069-4c6b-9703-542bbe61e572">
