### PR TITLE
Fix broken tests on MacOS

### DIFF
--- a/ebpf/cmd/playground/main.go
+++ b/ebpf/cmd/playground/main.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package main
 
 import (

--- a/ebpf/cmd/playground/main.go
+++ b/ebpf/cmd/playground/main.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package main
 

--- a/ebpf/rlimit/internal/internal_mirror.go
+++ b/ebpf/rlimit/internal/internal_mirror.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package internal
 

--- a/ebpf/rlimit/internal/internal_mirror.go
+++ b/ebpf/rlimit/internal/internal_mirror.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package internal
 
 import (


### PR DESCRIPTION
When I run `make test` on my MacOS. I got some errors:
```console
ebpf/rlimit/internal/internal_mirror.go:13:20: undefined: unix.BPF_OBJ_NAME_LEN
ebpf/rlimit/internal/internal_mirror.go:39:36: undefined: unix.SYS_BPF
ebpf/cmd/playground/main.go:27:26: undefined: ebpfspy.NewSession
ebpf/cmd/playground/main.go:48:38: undefined: ebpfspy.SessionOptions
ebpf/cmd/playground/main.go:50:17: undefined: ebpfspy.SessionOptions
ebpf/cmd/playground/main.go:54:24: undefined: symtab.CacheOptions
```

This PR try add the right build tag to skip it on MacOS.