### PR TITLE
Bump golangci-lint to 1.54.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,10 +53,11 @@ linters-settings:
     local-prefixes: github.com/grafana/pyroscope/pkg,github.com/grafana/pyroscope/api,github.com/grafana/pyroscope/tools
 
   depguard:
-    list-type: blacklist
-    include-go-root: true
-    packages-with-error-message:
-      - github.com/go-kit/kit/log: "Use github.com/go-kit/log instead of github.com/go-kit/kit/log"
+    rules:
+      main:
+        deny:
+          - pkg: "github.com/go-kit/kit/log"
+            desc: "Use github.com/go-kit/log instead of github.com/go-kit/kit/log"
 
   revive:
     rules:

--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ $(BIN)/buf: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.0
 
 $(BIN)/protoc-gen-go: Makefile go.mod
 	@mkdir -p $(@D)


### PR DESCRIPTION
Bumped the golangci-lint to 1.54.0. The main change is we need to upgrade the depguard from v1 to v2. You can see more at: https://github.com/golangci/golangci-lint/pull/3795/files