### PR TITLE
fix(ebpf): make kallsyms lazy

### DIFF
--- a/ebpf/symtab/kallsyms.go
+++ b/ebpf/symtab/kallsyms.go
@@ -3,13 +3,26 @@ package symtab
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"runtime"
 	"strconv"
 )
 
 var kallsymsModule = []byte("kernel")
 
-func NewKallsyms(kallsyms []byte) (*SymbolTab, error) {
+func NewKallsyms() (*SymbolTab, error) {
+	return NewKallsymsFromFile("/proc/kallsyms")
+}
+
+func NewKallsymsFromFile(f string) (*SymbolTab, error) {
+	kallsymsData, err := os.ReadFile(f)
+	if err != nil {
+		return nil, fmt.Errorf("read kallsyms %w", err)
+	}
+	return NewKallsymsFromData(kallsymsData)
+}
+
+func NewKallsymsFromData(kallsyms []byte) (*SymbolTab, error) {
 	kernelAddrSpace := uint64(0)
 	if runtime.GOARCH == "amd64" {
 		// https://www.kernel.org/doc/Documentation/x86/x86_64/mm.txt

--- a/ebpf/symtab/kallsyms_test.go
+++ b/ebpf/symtab/kallsyms_test.go
@@ -28,7 +28,7 @@ ffffffff81001820 T early_memtest
 ffffffff810018a0 T early_memtest_report`
 
 func TestKallsyms(t *testing.T) {
-	kallsyms, err := NewKallsyms([]byte(testdata))
+	kallsyms, err := NewKallsymsFromData([]byte(testdata))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This will save couple of megabytes when `CollectKernel=false` ( /proc/kallsyms is 2M on our dev nodes and 16M on my machine)