### PR TITLE
fix(ebpf): disable gotable fallback by default, make gotablefallback smarter

### DIFF
--- a/ebpf/symtab/elf.go
+++ b/ebpf/symtab/elf.go
@@ -165,7 +165,7 @@ func (et *ElfTable) createSymbolTable(me *elf2.MMapedElfFile) (SymbolNameResolve
 	}
 	symbolOptions := elf2.SymbolsOptions{}
 	if goErr == nil && goTable.Index.Entry.Length() > 0 {
-		symbolOptions.FilterTo = goTable.Index.Entry.Get(0)
+		symbolOptions.FilterFrom = goTable.Index.Entry.Get(0)
 		symbolOptions.FilterTo = goTable.Index.End
 	}
 	symTable, symErr := me.NewSymbolTable(&symbolOptions)

--- a/ebpf/symtab/elf.go
+++ b/ebpf/symtab/elf.go
@@ -30,13 +30,24 @@ type ElfTable struct {
 	logger  log.Logger
 	procMap *ProcMap
 }
+type SymbolOptions struct {
+	GoTableFallback bool
+}
+
+var DefaultSymbolOptions = &SymbolOptions{
+	GoTableFallback: false,
+}
 
 type ElfTableOptions struct {
-	ElfCache *ElfCache
-	Metrics  *Metrics // may be nil for tests
+	ElfCache      *ElfCache
+	Metrics       *Metrics // may be nil for tests
+	SymbolOptions *SymbolOptions
 }
 
 func NewElfTable(logger log.Logger, procMap *ProcMap, fs string, elfFilePath string, options ElfTableOptions) *ElfTable {
+	if options.SymbolOptions == nil {
+		options.SymbolOptions = DefaultSymbolOptions
+	}
 	res := &ElfTable{
 		procMap:     procMap,
 		fs:          fs,
@@ -148,8 +159,16 @@ func (et *ElfTable) load() {
 }
 
 func (et *ElfTable) createSymbolTable(me *elf2.MMapedElfFile) (SymbolNameResolver, error) {
-	symTable, symErr := me.NewSymbolTable()
 	goTable, goErr := me.NewGoTable()
+	if !et.options.SymbolOptions.GoTableFallback && goErr == nil {
+		return goTable, nil
+	}
+	symbolOptions := elf2.SymbolsOptions{}
+	if goErr == nil && goTable.Index.Entry.Length() > 0 {
+		symbolOptions.FilterTo = goTable.Index.Entry.Get(0)
+		symbolOptions.FilterTo = goTable.Index.End
+	}
+	symTable, symErr := me.NewSymbolTable(&symbolOptions)
 	if symErr != nil && goErr != nil {
 		return nil, fmt.Errorf("s: %s g: %s", symErr.Error(), goErr.Error())
 	}

--- a/ebpf/symtab/elf/elfmmap_test.go
+++ b/ebpf/symtab/elf/elfmmap_test.go
@@ -21,7 +21,7 @@ func TestElfSymbolComparison(t *testing.T) {
 		require.NoError(t, err)
 		defer me.Close()
 
-		tab, _ := me.NewSymbolTable()
+		tab, _ := me.NewSymbolTable(new(SymbolsOptions))
 		if tab == nil {
 			tab = &SymbolTable{}
 		}

--- a/ebpf/symtab/elf/symbol_table.go
+++ b/ebpf/symtab/elf/symbol_table.go
@@ -85,13 +85,13 @@ func (st *SymbolTable) Cleanup() {
 	st.File.Close()
 }
 
-func (f *MMapedElfFile) NewSymbolTable() (*SymbolTable, error) {
-	sym, sectionSym, err := f.getSymbols(elf.SHT_SYMTAB)
+func (f *MMapedElfFile) NewSymbolTable(opt *SymbolsOptions) (*SymbolTable, error) {
+	sym, sectionSym, err := f.getSymbols(elf.SHT_SYMTAB, opt)
 	if err != nil && !errors.Is(err, ErrNoSymbols) {
 		return nil, err
 	}
 
-	dynsym, sectionDynSym, err := f.getSymbols(elf.SHT_DYNSYM)
+	dynsym, sectionDynSym, err := f.getSymbols(elf.SHT_DYNSYM, opt)
 	if err != nil && !errors.Is(err, ErrNoSymbols) {
 		return nil, err
 	}

--- a/ebpf/symtab/elf_test.go
+++ b/ebpf/symtab/elf_test.go
@@ -1,8 +1,10 @@
 package symtab
 
 import (
-	"github.com/grafana/pyroscope/ebpf/util"
 	"testing"
+
+	"github.com/grafana/pyroscope/ebpf/symtab/elf"
+	"github.com/grafana/pyroscope/ebpf/util"
 
 	"github.com/stretchr/testify/require"
 )
@@ -27,4 +29,72 @@ func TestElf(t *testing.T) {
 		res := tab.Resolve(sym.pc)
 		require.Equal(t, res, sym.name)
 	}
+}
+
+func TestGoTableFallbackFiltering(t *testing.T) {
+	ts := []struct {
+		f string
+	}{
+		{"elf/testdata/elfs/go12"},
+		{"elf/testdata/elfs/go16"},
+		{"elf/testdata/elfs/go18"},
+		{"elf/testdata/elfs/go20"},
+		{"elf/testdata/elfs/go12-static"},
+		{"elf/testdata/elfs/go16-static"},
+		{"elf/testdata/elfs/go18-static"},
+		{"elf/testdata/elfs/go20-static"},
+	}
+	for _, e := range ts {
+		elfCache, _ := NewElfCache(testCacheOptions, testCacheOptions)
+		logger := util.TestLogger(t)
+		tab := NewElfTable(logger, &ProcMap{StartAddr: 0x1000, Offset: 0x1000}, ".", e.f,
+			ElfTableOptions{
+				ElfCache:      elfCache,
+				SymbolOptions: &SymbolOptions{GoTableFallback: true},
+			})
+		tab.load()
+		require.NoError(t, tab.err)
+		gt, ok := tab.table.(*elf.GoTableWithFallback)
+		require.True(t, ok)
+		_ = gt
+		for i := 0; i < gt.GoTable.Index.Entry.Length(); i++ {
+			pc := gt.GoTable.Index.Entry.Get(i)
+			s1 := gt.GoTable.Resolve(pc)
+			s2 := gt.SymTable.Resolve(pc)
+			require.NotEqual(t, "", s1)
+			require.Equal(t, "", s2)
+		}
+		elfCache.Cleanup()
+	}
+
+}
+
+func TestGoTableFallbackDisabled(t *testing.T) {
+	ts := []struct {
+		f string
+	}{
+		{"elf/testdata/elfs/go12"},
+		{"elf/testdata/elfs/go16"},
+		{"elf/testdata/elfs/go18"},
+		{"elf/testdata/elfs/go20"},
+		{"elf/testdata/elfs/go12-static"},
+		{"elf/testdata/elfs/go16-static"},
+		{"elf/testdata/elfs/go18-static"},
+		{"elf/testdata/elfs/go20-static"},
+	}
+	for _, e := range ts {
+		elfCache, _ := NewElfCache(testCacheOptions, testCacheOptions)
+		logger := util.TestLogger(t)
+		tab := NewElfTable(logger, &ProcMap{StartAddr: 0x1000, Offset: 0x1000}, ".", e.f,
+			ElfTableOptions{
+				ElfCache:      elfCache,
+				SymbolOptions: &SymbolOptions{GoTableFallback: false},
+			})
+		tab.load()
+		require.NoError(t, tab.err)
+		_, ok := tab.table.(*elf.GoTable)
+		require.True(t, ok)
+		elfCache.Cleanup()
+	}
+
 }

--- a/ebpf/symtab/gosym/pcindex.go
+++ b/ebpf/symtab/gosym/pcindex.go
@@ -102,3 +102,10 @@ func (it *PCIndex) PCIndex64() PCIndex {
 	res.i32 = nil
 	return res
 }
+
+func (it *PCIndex) Get(i int) uint64 {
+	if it.i32 != nil {
+		return uint64(it.i32[i])
+	}
+	return it.i64[i]
+}

--- a/ebpf/symtab/proc_linux_test.go
+++ b/ebpf/symtab/proc_linux_test.go
@@ -59,7 +59,7 @@ func TestSelfElfSymbolsLazy(t *testing.T) {
 	me, err := elf.NewMMapedElfFile(f)
 	require.NoError(t, err)
 
-	symbolTable, err := me.NewSymbolTable()
+	symbolTable, err := me.NewSymbolTable(new(elf.SymbolsOptions))
 	require.NoError(t, err)
 
 	require.Greater(t, len(symbolTable.Index.Names), 500)

--- a/ebpf/symtab/symbols.go
+++ b/ebpf/symtab/symbols.go
@@ -21,13 +21,15 @@ type SymbolCache struct {
 	elfCache *ElfCache
 	kallsyms SymbolTable
 	logger   log.Logger
-	metrics  *Metrics
+
+	options CacheOptions
 }
 type CacheOptions struct {
 	PidCacheOptions      GCacheOptions
 	BuildIDCacheOptions  GCacheOptions
 	SameFileCacheOptions GCacheOptions
 	Metrics              *Metrics // may be nil for tests
+	SymbolOptions        SymbolOptions
 }
 
 func NewSymbolCache(logger log.Logger, options CacheOptions) (*SymbolCache, error) {
@@ -56,7 +58,7 @@ func NewSymbolCache(logger log.Logger, options CacheOptions) (*SymbolCache, erro
 		pidCache: cache,
 		kallsyms: kallsyms,
 		elfCache: elfCache,
-		metrics:  options.Metrics,
+		options:  options,
 	}, nil
 }
 
@@ -88,8 +90,9 @@ func (sc *SymbolCache) getOrCreateCacheEntry(pid PidKey) SymbolTable {
 	fresh := NewProcTable(sc.logger, ProcTableOptions{
 		Pid: int(pid),
 		ElfTableOptions: ElfTableOptions{
-			ElfCache: sc.elfCache,
-			Metrics:  sc.metrics,
+			ElfCache:      sc.elfCache,
+			Metrics:       sc.options.Metrics,
+			SymbolOptions: &sc.options.SymbolOptions,
 		},
 	})
 


### PR DESCRIPTION
for golang binaries we create symbol table from `.gopclntab` section. it is useful for striped binaries.
It may be usefull to still look into `.sym`  sections for non go functions ie cgo . Thus there's a GoTableWithFallback. 
However for unstripped binaries it now keeps in memory duplicate symbols for go functions  (both from   `.gopclntab` and  `.sym` )

This PR:
- disable gotable fallback by default
- when  gotable fallback is enabled, do not duplicate symbols between gotable and `.sym` table