### PR TITLE
fix(ebpf): do not clear ElfCache

### DIFF
--- a/ebpf/symtab/elf/go_table.go
+++ b/ebpf/symtab/elf/go_table.go
@@ -21,7 +21,7 @@ func (g *GoTable) IsDead() bool {
 
 func (g *GoTable) DebugInfo() SymTabDebugInfo {
 	return SymTabDebugInfo{
-		Name: "GoTable",
+		Name: fmt.Sprintf("GoTable %p", g),
 		Size: len(g.Index.Name),
 		File: g.File.fpath,
 	}
@@ -153,7 +153,7 @@ func (g *GoTableWithFallback) IsDead() bool {
 
 func (g *GoTableWithFallback) DebugInfo() SymTabDebugInfo {
 	return SymTabDebugInfo{
-		Name: "GoTableWithFallback",
+		Name: fmt.Sprintf("GoTableWithFallback %p ", g),
 		Size: g.GoTable.Size() + g.SymTable.Size(),
 		File: g.GoTable.File.fpath,
 	}

--- a/ebpf/symtab/elf/symbol_table.go
+++ b/ebpf/symtab/elf/symbol_table.go
@@ -51,7 +51,7 @@ func (st *SymbolTable) IsDead() bool {
 
 func (st *SymbolTable) DebugInfo() SymTabDebugInfo {
 	return SymTabDebugInfo{
-		Name: "SymbolTable",
+		Name: fmt.Sprintf("SymbolTable %p", st),
 		Size: len(st.Index.Names),
 		File: st.File.fpath,
 	}
@@ -137,7 +137,8 @@ func (st *SymbolTable) symbolName(idx int) (string, error) {
 }
 
 type SymTabDebugInfo struct {
-	Name string `river:"name,attr,optional"`
-	Size int    `river:"symbol_count,attr,optional"`
-	File string `river:"file,attr,optional"`
+	Name          string `river:"name,attr,optional"`
+	Size          int    `river:"symbol_count,attr,optional"`
+	File          string `river:"file,attr,optional"`
+	LastUsedRound int    `river:"last_used_round,attr,optional"`
 }

--- a/ebpf/symtab/elf_cache.go
+++ b/ebpf/symtab/elf_cache.go
@@ -75,12 +75,6 @@ func (e *ElfCache) NextRound() {
 func (e *ElfCache) Cleanup() {
 	e.BuildIDCache.Cleanup()
 	e.SameFileCache.Cleanup()
-	//e.BuildIDCache.Each(func(k elf.BuildID, v SymbolNameResolver) {
-	//	e.BuildIDCache.Remove(k)
-	//})
-	//e.SameFileCache.Each(func(k Stat, v SymbolNameResolver) {
-	//	e.SameFileCache.Remove(k)
-	//})
 }
 
 type ElfCacheDebugInfo struct {

--- a/ebpf/symtab/elf_cache.go
+++ b/ebpf/symtab/elf_cache.go
@@ -75,12 +75,12 @@ func (e *ElfCache) NextRound() {
 func (e *ElfCache) Cleanup() {
 	e.BuildIDCache.Cleanup()
 	e.SameFileCache.Cleanup()
-	e.BuildIDCache.Each(func(k elf.BuildID, v SymbolNameResolver) {
-		e.BuildIDCache.Remove(k)
-	})
-	e.SameFileCache.Each(func(k Stat, v SymbolNameResolver) {
-		e.SameFileCache.Remove(k)
-	})
+	//e.BuildIDCache.Each(func(k elf.BuildID, v SymbolNameResolver) {
+	//	e.BuildIDCache.Remove(k)
+	//})
+	//e.SameFileCache.Each(func(k Stat, v SymbolNameResolver) {
+	//	e.SameFileCache.Remove(k)
+	//})
 }
 
 type ElfCacheDebugInfo struct {
@@ -92,13 +92,17 @@ func (e *ElfCache) DebugInfo() ElfCacheDebugInfo {
 	return ElfCacheDebugInfo{
 		BuildIDCache: DebugInfo[elf.BuildID, SymbolNameResolver, elf.SymTabDebugInfo](
 			e.BuildIDCache,
-			func(b elf.BuildID, v SymbolNameResolver) elf.SymTabDebugInfo {
-				return v.DebugInfo()
+			func(b elf.BuildID, v SymbolNameResolver, round int) elf.SymTabDebugInfo {
+				res := v.DebugInfo()
+				res.LastUsedRound = round
+				return res
 			}),
 		SameFileCache: DebugInfo[Stat, SymbolNameResolver, elf.SymTabDebugInfo](
 			e.SameFileCache,
-			func(s Stat, v SymbolNameResolver) elf.SymTabDebugInfo {
-				return v.DebugInfo()
+			func(s Stat, v SymbolNameResolver, round int) elf.SymTabDebugInfo {
+				res := v.DebugInfo()
+				res.LastUsedRound = round
+				return res
 			}),
 	}
 }

--- a/ebpf/symtab/proc.go
+++ b/ebpf/symtab/proc.go
@@ -24,9 +24,10 @@ type ProcTable struct {
 }
 
 type ProcTableDebugInfo struct {
-	ElfTables map[string]elf.SymTabDebugInfo `river:"elfs,block,optional"`
-	Size      int                            `river:"size,attr,optional"`
-	Pid       int                            `river:"pid,attr,optional"`
+	ElfTables     map[string]elf.SymTabDebugInfo `river:"elfs,block,optional"`
+	Size          int                            `river:"size,attr,optional"`
+	Pid           int                            `river:"pid,attr,optional"`
+	LastUsedRound int                            `river:"last_used_round,attr,optional"`
 }
 
 func (p *ProcTable) DebugInfo() ProcTableDebugInfo {

--- a/ebpf/symtab/symbols.go
+++ b/ebpf/symtab/symbols.go
@@ -105,8 +105,10 @@ func (sc *SymbolCache) UpdateOptions(options CacheOptions) {
 func (sc *SymbolCache) PidCacheDebugInfo() GCacheDebugInfo[ProcTableDebugInfo] {
 	return DebugInfo[PidKey, *ProcTable, ProcTableDebugInfo](
 		sc.pidCache,
-		func(k PidKey, v *ProcTable) ProcTableDebugInfo {
-			return v.DebugInfo()
+		func(k PidKey, v *ProcTable, round int) ProcTableDebugInfo {
+			res := v.DebugInfo()
+			res.LastUsedRound = round
+			return res
 		})
 }
 


### PR DESCRIPTION
fix bug: ElfCache.Cleanup should clear the whole cache, only Close all files, and remove entries witch did not update for couple of rounds .

In this PR:
- fix the bug
- improve debug info a bit - add pointers to the expensive objects, add last_updated_round bits.