### PR TITLE
fix(ebpf): improve pcindex binary search speed

### DIFF
--- a/ebpf/symtab/gosym/pcindex.go
+++ b/ebpf/symtab/gosym/pcindex.go
@@ -2,6 +2,8 @@ package gosym
 
 import (
 	"math"
+
+	"golang.org/x/exp/slices"
 )
 
 type PCIndex struct {
@@ -61,38 +63,33 @@ func (it *PCIndex) First() uint64 {
 
 func (it *PCIndex) FindIndex(addr uint64) int {
 	if it.i32 != nil {
-		n := len(it.i32)
+
 		if addr < uint64(it.i32[0]) {
 			return -1
 		}
-		i, j := 0, n
-		for i < j {
-			h := int(uint(i+j) >> 1) // avoid overflow when computing h
-			// i ≤ h < j
-			if !(addr < uint64(it.i32[h])) {
-				i = h + 1 // preserves f(i-1) == false
-			} else {
-				j = h // preserves f(j) == true
-			}
+		i, found := slices.BinarySearch(it.i32, uint32(addr))
+		if found {
+			return i
 		}
 		i--
+		v := it.i32[i]
+		for i > 0 && it.i32[i-1] == v {
+			i--
+		}
 		return i
 	}
-	n := len(it.i64)
 	if addr < it.i64[0] {
 		return -1
 	}
-	i, j := 0, n
-	for i < j {
-		h := int(uint(i+j) >> 1) // avoid overflow when computing h
-		// i ≤ h < j
-		if !(addr < it.i64[h]) {
-			i = h + 1 // preserves f(i-1) == false
-		} else {
-			j = h // preserves f(j) == true
-		}
+	i, found := slices.BinarySearch(it.i64, addr)
+	if found {
+		return i
 	}
 	i--
+	v := it.i64[i]
+	for i > 0 && it.i64[i-1] == v {
+		i--
+	}
 	return i
 }
 

--- a/ebpf/symtab/gosym/pcindex.go
+++ b/ebpf/symtab/gosym/pcindex.go
@@ -2,7 +2,6 @@ package gosym
 
 import (
 	"math"
-	"sort"
 )
 
 type PCIndex struct {
@@ -61,25 +60,38 @@ func (it *PCIndex) First() uint64 {
 }
 
 func (it *PCIndex) FindIndex(addr uint64) int {
-	n := len(it.i32) + len(it.i64)
 	if it.i32 != nil {
-		var i int
+		n := len(it.i32)
 		if addr < uint64(it.i32[0]) {
 			return -1
 		}
-		i = sort.Search(n, func(i int) bool {
-			return addr < uint64(it.i32[i])
-		})
+		i, j := 0, n
+		for i < j {
+			h := int(uint(i+j) >> 1) // avoid overflow when computing h
+			// i ≤ h < j
+			if !(addr < uint64(it.i32[h])) {
+				i = h + 1 // preserves f(i-1) == false
+			} else {
+				j = h // preserves f(j) == true
+			}
+		}
 		i--
 		return i
 	}
-	var i int
+	n := len(it.i64)
 	if addr < it.i64[0] {
 		return -1
 	}
-	i = sort.Search(n, func(i int) bool {
-		return addr < it.i64[i]
-	})
+	i, j := 0, n
+	for i < j {
+		h := int(uint(i+j) >> 1) // avoid overflow when computing h
+		// i ≤ h < j
+		if !(addr < it.i64[h]) {
+			i = h + 1 // preserves f(i-1) == false
+		} else {
+			j = h // preserves f(j) == true
+		}
+	}
 	i--
 	return i
 }

--- a/ebpf/symtab/gosym/pcindex_test.go
+++ b/ebpf/symtab/gosym/pcindex_test.go
@@ -1,0 +1,33 @@
+package gosym
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"golang.org/x/exp/slices"
+)
+
+func BenchmarkBinSearch(b *testing.B) {
+	const nsym = 64 * 1024
+	rnd := rand.NewSource(239)
+	syms := make([]uint64, nsym)
+	for i := 0; i < nsym; i++ {
+		syms[i] = uint64(rnd.Int63()) & 0x7fffffff
+	}
+	slices.Sort(syms)
+
+	pci := NewPCIndex(nsym)
+	for i, sym := range syms {
+		pci.Set(i, sym)
+	}
+	b.ResetTimer()
+	idx := 0
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < nsym; j++ {
+			idx += pci.FindIndex(syms[j])
+		}
+	}
+	b.StopTimer()
+	fmt.Println(idx)
+}

--- a/ebpf/symtab/gosym/pcindex_test.go
+++ b/ebpf/symtab/gosym/pcindex_test.go
@@ -1,7 +1,6 @@
 package gosym
 
 import (
-	"fmt"
 	"math/rand"
 	"testing"
 
@@ -29,5 +28,5 @@ func BenchmarkBinSearch(b *testing.B) {
 		}
 	}
 	b.StopTimer()
-	fmt.Println(idx)
+	//fmt.Println(idx)
 }

--- a/ebpf/symtab/gosym/pcindex_test.go
+++ b/ebpf/symtab/gosym/pcindex_test.go
@@ -4,8 +4,25 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/exp/slices"
 )
+
+func TestPCIndex_FindIndex(t *testing.T) {
+	s := "aaaaccfff"
+	pci := NewPCIndex(len(s))
+	for i := 0; i < len(s); i++ {
+		pci.Set(i, uint64(s[i]))
+	}
+	assert.Equal(t, -1, pci.FindIndex(uint64(0x20)))
+	assert.Equal(t, 0, pci.FindIndex(uint64('a')))
+	assert.Equal(t, 0, pci.FindIndex(uint64('b')))
+	assert.Equal(t, 4, pci.FindIndex(uint64('c')))
+	assert.Equal(t, 4, pci.FindIndex(uint64('d')))
+	assert.Equal(t, 4, pci.FindIndex(uint64('e')))
+	assert.Equal(t, 6, pci.FindIndex(uint64('f')))
+	assert.Equal(t, 6, pci.FindIndex(uint64('z')))
+}
 
 func BenchmarkBinSearch(b *testing.B) {
 	const nsym = 64 * 1024


### PR DESCRIPTION
PCIndex.FindIndex is not super hot, it is only 3%. However the change is not hard so I do it anyway. "It ain't much, but it's honest work"

In this PR I've inlined sort.Search in PCIndex.FindIndex.

```
goos: linux
goarch: amd64
pkg: github.com/grafana/pyroscope/ebpf/symtab/gosym
cpu: AMD Ryzen 9 5950X 16-Core Processor            
             │   old.txt    │               new.txt               │
             │    sec/op    │   sec/op     vs base                │
BinSearch-32   3.354m ± 11%   1.716m ± 1%  -48.83% (p=0.000 n=10)
```