### PR TITLE
chore: renames phlaredb to pyroscopedb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ define deploy
 		--set pyroscope.podAnnotations."profiles\.grafana\.com\/cpu\.port_name"=http-metrics \
 		--set pyroscope.podAnnotations."profiles\.grafana\.com\/goroutine\.port_name"=http-metrics \
 		--set pyroscope.extraEnvVars.JAEGER_AGENT_HOST=jaeger.monitoring.svc.cluster.local. \
-		--set pyroscope.extraArgs."phlaredb\.max-block-duration"=5m
+		--set pyroscope.extraArgs."pyroscopedb\.max-block-duration"=5m
   endef
 
 .PHONY: docker-image/pyroscope/build-debug

--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -339,11 +339,11 @@ Usage of ./pyroscope:
     	Maximum time to wait for ring stability at startup. If the overrides-exporter ring keeps changing after this period of time, it will start anyway. (default 5m0s)
   -overrides-exporter.ring.wait-stability-min-duration duration
     	Minimum time to wait for ring stability at startup, if set to positive value. Set to 0 to disable.
-  -phlaredb.data-path string
+  -pyroscopedb.data-path string
     	Directory used for local storage. (default "./data")
-  -phlaredb.max-block-duration duration
+  -pyroscopedb.max-block-duration duration
     	Upper limit to the duration of a Phlare block. (default 3h0m0s)
-  -phlaredb.row-group-target-size uint
+  -pyroscopedb.row-group-target-size uint
     	How big should a single row group be uncompressed (default 1342177280)
   -querier.client-cleanup-period duration
     	How frequently to clean up clients for ingesters that have gone away. (default 15s)

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -117,11 +117,11 @@ Usage of ./pyroscope:
     	Port to advertise in the ring (defaults to -server.http-listen-port). (default 4040)
   -overrides-exporter.ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
-  -phlaredb.data-path string
+  -pyroscopedb.data-path string
     	Directory used for local storage. (default "./data")
-  -phlaredb.max-block-duration duration
+  -pyroscopedb.max-block-duration duration
     	Upper limit to the duration of a Phlare block. (default 3h0m0s)
-  -phlaredb.row-group-target-size uint
+  -pyroscopedb.row-group-target-size uint
     	How big should a single row group be uncompressed (default 1342177280)
   -querier.client-cleanup-period duration
     	How frequently to clean up clients for ingesters that have gone away. (default 15s)

--- a/docs/sources/configure-server/configure-disk-storage.md
+++ b/docs/sources/configure-server/configure-disk-storage.md
@@ -10,10 +10,10 @@ weight: 20
 Grafana Phlare's [ingester] component processes the received profiling data.
 First it keeps the data organized in memory, in the so called head block. Once
 the size of it exceeds a threshold or the head block is older than
-`-phlaredb.max-block-duration` (by default 3 hours), it will write the block to
+`-pyroscopedb.max-block-duration` (by default 3 hours), it will write the block to
 the local persistent disk (see [block format] for more detail about the block's
 layout). Each of those blocks are identified by an [ULID] and stored within
-Grafana Phlare's data path `-phlaredb.data-path=` (by default
+Grafana Phlare's data path `-pyroscopedb.data-path=` (by default
 `./data`) is organized the following:
 
 * `./<tenant-id>`: Each tenant has its own subdirectory with the following subdirectories:

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -542,17 +542,17 @@ store_gateway:
 # The memberlist block configures the Gossip memberlist.
 [memberlist: <memberlist>]
 
-phlaredb:
+pyroscopedb:
   # Directory used for local storage.
-  # CLI flag: -phlaredb.data-path
+  # CLI flag: -pyroscopedb.data-path
   [data_path: <string> | default = "./data"]
 
   # Upper limit to the duration of a Phlare block.
-  # CLI flag: -phlaredb.max-block-duration
+  # CLI flag: -pyroscopedb.max-block-duration
   [max_block_duration: <duration> | default = 3h]
 
   # How big should a single row group be uncompressed
-  # CLI flag: -phlaredb.row-group-target-size
+  # CLI flag: -pyroscopedb.row-group-target-size
   [row_group_target_size: <int> | default = 1342177280]
 
 tracing:

--- a/operations/pyroscope/helm/pyroscope/values.yaml
+++ b/operations/pyroscope/helm/pyroscope/values.yaml
@@ -79,11 +79,11 @@ pyroscope:
     # lines, adjust them as necessary, and remove the curly braces after 'resources'.
     #
     # Note that if memory consumption is higher than you would like, you can decrease the interval
-    # that profiles are written into blocks by setting `phlaredb.max-block-duration` in the `extraArgs`
+    # that profiles are written into blocks by setting `pyroscopedb.max-block-duration` in the `extraArgs`
     # stanza. By default, it is set to 3h - override it, for example, as below:
     # ```
     # extraArgs:
-    #   phlaredb.max-block-duration: 30m
+    #   pyroscopedb.max-block-duration: 30m
     # ```
     #
     # limits:

--- a/pkg/phlaredb/phlaredb.go
+++ b/pkg/phlaredb/phlaredb.go
@@ -50,9 +50,9 @@ type ParquetConfig struct {
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.StringVar(&cfg.DataPath, "phlaredb.data-path", "./data", "Directory used for local storage.")
-	f.DurationVar(&cfg.MaxBlockDuration, "phlaredb.max-block-duration", 3*time.Hour, "Upper limit to the duration of a Phlare block.")
-	f.Uint64Var(&cfg.RowGroupTargetSize, "phlaredb.row-group-target-size", 10*128*1024*1024, "How big should a single row group be uncompressed") // This should roughly be 128MiB compressed
+	f.StringVar(&cfg.DataPath, "pyroscopedb.data-path", "./data", "Directory used for local storage.")
+	f.DurationVar(&cfg.MaxBlockDuration, "pyroscopedb.max-block-duration", 3*time.Hour, "Upper limit to the duration of a Phlare block.")
+	f.Uint64Var(&cfg.RowGroupTargetSize, "pyroscopedb.row-group-target-size", 10*128*1024*1024, "How big should a single row group be uncompressed") // This should roughly be 128MiB compressed
 }
 
 type TenantLimiter interface {

--- a/pkg/phlaredb/profile_store.go
+++ b/pkg/phlaredb/profile_store.go
@@ -65,8 +65,8 @@ type profileStore struct {
 
 func newProfileWriter(writer io.Writer) *parquet.GenericWriter[*schemav1.Profile] {
 	return parquet.NewGenericWriter[*schemav1.Profile](writer, schemav1.ProfilesSchema,
-		parquet.ColumnPageBuffers(parquet.NewFileBufferPool(os.TempDir(), "phlaredb-parquet-buffers*")),
-		parquet.CreatedBy("github.com/grafana/phlare/", build.Version, build.Revision),
+		parquet.ColumnPageBuffers(parquet.NewFileBufferPool(os.TempDir(), "pyroscopedb-parquet-buffers*")),
+		parquet.CreatedBy("github.com/grafana/pyroscope/", build.Version, build.Revision),
 		parquet.PageBufferSize(3*1024*1024),
 	)
 }


### PR DESCRIPTION
As far as I can tell we don't use this config parameter anywhere. I left some names untouched, because that would break hard, so I think we should change those later e.g:
* https://github.com/pyroscope-io/pyroscope/blob/d97de8a608786a23270b167de18e495f61cfeceb/pkg/storegateway/bucket.go#L45
* https://github.com/pyroscope-io/pyroscope/blob/5dbd4fb1fe294f57651fa70405acf5a666b13d2e/pkg/phlaredb/profile_store.go#L68
