### PR TITLE
Handle OG Pyroscope endpoints in query frontend

### DIFF
--- a/pkg/frontend/frontend_diff.go
+++ b/pkg/frontend/frontend_diff.go
@@ -2,13 +2,52 @@ package frontend
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/bufbuild/connect-go"
+	"golang.org/x/sync/errgroup"
 
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect"
+	phlaremodel "github.com/grafana/pyroscope/pkg/model"
 	"github.com/grafana/pyroscope/pkg/util/connectgrpc"
+	"github.com/grafana/pyroscope/pkg/util/math"
 )
 
-func (f *Frontend) Diff(ctx context.Context, c *connect.Request[querierv1.DiffRequest]) (*connect.Response[querierv1.DiffResponse], error) {
-	return connectgrpc.RoundTripUnary[querierv1.DiffRequest, querierv1.DiffResponse](ctx, f, c)
+func (f *Frontend) Diff(ctx context.Context,
+	c *connect.Request[querierv1.DiffRequest]) (
+	*connect.Response[querierv1.DiffResponse], error,
+) {
+	ctx = connectgrpc.WithProcedure(ctx, querierv1connect.QuerierServiceDiffProcedure)
+	g, ctx := errgroup.WithContext(ctx)
+
+	var left, right *phlaremodel.Tree
+	g.Go(func() error {
+		resp, err := f.SelectMergeStacktraces(ctx, connect.NewRequest(c.Msg.Left))
+		m := phlaremodel.NewFlameGraphMerger()
+		m.MergeFlameGraph(resp.Msg.Flamegraph)
+		left = m.Tree()
+		return err
+	})
+	g.Go(func() error {
+		resp, err := f.SelectMergeStacktraces(ctx, connect.NewRequest(c.Msg.Right))
+		if err != nil {
+			return err
+		}
+		m := phlaremodel.NewFlameGraphMerger()
+		m.MergeFlameGraph(resp.Msg.Flamegraph)
+		right = m.Tree()
+		return err
+	})
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	maxNodes := int(math.Max(c.Msg.Left.GetMaxNodes(), c.Msg.Right.GetMaxNodes()))
+	diff, err := phlaremodel.NewFlamegraphDiff(left, right, maxNodes)
+	if err != nil {
+		return nil, connect.NewError(http.StatusBadRequest, err)
+	}
+
+	return connect.NewResponse(&querierv1.DiffResponse{Flamegraph: diff}), nil
 }

--- a/pkg/frontend/frontend_diff.go
+++ b/pkg/frontend/frontend_diff.go
@@ -24,6 +24,9 @@ func (f *Frontend) Diff(ctx context.Context,
 	var left, right *phlaremodel.Tree
 	g.Go(func() error {
 		resp, err := f.SelectMergeStacktraces(ctx, connect.NewRequest(c.Msg.Left))
+		if err != nil {
+			return err
+		}
 		m := phlaremodel.NewFlameGraphMerger()
 		m.MergeFlameGraph(resp.Msg.Flamegraph)
 		left = m.Tree()

--- a/pkg/frontend/frontend_label_names.go
+++ b/pkg/frontend/frontend_label_names.go
@@ -5,10 +5,12 @@ import (
 
 	"github.com/bufbuild/connect-go"
 
+	"github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	"github.com/grafana/pyroscope/pkg/util/connectgrpc"
 )
 
 func (f *Frontend) LabelNames(ctx context.Context, c *connect.Request[typesv1.LabelNamesRequest]) (*connect.Response[typesv1.LabelNamesResponse], error) {
+	ctx = connectgrpc.WithProcedure(ctx, querierv1connect.QuerierServiceLabelNamesProcedure)
 	return connectgrpc.RoundTripUnary[typesv1.LabelNamesRequest, typesv1.LabelNamesResponse](ctx, f, c)
 }

--- a/pkg/frontend/frontend_label_values.go
+++ b/pkg/frontend/frontend_label_values.go
@@ -5,10 +5,12 @@ import (
 
 	"github.com/bufbuild/connect-go"
 
+	"github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	"github.com/grafana/pyroscope/pkg/util/connectgrpc"
 )
 
 func (f *Frontend) LabelValues(ctx context.Context, c *connect.Request[typesv1.LabelValuesRequest]) (*connect.Response[typesv1.LabelValuesResponse], error) {
+	ctx = connectgrpc.WithProcedure(ctx, querierv1connect.QuerierServiceLabelValuesProcedure)
 	return connectgrpc.RoundTripUnary[typesv1.LabelValuesRequest, typesv1.LabelValuesResponse](ctx, f, c)
 }

--- a/pkg/frontend/frontend_profile_types.go
+++ b/pkg/frontend/frontend_profile_types.go
@@ -6,9 +6,11 @@ import (
 	"github.com/bufbuild/connect-go"
 
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect"
 	"github.com/grafana/pyroscope/pkg/util/connectgrpc"
 )
 
 func (f *Frontend) ProfileTypes(ctx context.Context, c *connect.Request[querierv1.ProfileTypesRequest]) (*connect.Response[querierv1.ProfileTypesResponse], error) {
+	ctx = connectgrpc.WithProcedure(ctx, querierv1connect.QuerierServiceProfileTypesProcedure)
 	return connectgrpc.RoundTripUnary[querierv1.ProfileTypesRequest, querierv1.ProfileTypesResponse](ctx, f, c)
 }

--- a/pkg/frontend/frontend_select_merge_profile.go
+++ b/pkg/frontend/frontend_select_merge_profile.go
@@ -11,11 +11,13 @@ import (
 
 	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect"
 	"github.com/grafana/pyroscope/pkg/util/connectgrpc"
 	"github.com/grafana/pyroscope/pkg/validation"
 )
 
 func (f *Frontend) SelectMergeProfile(ctx context.Context, c *connect.Request[querierv1.SelectMergeProfileRequest]) (*connect.Response[profilev1.Profile], error) {
+	ctx = connectgrpc.WithProcedure(ctx, querierv1connect.QuerierServiceSelectMergeProfileProcedure)
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
 		return nil, connect.NewError(http.StatusBadRequest, err)

--- a/pkg/frontend/frontend_select_merge_stacktraces.go
+++ b/pkg/frontend/frontend_select_merge_stacktraces.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect"
 	phlaremodel "github.com/grafana/pyroscope/pkg/model"
 	"github.com/grafana/pyroscope/pkg/util/connectgrpc"
 	validationutil "github.com/grafana/pyroscope/pkg/util/validation"
@@ -21,6 +22,7 @@ func (f *Frontend) SelectMergeStacktraces(ctx context.Context,
 	c *connect.Request[querierv1.SelectMergeStacktracesRequest]) (
 	*connect.Response[querierv1.SelectMergeStacktracesResponse], error,
 ) {
+	ctx = connectgrpc.WithProcedure(ctx, querierv1connect.QuerierServiceSelectMergeStacktracesProcedure)
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
 		return nil, connect.NewError(http.StatusBadRequest, err)

--- a/pkg/frontend/frontend_select_series.go
+++ b/pkg/frontend/frontend_select_series.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect"
 	phlaremodel "github.com/grafana/pyroscope/pkg/model"
 	"github.com/grafana/pyroscope/pkg/util/connectgrpc"
 	validationutil "github.com/grafana/pyroscope/pkg/util/validation"
@@ -21,6 +22,7 @@ func (f *Frontend) SelectSeries(ctx context.Context,
 	c *connect.Request[querierv1.SelectSeriesRequest]) (
 	*connect.Response[querierv1.SelectSeriesResponse], error,
 ) {
+	ctx = connectgrpc.WithProcedure(ctx, querierv1connect.QuerierServiceSelectSeriesProcedure)
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
 		return nil, connect.NewError(http.StatusBadRequest, err)

--- a/pkg/frontend/frontend_series.go
+++ b/pkg/frontend/frontend_series.go
@@ -6,9 +6,11 @@ import (
 	"github.com/bufbuild/connect-go"
 
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect"
 	"github.com/grafana/pyroscope/pkg/util/connectgrpc"
 )
 
 func (f *Frontend) Series(ctx context.Context, c *connect.Request[querierv1.SeriesRequest]) (*connect.Response[querierv1.SeriesResponse], error) {
+	ctx = connectgrpc.WithProcedure(ctx, querierv1connect.QuerierServiceSeriesProcedure)
 	return connectgrpc.RoundTripUnary[querierv1.SeriesRequest, querierv1.SeriesResponse](ctx, f, c)
 }

--- a/pkg/model/flamegraph_diff.go
+++ b/pkg/model/flamegraph_diff.go
@@ -50,7 +50,10 @@ func NewFlamegraphDiff(left, right *Tree, maxNodes int) (*querierv1.FlameGraphDi
 	leftNodes, xLeftOffsets := leftTree.root, []int64{0}
 	rghtNodes, xRghtOffsets := rightTree.root, []int64{0}
 	levels := []int{0}
-	minVal := int64(combineMinValues(leftTree, rightTree, maxNodes))
+	var minVal int64
+	if maxNodes > 0 {
+		minVal = int64(combineMinValues(leftTree, rightTree, maxNodes))
+	}
 	nameLocationCache := map[string]int{}
 
 	for len(leftNodes) > 0 {

--- a/pkg/phlare/modules.go
+++ b/pkg/phlare/modules.go
@@ -98,7 +98,7 @@ func (f *Phlare) initQueryFrontend() (services.Service, error) {
 		return nil, err
 	}
 
-	f.API.RegisterPyroscopeHandlers(querier.NewGRPCRoundTripper(frontendSvc))
+	f.API.RegisterPyroscopeHandlers(frontendSvc)
 	f.API.RegisterQueryFrontend(frontendSvc)
 	f.API.RegisterQuerier(frontendSvc)
 

--- a/pkg/util/connectgrpc/connectgrpc.go
+++ b/pkg/util/connectgrpc/connectgrpc.go
@@ -127,9 +127,9 @@ func ProcedureFromContext(ctx context.Context) string {
 }
 
 func encodeRequest[Req any](ctx context.Context, req *connect.Request[Req]) (*httpgrpc.HTTPRequest, error) {
-	url := req.Spec().Procedure
+	url := ProcedureFromContext(ctx)
 	if url == "" {
-		if url = ProcedureFromContext(ctx); url == "" {
+		if url = req.Spec().Procedure; url == "" {
 			return nil, errors.New("cannot encode a request with empty procedure")
 		}
 	}

--- a/pkg/util/connectgrpc/connectgrpc_test.go
+++ b/pkg/util/connectgrpc/connectgrpc_test.go
@@ -25,42 +25,69 @@ type fakeQuerier struct {
 	resp *connect.Response[typesv1.LabelValuesResponse]
 }
 
-func (f *fakeQuerier) LabelValues(ctx context.Context, req *connect.Request[typesv1.LabelValuesRequest]) (*connect.Response[typesv1.LabelValuesResponse], error) {
+func (f *fakeQuerier) LabelValues(_ context.Context, req *connect.Request[typesv1.LabelValuesRequest]) (*connect.Response[typesv1.LabelValuesResponse], error) {
 	f.req = req
 	return f.resp, nil
 }
 
-func Test_DecodeGRPC(t *testing.T) {
-	server := httptest.NewUnstartedServer(nil)
-	mux := mux.NewRouter()
-	server.Config.Handler = h2c.NewHandler(mux, &http2.Server{})
+type mockRoundTripper struct {
+	req  *httpgrpc.HTTPRequest
+	resp *httpgrpc.HTTPResponse
+}
 
-	server.Start()
-	defer server.Close()
-	f := &fakeQuerier{resp: &connect.Response[typesv1.LabelValuesResponse]{
-		Msg: &typesv1.LabelValuesResponse{Names: []string{"foo", "bar"}},
-	}}
-	querierv1connect.RegisterQuerierServiceHandler(mux, f)
+func (m *mockRoundTripper) RoundTripGRPC(_ context.Context, req *httpgrpc.HTTPRequest) (*httpgrpc.HTTPResponse, error) {
+	m.req = req
+	return m.resp, nil
+}
 
-	client := querierv1connect.NewQuerierServiceClient(http.DefaultClient, server.URL)
-	req := &typesv1.LabelValuesRequest{
-		Name: "foo",
+func Test_RoundTripUnary(t *testing.T) {
+	request := func(t *testing.T) *connect.Request[typesv1.LabelValuesRequest] {
+		server := httptest.NewUnstartedServer(nil)
+		mux := mux.NewRouter()
+		server.Config.Handler = h2c.NewHandler(mux, &http2.Server{})
+
+		server.Start()
+		defer server.Close()
+		f := &fakeQuerier{resp: &connect.Response[typesv1.LabelValuesResponse]{
+			Msg: &typesv1.LabelValuesResponse{Names: []string{"foo", "bar"}},
+		}}
+		querierv1connect.RegisterQuerierServiceHandler(mux, f)
+
+		client := querierv1connect.NewQuerierServiceClient(http.DefaultClient, server.URL)
+		req := &typesv1.LabelValuesRequest{
+			Name: "foo",
+		}
+		_, err := client.LabelValues(context.Background(), connect.NewRequest(req))
+		require.NoError(t, err)
+		return f.req
 	}
-	_, _ = client.LabelValues(context.Background(), connect.NewRequest(req))
 
-	encoded, err := encodeRequest(context.Background(), f.req)
-	require.NoError(t, err)
-	require.Equal(t, "POST", encoded.Method)
-	require.Equal(t, "/querier.v1.QuerierService/LabelValues", encoded.Url)
-	//  require.Len(t, encoded.Headers, 4)
-	actualHeaders := lo.Map(encoded.Headers, func(h *httpgrpc.Header, index int) string {
-		return h.Key + ": " + strings.Join(h.Values, ",")
+	t.Run("HTTP request can trip GRPC", func(t *testing.T) {
+		req := request(t)
+		m := &mockRoundTripper{resp: &httpgrpc.HTTPResponse{Code: 200}}
+		_, err := RoundTripUnary[typesv1.LabelValuesRequest, typesv1.LabelValuesResponse](context.Background(), m, req)
+		require.NoError(t, err)
+		require.Equal(t, "POST", m.req.Method)
+		require.Equal(t, "/querier.v1.QuerierService/LabelValues", m.req.Url)
+		actualHeaders := lo.Map(m.req.Headers, func(h *httpgrpc.Header, index int) string {
+			return h.Key + ": " + strings.Join(h.Values, ",")
+		})
+		require.Contains(t, actualHeaders, "Content-Type: application/proto")
+		require.Contains(t, actualHeaders, "Connect-Protocol-Version: 1")
+		require.Contains(t, actualHeaders, "Accept-Encoding: gzip")
+
+		decoded, err := decodeRequest[typesv1.LabelValuesRequest](m.req)
+		require.NoError(t, err)
+		require.Equal(t, req.Msg.Name, decoded.Msg.Name)
 	})
-	require.Contains(t, actualHeaders, "Content-Type: application/proto")
-	require.Contains(t, actualHeaders, "Connect-Protocol-Version: 1")
-	require.Contains(t, actualHeaders, "Accept-Encoding: gzip")
 
-	decoded, err := decodeRequest[typesv1.LabelValuesRequest](encoded)
-	require.NoError(t, err)
-	require.Equal(t, req.Name, decoded.Msg.Name)
+	t.Run("HTTP request URL can be overridden", func(t *testing.T) {
+		req := request(t)
+		m := &mockRoundTripper{resp: &httpgrpc.HTTPResponse{Code: 200}}
+		const url = "TestURL"
+		ctx := WithProcedure(context.Background(), url)
+		_, err := RoundTripUnary[typesv1.LabelValuesRequest, typesv1.LabelValuesResponse](ctx, m, req)
+		require.NoError(t, err)
+		require.Equal(t, url, m.req.Url)
+	})
 }

--- a/pkg/util/connectgrpc/connectgrpc_test.go
+++ b/pkg/util/connectgrpc/connectgrpc_test.go
@@ -48,7 +48,7 @@ func Test_DecodeGRPC(t *testing.T) {
 	}
 	_, _ = client.LabelValues(context.Background(), connect.NewRequest(req))
 
-	encoded, err := encodeRequest(f.req)
+	encoded, err := encodeRequest(context.Background(), f.req)
 	require.NoError(t, err)
 	require.Equal(t, "POST", encoded.Method)
 	require.Equal(t, "/querier.v1.QuerierService/LabelValues", encoded.Url)


### PR DESCRIPTION
Resolves #2133. The change allows to deprecate the [`querier.Diff`](https://github.com/grafana/pyroscope/blob/1596f8a119d74d9272a523444dbb2ff0f84cecf4/api/querier/v1/querier.proto#L16) method. 