### PR TITLE
chore: fixes release pipeline's GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           version: latest
           args: release --rm-dist --timeout 60m
         env:
-          GITHUB_TOKEN: ${{ steps.app-releaser.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-goreleaser.outputs.token }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro'
           # distribution:
           # GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}


### PR DESCRIPTION
cc @simonswine 

I figured this might be the issue we saw with weekly releases — but they work now, so I'm not sure.