### PR TITLE
Snap start and end window to bucket boundaries

### DIFF
--- a/pkg/querier/timeline/timeline.go
+++ b/pkg/querier/timeline/timeline.go
@@ -7,9 +7,8 @@ import (
 )
 
 // New generates a FlamebearerTimeline, backfilling any missing data with zeros.
-// If startMs is in the middle of its durationDeltaSec bucket, it will be
-// snapped to the beginning of that bucket. Similarly, if endMs is in the middle
-// of its bucket, it will be snapped to the beginning of the next bucket.
+// If startMs or endMs are in the middle of its durationDeltaSec bucket, they
+// will be snapped to the beginning of that bucket.
 //
 // It assumes:
 // * Ordered
@@ -18,7 +17,7 @@ func New(series *v1.Series, startMs int64, endMs int64, durationDeltaSec int64) 
 	// Snap startMs and endMs to bucket boundaries.
 	durationDeltaMs := durationDeltaSec * 1000
 	startMs = (startMs / durationDeltaMs) * durationDeltaMs
-	endMs = ((endMs + (durationDeltaMs - 1)) / durationDeltaMs) * durationDeltaMs
+	endMs = (endMs / durationDeltaMs) * durationDeltaMs
 
 	// ms to seconds
 	startSec := startMs / 1000

--- a/pkg/querier/timeline/timeline.go
+++ b/pkg/querier/timeline/timeline.go
@@ -6,12 +6,20 @@ import (
 	v1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 )
 
-// New generates a FlamebearerTimeline,
-// backfilling any missing data with zeros
+// New generates a FlamebearerTimeline, backfilling any missing data with zeros.
+// If startMs is in the middle of its durationDeltaSec bucket, it will be
+// snapped to the beginning of that bucket. Similarly, if endMs is in the middle
+// of its bucket, it will be snapped to the beginning of the next bucket.
+//
 // It assumes:
 // * Ordered
 // * Series timestamps are within [startMs, endMs)
 func New(series *v1.Series, startMs int64, endMs int64, durationDeltaSec int64) *flamebearer.FlamebearerTimelineV1 {
+	// Snap startMs and endMs to bucket boundaries.
+	durationDeltaMs := durationDeltaSec * 1000
+	startMs = (startMs / durationDeltaMs) * durationDeltaMs
+	endMs = ((endMs + (durationDeltaMs - 1)) / durationDeltaMs) * durationDeltaMs
+
 	// ms to seconds
 	startSec := startMs / 1000
 	points := series.GetPoints()

--- a/pkg/querier/timeline/timeline_test.go
+++ b/pkg/querier/timeline/timeline_test.go
@@ -325,4 +325,43 @@ func Test_Timeline_Bounds(t *testing.T) {
 			0, // 19000 ms
 		}, tl.Samples)
 	})
+
+	t.Run("start is halfway through a bucket window", func(t *testing.T) {
+		startMs := int64(500)
+		endMs := int64(9000)
+
+		tl := timeline.New(series, startMs, endMs, step)
+		assert.Equal(t, startMs/1000, tl.StartTime)
+
+		assert.Equal(t, []uint64{
+			0,  //    0 ms
+			0,  // 1000 ms
+			69, // 2000 ms
+			83, // 3000 ms
+			0,  // 4000 ms
+			0,  // 5000 ms
+			85, // 6000 ms
+			0,  // 7000 ms
+			91, // 8000 ms
+		}, tl.Samples)
+	})
+
+	t.Run("end is halfway through a bucket window", func(t *testing.T) {
+		startMs := int64(0)
+		endMs := int64(8500)
+
+		tl := timeline.New(series, startMs, endMs, step)
+		assert.Equal(t, startMs/1000, tl.StartTime)
+
+		assert.Equal(t, []uint64{
+			0,  //    0 ms
+			0,  // 1000 ms
+			69, // 2000 ms
+			83, // 3000 ms
+			0,  // 4000 ms
+			0,  // 5000 ms
+			85, // 6000 ms
+			0,  // 7000 ms
+		}, tl.Samples)
+	})
 }


### PR DESCRIPTION
Closes https://github.com/grafana/pyroscope/issues/2275

This PR fixes a bug where selecting an absolute time window could result in an oddly rendered timeline.

When creating a timeline from a series, we first allocate a slice exactly the size we want, then append elements into the slice from the series or as we need to backfill between series values. However, if a timeline was created where the `startMs` and `endMs` weren't exactly aligned with the delta bucket size, and there was a value in the very last bucket, we would end up appending the final series value to a full slice, thusly allocating a larger slice. Then, the logic to backfill from the last value up to the end of the slice will fill the remainder of the slice with 0s.

I changed the function that builds the timeline to snap the `startMs` and `endMs` values to the beginning of whatever delta bucket they are currently in. Note that it doesn't make sense to extend `endMs` to the beginning of the next bucket. If we do so, the timeline will almost always dip to zero at the end, unless you happen to precisely set end on a bucket boundary (unlikely).

In other words, if we are given the series:

```
0   100  200  300  400  500  600  700  800  900  1000
|----|----|----|----|----|----|----|----|----|----|
  [===================)
  s                   e
```

Then we know we need to produce a timeline with 4 samples (if we count the partial sample that start points to and truncate the partial sample that end points to). So we want our timeline to look like:

```
0   100  200  300  400  500  600  700  800  900  1000
|----|----|----|----|----|----|----|----|----|----|
[===================)
s                   e
```