### PR TITLE
Adjust default parquet reader buffer size

### DIFF
--- a/pkg/phlaredb/block_querier.go
+++ b/pkg/phlaredb/block_querier.go
@@ -48,7 +48,7 @@ import (
 
 const (
 	defaultBatchSize      = 4096
-	parquetReadBufferSize = 2 * 1024 * 1024 // 2MB
+	parquetReadBufferSize = 256 << 10 // 256KB
 )
 
 type tableReader interface {

--- a/pkg/phlaredb/symdb/block_reader.go
+++ b/pkg/phlaredb/symdb/block_reader.go
@@ -403,7 +403,7 @@ type parquetFile struct {
 	size   int64
 }
 
-const parquetReadBufferSize = 2 << 20 // 2MB
+const parquetReadBufferSize = 256 << 10 // 256KB
 
 func (f *parquetFile) open(ctx context.Context, b objstore.BucketReader, meta block.File) error {
 	f.path = meta.RelPath


### PR DESCRIPTION
Now that we read symbols from parquet tables at query time, reader buffers may take up quite significant amount of memory. The current value is 2MB (defaults to 64KB), and the buffer is allocated for each column chunk (and dictionary page). I've been testing various values and can conclude that decreasing it to 256KB for both symbols and profile tables do not increase latency to any noticeable extent:

![image](https://github.com/grafana/pyroscope/assets/12090599/c7359c7d-e531-4ea9-85be-740c6a219f5f)

Although it makes sense to make this configurable and even allocate buffers of different sizes depending on the media (disk or object storage), I decided to set the default value first, as I imagine it would be difficult for users to determine the appropriate value.