### PR TITLE
Add pod disruption budget

### DIFF
--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -1,4 +1,44 @@
 ---
+# Source: pyroscope/templates/deployments-statefulsets.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: pyroscope-dev-ingester
+  labels:
+    helm.sh/chart: pyroscope-0.5.4
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/version: "0.5.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "ingester"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pyroscope
+      app.kubernetes.io/instance: pyroscope-dev
+      app.kubernetes.io/component: "ingester"
+---
+# Source: pyroscope/templates/deployments-statefulsets.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: pyroscope-dev-store-gateway
+  labels:
+    helm.sh/chart: pyroscope-0.5.4
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/version: "0.5.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "store-gateway"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pyroscope
+      app.kubernetes.io/instance: pyroscope-dev
+      app.kubernetes.io/component: "store-gateway"
+---
 # Source: pyroscope/charts/minio/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
@@ -1,4 +1,24 @@
 ---
+# Source: pyroscope/templates/deployments-statefulsets.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: pyroscope-dev
+  labels:
+    helm.sh/chart: pyroscope-0.5.4
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/version: "0.5.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "all"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pyroscope
+      app.kubernetes.io/instance: pyroscope-dev
+      app.kubernetes.io/component: "all"
+---
 # Source: pyroscope/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount

--- a/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
@@ -153,5 +153,21 @@ spec:
         {{- toYaml $persistence.selector | nindent 8 }}
       {{- end }}
   {{- end }}
+{{- if eq $values.kind "StatefulSet" }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $cfg.name }}
+  labels:
+    {{- include "pyroscope.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ $component | quote }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      {{- include "pyroscope.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: {{ $component | quote }}
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This makes sure no more than a single pod of a stateful set can be interrupted by e.g. node updates.
