### PR TITLE
Fix reference counting

### DIFF
--- a/pkg/phlaredb/block_querier_symbols.go
+++ b/pkg/phlaredb/block_querier_symbols.go
@@ -129,10 +129,14 @@ func (r *symbolsResolverV2) Load(ctx context.Context) error {
 }
 
 func (r *symbolsResolverV2) Close() error {
-	return multierror.New(
-		r.symbols.Close(),
-		r.inMemoryParquetTables.Close()).
-		Err()
+	err := multierror.New()
+	if r.symbols != nil {
+		err.Add(r.symbols.Close())
+	}
+	if r.inMemoryParquetTables != nil {
+		err.Add(r.inMemoryParquetTables.Close())
+	}
+	return err.Err()
 }
 
 func (r *symbolsResolverV2) Partition(ctx context.Context, partition uint64) (symdb.PartitionReader, error) {

--- a/pkg/phlaredb/sample_merge.go
+++ b/pkg/phlaredb/sample_merge.go
@@ -21,6 +21,7 @@ func (b *singleBlockQuerier) MergeByStacktraces(ctx context.Context, rows iter.I
 	sp, ctx := opentracing.StartSpanFromContext(ctx, "MergeByStacktraces - Block")
 	defer sp.Finish()
 	r := symdb.NewResolver(ctx, b.symbols)
+	defer r.Release()
 	if err := mergeByStacktraces(ctx, b.profiles.file, rows, r); err != nil {
 		return nil, err
 	}

--- a/pkg/phlaredb/symdb/resolver.go
+++ b/pkg/phlaredb/symdb/resolver.go
@@ -122,6 +122,7 @@ func (r *Resolver) Tree() (*model.Tree, error) {
 			defer close(p.done)
 			select {
 			case <-ctx.Done():
+				return ctx.Err()
 			case symbols := <-p.c:
 				samples := schemav1.NewSamplesFromMap(p.samples)
 				rt, err := symbols.Tree(ctx, samples)

--- a/pkg/phlaredb/symdb/resolver_test.go
+++ b/pkg/phlaredb/symdb/resolver_test.go
@@ -81,8 +81,7 @@ func Test_Resolver_Unreleased_Failed_Partition(t *testing.T) {
 	s := newBlockSuite(t, [][]string{{"testdata/profile.pb.gz"}})
 	defer s.teardown()
 	ctx, cancel := context.WithCancel(context.Background())
-	// Pass canceled context to make partition
-	// initialization to fail and.
+	// Pass canceled context to make partition initialization to fail.
 	cancel()
 
 	r := NewResolver(ctx, s.reader)

--- a/pkg/phlaredb/symdb/resolver_test.go
+++ b/pkg/phlaredb/symdb/resolver_test.go
@@ -41,7 +41,7 @@ func Test_block_Resolver_ResolveProfile(t *testing.T) {
 	require.Equal(t, expectedFingerprint, profileFingerprint(resolved, 0))
 }
 
-func Test_lock_Resolver_ResolveTree(t *testing.T) {
+func Test_block_Resolver_ResolveTree(t *testing.T) {
 	s := newBlockSuite(t, [][]string{{"testdata/profile.pb.gz"}})
 	defer s.teardown()
 	expectedFingerprint := pprofFingerprint(s.profiles[0].Profile, 1)
@@ -75,4 +75,26 @@ func Benchmark_block_Resolver_ResolveTree(t *testing.B) {
 		r.AddSamples(0, s.indexed[0][0].Samples)
 		_, _ = r.Tree()
 	}
+}
+
+func Test_Resolver_Unreleased_Failed_Partition(t *testing.T) {
+	s := newBlockSuite(t, [][]string{{"testdata/profile.pb.gz"}})
+	defer s.teardown()
+	ctx, cancel := context.WithCancel(context.Background())
+	// Pass canceled context to make partition
+	// initialization to fail and.
+	cancel()
+
+	r := NewResolver(ctx, s.reader)
+	r.AddSamples(0, s.indexed[0][0].Samples)
+	_, err := r.Tree()
+	require.ErrorIs(t, err, context.Canceled)
+	r.Release()
+
+	// This time we pass normal context.
+	r = NewResolver(context.Background(), s.reader)
+	r.AddSamples(0, s.indexed[0][0].Samples)
+	_, err = r.Tree()
+	require.NoError(t, err)
+	r.Release()
 }


### PR DESCRIPTION
Fixes #2291

Additionally we could check if the tree/table is nil, but in case if ref counting is not respected it will lead to a memory leak
