### PR TITLE
Fix profile type mismatch

### DIFF
--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -96,7 +96,7 @@ func (q *QueryHandlers) RenderDiff(w http.ResponseWriter, req *http.Request) {
 	}
 	// TODO: check profile types?
 	if leftProfileType.ID != rightProfileType.ID {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		http.Error(w, "profile types must match", http.StatusBadRequest)
 		return
 	}
 


### PR DESCRIPTION
If profile types in the diff view don't match, the handler panics: 

<img width="620" alt="image" src="https://github.com/grafana/pyroscope/assets/12090599/17707134-3cdf-4411-9c0e-3818cc814de8">
