### PR TITLE
Update alpine version to 3.18.3

### DIFF
--- a/cmd/pyroscope/Dockerfile
+++ b/cmd/pyroscope/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.4
+FROM alpine:3.18.3
 
 RUN apk add --no-cache ca-certificates
 

--- a/cmd/pyroscope/debug.Dockerfile
+++ b/cmd/pyroscope/debug.Dockerfile
@@ -1,7 +1,7 @@
 FROM golang as builder
 
 WORKDIR /app
-FROM alpine:3.17.4
+FROM alpine:3.18.3
 
 RUN apk add --no-cache ca-certificates
 

--- a/og/Dockerfile
+++ b/og/Dockerfile
@@ -7,7 +7,7 @@
 # | |         | |       | |     __/ |
 # |_|         |_|       |_|    |___/
 
-FROM alpine:3.16 as phpspy-builder
+FROM alpine:3.18.3 as phpspy-builder
 RUN apk update && apk upgrade \
     && apk add --update alpine-sdk
 COPY Makefile Makefile
@@ -52,7 +52,7 @@ RUN EXTRA_METADATA=$EXTRA_METADATA make assets-release
 #  \___|_.__/| .__/|_|
 #            | |
 #            |_|
-FROM alpine:3.16 as ebpf-builder
+FROM alpine:3.18.3 as ebpf-builder
 RUN apk update && apk upgrade && \
     apk add cmake make binutils gcc g++ clang musl-dev linux-headers zlib-dev elfutils-dev libelf-static zlib-static git openssh
 ADD third_party/libbpf/Makefile /build/libbpf/
@@ -115,7 +115,7 @@ RUN ENABLED_SPIES_RELEASE="ebpfspy,phpspy,dotnetspy" \
 #                                           __/ |
 #                                          |___/
 
-FROM alpine:3.16
+FROM alpine:3.18.3
 
 LABEL maintainer="Pyroscope team <hello@pyroscope.io>"
 

--- a/tools/docker-compose/golang/Dockerfile
+++ b/tools/docker-compose/golang/Dockerfile
@@ -7,7 +7,7 @@ COPY main.go .
 COPY go.mod .
 RUN CGO_ENABLED=0 GOOS=linux go build
 
-FROM alpine:3.17.4
+FROM alpine:3.18.3
 
 # Copy over the directory containing the compiled binary for the profiling.
 COPY --from=builder /app/golang /golang


### PR DESCRIPTION
Addresses those:

```grafana/pyroscope:1.0.0-rc.0 (alpine 3.17.4)

Total: 6 (UNKNOWN: 0, LOW: 0, MEDIUM: 6, HIGH: 0, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                            Title                            │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-2975 │ MEDIUM   │ 3.0.9-r1          │ 3.0.9-r2      │ AES-SIV cipher implementation contains a bug that causes it │
│            │               │          │                   │               │ to ignore empty...                                          │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-2975                   │
│            ├───────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│            │ CVE-2023-3446 │          │                   │ 3.0.9-r3      │ Excessive time spent checking DH keys and parameters        │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3446                   │
│            ├───────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│            │ CVE-2023-3817 │          │                   │ 3.0.10-r0     │ Excessive time spent checking DH q parameter value          │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3817                   │
├────────────┼───────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│ libssl3    │ CVE-2023-2975 │          │                   │ 3.0.9-r2      │ AES-SIV cipher implementation contains a bug that causes it │
│            │               │          │                   │               │ to ignore empty...                                          │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-2975                   │
│            ├───────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│            │ CVE-2023-3446 │          │                   │ 3.0.9-r3      │ Excessive time spent checking DH keys and parameters        │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3446                   │
│            ├───────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│            │ CVE-2023-3817 │          │                   │ 3.0.10-r0     │ Excessive time spent checking DH q parameter value          │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3817                   │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘
```