### PR TITLE
Activate store-gateway when using single binary mode.

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -856,7 +856,7 @@ Usage of ./pyroscope:
   -store-gateway.sharding-ring.prefix string
     	The prefix for the keys in the store. Should end with a /. (default "collectors/")
   -store-gateway.sharding-ring.replication-factor int
-    	The replication factor to use when sharding blocks. This option needs be set both on the store-gateway, querier and ruler when running in microservices mode. (default 3)
+    	The replication factor to use when sharding blocks. This option needs be set both on the store-gateway, querier and ruler when running in microservices mode. (default 1)
   -store-gateway.sharding-ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
   -store-gateway.sharding-ring.tokens-file-path string

--- a/cmd/pyroscope/pyroscope.yaml
+++ b/cmd/pyroscope/pyroscope.yaml
@@ -1,2 +1,10 @@
 server:
   http_listen_port: 4040
+
+storage:
+  backend: gcs
+  gcs:
+    bucket_name: cyriltovena
+
+phlaredb:
+  max_block_duration: 5m

--- a/cmd/pyroscope/pyroscope.yaml
+++ b/cmd/pyroscope/pyroscope.yaml
@@ -1,10 +1,2 @@
 server:
   http_listen_port: 4040
-
-storage:
-  backend: gcs
-  gcs:
-    bucket_name: cyriltovena
-
-phlaredb:
-  max_block_duration: 5m

--- a/docs/sources/configure-server/about-configurations.md
+++ b/docs/sources/configure-server/about-configurations.md
@@ -16,12 +16,11 @@ To see the CLI flags that you need to get started with Pyroscope, run the `pyros
 
 To see the current configuration state of any component, use the `/api/v1/status/config` HTTP API endpoint.
 
-
 ## Operational considerations
 
 It is recommended to use a single configuration file and either pass it to all replicas of Pyroscope (if you are running multiple single-process Pyroscope replicas) or to all components of Pyroscope (if you are running Pyroscope as microservices). If you are running Pyroscope on Kubernetes, you can achieve this by storing the configuration file in a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) and mounting it in each Pyroscope container.
 
-This helps avoid a common misconfiguration pitfall: while certain configuration parameters might look like they’re only needed by one type of component, they might in fact be used by multiple components. For example, the `-ingester.ring.replication-factor` CLI flag is not only required by ingesters, but also by distributors and queriers.
+This helps avoid a common misconfiguration pitfall: while certain configuration parameters might look like they’re only needed by one type of component, they might in fact be used by multiple components. For example, the `-distributor.replication-factor` CLI flag is not only required by ingesters, but also by distributors and queriers.
 
 By using a single configuration file, you ensure that each component gets all of the configuration that it needs without needing to track which parameter belongs to which component.
 There is no harm in passing a configuration that is specific to one component (such as an ingester) to another component (such as a querier). In such case, the configuration is simply ignored.

--- a/docs/sources/reference-pyroscope-architecture/components/distributor.md
+++ b/docs/sources/reference-pyroscope-architecture/components/distributor.md
@@ -27,7 +27,7 @@ The distributor data cleanup includes the following transformation:
 ## Replication
 
 The distributor shards and replicates incoming series across ingesters.
-You can configure the number of ingester replicas that each series is written to via the `-ingester.ring.replication-factor` flag, which is `1` by default.
+You can configure the number of ingester replicas that each series is written to via the `-distributor.replication-factor` flag, which is `1` by default.
 Distributors use consistent hashing, in conjunction with a configurable replication factor, to determine which ingesters receive a given series.
 
 Sharding and replication uses the ingesters' hash ring.

--- a/pkg/phlare/modules.go
+++ b/pkg/phlare/modules.go
@@ -188,8 +188,9 @@ func (f *Phlare) initQuerier() (services.Service, error) {
 		storeGatewayQuerier *querier.StoreGatewayQuerier
 		err                 error
 	)
-	// In microservices mode the store gateway is mandatory.
-	if f.Cfg.Target.String() != All {
+
+	// if a storage bucket is configure we need to create a store gateway querier
+	if f.storageBucket != nil {
 		storeGatewayQuerier, err = querier.NewStoreGatewayQuerier(f.Cfg.StoreGateway, nil, f.Overrides, log.With(f.logger, "component", "store-gateway-querier"), f.reg, f.auth)
 		if err != nil {
 			return nil, err
@@ -345,6 +346,9 @@ func (f *Phlare) initIngester() (_ services.Service, err error) {
 
 func (f *Phlare) initStoreGateway() (serv services.Service, err error) {
 	f.Cfg.StoreGateway.ShardingRing.ListenPort = f.Cfg.Server.HTTPListenPort
+	if f.storageBucket == nil {
+		return nil, nil
+	}
 
 	svc, err := storegateway.NewStoreGateway(f.Cfg.StoreGateway, f.storageBucket, f.Overrides, f.logger, f.reg)
 	if err != nil {

--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -289,7 +289,7 @@ func (f *Phlare) setupModuleManager() error {
 
 	// Add dependencies
 	deps := map[string][]string{
-		All: {Ingester, Distributor, QueryScheduler, QueryFrontend, Querier},
+		All: {Ingester, Distributor, QueryScheduler, QueryFrontend, Querier, StoreGateway},
 
 		Server:         {GRPCGateway},
 		API:            {Server},
@@ -298,7 +298,7 @@ func (f *Phlare) setupModuleManager() error {
 		QueryFrontend:  {OverridesExporter, API, MemberlistKV, UsageReport},
 		QueryScheduler: {Overrides, API, MemberlistKV, UsageReport},
 		Ingester:       {Overrides, API, MemberlistKV, Storage, UsageReport},
-		StoreGateway:   {API, Storage, Overrides, MemberlistKV},
+		StoreGateway:   {API, Storage, Overrides, MemberlistKV, UsageReport},
 
 		UsageReport:       {Storage, MemberlistKV},
 		Overrides:         {RuntimeConfig},

--- a/pkg/storegateway/gateway_ring.go
+++ b/pkg/storegateway/gateway_ring.go
@@ -96,7 +96,7 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	cfg.KVStore.RegisterFlagsWithPrefix(ringFlagsPrefix, "collectors/", f)
 	f.DurationVar(&cfg.HeartbeatPeriod, ringFlagsPrefix+"heartbeat-period", 15*time.Second, "Period at which to heartbeat to the ring. 0 = disabled.")
 	f.DurationVar(&cfg.HeartbeatTimeout, ringFlagsPrefix+"heartbeat-timeout", time.Minute, "The heartbeat timeout after which store gateways are considered unhealthy within the ring. 0 = never (timeout disabled)."+sharedOptionWithRingClient)
-	f.IntVar(&cfg.ReplicationFactor, ringFlagsPrefix+"replication-factor", 3, "The replication factor to use when sharding blocks."+sharedOptionWithRingClient)
+	f.IntVar(&cfg.ReplicationFactor, ringFlagsPrefix+"replication-factor", 1, "The replication factor to use when sharding blocks."+sharedOptionWithRingClient)
 	f.StringVar(&cfg.TokensFilePath, ringFlagsPrefix+"tokens-file-path", "", "File path where tokens are stored. If empty, tokens are not stored at shutdown and restored at startup.")
 	f.BoolVar(&cfg.ZoneAwarenessEnabled, ringFlagsPrefix+"zone-awareness-enabled", false, "True to enable zone-awareness and replicate blocks across different availability zones."+sharedOptionWithRingClient)
 


### PR DESCRIPTION
This activate the store-gateway when using single binary mode with object storage configured properly.

This doesn't work for filesystem because of https://github.com/grafana/pyroscope/issues/2029.

I'm still testing this and found https://github.com/grafana/pyroscope/issues/2317 that affect PGO feature when using single binary and querying for historical timerange.

In this PR I also changed the default for replication factor of the store-gateway to 1.


Closes #2247 