### PR TITLE
helm: Removes kubeVersion check

### DIFF
--- a/operations/pyroscope/helm/pyroscope/Chart.yaml
+++ b/operations/pyroscope/helm/pyroscope/Chart.yaml
@@ -2,8 +2,7 @@ apiVersion: v2
 name: pyroscope
 description: 🔥 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 type: application
-kubeVersion: ">=1.22"
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.0.0
 dependencies:
   - name: grafana-agent

--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -1,12 +1,10 @@
 # pyroscope
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 🔥 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 
 ## Requirements
-
-Kubernetes: `>=1.22`
 
 | Repository | Name | Version |
 |------------|------|---------|

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -5,7 +5,7 @@ kind: PodDisruptionBudget
 metadata:
   name: pyroscope-dev-ingester
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -25,7 +25,7 @@ kind: PodDisruptionBudget
 metadata:
   name: pyroscope-dev-store-gateway
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -64,7 +64,7 @@ kind: ServiceAccount
 metadata:
   name: pyroscope-dev
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -410,7 +410,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent-config-pyroscope
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1072,7 +1072,7 @@ kind: ConfigMap
 metadata:
   name: pyroscope-dev-overrides-config
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1088,7 +1088,7 @@ kind: ConfigMap
 metadata:
   name: pyroscope-dev-config
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1191,7 +1191,7 @@ kind: ClusterRole
 metadata:
   name: default-pyroscope-dev
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1237,7 +1237,7 @@ kind: ClusterRoleBinding
 metadata:
   name: default-pyroscope-dev
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1376,7 +1376,7 @@ kind: Service
 metadata:
   name: pyroscope-dev-memberlist
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1402,7 +1402,7 @@ kind: Service
 metadata:
   name: pyroscope-dev-distributor
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1426,7 +1426,7 @@ kind: Service
 metadata:
   name: pyroscope-dev-distributor-headless
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1451,7 +1451,7 @@ kind: Service
 metadata:
   name: pyroscope-dev-ingester
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1475,7 +1475,7 @@ kind: Service
 metadata:
   name: pyroscope-dev-ingester-headless
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1500,7 +1500,7 @@ kind: Service
 metadata:
   name: pyroscope-dev-querier
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1524,7 +1524,7 @@ kind: Service
 metadata:
   name: pyroscope-dev-querier-headless
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1549,7 +1549,7 @@ kind: Service
 metadata:
   name: pyroscope-dev-query-frontend
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1573,7 +1573,7 @@ kind: Service
 metadata:
   name: pyroscope-dev-query-frontend-headless
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1598,7 +1598,7 @@ kind: Service
 metadata:
   name: pyroscope-dev-query-scheduler
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1622,7 +1622,7 @@ kind: Service
 metadata:
   name: pyroscope-dev-query-scheduler-headless
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1647,7 +1647,7 @@ kind: Service
 metadata:
   name: pyroscope-dev-store-gateway
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1671,7 +1671,7 @@ kind: Service
 metadata:
   name: pyroscope-dev-store-gateway-headless
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1696,7 +1696,7 @@ kind: Deployment
 metadata:
   name: pyroscope-dev-distributor
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1712,7 +1712,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc6a4cfa0996af246e950c36d0a918510f411da7d44a0424a699b84869add135
+        checksum/config: d86a38102a87ea595a010fd7817d6fde5ef189f48a755abc8d5ffdde2b186d96
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -1786,7 +1786,7 @@ kind: Deployment
 metadata:
   name: pyroscope-dev-querier
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1802,7 +1802,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc6a4cfa0996af246e950c36d0a918510f411da7d44a0424a699b84869add135
+        checksum/config: d86a38102a87ea595a010fd7817d6fde5ef189f48a755abc8d5ffdde2b186d96
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -1876,7 +1876,7 @@ kind: Deployment
 metadata:
   name: pyroscope-dev-query-frontend
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1892,7 +1892,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc6a4cfa0996af246e950c36d0a918510f411da7d44a0424a699b84869add135
+        checksum/config: d86a38102a87ea595a010fd7817d6fde5ef189f48a755abc8d5ffdde2b186d96
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -1966,7 +1966,7 @@ kind: Deployment
 metadata:
   name: pyroscope-dev-query-scheduler
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1982,7 +1982,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc6a4cfa0996af246e950c36d0a918510f411da7d44a0424a699b84869add135
+        checksum/config: d86a38102a87ea595a010fd7817d6fde5ef189f48a755abc8d5ffdde2b186d96
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2232,7 +2232,7 @@ kind: StatefulSet
 metadata:
   name: pyroscope-dev-ingester
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -2250,7 +2250,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc6a4cfa0996af246e950c36d0a918510f411da7d44a0424a699b84869add135
+        checksum/config: d86a38102a87ea595a010fd7817d6fde5ef189f48a755abc8d5ffdde2b186d96
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2325,7 +2325,7 @@ kind: StatefulSet
 metadata:
   name: pyroscope-dev-store-gateway
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -2343,7 +2343,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc6a4cfa0996af246e950c36d0a918510f411da7d44a0424a699b84869add135
+        checksum/config: d86a38102a87ea595a010fd7817d6fde5ef189f48a755abc8d5ffdde2b186d96
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
@@ -5,7 +5,7 @@ kind: PodDisruptionBudget
 metadata:
   name: pyroscope-dev
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -37,7 +37,7 @@ kind: ServiceAccount
 metadata:
   name: pyroscope-dev
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -49,7 +49,7 @@ kind: ConfigMap
 metadata:
   name: grafana-agent-config-pyroscope
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -711,7 +711,7 @@ kind: ConfigMap
 metadata:
   name: pyroscope-dev-overrides-config
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -727,7 +727,7 @@ kind: ConfigMap
 metadata:
   name: pyroscope-dev-config
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -823,7 +823,7 @@ kind: ClusterRole
 metadata:
   name: default-pyroscope-dev
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -869,7 +869,7 @@ kind: ClusterRoleBinding
 metadata:
   name: default-pyroscope-dev
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -940,7 +940,7 @@ kind: Service
 metadata:
   name: pyroscope-dev-memberlist
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -966,7 +966,7 @@ kind: Service
 metadata:
   name: pyroscope-dev
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -990,7 +990,7 @@ kind: Service
 metadata:
   name: pyroscope-dev-headless
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1096,7 +1096,7 @@ kind: StatefulSet
 metadata:
   name: pyroscope-dev
   labels:
-    helm.sh/chart: pyroscope-1.0.0
+    helm.sh/chart: pyroscope-1.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.0.0"
@@ -1114,7 +1114,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6c0fbd77599e412301fe2024745cad7074928c2ad4801948d49fcb8e0b78b91e
+        checksum/config: 0f60c90f1bdca3bd03effff4b1ed337c871310121e4c00770a2ebd0d343b9c3d
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2


### PR DESCRIPTION
I had this issue too locally https://github.com/grafana/pyroscope/issues/2328 and I had to update my helm version. Not sure we want to force people to upgrade helm just for this.

FYI The grafana agent requires kubernetes 1.22.