### PR TITLE
Mixin: Change from Phlare to Pyroscope

### DIFF
--- a/operations/pyroscope/jsonnet/pyroscope-mixin/pyroscope-mixin/config.libsonnet
+++ b/operations/pyroscope/jsonnet/pyroscope-mixin/pyroscope-mixin/config.libsonnet
@@ -1,7 +1,7 @@
 {
   _config+:: {
     // Tags for dashboards.
-    tags: ['phlare'],
+    tags: ['pyroscope'],
 
     // The label used to differentiate between different application instances (i.e. 'pod' in a kubernetes install).
     per_instance_label: 'pod',

--- a/operations/pyroscope/jsonnet/pyroscope-mixin/pyroscope-mixin/dashboards.libsonnet
+++ b/operations/pyroscope/jsonnet/pyroscope-mixin/pyroscope-mixin/dashboards.libsonnet
@@ -1,3 +1,3 @@
 (import 'config.libsonnet') +
-(import 'dashboards/phlare-writes.libsonnet') +
-(import 'dashboards/phlare-reads.libsonnet')
+(import 'dashboards/pyroscope-writes.libsonnet') +
+(import 'dashboards/pyroscope-reads.libsonnet')

--- a/operations/pyroscope/jsonnet/pyroscope-mixin/pyroscope-mixin/dashboards/pyroscope-reads.libsonnet
+++ b/operations/pyroscope/jsonnet/pyroscope-mixin/pyroscope-mixin/dashboards/pyroscope-reads.libsonnet
@@ -4,7 +4,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
   grafanaDashboards+: {
     local dashboards = self,
     local http_route = '.*merge.*|.*series.*|.*type.*',
-    'phlare-reads.json': {
+    'pyroscope-reads.json': {
                            local cfg = self,
 
                            showMultiCluster:: $._config.multi_cluster,
@@ -16,8 +16,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
                                [],
 
                            matchers:: {
-                             querier: [utils.selector.re('job', '($namespace)/(phlare|querier)')],
-                             ingester: [utils.selector.re('job', '($namespace)/(phlare|ingester)')],
+                             querier: [utils.selector.re('job', '($namespace)/(pyroscope|querier)')],
+                             ingester: [utils.selector.re('job', '($namespace)/(pyroscope|ingester)')],
                            },
 
                            local selector(matcherId) =
@@ -28,7 +28,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                            querierSelector:: selector('querier'),
                            ingesterSelector:: selector('ingester'),
                          } +
-                         $.dashboard('Phlare / Reads', uid='phlare-reads')
+                         $.dashboard('Pyroscope / Reads', uid='pyroscope-reads')
                          .addCluster()
                          .addNamespace()
                          .addTag()
@@ -36,13 +36,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
                            $.row('Querier')
                            .addPanel(
                              $.panel('QPS') +
-                             $.qpsPanel('pyroscope_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['phlare-reads.json'].querierSelector, http_route])
+                             $.qpsPanel('pyroscope_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['pyroscope-reads.json'].querierSelector, http_route])
                            )
                            .addPanel(
                              $.panel('Latency') +
                              utils.latencyRecordingRulePanel(
                                'pyroscope_request_duration_seconds',
-                               dashboards['phlare-reads.json'].matchers.querier + [utils.selector.re('route', http_route)] + dashboards['phlare-reads.json'].clusterMatchers,
+                               dashboards['pyroscope-reads.json'].matchers.querier + [utils.selector.re('route', http_route)] + dashboards['pyroscope-reads.json'].clusterMatchers,
                                sum_by=['route']
                              )
                            )
@@ -51,13 +51,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
                            $.row('Ingester')
                            .addPanel(
                              $.panel('QPS') +
-                             $.qpsPanel('pyroscope_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['phlare-reads.json'].ingesterSelector, http_route])
+                             $.qpsPanel('pyroscope_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['pyroscope-reads.json'].ingesterSelector, http_route])
                            )
                            .addPanel(
                              $.panel('Latency') +
                              utils.latencyRecordingRulePanel(
                                'pyroscope_request_duration_seconds',
-                               dashboards['phlare-reads.json'].matchers.ingester + [utils.selector.re('route', http_route)] + dashboards['phlare-reads.json'].clusterMatchers,
+                               dashboards['pyroscope-reads.json'].matchers.ingester + [utils.selector.re('route', http_route)] + dashboards['pyroscope-reads.json'].clusterMatchers,
                                sum_by=['route']
                              )
                            )

--- a/operations/pyroscope/jsonnet/pyroscope-mixin/pyroscope-mixin/dashboards/pyroscope-reads.libsonnet
+++ b/operations/pyroscope/jsonnet/pyroscope-mixin/pyroscope-mixin/dashboards/pyroscope-reads.libsonnet
@@ -5,62 +5,62 @@ local utils = import 'mixin-utils/utils.libsonnet';
     local dashboards = self,
     local http_route = '.*merge.*|.*series.*|.*type.*',
     'pyroscope-reads.json': {
-                           local cfg = self,
+                              local cfg = self,
 
-                           showMultiCluster:: $._config.multi_cluster,
-                           clusterLabel:: $._config.per_cluster_label,
-                           clusterMatchers::
-                             if cfg.showMultiCluster then
-                               [utils.selector.re(cfg.clusterLabel, '$cluster')]
-                             else
-                               [],
+                              showMultiCluster:: $._config.multi_cluster,
+                              clusterLabel:: $._config.per_cluster_label,
+                              clusterMatchers::
+                                if cfg.showMultiCluster then
+                                  [utils.selector.re(cfg.clusterLabel, '$cluster')]
+                                else
+                                  [],
 
-                           matchers:: {
-                             querier: [utils.selector.re('job', '($namespace)/(pyroscope|querier)')],
-                             ingester: [utils.selector.re('job', '($namespace)/(pyroscope|ingester)')],
-                           },
+                              matchers:: {
+                                querier: [utils.selector.re('job', '($namespace)/(pyroscope|querier)')],
+                                ingester: [utils.selector.re('job', '($namespace)/(pyroscope|ingester)')],
+                              },
 
-                           local selector(matcherId) =
-                             local ms = (cfg.clusterMatchers + cfg.matchers[matcherId]);
-                             if std.length(ms) > 0 then
-                               std.join(',', ['%(label)s%(op)s"%(value)s"' % matcher for matcher in ms]) + ','
-                             else '',
-                           querierSelector:: selector('querier'),
-                           ingesterSelector:: selector('ingester'),
-                         } +
-                         $.dashboard('Pyroscope / Reads', uid='pyroscope-reads')
-                         .addCluster()
-                         .addNamespace()
-                         .addTag()
-                         .addRow(
-                           $.row('Querier')
-                           .addPanel(
-                             $.panel('QPS') +
-                             $.qpsPanel('pyroscope_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['pyroscope-reads.json'].querierSelector, http_route])
-                           )
-                           .addPanel(
-                             $.panel('Latency') +
-                             utils.latencyRecordingRulePanel(
-                               'pyroscope_request_duration_seconds',
-                               dashboards['pyroscope-reads.json'].matchers.querier + [utils.selector.re('route', http_route)] + dashboards['pyroscope-reads.json'].clusterMatchers,
-                               sum_by=['route']
-                             )
-                           )
-                         )
-                         .addRow(
-                           $.row('Ingester')
-                           .addPanel(
-                             $.panel('QPS') +
-                             $.qpsPanel('pyroscope_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['pyroscope-reads.json'].ingesterSelector, http_route])
-                           )
-                           .addPanel(
-                             $.panel('Latency') +
-                             utils.latencyRecordingRulePanel(
-                               'pyroscope_request_duration_seconds',
-                               dashboards['pyroscope-reads.json'].matchers.ingester + [utils.selector.re('route', http_route)] + dashboards['pyroscope-reads.json'].clusterMatchers,
-                               sum_by=['route']
-                             )
-                           )
-                         ),
+                              local selector(matcherId) =
+                                local ms = (cfg.clusterMatchers + cfg.matchers[matcherId]);
+                                if std.length(ms) > 0 then
+                                  std.join(',', ['%(label)s%(op)s"%(value)s"' % matcher for matcher in ms]) + ','
+                                else '',
+                              querierSelector:: selector('querier'),
+                              ingesterSelector:: selector('ingester'),
+                            } +
+                            $.dashboard('Pyroscope / Reads', uid='pyroscope-reads')
+                            .addCluster()
+                            .addNamespace()
+                            .addTag()
+                            .addRow(
+                              $.row('Querier')
+                              .addPanel(
+                                $.panel('QPS') +
+                                $.qpsPanel('pyroscope_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['pyroscope-reads.json'].querierSelector, http_route])
+                              )
+                              .addPanel(
+                                $.panel('Latency') +
+                                utils.latencyRecordingRulePanel(
+                                  'pyroscope_request_duration_seconds',
+                                  dashboards['pyroscope-reads.json'].matchers.querier + [utils.selector.re('route', http_route)] + dashboards['pyroscope-reads.json'].clusterMatchers,
+                                  sum_by=['route']
+                                )
+                              )
+                            )
+                            .addRow(
+                              $.row('Ingester')
+                              .addPanel(
+                                $.panel('QPS') +
+                                $.qpsPanel('pyroscope_request_duration_seconds_count{%s route=~"%s"}' % [dashboards['pyroscope-reads.json'].ingesterSelector, http_route])
+                              )
+                              .addPanel(
+                                $.panel('Latency') +
+                                utils.latencyRecordingRulePanel(
+                                  'pyroscope_request_duration_seconds',
+                                  dashboards['pyroscope-reads.json'].matchers.ingester + [utils.selector.re('route', http_route)] + dashboards['pyroscope-reads.json'].clusterMatchers,
+                                  sum_by=['route']
+                                )
+                              )
+                            ),
   },
 }

--- a/operations/pyroscope/jsonnet/pyroscope-mixin/pyroscope-mixin/dashboards/pyroscope-writes.libsonnet
+++ b/operations/pyroscope/jsonnet/pyroscope-mixin/pyroscope-mixin/dashboards/pyroscope-writes.libsonnet
@@ -6,7 +6,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
   grafanaDashboards+: {
     local dashboards = self,
 
-    'phlare-writes.json': {
+    'pyroscope-writes.json': {
                             local cfg = self,
 
                             showMultiCluster:: $._config.multi_cluster,
@@ -18,8 +18,8 @@ local utils = import 'mixin-utils/utils.libsonnet';
                                 [],
 
                             matchers:: {
-                              distributor: [utils.selector.re('job', '($namespace)/(phlare|distributor)')],
-                              ingester: [utils.selector.re('job', '($namespace)/(phlare|ingester)')],
+                              distributor: [utils.selector.re('job', '($namespace)/(pyroscope|distributor)')],
+                              ingester: [utils.selector.re('job', '($namespace)/(pyroscope|ingester)')],
                             },
 
                             local selector(matcherId) =
@@ -31,7 +31,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                             distributorSelector:: selector('distributor'),
                             ingesterSelector:: selector('ingester'),
                           } +
-                          $.dashboard('Phlare / Writes', uid='phlare-writes')
+                          $.dashboard('Pyroscope / Writes', uid='pyroscope-writes')
                           .addCluster()
                           .addNamespace()
                           .addTag()
@@ -41,7 +41,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                               $.panel('Compressed Size') +
                               utils.latencyRecordingRulePanel(
                                 'pyroscope_distributor_received_compressed_bytes',
-                                dashboards['phlare-writes.json'].matchers.distributor + [utils.selector.re('type', '.*')] + dashboards['phlare-writes.json'].clusterMatchers,
+                                dashboards['pyroscope-writes.json'].matchers.distributor + [utils.selector.re('type', '.*')] + dashboards['pyroscope-writes.json'].clusterMatchers,
                                 multiplier='1',
                                 sum_by=['type'],
                               ) + { yaxes: g.yaxes('bytes') },
@@ -50,7 +50,7 @@ local utils = import 'mixin-utils/utils.libsonnet';
                               $.panel('Samples') +
                               utils.latencyRecordingRulePanel(
                                 'pyroscope_distributor_received_samples',
-                                dashboards['phlare-writes.json'].matchers.distributor + [utils.selector.re('type', '.*')] + dashboards['phlare-writes.json'].clusterMatchers,
+                                dashboards['pyroscope-writes.json'].matchers.distributor + [utils.selector.re('type', '.*')] + dashboards['pyroscope-writes.json'].clusterMatchers,
                                 multiplier='1',
                                 sum_by=['type'],
                               ) + { yaxes: g.yaxes('count') },
@@ -60,13 +60,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
                             $.row('Distributor Requests')
                             .addPanel(
                               $.panel('QPS') +
-                              $.qpsPanel('pyroscope_request_duration_seconds_count{%s, route=~".*push.*|.*ingest.*"}' % std.rstripChars(dashboards['phlare-writes.json'].distributorSelector, ','))
+                              $.qpsPanel('pyroscope_request_duration_seconds_count{%s, route=~".*push.*|.*ingest.*"}' % std.rstripChars(dashboards['pyroscope-writes.json'].distributorSelector, ','))
                             )
                             .addPanel(
                               $.panel('Latency') +
                               utils.latencyRecordingRulePanel(
                                 'pyroscope_request_duration_seconds',
-                                dashboards['phlare-writes.json'].matchers.distributor + [utils.selector.re('route', '.*push.*')] + dashboards['phlare-writes.json'].clusterMatchers,
+                                dashboards['pyroscope-writes.json'].matchers.distributor + [utils.selector.re('route', '.*push.*')] + dashboards['pyroscope-writes.json'].clusterMatchers,
                               )
                             )
                           )
@@ -74,13 +74,13 @@ local utils = import 'mixin-utils/utils.libsonnet';
                             $.row('Ingester')
                             .addPanel(
                               $.panel('QPS') +
-                              $.qpsPanel('pyroscope_request_duration_seconds_count{%s route=~".*push.*|.*ingest.*"}' % dashboards['phlare-writes.json'].ingesterSelector)
+                              $.qpsPanel('pyroscope_request_duration_seconds_count{%s route=~".*push.*|.*ingest.*"}' % dashboards['pyroscope-writes.json'].ingesterSelector)
                             )
                             .addPanel(
                               $.panel('Latency') +
                               utils.latencyRecordingRulePanel(
                                 'pyroscope_request_duration_seconds',
-                                dashboards['phlare-writes.json'].matchers.ingester + [utils.selector.re('route', '.*push.*|.*ingest.*')] + dashboards['phlare-writes.json'].clusterMatchers,
+                                dashboards['pyroscope-writes.json'].matchers.ingester + [utils.selector.re('route', '.*push.*|.*ingest.*')] + dashboards['pyroscope-writes.json'].clusterMatchers,
                               )
                             )
                           )
@@ -97,14 +97,14 @@ local utils = import 'mixin-utils/utils.libsonnet';
                               local short_desc = 'Head size in bytes per table type';
                               $.panel(short_desc) +
                               $.panelDescription(short_desc, long_desc,) +
-                              $.queryPanel('sum(pyroscope_head_size_bytes{%s}) by (type)' % dashboards['phlare-writes.json'].ingesterSelector, '{{type}}') +
+                              $.queryPanel('sum(pyroscope_head_size_bytes{%s}) by (type)' % dashboards['pyroscope-writes.json'].ingesterSelector, '{{type}}') +
                               { yaxes: $.yaxes('bytes') },
                             )
                             .addPanel(
                               local short_desc = 'Head size in bytes per pod';
                               $.panel(short_desc) +
                               $.panelDescription(short_desc, long_desc,) +
-                              $.queryPanel('sum(pyroscope_head_size_bytes{%s}) by (instance)' % dashboards['phlare-writes.json'].ingesterSelector, '{{instance}}') +
+                              $.queryPanel('sum(pyroscope_head_size_bytes{%s}) by (instance)' % dashboards['pyroscope-writes.json'].ingesterSelector, '{{instance}}') +
                               { yaxes: $.yaxes('bytes') },
                             )
                           ),

--- a/operations/pyroscope/jsonnet/pyroscope-mixin/pyroscope-mixin/dashboards/pyroscope-writes.libsonnet
+++ b/operations/pyroscope/jsonnet/pyroscope-mixin/pyroscope-mixin/dashboards/pyroscope-writes.libsonnet
@@ -7,106 +7,106 @@ local utils = import 'mixin-utils/utils.libsonnet';
     local dashboards = self,
 
     'pyroscope-writes.json': {
-                            local cfg = self,
+                               local cfg = self,
 
-                            showMultiCluster:: $._config.multi_cluster,
-                            clusterLabel:: $._config.per_cluster_label,
-                            clusterMatchers::
-                              if cfg.showMultiCluster then
-                                [utils.selector.re(cfg.clusterLabel, '$cluster')]
-                              else
-                                [],
+                               showMultiCluster:: $._config.multi_cluster,
+                               clusterLabel:: $._config.per_cluster_label,
+                               clusterMatchers::
+                                 if cfg.showMultiCluster then
+                                   [utils.selector.re(cfg.clusterLabel, '$cluster')]
+                                 else
+                                   [],
 
-                            matchers:: {
-                              distributor: [utils.selector.re('job', '($namespace)/(pyroscope|distributor)')],
-                              ingester: [utils.selector.re('job', '($namespace)/(pyroscope|ingester)')],
-                            },
+                               matchers:: {
+                                 distributor: [utils.selector.re('job', '($namespace)/(pyroscope|distributor)')],
+                                 ingester: [utils.selector.re('job', '($namespace)/(pyroscope|ingester)')],
+                               },
 
-                            local selector(matcherId) =
-                              local ms = cfg.clusterMatchers + cfg.matchers[matcherId];
-                              if std.length(ms) > 0 then
-                                std.join(',', ['%(label)s%(op)s"%(value)s"' % matcher for matcher in ms]) + ','
-                              else '',
+                               local selector(matcherId) =
+                                 local ms = cfg.clusterMatchers + cfg.matchers[matcherId];
+                                 if std.length(ms) > 0 then
+                                   std.join(',', ['%(label)s%(op)s"%(value)s"' % matcher for matcher in ms]) + ','
+                                 else '',
 
-                            distributorSelector:: selector('distributor'),
-                            ingesterSelector:: selector('ingester'),
-                          } +
-                          $.dashboard('Pyroscope / Writes', uid='pyroscope-writes')
-                          .addCluster()
-                          .addNamespace()
-                          .addTag()
-                          .addRow(
-                            $.row('Distributor Profiles received')
-                            .addPanel(
-                              $.panel('Compressed Size') +
-                              utils.latencyRecordingRulePanel(
-                                'pyroscope_distributor_received_compressed_bytes',
-                                dashboards['pyroscope-writes.json'].matchers.distributor + [utils.selector.re('type', '.*')] + dashboards['pyroscope-writes.json'].clusterMatchers,
-                                multiplier='1',
-                                sum_by=['type'],
-                              ) + { yaxes: g.yaxes('bytes') },
-                            )
-                            .addPanel(
-                              $.panel('Samples') +
-                              utils.latencyRecordingRulePanel(
-                                'pyroscope_distributor_received_samples',
-                                dashboards['pyroscope-writes.json'].matchers.distributor + [utils.selector.re('type', '.*')] + dashboards['pyroscope-writes.json'].clusterMatchers,
-                                multiplier='1',
-                                sum_by=['type'],
-                              ) + { yaxes: g.yaxes('count') },
-                            )
-                          )
-                          .addRow(
-                            $.row('Distributor Requests')
-                            .addPanel(
-                              $.panel('QPS') +
-                              $.qpsPanel('pyroscope_request_duration_seconds_count{%s, route=~".*push.*|.*ingest.*"}' % std.rstripChars(dashboards['pyroscope-writes.json'].distributorSelector, ','))
-                            )
-                            .addPanel(
-                              $.panel('Latency') +
-                              utils.latencyRecordingRulePanel(
-                                'pyroscope_request_duration_seconds',
-                                dashboards['pyroscope-writes.json'].matchers.distributor + [utils.selector.re('route', '.*push.*')] + dashboards['pyroscope-writes.json'].clusterMatchers,
-                              )
-                            )
-                          )
-                          .addRow(
-                            $.row('Ingester')
-                            .addPanel(
-                              $.panel('QPS') +
-                              $.qpsPanel('pyroscope_request_duration_seconds_count{%s route=~".*push.*|.*ingest.*"}' % dashboards['pyroscope-writes.json'].ingesterSelector)
-                            )
-                            .addPanel(
-                              $.panel('Latency') +
-                              utils.latencyRecordingRulePanel(
-                                'pyroscope_request_duration_seconds',
-                                dashboards['pyroscope-writes.json'].matchers.ingester + [utils.selector.re('route', '.*push.*|.*ingest.*')] + dashboards['pyroscope-writes.json'].clusterMatchers,
-                              )
-                            )
-                          )
-                          .addRow(
-                            local long_desc = |||
-                              Ingesters maintain a local Head per-tenant. Each
-                              Head maintains the active profiling series; Then
-                              the head gets periodically compacted into a block
-                              on disk. This panel shows the estimated size of
-                              the Head in memory for all ingesters.
-                            |||;
-                            $.row('Ingester - Head')
-                            .addPanel(
-                              local short_desc = 'Head size in bytes per table type';
-                              $.panel(short_desc) +
-                              $.panelDescription(short_desc, long_desc,) +
-                              $.queryPanel('sum(pyroscope_head_size_bytes{%s}) by (type)' % dashboards['pyroscope-writes.json'].ingesterSelector, '{{type}}') +
-                              { yaxes: $.yaxes('bytes') },
-                            )
-                            .addPanel(
-                              local short_desc = 'Head size in bytes per pod';
-                              $.panel(short_desc) +
-                              $.panelDescription(short_desc, long_desc,) +
-                              $.queryPanel('sum(pyroscope_head_size_bytes{%s}) by (instance)' % dashboards['pyroscope-writes.json'].ingesterSelector, '{{instance}}') +
-                              { yaxes: $.yaxes('bytes') },
-                            )
-                          ),
+                               distributorSelector:: selector('distributor'),
+                               ingesterSelector:: selector('ingester'),
+                             } +
+                             $.dashboard('Pyroscope / Writes', uid='pyroscope-writes')
+                             .addCluster()
+                             .addNamespace()
+                             .addTag()
+                             .addRow(
+                               $.row('Distributor Profiles received')
+                               .addPanel(
+                                 $.panel('Compressed Size') +
+                                 utils.latencyRecordingRulePanel(
+                                   'pyroscope_distributor_received_compressed_bytes',
+                                   dashboards['pyroscope-writes.json'].matchers.distributor + [utils.selector.re('type', '.*')] + dashboards['pyroscope-writes.json'].clusterMatchers,
+                                   multiplier='1',
+                                   sum_by=['type'],
+                                 ) + { yaxes: g.yaxes('bytes') },
+                               )
+                               .addPanel(
+                                 $.panel('Samples') +
+                                 utils.latencyRecordingRulePanel(
+                                   'pyroscope_distributor_received_samples',
+                                   dashboards['pyroscope-writes.json'].matchers.distributor + [utils.selector.re('type', '.*')] + dashboards['pyroscope-writes.json'].clusterMatchers,
+                                   multiplier='1',
+                                   sum_by=['type'],
+                                 ) + { yaxes: g.yaxes('count') },
+                               )
+                             )
+                             .addRow(
+                               $.row('Distributor Requests')
+                               .addPanel(
+                                 $.panel('QPS') +
+                                 $.qpsPanel('pyroscope_request_duration_seconds_count{%s, route=~".*push.*|.*ingest.*"}' % std.rstripChars(dashboards['pyroscope-writes.json'].distributorSelector, ','))
+                               )
+                               .addPanel(
+                                 $.panel('Latency') +
+                                 utils.latencyRecordingRulePanel(
+                                   'pyroscope_request_duration_seconds',
+                                   dashboards['pyroscope-writes.json'].matchers.distributor + [utils.selector.re('route', '.*push.*')] + dashboards['pyroscope-writes.json'].clusterMatchers,
+                                 )
+                               )
+                             )
+                             .addRow(
+                               $.row('Ingester')
+                               .addPanel(
+                                 $.panel('QPS') +
+                                 $.qpsPanel('pyroscope_request_duration_seconds_count{%s route=~".*push.*|.*ingest.*"}' % dashboards['pyroscope-writes.json'].ingesterSelector)
+                               )
+                               .addPanel(
+                                 $.panel('Latency') +
+                                 utils.latencyRecordingRulePanel(
+                                   'pyroscope_request_duration_seconds',
+                                   dashboards['pyroscope-writes.json'].matchers.ingester + [utils.selector.re('route', '.*push.*|.*ingest.*')] + dashboards['pyroscope-writes.json'].clusterMatchers,
+                                 )
+                               )
+                             )
+                             .addRow(
+                               local long_desc = |||
+                                 Ingesters maintain a local Head per-tenant. Each
+                                 Head maintains the active profiling series; Then
+                                 the head gets periodically compacted into a block
+                                 on disk. This panel shows the estimated size of
+                                 the Head in memory for all ingesters.
+                               |||;
+                               $.row('Ingester - Head')
+                               .addPanel(
+                                 local short_desc = 'Head size in bytes per table type';
+                                 $.panel(short_desc) +
+                                 $.panelDescription(short_desc, long_desc,) +
+                                 $.queryPanel('sum(pyroscope_head_size_bytes{%s}) by (type)' % dashboards['pyroscope-writes.json'].ingesterSelector, '{{type}}') +
+                                 { yaxes: $.yaxes('bytes') },
+                               )
+                               .addPanel(
+                                 local short_desc = 'Head size in bytes per pod';
+                                 $.panel(short_desc) +
+                                 $.panelDescription(short_desc, long_desc,) +
+                                 $.queryPanel('sum(pyroscope_head_size_bytes{%s}) by (instance)' % dashboards['pyroscope-writes.json'].ingesterSelector, '{{instance}}') +
+                                 { yaxes: $.yaxes('bytes') },
+                               )
+                             ),
   },
 }

--- a/operations/pyroscope/jsonnet/pyroscope-mixin/pyroscope-mixin/mixin.libsonnet
+++ b/operations/pyroscope/jsonnet/pyroscope-mixin/pyroscope-mixin/mixin.libsonnet
@@ -1,4 +1,4 @@
 (import 'recording_rules.libsonnet') +
 (import 'dashboards.libsonnet') + {
-  grafanaDashboardFolder: 'Phlare',
+  grafanaDashboardFolder: 'Pyroscope',
 }


### PR DESCRIPTION
Before this fix:

```
❯ mixtool generate all mixin.libsonnet
2023/08/31 10:02:14 RUNTIME ERROR: couldn't open import "dashboards/phlare-writes.libsonnet": no match locally or in the Jsonnet library paths
        dashboards.libsonnet:2:2-45     $
        mixin.libsonnet:2:2-31  $
        2:16-40 thunk <mixin> from <$>
        4:21-26 thunk from <$>
        <std>:1548:21-22        thunk from <function <anonymous>>
        <std>:1548:5-32 function <anonymous>
        4:4-47  $
        During evaluation
```

After:

```
❯ mixtool generate all mixin.libsonnet
❯ ls dashboards_out
pyroscope-reads.json    pyroscope-writes.json
```