### PR TITLE
Record query parameters before parallelization

### DIFF
--- a/pkg/frontend/frontend_select_merge_stacktraces.go
+++ b/pkg/frontend/frontend_select_merge_stacktraces.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bufbuild/connect-go"
 	"github.com/grafana/dskit/tenant"
+	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/common/model"
 	"golang.org/x/sync/errgroup"
 
@@ -22,6 +23,12 @@ func (f *Frontend) SelectMergeStacktraces(ctx context.Context,
 	c *connect.Request[querierv1.SelectMergeStacktracesRequest]) (
 	*connect.Response[querierv1.SelectMergeStacktracesResponse], error,
 ) {
+	opentracing.SpanFromContext(ctx).
+		SetTag("start", model.Time(c.Msg.Start).Time().String()).
+		SetTag("end", model.Time(c.Msg.End).Time().String()).
+		SetTag("selector", c.Msg.LabelSelector).
+		SetTag("profile_type", c.Msg.ProfileTypeID)
+
 	ctx = connectgrpc.WithProcedure(ctx, querierv1connect.QuerierServiceSelectMergeStacktracesProcedure)
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {

--- a/pkg/frontend/frontend_select_series.go
+++ b/pkg/frontend/frontend_select_series.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bufbuild/connect-go"
 	"github.com/grafana/dskit/tenant"
+	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/common/model"
 	"golang.org/x/sync/errgroup"
 
@@ -22,6 +23,12 @@ func (f *Frontend) SelectSeries(ctx context.Context,
 	c *connect.Request[querierv1.SelectSeriesRequest]) (
 	*connect.Response[querierv1.SelectSeriesResponse], error,
 ) {
+	opentracing.SpanFromContext(ctx).
+		SetTag("start", model.Time(c.Msg.Start).Time().String()).
+		SetTag("end", model.Time(c.Msg.End).Time().String()).
+		SetTag("selector", c.Msg.LabelSelector).
+		SetTag("profile_type", c.Msg.ProfileTypeID)
+
 	ctx = connectgrpc.WithProcedure(ctx, querierv1connect.QuerierServiceSelectSeriesProcedure)
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {


### PR DESCRIPTION
Currently we only record query params in the querier, which makes it hard to find the source query time range if it has been split into multiple sub-queries.