### PR TITLE
Fix symbols split-compaction

### DIFF
--- a/pkg/phlaredb/schemas/v1/functions.go
+++ b/pkg/phlaredb/schemas/v1/functions.go
@@ -53,3 +53,8 @@ type InMemoryFunction struct {
 	// Line number in source file.
 	StartLine uint32
 }
+
+func (f *InMemoryFunction) Clone() *InMemoryFunction {
+	n := *f
+	return &n
+}

--- a/pkg/phlaredb/schemas/v1/locations.go
+++ b/pkg/phlaredb/schemas/v1/locations.go
@@ -110,6 +110,13 @@ type InMemoryLocation struct {
 	Line []InMemoryLine
 }
 
+func (l *InMemoryLocation) Clone() *InMemoryLocation {
+	x := *l
+	x.Line = make([]InMemoryLine, len(l.Line))
+	copy(x.Line, l.Line)
+	return &x
+}
+
 type InMemoryLine struct {
 	// The id of the corresponding profile.Function for this line.
 	FunctionId uint32

--- a/pkg/phlaredb/schemas/v1/mappings.go
+++ b/pkg/phlaredb/schemas/v1/mappings.go
@@ -73,3 +73,8 @@ type InMemoryMapping struct {
 	HasLineNumbers  bool
 	HasInlineFrames bool
 }
+
+func (m *InMemoryMapping) Clone() *InMemoryMapping {
+	n := *m
+	return &n
+}

--- a/pkg/phlaredb/symdb/rewriter.go
+++ b/pkg/phlaredb/symdb/rewriter.go
@@ -54,14 +54,15 @@ func (r *Rewriter) getOrCreatePartition(partition uint64) (_ *partitionRewriter,
 
 	n := &partitionRewriter{name: partition}
 	n.dst = r.symdb.PartitionWriter(partition)
+	// Note that the partition is not released: we want to keep
+	// it during the whole lifetime of the rewriter.
 	pr, err := r.source.Partition(context.TODO(), partition)
 	if err != nil {
 		return nil, err
 	}
-
-	// Note that the partition is not released: we want to keep
-	// it during the whole lifetime of the rewriter.
-	n.src = pr.Symbols()
+	// We clone locations, functions, and mappings,
+	// because these object will be modified.
+	n.src = cloneSymbolsPartially(pr.Symbols())
 	var stats PartitionStats
 	pr.WriteStats(&stats)
 
@@ -240,6 +241,26 @@ func (p *partitionRewriter) InsertStacktrace(stacktrace uint32, locations []int3
 	copy(n, locations)
 	// Preserve allocated capacity.
 	p.stacktraces.values[idx] = n
+}
+
+func cloneSymbolsPartially(x *Symbols) *Symbols {
+	n := Symbols{
+		Stacktraces: x.Stacktraces,
+		Locations:   make([]*schemav1.InMemoryLocation, len(x.Locations)),
+		Mappings:    make([]*schemav1.InMemoryMapping, len(x.Mappings)),
+		Functions:   make([]*schemav1.InMemoryFunction, len(x.Functions)),
+		Strings:     x.Strings,
+	}
+	for i, l := range x.Locations {
+		n.Locations[i] = l.Clone()
+	}
+	for i, m := range x.Mappings {
+		n.Mappings[i] = m.Clone()
+	}
+	for i, f := range x.Functions {
+		n.Functions[i] = f.Clone()
+	}
+	return &n
 }
 
 const (


### PR DESCRIPTION
The fix allows using the same block symbols reader by multiple stack trace rewrites. Note that this will cause excessive memory usage. We likely need a better way of handling this.

The failing test is irrelevant to the change.