### PR TITLE
Refactoring: Create a common ring configuration

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -88,17 +88,19 @@ Usage of ./pyroscope:
   -distributor.ring.etcd.username string
     	Etcd username.
   -distributor.ring.heartbeat-period duration
-    	Period at which to heartbeat to the ring. 0 = disabled. (default 5s)
+    	Period at which to heartbeat to the ring. 0 = disabled. (default 15s)
   -distributor.ring.heartbeat-timeout duration
     	The heartbeat timeout after which distributors are considered unhealthy within the ring. 0 = never (timeout disabled). (default 1m0s)
   -distributor.ring.instance-addr string
-    	IP address to advertise in the ring.
+    	IP address to advertise in the ring. Default is auto-detected.
+  -distributor.ring.instance-enable-ipv6
+    	Enable using a IPv6 instance address. (default false)
   -distributor.ring.instance-id string
     	Instance ID to register in the ring. (default "<hostname>")
   -distributor.ring.instance-interface-names string
-    	Name of network interface to read address from. (default [<private network interfaces>])
+    	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -distributor.ring.instance-port int
-    	Port to advertise in the ring (defaults to server.http-listen-port). (default 4040)
+    	Port to advertise in the ring (defaults to -server.grpc-listen-port). (default 4040)
   -distributor.ring.multi.mirror-enabled
     	Mirror writes to secondary store.
   -distributor.ring.multi.mirror-timeout duration
@@ -108,7 +110,7 @@ Usage of ./pyroscope:
   -distributor.ring.multi.secondary string
     	Secondary backend storage used by multi-client.
   -distributor.ring.prefix string
-    	The prefix for the keys in the store. Should end with a /. (default "collectors/")
+    	The prefix for the keys in the store. Should end with a /. (default "collector")
   -distributor.ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
   -distributor.zone-awareness-enabled
@@ -313,12 +315,14 @@ Usage of ./pyroscope:
     	The heartbeat timeout after which overrides-exporters are considered unhealthy within the ring. 0 = never (timeout disabled). (default 1m0s)
   -overrides-exporter.ring.instance-addr string
     	IP address to advertise in the ring. Default is auto-detected.
+  -overrides-exporter.ring.instance-enable-ipv6
+    	Enable using a IPv6 instance address. (default false)
   -overrides-exporter.ring.instance-id string
     	Instance ID to register in the ring. (default "<hostname>")
   -overrides-exporter.ring.instance-interface-names string
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -overrides-exporter.ring.instance-port int
-    	Port to advertise in the ring (defaults to -server.http-listen-port). (default 4040)
+    	Port to advertise in the ring (defaults to -server.grpc-listen-port). (default 4040)
   -overrides-exporter.ring.multi.mirror-enabled
     	Mirror writes to secondary store.
   -overrides-exporter.ring.multi.mirror-timeout duration
@@ -548,9 +552,11 @@ Usage of ./pyroscope:
   -query-scheduler.ring.heartbeat-period duration
     	Period at which to heartbeat to the ring. 0 = disabled. (default 15s)
   -query-scheduler.ring.heartbeat-timeout duration
-    	The heartbeat timeout after which query-schedulers are considered unhealthy within the ring. When query-scheduler ring-based service discovery is enabled, this option needs be set on query-schedulers, query-frontends and queriers. (default 1m0s)
+    	The heartbeat timeout after which query-scheduler are considered unhealthy within the ring. 0 = never (timeout disabled). (default 1m0s)
   -query-scheduler.ring.instance-addr string
     	IP address to advertise in the ring. Default is auto-detected.
+  -query-scheduler.ring.instance-enable-ipv6
+    	Enable using a IPv6 instance address. (default false)
   -query-scheduler.ring.instance-id string
     	Instance ID to register in the ring. (default "<hostname>")
   -query-scheduler.ring.instance-interface-names string

--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -100,7 +100,7 @@ Usage of ./pyroscope:
   -distributor.ring.instance-interface-names string
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -distributor.ring.instance-port int
-    	Port to advertise in the ring (defaults to -server.grpc-listen-port). (default 4040)
+    	Port to advertise in the ring (defaults to -server.http-listen-port). (default 4040)
   -distributor.ring.multi.mirror-enabled
     	Mirror writes to secondary store.
   -distributor.ring.multi.mirror-timeout duration
@@ -110,7 +110,7 @@ Usage of ./pyroscope:
   -distributor.ring.multi.secondary string
     	Secondary backend storage used by multi-client.
   -distributor.ring.prefix string
-    	The prefix for the keys in the store. Should end with a /. (default "collector")
+    	The prefix for the keys in the store. Should end with a /. (default "collectors/")
   -distributor.ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
   -distributor.zone-awareness-enabled
@@ -322,7 +322,7 @@ Usage of ./pyroscope:
   -overrides-exporter.ring.instance-interface-names string
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -overrides-exporter.ring.instance-port int
-    	Port to advertise in the ring (defaults to -server.grpc-listen-port). (default 4040)
+    	Port to advertise in the ring (defaults to -server.http-listen-port). (default 4040)
   -overrides-exporter.ring.multi.mirror-enabled
     	Mirror writes to secondary store.
   -overrides-exporter.ring.multi.mirror-timeout duration
@@ -562,7 +562,7 @@ Usage of ./pyroscope:
   -query-scheduler.ring.instance-interface-names string
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -query-scheduler.ring.instance-port int
-    	Port to advertise in the ring (defaults to -server.grpc-listen-port).
+    	Port to advertise in the ring (defaults to -server.http-listen-port). (default 4040)
   -query-scheduler.ring.multi.mirror-enabled
     	Mirror writes to secondary store.
   -query-scheduler.ring.multi.mirror-timeout duration
@@ -838,7 +838,7 @@ Usage of ./pyroscope:
   -store-gateway.sharding-ring.heartbeat-period duration
     	Period at which to heartbeat to the ring. 0 = disabled. (default 15s)
   -store-gateway.sharding-ring.heartbeat-timeout duration
-    	The heartbeat timeout after which store gateways are considered unhealthy within the ring. 0 = never (timeout disabled). This option needs be set both on the store-gateway, querier and ruler when running in microservices mode. (default 1m0s)
+    	The heartbeat timeout after which store-gateways are considered unhealthy within the ring. 0 = never (timeout disabled). (default 1m0s)
   -store-gateway.sharding-ring.instance-addr string
     	IP address to advertise in the ring. Default is auto-detected.
   -store-gateway.sharding-ring.instance-availability-zone string
@@ -850,7 +850,7 @@ Usage of ./pyroscope:
   -store-gateway.sharding-ring.instance-interface-names string
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -store-gateway.sharding-ring.instance-port int
-    	Port to advertise in the ring (defaults to -server.grpc-listen-port).
+    	Port to advertise in the ring (defaults to -server.http-listen-port).
   -store-gateway.sharding-ring.multi.mirror-enabled
     	Mirror writes to secondary store.
   -store-gateway.sharding-ring.multi.mirror-timeout duration

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -35,18 +35,8 @@ Usage of ./pyroscope:
     	Etcd password.
   -distributor.ring.etcd.username string
     	Etcd username.
-  -distributor.ring.heartbeat-period duration
-    	Period at which to heartbeat to the ring. 0 = disabled. (default 5s)
-  -distributor.ring.heartbeat-timeout duration
-    	The heartbeat timeout after which distributors are considered unhealthy within the ring. 0 = never (timeout disabled). (default 1m0s)
-  -distributor.ring.instance-addr string
-    	IP address to advertise in the ring.
-  -distributor.ring.instance-id string
-    	Instance ID to register in the ring. (default "<hostname>")
   -distributor.ring.instance-interface-names string
-    	Name of network interface to read address from. (default [<private network interfaces>])
-  -distributor.ring.instance-port int
-    	Port to advertise in the ring (defaults to server.http-listen-port). (default 4040)
+    	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -distributor.ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
   -distributor.zone-awareness-enabled
@@ -99,18 +89,8 @@ Usage of ./pyroscope:
     	Etcd password.
   -overrides-exporter.ring.etcd.username string
     	Etcd username.
-  -overrides-exporter.ring.heartbeat-period duration
-    	Period at which to heartbeat to the ring. 0 = disabled. (default 15s)
-  -overrides-exporter.ring.heartbeat-timeout duration
-    	The heartbeat timeout after which overrides-exporters are considered unhealthy within the ring. 0 = never (timeout disabled). (default 1m0s)
-  -overrides-exporter.ring.instance-addr string
-    	IP address to advertise in the ring. Default is auto-detected.
-  -overrides-exporter.ring.instance-id string
-    	Instance ID to register in the ring. (default "<hostname>")
   -overrides-exporter.ring.instance-interface-names string
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
-  -overrides-exporter.ring.instance-port int
-    	Port to advertise in the ring (defaults to -server.http-listen-port). (default 4040)
   -overrides-exporter.ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
   -pyroscopedb.data-path string

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -190,8 +190,6 @@ store_gateway:
   # The hash ring configuration.
   sharding_ring:
     # The key-value store used to share the hash ring across multiple instances.
-    # This option needs be set both on the store-gateway, querier and ruler when
-    # running in microservices mode.
     kvstore:
       # Backend storage to use for the ring. Supported values are: consul, etcd,
       # inmemory, memberlist, multi.
@@ -341,12 +339,31 @@ store_gateway:
     # CLI flag: -store-gateway.sharding-ring.heartbeat-period
     [heartbeat_period: <duration> | default = 15s]
 
-    # The heartbeat timeout after which store gateways are considered unhealthy
-    # within the ring. 0 = never (timeout disabled). This option needs be set
-    # both on the store-gateway, querier and ruler when running in microservices
-    # mode.
+    # The heartbeat timeout after which store-gateways are considered unhealthy
+    # within the ring. 0 = never (timeout disabled).
     # CLI flag: -store-gateway.sharding-ring.heartbeat-timeout
     [heartbeat_timeout: <duration> | default = 1m]
+
+    # Instance ID to register in the ring.
+    # CLI flag: -store-gateway.sharding-ring.instance-id
+    [instance_id: <string> | default = "<hostname>"]
+
+    # List of network interface names to look up when finding the instance IP
+    # address.
+    # CLI flag: -store-gateway.sharding-ring.instance-interface-names
+    [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
+
+    # Port to advertise in the ring (defaults to -server.http-listen-port).
+    # CLI flag: -store-gateway.sharding-ring.instance-port
+    [instance_port: <int> | default = 0]
+
+    # IP address to advertise in the ring. Default is auto-detected.
+    # CLI flag: -store-gateway.sharding-ring.instance-addr
+    [instance_addr: <string> | default = ""]
+
+    # Enable using a IPv6 instance address. (default false)
+    # CLI flag: -store-gateway.sharding-ring.instance-enable-ipv6
+    [instance_enable_ipv6: <boolean> | default = false]
 
     # The replication factor to use when sharding blocks. This option needs be
     # set both on the store-gateway, querier and ruler when running in
@@ -375,27 +392,6 @@ store_gateway:
     # start anyway.
     # CLI flag: -store-gateway.sharding-ring.wait-stability-max-duration
     [wait_stability_max_duration: <duration> | default = 5m]
-
-    # Instance ID to register in the ring.
-    # CLI flag: -store-gateway.sharding-ring.instance-id
-    [instance_id: <string> | default = "<hostname>"]
-
-    # List of network interface names to look up when finding the instance IP
-    # address.
-    # CLI flag: -store-gateway.sharding-ring.instance-interface-names
-    [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
-
-    # Port to advertise in the ring (defaults to -server.grpc-listen-port).
-    # CLI flag: -store-gateway.sharding-ring.instance-port
-    [instance_port: <int> | default = 0]
-
-    # IP address to advertise in the ring. Default is auto-detected.
-    # CLI flag: -store-gateway.sharding-ring.instance-addr
-    [instance_addr: <string> | default = ""]
-
-    # Enable using a IPv6 instance address. (default false)
-    # CLI flag: -store-gateway.sharding-ring.instance-enable-ipv6
-    [instance_enable_ipv6: <boolean> | default = false]
 
     # The availability zone where this instance is running. Required if
     # zone-awareness is enabled.

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -68,7 +68,7 @@ type Config struct {
 func (cfg *Config) RegisterFlags(fs *flag.FlagSet, logger log.Logger) {
 	cfg.PoolConfig.RegisterFlagsWithPrefix("distributor", fs)
 	fs.DurationVar(&cfg.PushTimeout, "distributor.push.timeout", 5*time.Second, "Timeout when pushing data to ingester.")
-	cfg.DistributorRing.RegisterFlags("distributor.ring.", "collector", "distributors", fs, logger)
+	cfg.DistributorRing.RegisterFlags("distributor.ring.", "collectors/", "distributors", fs, logger)
 }
 
 // Distributor coordinates replicates and distribution of log streams.

--- a/pkg/distributor/distributor_ring.go
+++ b/pkg/distributor/distributor_ring.go
@@ -1,16 +1,9 @@
 package distributor
 
 import (
-	"flag"
 	"fmt"
-	"os"
-	"time"
 
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
-	"github.com/grafana/dskit/flagext"
-	"github.com/grafana/dskit/kv"
-	"github.com/grafana/dskit/netutil"
 	"github.com/grafana/dskit/ring"
 
 	"github.com/grafana/pyroscope/pkg/util"
@@ -23,48 +16,7 @@ const (
 	ringNumTokens = 1
 )
 
-// RingConfig masks the ring lifecycler config which contains
-// many options not really required by the distributors ring. This config
-// is used to strip down the config to the minimum, and avoid confusion
-// to the user.
-type RingConfig struct {
-	KVStore          kv.Config     `yaml:"kvstore"`
-	HeartbeatPeriod  time.Duration `yaml:"heartbeat_period"`
-	HeartbeatTimeout time.Duration `yaml:"heartbeat_timeout"`
-
-	// Instance details
-	InstanceID             string   `yaml:"instance_id" doc:"default=<hostname>"`
-	InstanceInterfaceNames []string `yaml:"instance_interface_names" doc:"default=[<private network interfaces>]"`
-	InstancePort           int      `yaml:"instance_port" doc:"hidden"`
-	InstanceAddr           string   `yaml:"instance_addr" doc:"hidden"`
-
-	// Injected internally
-	ListenPort int `yaml:"-"`
-}
-
-// RegisterFlags adds the flags required to config this to the given FlagSet
-func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet) {
-	hostname, err := os.Hostname()
-	if err != nil {
-		level.Error(util.Logger).Log("msg", "failed to get hostname", "err", err)
-		os.Exit(1)
-	}
-
-	cfg.KVStore.Store = "memberlist" // Override default value.
-	// Ring flags
-	cfg.KVStore.RegisterFlagsWithPrefix("distributor.ring.", "collectors/", f)
-	f.DurationVar(&cfg.HeartbeatPeriod, "distributor.ring.heartbeat-period", 5*time.Second, "Period at which to heartbeat to the ring. 0 = disabled.")
-	f.DurationVar(&cfg.HeartbeatTimeout, "distributor.ring.heartbeat-timeout", time.Minute, "The heartbeat timeout after which distributors are considered unhealthy within the ring. 0 = never (timeout disabled).")
-
-	// Instance flags
-	cfg.InstanceInterfaceNames = netutil.PrivateNetworkInterfacesWithFallback([]string{"eth0", "en0"}, util.Logger)
-	f.Var((*flagext.StringSlice)(&cfg.InstanceInterfaceNames), "distributor.ring.instance-interface-names", "Name of network interface to read address from.")
-	f.StringVar(&cfg.InstanceAddr, "distributor.ring.instance-addr", "", "IP address to advertise in the ring.")
-	f.IntVar(&cfg.InstancePort, "distributor.ring.instance-port", 0, "Port to advertise in the ring (defaults to server.http-listen-port).")
-	f.StringVar(&cfg.InstanceID, "distributor.ring.instance-id", hostname, "Instance ID to register in the ring.")
-}
-
-func (cfg *RingConfig) ToBasicLifecyclerConfig(logger log.Logger) (ring.BasicLifecyclerConfig, error) {
+func toBasicLifecyclerConfig(cfg util.CommonRingConfig, logger log.Logger) (ring.BasicLifecyclerConfig, error) {
 	instanceAddr, err := ring.GetInstanceAddr(cfg.InstanceAddr, cfg.InstanceInterfaceNames, logger, false)
 	if err != nil {
 		return ring.BasicLifecyclerConfig{}, err
@@ -81,13 +33,4 @@ func (cfg *RingConfig) ToBasicLifecyclerConfig(logger log.Logger) (ring.BasicLif
 		NumTokens:                       ringNumTokens,
 		KeepInstanceInTheRingOnShutdown: false,
 	}, nil
-}
-
-func (cfg *RingConfig) ToRingConfig() ring.Config {
-	rc := ring.Config{}
-	rc.KVStore = cfg.KVStore
-	rc.HeartbeatTimeout = cfg.HeartbeatTimeout
-	rc.ReplicationFactor = 1
-
-	return rc
 }

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	phlaremodel "github.com/grafana/pyroscope/pkg/model"
+	"github.com/grafana/pyroscope/pkg/util"
 
 	pushv1 "github.com/grafana/pyroscope/api/gen/proto/go/push/v1"
 	"github.com/grafana/pyroscope/api/gen/proto/go/push/v1/pushv1connect"
@@ -35,7 +36,7 @@ import (
 	"github.com/grafana/pyroscope/pkg/validation"
 )
 
-var ringConfig = RingConfig{
+var ringConfig = util.CommonRingConfig{
 	KVStore:      kv.Config{Store: "inmemory"},
 	InstanceID:   "foo",
 	InstancePort: 8080,

--- a/pkg/phlare/modules.go
+++ b/pkg/phlare/modules.go
@@ -282,7 +282,7 @@ func (f *Phlare) initMemberlistKV() (services.Service, error) {
 	f.Cfg.Distributor.DistributorRing.KVStore.MemberlistKV = f.MemberlistKV.GetMemberlistKV
 	f.Cfg.Ingester.LifecyclerConfig.RingConfig.KVStore.MemberlistKV = f.MemberlistKV.GetMemberlistKV
 	f.Cfg.QueryScheduler.ServiceDiscovery.SchedulerRing.KVStore.MemberlistKV = f.MemberlistKV.GetMemberlistKV
-	f.Cfg.OverridesExporter.Ring.KVStore.MemberlistKV = f.MemberlistKV.GetMemberlistKV
+	f.Cfg.OverridesExporter.Ring.Ring.KVStore.MemberlistKV = f.MemberlistKV.GetMemberlistKV
 	f.Cfg.StoreGateway.ShardingRing.KVStore.MemberlistKV = f.MemberlistKV.GetMemberlistKV
 
 	f.Cfg.Frontend.QuerySchedulerDiscovery = f.Cfg.QueryScheduler.ServiceDiscovery

--- a/pkg/phlare/modules.go
+++ b/pkg/phlare/modules.go
@@ -283,7 +283,7 @@ func (f *Phlare) initMemberlistKV() (services.Service, error) {
 	f.Cfg.Ingester.LifecyclerConfig.RingConfig.KVStore.MemberlistKV = f.MemberlistKV.GetMemberlistKV
 	f.Cfg.QueryScheduler.ServiceDiscovery.SchedulerRing.KVStore.MemberlistKV = f.MemberlistKV.GetMemberlistKV
 	f.Cfg.OverridesExporter.Ring.Ring.KVStore.MemberlistKV = f.MemberlistKV.GetMemberlistKV
-	f.Cfg.StoreGateway.ShardingRing.KVStore.MemberlistKV = f.MemberlistKV.GetMemberlistKV
+	f.Cfg.StoreGateway.ShardingRing.Ring.KVStore.MemberlistKV = f.MemberlistKV.GetMemberlistKV
 
 	f.Cfg.Frontend.QuerySchedulerDiscovery = f.Cfg.QueryScheduler.ServiceDiscovery
 	f.Cfg.Worker.QuerySchedulerDiscovery = f.Cfg.QueryScheduler.ServiceDiscovery
@@ -345,7 +345,7 @@ func (f *Phlare) initIngester() (_ services.Service, err error) {
 }
 
 func (f *Phlare) initStoreGateway() (serv services.Service, err error) {
-	f.Cfg.StoreGateway.ShardingRing.ListenPort = f.Cfg.Server.HTTPListenPort
+	f.Cfg.StoreGateway.ShardingRing.Ring.ListenPort = f.Cfg.Server.HTTPListenPort
 	if f.storageBucket == nil {
 		return nil, nil
 	}

--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -164,6 +164,10 @@ func (c *Config) registerServerFlagsWithChangedDefaultValues(fs *flag.FlagSet) {
 			_ = f.Value.Set("4040")
 		case "distributor.ring.instance-port":
 			_ = f.Value.Set("4040")
+		case "store-gateway.sharding-ring.instance-port":
+			_ = f.Value.Set("4040")
+		case "query-scheduler.ring.instance-port":
+			_ = f.Value.Set("4040")
 		case "overrides-exporter.ring.instance-port":
 			_ = f.Value.Set("4040")
 		case "distributor.replication-factor":
@@ -189,7 +193,7 @@ func (c *Config) ApplyDynamicConfig() cfg.Source {
 	c.Frontend.QuerySchedulerDiscovery.SchedulerRing.KVStore.Store = c.Ingester.LifecyclerConfig.RingConfig.KVStore.Store
 	c.Worker.QuerySchedulerDiscovery.SchedulerRing.KVStore.Store = c.Ingester.LifecyclerConfig.RingConfig.KVStore.Store
 	c.QueryScheduler.ServiceDiscovery.SchedulerRing.KVStore.Store = c.Ingester.LifecyclerConfig.RingConfig.KVStore.Store
-	c.StoreGateway.ShardingRing.KVStore.Store = c.Ingester.LifecyclerConfig.RingConfig.KVStore.Store
+	c.StoreGateway.ShardingRing.Ring.KVStore.Store = c.Ingester.LifecyclerConfig.RingConfig.KVStore.Store
 
 	return func(dst cfg.Cloneable) error {
 		return nil

--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -149,7 +149,7 @@ func (c *Config) registerServerFlagsWithChangedDefaultValues(fs *flag.FlagSet) {
 	// but we can take values from throwaway flag set and reregister into supplied flags with new default values.
 	c.Server.RegisterFlags(throwaway)
 	c.Ingester.RegisterFlags(throwaway)
-	c.Distributor.RegisterFlags(throwaway)
+	c.Distributor.RegisterFlags(throwaway, log.NewLogfmtLogger(os.Stderr))
 	c.Frontend.RegisterFlags(throwaway, log.NewLogfmtLogger(os.Stderr))
 	c.QueryScheduler.RegisterFlags(throwaway, log.NewLogfmtLogger(os.Stderr))
 	c.Worker.RegisterFlags(throwaway)
@@ -185,7 +185,7 @@ func (c *Config) Validate() error {
 func (c *Config) ApplyDynamicConfig() cfg.Source {
 	c.Ingester.LifecyclerConfig.RingConfig.KVStore.Store = "memberlist"
 	c.Distributor.DistributorRing.KVStore.Store = c.Ingester.LifecyclerConfig.RingConfig.KVStore.Store
-	c.OverridesExporter.Ring.KVStore.Store = c.Ingester.LifecyclerConfig.RingConfig.KVStore.Store
+	c.OverridesExporter.Ring.Ring.KVStore.Store = c.Ingester.LifecyclerConfig.RingConfig.KVStore.Store
 	c.Frontend.QuerySchedulerDiscovery.SchedulerRing.KVStore.Store = c.Ingester.LifecyclerConfig.RingConfig.KVStore.Store
 	c.Worker.QuerySchedulerDiscovery.SchedulerRing.KVStore.Store = c.Ingester.LifecyclerConfig.RingConfig.KVStore.Store
 	c.QueryScheduler.ServiceDiscovery.SchedulerRing.KVStore.Store = c.Ingester.LifecyclerConfig.RingConfig.KVStore.Store

--- a/pkg/querier/store_gateway_querier.go
+++ b/pkg/querier/store_gateway_querier.go
@@ -55,7 +55,7 @@ func NewStoreGatewayQuerier(
 	reg prometheus.Registerer,
 	clientsOptions ...connect.ClientOption,
 ) (*StoreGatewayQuerier, error) {
-	storesRingCfg := gatewayCfg.ShardingRing.ToRingConfig()
+	storesRingCfg := gatewayCfg.ShardingRing.Ring.ToRingConfig()
 	storesRingBackend, err := kv.NewClient(
 		storesRingCfg.KVStore,
 		ring.GetCodec(),

--- a/pkg/scheduler/schedulerdiscovery/config.go
+++ b/pkg/scheduler/schedulerdiscovery/config.go
@@ -23,15 +23,15 @@ const (
 var modes = []string{ModeDNS, ModeRing}
 
 type Config struct {
-	Mode             string     `yaml:"service_discovery_mode" category:"experimental" doc:"hidden"`
-	SchedulerRing    RingConfig `yaml:"ring" doc:"hidden"`
-	MaxUsedInstances int        `yaml:"max_used_instances" category:"experimental"`
+	Mode             string                `yaml:"service_discovery_mode" category:"experimental" doc:"hidden"`
+	SchedulerRing    util.CommonRingConfig `yaml:"ring" doc:"hidden"`
+	MaxUsedInstances int                   `yaml:"max_used_instances" category:"experimental"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.StringVar(&cfg.Mode, ModeFlagName, ModeDNS, fmt.Sprintf("Service discovery mode that query-frontends and queriers use to find query-scheduler instances.%s Supported values are: %s.", sharedOptionWithRingClient, strings.Join(modes, ", ")))
 	f.IntVar(&cfg.MaxUsedInstances, "query-scheduler.max-used-instances", 0, fmt.Sprintf("The maximum number of query-scheduler instances to use, regardless how many replicas are running. This option can be set only when -%s is set to '%s'. 0 to use all available query-scheduler instances.", ModeFlagName, ModeRing))
-	cfg.SchedulerRing.RegisterFlags(f, logger)
+	cfg.SchedulerRing.RegisterFlags("query-scheduler.ring.", "collectors/", ringKey, f, logger)
 }
 
 func (cfg *Config) Validate() error {

--- a/pkg/scheduler/schedulerdiscovery/ring.go
+++ b/pkg/scheduler/schedulerdiscovery/ring.go
@@ -3,21 +3,15 @@
 package schedulerdiscovery
 
 import (
-	"flag"
 	"fmt"
-	"os"
-	"time"
 
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
-	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/kv"
-	"github.com/grafana/dskit/netutil"
 	"github.com/grafana/dskit/ring"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 
-	util_log "github.com/grafana/pyroscope/pkg/util"
+	"github.com/grafana/pyroscope/pkg/util"
 )
 
 const (
@@ -37,49 +31,8 @@ const (
 	sharedOptionWithRingClient = " When query-scheduler ring-based service discovery is enabled, this option needs be set on query-schedulers, query-frontends and queriers."
 )
 
-// RingConfig masks the ring lifecycler config which contains
-// many options not really required by the query-scheduler ring. This config
-// is used to strip down the config to the minimum, and avoid confusion
-// to the user.
-type RingConfig struct {
-	KVStore          kv.Config     `yaml:"kvstore" doc:"description=The key-value store used to share the hash ring across multiple instances. When query-scheduler ring-based service discovery is enabled, this option needs be set on query-schedulers, query-frontends and queriers."`
-	HeartbeatPeriod  time.Duration `yaml:"heartbeat_period" category:"advanced"`
-	HeartbeatTimeout time.Duration `yaml:"heartbeat_timeout" category:"advanced"`
-
-	// Instance details
-	InstanceID             string   `yaml:"instance_id" doc:"default=<hostname>" category:"advanced"`
-	InstanceInterfaceNames []string `yaml:"instance_interface_names" doc:"default=[<private network interfaces>]"`
-	InstancePort           int      `yaml:"instance_port" category:"advanced"`
-	InstanceAddr           string   `yaml:"instance_addr" category:"advanced"`
-
-	// Injected internally
-	ListenPort int `yaml:"-"`
-}
-
-// RegisterFlags adds the flags required to config this to the given flag.FlagSet.
-func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
-	hostname, err := os.Hostname()
-	if err != nil {
-		level.Error(util_log.Logger).Log("msg", "failed to get hostname", "err", err)
-		os.Exit(1)
-	}
-
-	// Ring flags
-	cfg.KVStore.Store = "memberlist" // Override default value.
-	cfg.KVStore.RegisterFlagsWithPrefix("query-scheduler.ring.", "collectors/", f)
-	f.DurationVar(&cfg.HeartbeatPeriod, "query-scheduler.ring.heartbeat-period", 15*time.Second, "Period at which to heartbeat to the ring. 0 = disabled.")
-	f.DurationVar(&cfg.HeartbeatTimeout, "query-scheduler.ring.heartbeat-timeout", time.Minute, "The heartbeat timeout after which query-schedulers are considered unhealthy within the ring."+sharedOptionWithRingClient)
-
-	// Instance flags
-	cfg.InstanceInterfaceNames = netutil.PrivateNetworkInterfacesWithFallback([]string{"eth0", "en0"}, logger)
-	f.Var((*flagext.StringSlice)(&cfg.InstanceInterfaceNames), "query-scheduler.ring.instance-interface-names", "List of network interface names to look up when finding the instance IP address.")
-	f.StringVar(&cfg.InstanceAddr, "query-scheduler.ring.instance-addr", "", "IP address to advertise in the ring. Default is auto-detected.")
-	f.IntVar(&cfg.InstancePort, "query-scheduler.ring.instance-port", 0, "Port to advertise in the ring (defaults to -server.grpc-listen-port).")
-	f.StringVar(&cfg.InstanceID, "query-scheduler.ring.instance-id", hostname, "Instance ID to register in the ring.")
-}
-
-// ToBasicLifecyclerConfig returns a ring.BasicLifecyclerConfig based on the query-scheduler ring config.
-func (cfg *RingConfig) ToBasicLifecyclerConfig(logger log.Logger) (ring.BasicLifecyclerConfig, error) {
+// toBasicLifecyclerConfig returns a ring.BasicLifecyclerConfig based on the query-scheduler ring config.
+func toBasicLifecyclerConfig(cfg util.CommonRingConfig, logger log.Logger) (ring.BasicLifecyclerConfig, error) {
 	instanceAddr, err := ring.GetInstanceAddr(cfg.InstanceAddr, cfg.InstanceInterfaceNames, logger, false)
 	if err != nil {
 		return ring.BasicLifecyclerConfig{}, err
@@ -98,28 +51,15 @@ func (cfg *RingConfig) ToBasicLifecyclerConfig(logger log.Logger) (ring.BasicLif
 	}, nil
 }
 
-// ToRingConfig returns a ring.Config based on the query-scheduler ring config.
-func (cfg *RingConfig) ToRingConfig() ring.Config {
-	rc := ring.Config{}
-	flagext.DefaultValues(&rc)
-
-	rc.KVStore = cfg.KVStore
-	rc.HeartbeatTimeout = cfg.HeartbeatTimeout
-	rc.ReplicationFactor = 1
-	rc.SubringCacheDisabled = true
-
-	return rc
-}
-
 // NewRingLifecycler creates a new query-scheduler ring lifecycler with all required lifecycler delegates.
-func NewRingLifecycler(cfg RingConfig, logger log.Logger, reg prometheus.Registerer) (*ring.BasicLifecycler, error) {
+func NewRingLifecycler(cfg util.CommonRingConfig, logger log.Logger, reg prometheus.Registerer) (*ring.BasicLifecycler, error) {
 	reg = prometheus.WrapRegistererWithPrefix("pyroscope_", reg)
 	kvStore, err := kv.NewClient(cfg.KVStore, ring.GetCodec(), kv.RegistererWithKVName(reg, "query-scheduler-lifecycler"), logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize query-schedulers' KV store")
 	}
 
-	lifecyclerCfg, err := cfg.ToBasicLifecyclerConfig(logger)
+	lifecyclerCfg, err := toBasicLifecyclerConfig(cfg, logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to build query-schedulers' lifecycler config")
 	}
@@ -138,7 +78,7 @@ func NewRingLifecycler(cfg RingConfig, logger log.Logger, reg prometheus.Registe
 }
 
 // NewRingClient creates a client for the query-schedulers ring.
-func NewRingClient(cfg RingConfig, component string, logger log.Logger, reg prometheus.Registerer) (*ring.Ring, error) {
+func NewRingClient(cfg util.CommonRingConfig, component string, logger log.Logger, reg prometheus.Registerer) (*ring.Ring, error) {
 	client, err := ring.New(cfg.ToRingConfig(), component, ringKey, logger, prometheus.WrapRegistererWithPrefix("pyroscope_", reg))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize query-schedulers' ring client")

--- a/pkg/scheduler/schedulerdiscovery/ring_test.go
+++ b/pkg/scheduler/schedulerdiscovery/ring_test.go
@@ -15,36 +15,36 @@ import (
 )
 
 func TestRingConfig_DefaultConfigToBasicLifecyclerConfig(t *testing.T) {
-	cfg := RingConfig{}
+	cfg := Config{}
 	flagext.DefaultValues(&cfg)
-	cfg.InstanceAddr = "127.0.0.1"
-	cfg.InstancePort = 9095
+	cfg.SchedulerRing.InstanceAddr = "127.0.0.1"
+	cfg.SchedulerRing.InstancePort = 9095
 
 	expected := ring.BasicLifecyclerConfig{
-		ID:                              cfg.InstanceID,
-		Addr:                            fmt.Sprintf("%s:%d", cfg.InstanceAddr, cfg.InstancePort),
-		HeartbeatPeriod:                 cfg.HeartbeatPeriod,
-		HeartbeatTimeout:                cfg.HeartbeatTimeout,
+		ID:                              cfg.SchedulerRing.InstanceID,
+		Addr:                            fmt.Sprintf("%s:%d", cfg.SchedulerRing.InstanceAddr, cfg.SchedulerRing.InstancePort),
+		HeartbeatPeriod:                 cfg.SchedulerRing.HeartbeatPeriod,
+		HeartbeatTimeout:                cfg.SchedulerRing.HeartbeatTimeout,
 		TokensObservePeriod:             0,
 		NumTokens:                       1,
 		KeepInstanceInTheRingOnShutdown: false,
 	}
 
-	actual, err := cfg.ToBasicLifecyclerConfig(log.NewNopLogger())
+	actual, err := toBasicLifecyclerConfig(cfg.SchedulerRing, log.NewNopLogger())
 	require.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
 
 func TestRingConfig_CustomConfigToBasicLifecyclerConfig(t *testing.T) {
 	// Customize the query-scheduler ring config
-	cfg := RingConfig{}
+	cfg := Config{}
 	flagext.DefaultValues(&cfg)
-	cfg.HeartbeatPeriod = 1 * time.Second
-	cfg.HeartbeatTimeout = 10 * time.Second
-	cfg.InstanceID = "test"
-	cfg.InstancePort = 10
-	cfg.InstanceAddr = "1.2.3.4"
-	cfg.ListenPort = 10
+	cfg.SchedulerRing.HeartbeatPeriod = 1 * time.Second
+	cfg.SchedulerRing.HeartbeatTimeout = 10 * time.Second
+	cfg.SchedulerRing.InstanceID = "test"
+	cfg.SchedulerRing.InstancePort = 10
+	cfg.SchedulerRing.InstanceAddr = "1.2.3.4"
+	cfg.SchedulerRing.ListenPort = 10
 
 	// The lifecycler config should be generated based upon the query-scheduler
 	// ring config
@@ -58,7 +58,7 @@ func TestRingConfig_CustomConfigToBasicLifecyclerConfig(t *testing.T) {
 		KeepInstanceInTheRingOnShutdown: false,
 	}
 
-	actual, err := cfg.ToBasicLifecyclerConfig(log.NewNopLogger())
+	actual, err := toBasicLifecyclerConfig(cfg.SchedulerRing, log.NewNopLogger())
 	require.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }

--- a/pkg/storegateway/gateway_ring.go
+++ b/pkg/storegateway/gateway_ring.go
@@ -3,15 +3,11 @@ package storegateway
 import (
 	"flag"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
-	"github.com/grafana/dskit/flagext"
-	"github.com/grafana/dskit/kv"
-	"github.com/grafana/dskit/netutil"
 	"github.com/grafana/dskit/ring"
+	"github.com/grafana/pyroscope/pkg/util"
 )
 
 const (
@@ -55,47 +51,30 @@ var (
 )
 
 type RingConfig struct {
-	KVStore              kv.Config     `yaml:"kvstore" doc:"description=The key-value store used to share the hash ring across multiple instances. This option needs be set both on the store-gateway, querier and ruler when running in microservices mode."`
-	HeartbeatPeriod      time.Duration `yaml:"heartbeat_period" category:"advanced"`
-	HeartbeatTimeout     time.Duration `yaml:"heartbeat_timeout" category:"advanced"`
-	ReplicationFactor    int           `yaml:"replication_factor" category:"advanced"`
-	TokensFilePath       string        `yaml:"tokens_file_path"`
-	ZoneAwarenessEnabled bool          `yaml:"zone_awareness_enabled"`
+	Ring                 util.CommonRingConfig `yaml:",inline"`
+	ReplicationFactor    int                   `yaml:"replication_factor" category:"advanced"`
+	TokensFilePath       string                `yaml:"tokens_file_path"`
+	ZoneAwarenessEnabled bool                  `yaml:"zone_awareness_enabled"`
 
 	// Wait ring stability.
 	WaitStabilityMinDuration time.Duration `yaml:"wait_stability_min_duration" category:"advanced"`
 	WaitStabilityMaxDuration time.Duration `yaml:"wait_stability_max_duration" category:"advanced"`
 
 	// Instance details
-	InstanceID             string   `yaml:"instance_id" doc:"default=<hostname>" category:"advanced"`
-	InstanceInterfaceNames []string `yaml:"instance_interface_names" doc:"default=[<private network interfaces>]"`
-	InstancePort           int      `yaml:"instance_port" category:"advanced"`
-	InstanceAddr           string   `yaml:"instance_addr" category:"advanced"`
-	EnableIPv6             bool     `yaml:"instance_enable_ipv6" category:"advanced"`
-	InstanceZone           string   `yaml:"instance_availability_zone"`
+	InstanceZone string `yaml:"instance_availability_zone"`
 
 	UnregisterOnShutdown bool `yaml:"unregister_on_shutdown"`
 
 	// Injected internally
-	ListenPort      int           `yaml:"-"`
 	RingCheckPeriod time.Duration `yaml:"-"`
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
-	hostname, err := os.Hostname()
-	if err != nil {
-		level.Error(logger).Log("msg", "failed to get hostname", "err", err)
-		os.Exit(1)
-	}
-
 	ringFlagsPrefix := "store-gateway.sharding-ring."
 
 	// Ring flags
-	cfg.KVStore.Store = "memberlist"
-	cfg.KVStore.RegisterFlagsWithPrefix(ringFlagsPrefix, "collectors/", f)
-	f.DurationVar(&cfg.HeartbeatPeriod, ringFlagsPrefix+"heartbeat-period", 15*time.Second, "Period at which to heartbeat to the ring. 0 = disabled.")
-	f.DurationVar(&cfg.HeartbeatTimeout, ringFlagsPrefix+"heartbeat-timeout", time.Minute, "The heartbeat timeout after which store gateways are considered unhealthy within the ring. 0 = never (timeout disabled)."+sharedOptionWithRingClient)
+	cfg.Ring.RegisterFlags(ringFlagsPrefix, "collectors/", "store-gateways", f, logger)
 	f.IntVar(&cfg.ReplicationFactor, ringFlagsPrefix+"replication-factor", 1, "The replication factor to use when sharding blocks."+sharedOptionWithRingClient)
 	f.StringVar(&cfg.TokensFilePath, ringFlagsPrefix+"tokens-file-path", "", "File path where tokens are stored. If empty, tokens are not stored at shutdown and restored at startup.")
 	f.BoolVar(&cfg.ZoneAwarenessEnabled, ringFlagsPrefix+"zone-awareness-enabled", false, "True to enable zone-awareness and replicate blocks across different availability zones."+sharedOptionWithRingClient)
@@ -105,12 +84,6 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.DurationVar(&cfg.WaitStabilityMaxDuration, ringFlagsPrefix+"wait-stability-max-duration", 5*time.Minute, "Maximum time to wait for ring stability at startup. If the store-gateway ring keeps changing after this period of time, the store-gateway will start anyway.")
 
 	// Instance flags
-	cfg.InstanceInterfaceNames = netutil.PrivateNetworkInterfacesWithFallback([]string{"eth0", "en0"}, logger)
-	f.Var((*flagext.StringSlice)(&cfg.InstanceInterfaceNames), ringFlagsPrefix+"instance-interface-names", "List of network interface names to look up when finding the instance IP address.")
-	f.StringVar(&cfg.InstanceAddr, ringFlagsPrefix+"instance-addr", "", "IP address to advertise in the ring. Default is auto-detected.")
-	f.IntVar(&cfg.InstancePort, ringFlagsPrefix+"instance-port", 0, "Port to advertise in the ring (defaults to -server.grpc-listen-port).")
-	f.StringVar(&cfg.InstanceID, ringFlagsPrefix+"instance-id", hostname, "Instance ID to register in the ring.")
-	f.BoolVar(&cfg.EnableIPv6, ringFlagsPrefix+"instance-enable-ipv6", false, "Enable using a IPv6 instance address. (default false)")
 	f.StringVar(&cfg.InstanceZone, ringFlagsPrefix+"instance-availability-zone", "", "The availability zone where this instance is running. Required if zone-awareness is enabled.")
 
 	f.BoolVar(&cfg.UnregisterOnShutdown, ringFlagsPrefix+"unregister-on-shutdown", true, "Unregister from the ring upon clean shutdown.")
@@ -119,33 +92,20 @@ func (cfg *RingConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	cfg.RingCheckPeriod = 5 * time.Second
 }
 
-func (cfg *RingConfig) ToRingConfig() ring.Config {
-	rc := ring.Config{}
-	flagext.DefaultValues(&rc)
-
-	rc.KVStore = cfg.KVStore
-	rc.HeartbeatTimeout = cfg.HeartbeatTimeout
-	rc.ReplicationFactor = cfg.ReplicationFactor
-	rc.ZoneAwarenessEnabled = cfg.ZoneAwarenessEnabled
-	rc.SubringCacheDisabled = true
-
-	return rc
-}
-
 func (cfg *RingConfig) ToLifecyclerConfig(logger log.Logger) (ring.BasicLifecyclerConfig, error) {
-	instanceAddr, err := ring.GetInstanceAddr(cfg.InstanceAddr, cfg.InstanceInterfaceNames, logger, cfg.EnableIPv6)
+	instanceAddr, err := ring.GetInstanceAddr(cfg.Ring.InstanceAddr, cfg.Ring.InstanceInterfaceNames, logger, cfg.Ring.EnableIPv6)
 	if err != nil {
 		return ring.BasicLifecyclerConfig{}, err
 	}
 
-	instancePort := ring.GetInstancePort(cfg.InstancePort, cfg.ListenPort)
+	instancePort := ring.GetInstancePort(cfg.Ring.InstancePort, cfg.Ring.ListenPort)
 
 	return ring.BasicLifecyclerConfig{
-		ID:                              cfg.InstanceID,
+		ID:                              cfg.Ring.InstanceID,
 		Addr:                            fmt.Sprintf("%s:%d", instanceAddr, instancePort),
 		Zone:                            cfg.InstanceZone,
-		HeartbeatPeriod:                 cfg.HeartbeatPeriod,
-		HeartbeatTimeout:                cfg.HeartbeatTimeout,
+		HeartbeatPeriod:                 cfg.Ring.HeartbeatPeriod,
+		HeartbeatTimeout:                cfg.Ring.HeartbeatTimeout,
 		TokensObservePeriod:             0,
 		NumTokens:                       RingNumTokens,
 		KeepInstanceInTheRingOnShutdown: !cfg.UnregisterOnShutdown,

--- a/pkg/storegateway/gateway_ring.go
+++ b/pkg/storegateway/gateway_ring.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/ring"
+
 	"github.com/grafana/pyroscope/pkg/util"
 )
 

--- a/pkg/util/ring_config.go
+++ b/pkg/util/ring_config.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package util
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/flagext"
+	"github.com/grafana/dskit/kv"
+	"github.com/grafana/dskit/netutil"
+	"github.com/grafana/dskit/ring"
+)
+
+// CommonRingConfig is the configuration commonly used by components that use a ring
+// for various coordination tasks such as sharding or service discovery.
+type CommonRingConfig struct {
+	// KV store details
+	KVStore          kv.Config     `yaml:"kvstore" doc:"description=The key-value store used to share the hash ring across multiple instances."`
+	HeartbeatPeriod  time.Duration `yaml:"heartbeat_period" category:"advanced"`
+	HeartbeatTimeout time.Duration `yaml:"heartbeat_timeout" category:"advanced"`
+
+	// Instance details
+	InstanceID             string   `yaml:"instance_id" doc:"default=<hostname>" category:"advanced"`
+	InstanceInterfaceNames []string `yaml:"instance_interface_names" doc:"default=[<private network interfaces>]"`
+	InstancePort           int      `yaml:"instance_port" category:"advanced"`
+	InstanceAddr           string   `yaml:"instance_addr" category:"advanced"`
+	EnableIPv6             bool     `yaml:"instance_enable_ipv6" category:"advanced"`
+
+	// Injected internally
+	ListenPort int `yaml:"-"`
+}
+
+// RegisterFlags adds the flags required to config this to the given FlagSet
+func (cfg *CommonRingConfig) RegisterFlags(flagPrefix, kvStorePrefix, componentPlural string, f *flag.FlagSet, logger log.Logger) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to get hostname", "err", err)
+		os.Exit(1)
+	}
+
+	// Ring flags
+	cfg.KVStore.Store = "memberlist"
+	cfg.KVStore.RegisterFlagsWithPrefix(flagPrefix, kvStorePrefix, f)
+	f.DurationVar(&cfg.HeartbeatPeriod, flagPrefix+"heartbeat-period", 15*time.Second, "Period at which to heartbeat to the ring. 0 = disabled.")
+	f.DurationVar(&cfg.HeartbeatTimeout, flagPrefix+"heartbeat-timeout", time.Minute, fmt.Sprintf("The heartbeat timeout after which %s are considered unhealthy within the ring. 0 = never (timeout disabled).", componentPlural))
+
+	// Instance flags
+	cfg.InstanceInterfaceNames = netutil.PrivateNetworkInterfacesWithFallback([]string{"eth0", "en0"}, logger)
+	f.Var((*flagext.StringSlice)(&cfg.InstanceInterfaceNames), flagPrefix+"instance-interface-names", "List of network interface names to look up when finding the instance IP address.")
+	f.StringVar(&cfg.InstanceAddr, flagPrefix+"instance-addr", "", "IP address to advertise in the ring. Default is auto-detected.")
+	f.IntVar(&cfg.InstancePort, flagPrefix+"instance-port", 0, "Port to advertise in the ring (defaults to -server.grpc-listen-port).")
+	f.StringVar(&cfg.InstanceID, flagPrefix+"instance-id", hostname, "Instance ID to register in the ring.")
+	f.BoolVar(&cfg.EnableIPv6, flagPrefix+"instance-enable-ipv6", false, "Enable using a IPv6 instance address. (default false)")
+}
+
+func (cfg *CommonRingConfig) ToRingConfig() ring.Config {
+	rc := ring.Config{}
+	flagext.DefaultValues(&rc)
+
+	rc.KVStore = cfg.KVStore
+	rc.HeartbeatTimeout = cfg.HeartbeatTimeout
+	return rc
+}

--- a/pkg/util/ring_config.go
+++ b/pkg/util/ring_config.go
@@ -53,7 +53,7 @@ func (cfg *CommonRingConfig) RegisterFlags(flagPrefix, kvStorePrefix, componentP
 	cfg.InstanceInterfaceNames = netutil.PrivateNetworkInterfacesWithFallback([]string{"eth0", "en0"}, logger)
 	f.Var((*flagext.StringSlice)(&cfg.InstanceInterfaceNames), flagPrefix+"instance-interface-names", "List of network interface names to look up when finding the instance IP address.")
 	f.StringVar(&cfg.InstanceAddr, flagPrefix+"instance-addr", "", "IP address to advertise in the ring. Default is auto-detected.")
-	f.IntVar(&cfg.InstancePort, flagPrefix+"instance-port", 0, "Port to advertise in the ring (defaults to -server.grpc-listen-port).")
+	f.IntVar(&cfg.InstancePort, flagPrefix+"instance-port", 0, "Port to advertise in the ring (defaults to -server.http-listen-port).")
 	f.StringVar(&cfg.InstanceID, flagPrefix+"instance-id", hostname, "Instance ID to register in the ring.")
 	f.BoolVar(&cfg.EnableIPv6, flagPrefix+"instance-enable-ipv6", false, "Enable using a IPv6 instance address. (default false)")
 }

--- a/pkg/validation/exporter/exporter_test.go
+++ b/pkg/validation/exporter/exporter_test.go
@@ -44,10 +44,10 @@ func TestOverridesExporter_withConfig(t *testing.T) {
 	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
 	cfg1 := Config{RingConfig{}}
-	cfg1.Ring.KVStore.Mock = ringStore
-	cfg1.Ring.InstancePort = 1234
-	cfg1.Ring.HeartbeatPeriod = 15 * time.Second
-	cfg1.Ring.HeartbeatTimeout = 1 * time.Minute
+	cfg1.Ring.Ring.KVStore.Mock = ringStore
+	cfg1.Ring.Ring.InstancePort = 1234
+	cfg1.Ring.Ring.HeartbeatPeriod = 15 * time.Second
+	cfg1.Ring.Ring.HeartbeatTimeout = 1 * time.Minute
 
 	// Create an empty ring.
 	ctx := context.Background()
@@ -56,8 +56,8 @@ func TestOverridesExporter_withConfig(t *testing.T) {
 	}))
 
 	// Create an overrides-exporter.
-	cfg1.Ring.InstanceID = "overrides-exporter-1"
-	cfg1.Ring.InstanceAddr = "1.2.3.1"
+	cfg1.Ring.Ring.InstanceID = "overrides-exporter-1"
+	cfg1.Ring.Ring.InstanceAddr = "1.2.3.1"
 	exporter, err := NewOverridesExporter(cfg1, &validation.Limits{
 		IngestionRateMB:          20,
 		IngestionBurstSizeMB:     21,
@@ -146,10 +146,10 @@ func TestOverridesExporter_withRing(t *testing.T) {
 	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
 	cfg1 := Config{RingConfig{}}
-	cfg1.Ring.KVStore.Mock = ringStore
-	cfg1.Ring.InstancePort = 1234
-	cfg1.Ring.HeartbeatPeriod = 15 * time.Second
-	cfg1.Ring.HeartbeatTimeout = 1 * time.Minute
+	cfg1.Ring.Ring.KVStore.Mock = ringStore
+	cfg1.Ring.Ring.InstancePort = 1234
+	cfg1.Ring.Ring.HeartbeatPeriod = 15 * time.Second
+	cfg1.Ring.Ring.HeartbeatTimeout = 1 * time.Minute
 
 	// Create an empty ring.
 	ctx := context.Background()
@@ -158,8 +158,8 @@ func TestOverridesExporter_withRing(t *testing.T) {
 	}))
 
 	// Create an overrides-exporter.
-	cfg1.Ring.InstanceID = "overrides-exporter-1"
-	cfg1.Ring.InstanceAddr = "1.2.3.1"
+	cfg1.Ring.Ring.InstanceID = "overrides-exporter-1"
+	cfg1.Ring.Ring.InstanceAddr = "1.2.3.1"
 	e1, err := NewOverridesExporter(cfg1, &validation.Limits{}, validation.NewMockTenantLimits(tenantLimits), log.NewNopLogger(), nil)
 	l1 := e1.ring.lifecycler
 	require.NoError(t, err)
@@ -192,8 +192,8 @@ func TestOverridesExporter_withRing(t *testing.T) {
 
 	// Register a second instance.
 	cfg2 := cfg1
-	cfg2.Ring.InstanceID = "overrides-exporter-2"
-	cfg2.Ring.InstanceAddr = "1.2.3.2"
+	cfg2.Ring.Ring.InstanceID = "overrides-exporter-2"
+	cfg2.Ring.Ring.InstanceAddr = "1.2.3.2"
 	e2, err := NewOverridesExporter(cfg2, &validation.Limits{}, validation.NewMockTenantLimits(tenantLimits), log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, e2))

--- a/pkg/validation/exporter/ring_test.go
+++ b/pkg/validation/exporter/ring_test.go
@@ -27,10 +27,10 @@ func TestOverridesExporter_emptyRing(t *testing.T) {
 	}))
 
 	cfg := RingConfig{}
-	cfg.KVStore.Mock = ringStore
+	cfg.Ring.KVStore.Mock = ringStore
 
-	cfg.InstanceID = "instance-1"
-	cfg.InstanceAddr = "127.0.0.1"
+	cfg.Ring.InstanceID = "instance-1"
+	cfg.Ring.InstanceAddr = "127.0.0.1"
 	i1, err := newRing(cfg, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, i1.client))
@@ -47,19 +47,19 @@ func TestOverridesExporterRing_scaleDown(t *testing.T) {
 	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
 
 	cfg1 := RingConfig{}
-	cfg1.KVStore.Mock = ringStore
-	cfg1.HeartbeatPeriod = 1 * time.Second
-	cfg1.HeartbeatTimeout = 15 * time.Second
+	cfg1.Ring.KVStore.Mock = ringStore
+	cfg1.Ring.HeartbeatPeriod = 1 * time.Second
+	cfg1.Ring.HeartbeatTimeout = 15 * time.Second
 
-	cfg1.InstanceID = "instance-1"
-	cfg1.InstanceAddr = "127.0.0.1"
+	cfg1.Ring.InstanceID = "instance-1"
+	cfg1.Ring.InstanceAddr = "127.0.0.1"
 	i1, err := newRing(cfg1, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	l1 := i1.lifecycler
 
 	cfg2 := cfg1
-	cfg2.InstanceID = "instance-2"
-	cfg2.InstanceAddr = "127.0.0.2"
+	cfg2.Ring.InstanceID = "instance-2"
+	cfg2.Ring.InstanceAddr = "127.0.0.2"
 	i2, err := newRing(cfg2, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	l2 := i2.lifecycler
@@ -125,7 +125,7 @@ func TestOverridesExporterRing_scaleDown(t *testing.T) {
 	require.NoError(t, ringStore.CAS(ctx, ringKey, func(in interface{}) (out interface{}, retry bool, err error) {
 		desc := in.(*ring.Desc)
 		instance := desc.Ingesters[l1.GetInstanceID()]
-		instance.Timestamp = time.Now().Add(-ringAutoForgetUnhealthyPeriods * cfg1.HeartbeatTimeout).Unix()
+		instance.Timestamp = time.Now().Add(-ringAutoForgetUnhealthyPeriods * cfg1.Ring.HeartbeatTimeout).Unix()
 		desc.Ingesters[l1.GetInstanceID()] = instance
 		return desc, true, nil
 	}))

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -12,6 +12,10 @@ import (
 
 const (
 	bytesInMB = 1048576
+
+	// MinCompactorPartialBlockDeletionDelay is the minimum partial blocks deletion delay that can be configured in Mimir.
+	// Partial blocks are blocks that are not having meta file uploaded yet.
+	MinCompactorPartialBlockDeletionDelay = 4 * time.Hour
 )
 
 // Limits describe all the limits for tenants; can be used to describe global default

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -12,10 +12,6 @@ import (
 
 const (
 	bytesInMB = 1048576
-
-	// MinCompactorPartialBlockDeletionDelay is the minimum partial blocks deletion delay that can be configured in Mimir.
-	// Partial blocks are blocks that are not having meta file uploaded yet.
-	MinCompactorPartialBlockDeletionDelay = 4 * time.Hour
 )
 
 // Limits describe all the limits for tenants; can be used to describe global default


### PR DESCRIPTION
I was about to copy the code again for compaction and decided to end it here.

This basically refactors all component to use the same `RingConfig` struct. Added bonus the generated doc is now more consistent.