### PR TITLE
Reduce roundtrips to object store, when opening parquet files

### DIFF
--- a/pkg/objstore/parquet/file.go
+++ b/pkg/objstore/parquet/file.go
@@ -13,29 +13,31 @@ import (
 type File struct {
 	*parquet.File
 	reader objstore.ReaderAtCloser
-	path   string
-	size   int64
+	meta   block.File
 }
 
 func (f *File) Open(ctx context.Context, b objstore.BucketReader, meta block.File, options ...parquet.FileOption) error {
-	f.path = meta.RelPath
-	f.size = int64(meta.SizeBytes)
-
-	if f.size == 0 {
-		attrs, err := b.Attributes(ctx, f.path)
+	if meta.SizeBytes == 0 {
+		attrs, err := b.Attributes(ctx, meta.RelPath)
 		if err != nil {
 			return fmt.Errorf("getting attributes: %w", err)
 		}
-		f.size = attrs.Size
+		meta.SizeBytes = uint64(attrs.Size)
 	}
 	var err error
 	// the same reader is used to serve all requests, so we pass context.Background() here
-	if f.reader, err = OptimizedBucketReaderAt(b, context.Background(), f.path); err != nil {
+	ra, err := OptimizedBucketReaderAt(b, context.Background(), meta)
+	if err != nil {
 		return fmt.Errorf("creating reader: %w", err)
 	}
+	f.reader = ra
+	ora := ra.(*optimizedReaderAt)
+
+	// after finishing opening, clear footer cache
+	defer ora.clearFooterCache()
 
 	// first try to open file, this is required otherwise OpenFile panics
-	f.File, err = parquet.OpenFile(f.reader, f.size,
+	f.File, err = parquet.OpenFile(f.reader, int64(meta.SizeBytes),
 		parquet.SkipPageIndex(true),
 		parquet.SkipBloomFilters(true))
 	if err != nil {
@@ -43,7 +45,7 @@ func (f *File) Open(ctx context.Context, b objstore.BucketReader, meta block.Fil
 	}
 
 	// now open it for real
-	f.File, err = parquet.OpenFile(f.reader, f.size,
+	f.File, err = parquet.OpenFile(f.reader, int64(meta.SizeBytes),
 		options...,
 	)
 	return err
@@ -56,4 +58,4 @@ func (f *File) Close() (err error) {
 	return nil
 }
 
-func (f *File) Path() string { return f.path }
+func (f *File) Path() string { return f.meta.RelPath }

--- a/pkg/objstore/parquet/file.go
+++ b/pkg/objstore/parquet/file.go
@@ -1,0 +1,59 @@
+package parquet
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/parquet-go/parquet-go"
+
+	"github.com/grafana/pyroscope/pkg/objstore"
+	"github.com/grafana/pyroscope/pkg/phlaredb/block"
+)
+
+type File struct {
+	*parquet.File
+	reader objstore.ReaderAtCloser
+	path   string
+	size   int64
+}
+
+func (f *File) Open(ctx context.Context, b objstore.BucketReader, meta block.File, options ...parquet.FileOption) error {
+	f.path = meta.RelPath
+	f.size = int64(meta.SizeBytes)
+
+	if f.size == 0 {
+		attrs, err := b.Attributes(ctx, f.path)
+		if err != nil {
+			return fmt.Errorf("getting attributes: %w", err)
+		}
+		f.size = attrs.Size
+	}
+	var err error
+	// the same reader is used to serve all requests, so we pass context.Background() here
+	if f.reader, err = OptimizedBucketReaderAt(b, context.Background(), f.path); err != nil {
+		return fmt.Errorf("creating reader: %w", err)
+	}
+
+	// first try to open file, this is required otherwise OpenFile panics
+	f.File, err = parquet.OpenFile(f.reader, f.size,
+		parquet.SkipPageIndex(true),
+		parquet.SkipBloomFilters(true))
+	if err != nil {
+		return err
+	}
+
+	// now open it for real
+	f.File, err = parquet.OpenFile(f.reader, f.size,
+		options...,
+	)
+	return err
+}
+
+func (f *File) Close() (err error) {
+	if f.reader != nil {
+		return f.reader.Close()
+	}
+	return nil
+}
+
+func (f *File) Path() string { return f.path }

--- a/pkg/objstore/parquet/file_test.go
+++ b/pkg/objstore/parquet/file_test.go
@@ -1,0 +1,140 @@
+package parquet
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/parquet-go/parquet-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/pyroscope/pkg/objstore"
+	"github.com/grafana/pyroscope/pkg/objstore/providers/filesystem"
+	"github.com/grafana/pyroscope/pkg/phlaredb/block"
+)
+
+type readerAtCall struct {
+	offset int64
+	size   int64
+}
+
+type readerAtLogger struct {
+	objstore.ReaderAtCloser
+	calls []readerAtCall
+}
+
+func (r *readerAtLogger) ReadAt(p []byte, off int64) (n int, err error) {
+	r.calls = append(r.calls, readerAtCall{offset: off, size: int64(len(p))})
+	return r.ReaderAtCloser.ReadAt(p, off)
+
+}
+
+type bucketReadRangeLogger struct {
+	objstore.BucketReader
+	lastReaderAt *readerAtLogger
+}
+
+func (b *bucketReadRangeLogger) ReaderAt(ctx context.Context, filename string) (objstore.ReaderAtCloser, error) {
+	readerAt, err := b.BucketReader.ReaderAt(ctx, filename)
+	b.lastReaderAt = &readerAtLogger{
+		ReaderAtCloser: readerAt,
+	}
+	return b.lastReaderAt, err
+}
+
+func newBucketReader(t *testing.T, path string) *bucketReadRangeLogger {
+	bucketClient, err := filesystem.NewBucket(path)
+	require.NoError(t, err)
+
+	return &bucketReadRangeLogger{BucketReader: objstore.NewBucket(bucketClient)}
+}
+
+func newParquetFile(t *testing.T, rowCount int) (block.File, *bucketReadRangeLogger) {
+	batch := 10
+
+	type Row struct{ N, NTime2, NTimes3 int }
+
+	rows := make([]Row, batch)
+	pos := 0
+
+	tempDir := t.TempDir()
+	fileName := "test.parquet"
+
+	output, err := os.Create(tempDir + "/" + fileName)
+	require.NoError(t, err)
+
+	writer := parquet.NewGenericWriter[Row](output)
+
+	for {
+		for idx := range rows {
+			rows[idx].N = pos
+			rows[idx].NTime2 = pos * 2
+			rows[idx].NTimes3 = pos * 3
+			pos += 1
+
+			if pos >= rowCount {
+				rows = rows[:idx+1]
+				break
+			}
+		}
+
+		_, err = writer.Write(rows)
+		require.NoError(t, err)
+
+		if pos >= rowCount {
+			break
+		}
+	}
+
+	// closing the writer is necessary to flush buffers and write the file footer.
+	require.NoError(t, writer.Close())
+
+	// get file size
+	fi, err := output.Stat()
+	require.NoError(t, err)
+
+	return block.File{
+		RelPath:   "test.parquet",
+		SizeBytes: uint64(fi.Size()),
+		Parquet:   &block.ParquetFile{},
+	}, newBucketReader(t, tempDir)
+}
+
+const (
+	parquetReadBufferSize = 256 << 10 // 256KB
+)
+
+func DefaultFileOptions() []parquet.FileOption {
+	return []parquet.FileOption{
+		parquet.SkipBloomFilters(true), // we don't use bloom filters
+		parquet.FileReadMode(parquet.ReadModeAsync),
+		parquet.ReadBufferSize(parquetReadBufferSize),
+	}
+}
+
+func TestFile_Open(t *testing.T) {
+	var f File
+
+	t.Run("small parquet file, ensure single request to bucket", func(t *testing.T) {
+		meta, bucketReader := newParquetFile(t, 100)
+
+		require.NoError(t, f.Open(context.Background(), bucketReader, meta, DefaultFileOptions()...))
+		require.Len(t, bucketReader.lastReaderAt.calls, 1)
+
+		// parquet file smalle, so cache will actually hold all of it
+		assert.Equal(t, int64(0), bucketReader.lastReaderAt.calls[0].offset)
+		assert.Equal(t, int64(meta.SizeBytes), bucketReader.lastReaderAt.calls[0].size)
+	})
+
+	t.Run("bigger parquet file, ensure single request to bucket", func(t *testing.T) {
+		meta, bucketReader := newParquetFile(t, 100_000)
+
+		require.NoError(t, f.Open(context.Background(), bucketReader, meta, DefaultFileOptions()...))
+		require.Len(t, bucketReader.lastReaderAt.calls, 1)
+
+		// parquet file will use the minimum 32KiB cache size
+		assert.Equal(t, int64(meta.SizeBytes-(32*1024)), bucketReader.lastReaderAt.calls[0].offset)
+		assert.Equal(t, int64(32*1024), bucketReader.lastReaderAt.calls[0].size)
+	})
+}

--- a/pkg/objstore/parquet/reader.go
+++ b/pkg/objstore/parquet/reader.go
@@ -2,21 +2,59 @@ package parquet
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"sync"
 
 	phlareobjstore "github.com/grafana/pyroscope/pkg/objstore"
+	"github.com/grafana/pyroscope/pkg/phlaredb/block"
 )
+
+// bufferPool is a pool of bytes.Buffers.
+var bufferPool = sync.Pool{
+	New: func() interface{} {
+		buf := make([]byte, 0, 32*1024)
+		return &buf
+	},
+}
 
 type optimizedReaderAt struct {
 	phlareobjstore.ReaderAtCloser
-	// todo: cache footer section we currently don't have a way to get the footer size from meta.
-	// Not sure if we need to cache the footer size or not yet. Adding this to the footer size could help.
-	// footerSize uint32
+	meta block.File
+
+	footerCache *[]byte
+	footerLock  sync.RWMutex
+	footerLen   uint64
 }
 
 // NewOptimizedReader returns a reader that optimizes the reading of the parquet file.
-func NewOptimizedReader(r phlareobjstore.ReaderAtCloser) phlareobjstore.ReaderAtCloser {
+func NewOptimizedReader(r phlareobjstore.ReaderAtCloser, meta block.File) phlareobjstore.ReaderAtCloser {
+	var footerLen uint64
+
+	// as long as we don't keep the exact footer sizes in the meta estimate it
+	if meta.SizeBytes > 0 {
+		footerLen = meta.SizeBytes / uint64(10000)
+	}
+
+	// set a minimum footer size of 32KiB
+	if footerLen < 32*1024 {
+		footerLen = 32 * 1024
+	}
+
+	// set a maximum footer size of 512KiB
+	if footerLen > 512*1024 {
+		footerLen = 512 * 1024
+	}
+
+	// now check clamp it to the actual size of the whole object
+	if footerLen > meta.SizeBytes {
+		footerLen = meta.SizeBytes
+	}
+
 	return &optimizedReaderAt{
 		ReaderAtCloser: r,
+		meta:           meta,
+		footerLen:      footerLen,
 	}
 }
 
@@ -35,29 +73,97 @@ func NewOptimizedReader(r phlareobjstore.ReaderAtCloser) phlareobjstore.ReaderAt
 // 	// todo cache offset index section
 // }
 
-func (r *optimizedReaderAt) ReadAt(p []byte, off int64) (int, error) {
-	if len(p) == 4 && off == 0 {
-		// Magic header
-		return copy(p, []byte("PAR1")), nil
+const magic = "PAR1"
+
+// note cache needs to be held to call this method
+func (r *optimizedReaderAt) serveFromCache(p []byte, off int64) (int, error) {
+	if r.footerCache == nil {
+		return 0, errors.New("footerCache is nil")
+	}
+	// recalculate offset to start at the cache
+	off = off - int64(r.meta.SizeBytes) + int64(r.footerLen)
+	return copy(p, (*r.footerCache)[int(off):int(off)+len(p)]), nil
+}
+
+func (r *optimizedReaderAt) clearFooterCache() {
+	r.footerLock.Lock()
+	defer r.footerLock.Unlock()
+	if r.footerCache != nil {
+		bufferPool.Put(r.footerCache)
+		r.footerCache = nil
 	}
 
-	// // This requires knowing the footer size which we don't have access to in advance.
-	// if len(p) == 8 && off == r.Size()-8 && r.footerSize > 0  {
-	// 	// Magic footer
-	// 	binary.LittleEndian.PutUint32(p, r.footerSize)
-	// 	copy(p[4:8], []byte("PAR1"))
-	// 	return 8, nil
-	// }
+}
 
-	// todo handle cache
+func (r *optimizedReaderAt) Close() (err error) {
+	r.clearFooterCache()
+	return r.ReaderAtCloser.Close()
+}
+
+func (r *optimizedReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	// handle magic header
+	if len(p) == 4 && off == 0 {
+		return copy(p, []byte(magic)), nil
+	}
+
+	// check if the call falls into the footer
+	if off >= int64(r.meta.SizeBytes)-int64(r.footerLen) {
+		// check if the cache exists
+		r.footerLock.RLock()
+		cacheExists := r.footerCache != nil && len(*r.footerCache) == int(r.footerLen)
+		if cacheExists {
+			defer r.footerLock.RUnlock()
+			return r.serveFromCache(p, off)
+		}
+		r.footerLock.RUnlock()
+
+		// no valid cache found, create one under write lock
+		r.footerLock.Lock()
+		defer r.footerLock.Unlock()
+
+		// check again if cache has been populated in the meantime
+		cacheExists = r.footerCache != nil && len(*r.footerCache) == int(r.footerLen)
+		if cacheExists {
+			return r.serveFromCache(p, off)
+		}
+
+		// populate cache
+		if r.footerCache == nil {
+			r.footerCache = bufferPool.Get().(*[]byte)
+		}
+		if cap(*r.footerCache) < int(r.footerLen) {
+			// grow the buffer if it is too small
+			buf := make([]byte, int(r.footerLen))
+			r.footerCache = &buf
+		} else {
+			// reuse the buffer if it is big enough
+			*r.footerCache = (*r.footerCache)[:r.footerLen]
+		}
+
+		if n, err := r.ReaderAtCloser.ReadAt(*r.footerCache, int64(r.meta.SizeBytes)-int64(r.footerLen)); err != nil {
+			// return to pool
+			bufferPool.Put(r.footerCache)
+			r.footerCache = nil
+			return 0, err
+		} else if n != int(r.footerLen) { // check if we got the expected amount of bytes
+			// return to pool
+			bufferPool.Put(r.footerCache)
+			r.footerCache = nil
+			return 0, fmt.Errorf("unexpected read length, expected=%d actual=%d", r.footerLen, n)
+		}
+
+		return r.serveFromCache(p, off)
+	}
+
+	// anything else will just read through the optimizer
 	return r.ReaderAtCloser.ReadAt(p, off)
 }
 
 // OptimizedBucketReaderAt uses a bucket reader and wraps the optimized reader. Must not be used with non-parquet files.
-func OptimizedBucketReaderAt(bucketReader phlareobjstore.BucketReader, ctx context.Context, filename string) (phlareobjstore.ReaderAtCloser, error) {
-	rc, err := bucketReader.ReaderAt(ctx, filename)
+func OptimizedBucketReaderAt(bucketReader phlareobjstore.BucketReader, ctx context.Context, meta block.File) (phlareobjstore.ReaderAtCloser, error) {
+	rc, err := bucketReader.ReaderAt(ctx, meta.RelPath)
 	if err != nil {
 		return nil, err
 	}
-	return NewOptimizedReader(rc), nil
+	return NewOptimizedReader(rc, meta), nil
 }

--- a/pkg/phlaredb/block_querier_symbols.go
+++ b/pkg/phlaredb/block_querier_symbols.go
@@ -39,7 +39,7 @@ func newSymbolsResolverV1(ctx context.Context, bucketReader phlareobj.Bucket, me
 	p := r.stacktraces.relPath()
 	for _, f := range meta.Files {
 		if f.RelPath == p {
-			r.stacktraces.size = int64(f.SizeBytes)
+			r.stacktraces.meta = f
 			break
 		}
 	}
@@ -196,13 +196,13 @@ func openInMemoryParquetTables(ctx context.Context, r phlareobj.BucketReader, me
 	for _, f := range meta.Files {
 		switch f.RelPath {
 		case t.locations.relPath():
-			t.locations.size = int64(f.SizeBytes)
+			t.locations.meta = f
 		case t.functions.relPath():
-			t.functions.size = int64(f.SizeBytes)
+			t.functions.meta = f
 		case t.mappings.relPath():
-			t.mappings.size = int64(f.SizeBytes)
+			t.mappings.meta = f
 		case t.strings.relPath():
-			t.strings.size = int64(f.SizeBytes)
+			t.strings.meta = f
 		}
 	}
 	g, ctx := errgroup.WithContext(ctx)
@@ -229,63 +229,35 @@ type ResultWithRowNum[M any] struct {
 
 type inMemoryparquetReader[M schemav1.Models, P schemav1.Persister[M]] struct {
 	persister P
-	file      *parquet.File
-	size      int64
-	reader    phlareobj.ReaderAtCloser
+	meta      block.File
 	cache     []M
 }
 
 func (r *inMemoryparquetReader[M, P]) open(ctx context.Context, bucketReader phlareobj.BucketReader) error {
-	filePath := r.persister.Name() + block.ParquetSuffix
-
-	if r.size == 0 {
-		attrs, err := bucketReader.Attributes(ctx, filePath)
-		if err != nil {
-			return fmt.Errorf("getting attributes for '%s': %w", filePath, err)
-		}
-		r.size = attrs.Size
-	}
-
-	var err error
-	r.reader, err = parquetobj.OptimizedBucketReaderAt(bucketReader, ctx, filePath)
-	if err != nil {
-		return fmt.Errorf("create reader '%s': %w", filePath, err)
-	}
-
-	// first try to open file, this is required otherwise OpenFile panics
-	parquetFile, err := parquet.OpenFile(r.reader, r.size, parquet.SkipPageIndex(true), parquet.SkipBloomFilters(true))
-	if err != nil {
-		return fmt.Errorf("opening parquet file '%s': %w", filePath, err)
-	}
-	if parquetFile.NumRows() == 0 {
-		return fmt.Errorf("error parquet file '%s' contains no rows: %w", filePath, err)
-	}
-	opts := []parquet.FileOption{
+	var file parquetobj.File
+	if err := file.Open(
+		ctx,
+		bucketReader,
+		r.meta,
 		parquet.SkipBloomFilters(true), // we don't use bloom filters
 		parquet.FileReadMode(parquet.ReadModeAsync),
 		parquet.ReadBufferSize(parquetReadBufferSize),
-	}
-	// now open it for real
-	r.file, err = parquet.OpenFile(r.reader, r.size, opts...)
-	if err != nil {
-		return fmt.Errorf("opening parquet file '%s': %w", filePath, err)
+	); err != nil {
+		return err
 	}
 
 	// read all rows into memory
-	r.cache = make([]M, r.file.NumRows())
+	r.cache = make([]M, file.NumRows())
 	var offset int64
-	for _, rg := range r.file.RowGroups() {
+	for _, rg := range file.RowGroups() {
 		rows := rg.NumRows()
 		dst := r.cache[offset : offset+rows]
 		offset += rows
-		if err = r.readRG(dst, rg); err != nil {
-			return fmt.Errorf("reading row group from parquet file '%s': %w", filePath, err)
+		if err := r.readRG(dst, rg); err != nil {
+			return fmt.Errorf("reading row group from parquet file '%s': %w", file.Path(), err)
 		}
 	}
-	err = r.reader.Close()
-	r.reader = nil
-	r.file = nil
-	return err
+	return file.Close()
 }
 
 // parquet.CopyRows uses hardcoded buffer size:
@@ -319,11 +291,6 @@ func (r *inMemoryparquetReader[M, P]) readRG(dst []M, rg parquet.RowGroup) (err 
 }
 
 func (r *inMemoryparquetReader[M, P]) Close() error {
-	if r.reader != nil {
-		return r.reader.Close()
-	}
-	r.reader = nil
-	r.file = nil
 	r.cache = nil
 	return nil
 }

--- a/pkg/phlaredb/symdb/block_reader.go
+++ b/pkg/phlaredb/symdb/block_reader.go
@@ -34,10 +34,10 @@ type Reader struct {
 	index      IndexFile
 	partitions map[uint64]*partition
 
-	locations parquetFile
-	mappings  parquetFile
-	functions parquetFile
-	strings   parquetFile
+	locations parquetobj.File
+	mappings  parquetobj.File
+	functions parquetobj.File
+	strings   parquetobj.File
 }
 
 const (
@@ -96,8 +96,16 @@ func (r *Reader) openIndexFile(ctx context.Context) error {
 	return err
 }
 
+const parquetReadBufferSize = 256 << 10 // 256KB
+
 func (r *Reader) openParquetFiles(ctx context.Context) error {
-	m := map[string]*parquetFile{
+	options := []parquet.FileOption{
+		parquet.SkipBloomFilters(true), // we don't use bloom filters
+		parquet.FileReadMode(parquet.ReadModeAsync),
+		parquet.ReadBufferSize(parquetReadBufferSize),
+	}
+
+	m := map[string]*parquetobj.File{
 		new(schemav1.LocationPersister).Name() + block.ParquetSuffix: &r.locations,
 		new(schemav1.MappingPersister).Name() + block.ParquetSuffix:  &r.mappings,
 		new(schemav1.FunctionPersister).Name() + block.ParquetSuffix: &r.functions,
@@ -112,7 +120,7 @@ func (r *Reader) openParquetFiles(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-			if err = fp.open(ctx, r.bucket, fm); err != nil {
+			if err = fp.Open(ctx, r.bucket, fm, options...); err != nil {
 				return fmt.Errorf("openning file %q: %w", n, err)
 			}
 			return nil
@@ -162,10 +170,10 @@ func (r *Reader) Close() error {
 		return nil
 	}
 	return multierror.New(
-		r.locations.close(),
-		r.mappings.close(),
-		r.functions.close(),
-		r.strings.close()).
+		r.locations.Close(),
+		r.mappings.Close(),
+		r.functions.Close(),
+		r.strings.Close()).
 		Err()
 }
 
@@ -408,60 +416,12 @@ func (c *stacktraceChunkReader) release() {
 	c.m.Unlock()
 }
 
-type parquetFile struct {
-	*parquet.File
-	reader objstore.ReaderAtCloser
-	path   string
-	size   int64
-}
-
-const parquetReadBufferSize = 256 << 10 // 256KB
-
-func (f *parquetFile) open(ctx context.Context, b objstore.BucketReader, meta block.File) error {
-	f.path = meta.RelPath
-	f.size = int64(meta.SizeBytes)
-	if f.size == 0 {
-		attrs, err := b.Attributes(ctx, f.path)
-		if err != nil {
-			return fmt.Errorf("getting attributes: %w", err)
-		}
-		f.size = attrs.Size
-	}
-	var err error
-	// the same reader is used to serve all requests, so we pass context.Background() here
-	if f.reader, err = parquetobj.OptimizedBucketReaderAt(b, context.Background(), f.path); err != nil {
-		return fmt.Errorf("creating reader: %w", err)
-	}
-
-	// first try to open file, this is required otherwise OpenFile panics
-	f.File, err = parquet.OpenFile(f.reader, f.size,
-		parquet.SkipPageIndex(true),
-		parquet.SkipBloomFilters(true))
-	if err != nil {
-		return err
-	}
-
-	// now open it for real
-	f.File, err = parquet.OpenFile(f.reader, f.size,
-		parquet.SkipBloomFilters(true), // we don't use bloom filters
-		parquet.FileReadMode(parquet.ReadModeAsync),
-		parquet.ReadBufferSize(parquetReadBufferSize))
-	return err
-}
-
-func (f *parquetFile) close() (err error) {
-	if f.reader != nil {
-		return f.reader.Close()
-	}
-	return nil
-}
-
 type parquetTableRange[M schemav1.Models, P schemav1.Persister[M]] struct {
 	headers   []RowRangeReference
 	bucket    objstore.BucketReader
 	persister P
 
-	file *parquetFile
+	file *parquetobj.File
 
 	m sync.RWMutex
 	r int64
@@ -510,7 +470,7 @@ func (t *parquetTableRange[M, P]) fetch(ctx context.Context) (err error) {
 		}
 		dst := t.s[offset : offset+int(h.Rows)]
 		if err := t.readRows(dst, buf, rows); err != nil {
-			return fmt.Errorf("reading row group from parquet file %q: %w", t.file.path, err)
+			return fmt.Errorf("reading row group from parquet file %q: %w", t.file.Path(), err)
 		}
 		offset += int(h.Rows)
 	}

--- a/pkg/phlaredb/symdb/block_reader_load.go
+++ b/pkg/phlaredb/symdb/block_reader_load.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/grafana/pyroscope/pkg/iter"
+	parquetobj "github.com/grafana/pyroscope/pkg/objstore/parquet"
 	pparquet "github.com/grafana/pyroscope/pkg/parquet"
 )
 
@@ -94,7 +95,7 @@ func loadStrings(p *partition, i iter.Iterator[parquet.Row]) error { return p.st
 
 type loader func(*partition, iter.Iterator[parquet.Row]) error
 
-func withRowIterator(f parquetFile, partitions []*partition, x loader) error {
+func withRowIterator(f parquetobj.File, partitions []*partition, x loader) error {
 	rows := parquet.MultiRowGroup(f.RowGroups()...).Rows()
 	defer func() {
 		_ = rows.Close()


### PR DESCRIPTION
Opening a parquet files currently involves 6 RTT to the object store bucket, this PR will reduce this to one. (🤞)

- [x] Refactor parquet file opening from to use the same code for all parquet acceess
- [x] Retrieve n ending bytes (a percentage of the full parquet size) to cover footer-magic, footersize, offset- and column- indexes. Limit maximum download size to 256KiB. Cache this until the block is fully opened.
- ~Consider storing the correct size in `meta.json` and use those~ #2419


