### PR TITLE
fix: log tenant id

### DIFF
--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/felixge/httpsnoop"
-	log "github.com/go-kit/log"
+	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/gorilla/mux"
 	"github.com/grafana/dskit/instrument"
@@ -109,8 +109,11 @@ func (l Log) logWithRequest(r *http.Request) log.Logger {
 			localLog = log.With(localLog, "sourceIPs", ips)
 		}
 	}
-
-	return user.LogWith(r.Context(), localLog)
+	orgID := r.Header.Get(user.OrgIDHeaderName)
+	if orgID == "" {
+		orgID = "anonymous"
+	}
+	return log.With(localLog, "tenant", orgID)
 }
 
 // Wrap implements Middleware

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -111,9 +111,11 @@ func (l Log) logWithRequest(r *http.Request) log.Logger {
 	}
 	orgID := r.Header.Get(user.OrgIDHeaderName)
 	if orgID == "" {
-		orgID = "anonymous"
+		localLog = user.LogWith(r.Context(), localLog)
+	} else {
+		localLog = log.With(localLog, "orgID", orgID)
 	}
-	return log.With(localLog, "tenant", orgID)
+	return localLog
 }
 
 // Wrap implements Middleware


### PR DESCRIPTION
https://github.com/grafana/pyroscope/issues/2393

```
ts=2023-09-12T10:30:57.130450314Z caller=http.go:190 level=info traceID=1cfcc3ccda0a068b tenant=238 msg="POST /ingest?aggregationType=&from=1694514641&name=simple.golang.app-new%7B%7D&sampleRate=0&spyName=gospy&units=&until=1694514656 (200) 556.059µs"
```
