### PR TITLE
Adds a way to validate local blocks

### DIFF
--- a/pkg/phlaredb/validate.go
+++ b/pkg/phlaredb/validate.go
@@ -1,0 +1,35 @@
+package phlaredb
+
+import (
+	"context"
+	"path"
+
+	"github.com/grafana/dskit/runutil"
+	"github.com/grafana/pyroscope/pkg/objstore/client"
+	"github.com/grafana/pyroscope/pkg/objstore/providers/filesystem"
+	"github.com/grafana/pyroscope/pkg/phlaredb/block"
+	"github.com/grafana/pyroscope/pkg/util"
+)
+
+// ValidateLocalBlock validates the block in the given directory is readable.
+func ValidateLocalBlock(phlarectx context.Context, dir string) error {
+	meta, err := block.ReadMetaFromDir(dir)
+	if err != nil {
+		return err
+	}
+
+	bkt, err := client.NewBucket(phlarectx, client.Config{
+		StorageBackendConfig: client.StorageBackendConfig{
+			Backend: client.Filesystem,
+			Filesystem: filesystem.Config{
+				Directory: path.Dir(dir),
+			},
+		},
+	}, "validate")
+	if err != nil {
+		return err
+	}
+	q := NewSingleBlockQuerierFromMeta(phlarectx, bkt, meta)
+	defer runutil.CloseWithLogOnErr(util.Logger, q, "closing block querier")
+	return q.Open(phlarectx)
+}

--- a/pkg/phlaredb/validate.go
+++ b/pkg/phlaredb/validate.go
@@ -5,6 +5,7 @@ import (
 	"path"
 
 	"github.com/grafana/dskit/runutil"
+
 	"github.com/grafana/pyroscope/pkg/objstore/client"
 	"github.com/grafana/pyroscope/pkg/objstore/providers/filesystem"
 	"github.com/grafana/pyroscope/pkg/phlaredb/block"

--- a/pkg/phlaredb/validate_test.go
+++ b/pkg/phlaredb/validate_test.go
@@ -6,11 +6,12 @@ import (
 	"path"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/pyroscope/pkg/phlaredb"
 	"github.com/grafana/pyroscope/pkg/phlaredb/block"
 	"github.com/grafana/pyroscope/pkg/phlaredb/block/testutil"
 	"github.com/grafana/pyroscope/pkg/pprof/testhelper"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_ValidateBlock(t *testing.T) {

--- a/pkg/phlaredb/validate_test.go
+++ b/pkg/phlaredb/validate_test.go
@@ -1,0 +1,36 @@
+package phlaredb_test
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/grafana/pyroscope/pkg/phlaredb"
+	"github.com/grafana/pyroscope/pkg/phlaredb/block"
+	"github.com/grafana/pyroscope/pkg/phlaredb/block/testutil"
+	"github.com/grafana/pyroscope/pkg/pprof/testhelper"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ValidateBlock(t *testing.T) {
+	meta, dir, err := testutil.CreateBlock(t, func() []*testhelper.ProfileBuilder {
+		return []*testhelper.ProfileBuilder{
+			testhelper.NewProfileBuilder(int64(1)).
+				CPUProfile().
+				WithLabels(
+					"job", "a",
+				).ForStacktraceString("foo", "bar", "baz").AddSamples(1),
+		}
+	})
+	require.NoError(t, err)
+
+	err = phlaredb.ValidateLocalBlock(context.Background(), path.Join(dir, meta.ULID.String()))
+	require.NoError(t, err)
+	t.Run("should error when a file is missing", func(t *testing.T) {
+		os.Remove(path.Join(dir, meta.ULID.String(), block.IndexFilename))
+		err = phlaredb.ValidateLocalBlock(context.Background(), path.Join(dir, meta.ULID.String()))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no such file")
+	})
+}


### PR DESCRIPTION
This will allow us to ensure blocks downloaded locally are valid before uploading or compacting.

For now I'm using file system bucket storage for simplicity but it might be more efficient in the future to just use the filesystem.