### PR TITLE
fix: Rings are using the incorrect port

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -100,7 +100,7 @@ Usage of ./pyroscope:
   -distributor.ring.instance-interface-names string
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -distributor.ring.instance-port int
-    	Port to advertise in the ring (defaults to -server.http-listen-port). (default 4040)
+    	Port to advertise in the ring (defaults to -server.http-listen-port).
   -distributor.ring.multi.mirror-enabled
     	Mirror writes to secondary store.
   -distributor.ring.multi.mirror-timeout duration
@@ -322,7 +322,7 @@ Usage of ./pyroscope:
   -overrides-exporter.ring.instance-interface-names string
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -overrides-exporter.ring.instance-port int
-    	Port to advertise in the ring (defaults to -server.http-listen-port). (default 4040)
+    	Port to advertise in the ring (defaults to -server.http-listen-port).
   -overrides-exporter.ring.multi.mirror-enabled
     	Mirror writes to secondary store.
   -overrides-exporter.ring.multi.mirror-timeout duration
@@ -562,7 +562,7 @@ Usage of ./pyroscope:
   -query-scheduler.ring.instance-interface-names string
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -query-scheduler.ring.instance-port int
-    	Port to advertise in the ring (defaults to -server.http-listen-port). (default 4040)
+    	Port to advertise in the ring (defaults to -server.http-listen-port).
   -query-scheduler.ring.multi.mirror-enabled
     	Mirror writes to secondary store.
   -query-scheduler.ring.multi.mirror-timeout duration

--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -160,16 +160,6 @@ func (c *Config) registerServerFlagsWithChangedDefaultValues(fs *flag.FlagSet) {
 		switch f.Name {
 		case "server.http-listen-port":
 			_ = f.Value.Set("4040")
-		case "query-frontend.instance-port":
-			_ = f.Value.Set("4040")
-		case "distributor.ring.instance-port":
-			_ = f.Value.Set("4040")
-		case "store-gateway.sharding-ring.instance-port":
-			_ = f.Value.Set("4040")
-		case "query-scheduler.ring.instance-port":
-			_ = f.Value.Set("4040")
-		case "overrides-exporter.ring.instance-port":
-			_ = f.Value.Set("4040")
 		case "distributor.replication-factor":
 			_ = f.Value.Set("1")
 		case "query-scheduler.service-discovery-mode":


### PR DESCRIPTION
In https://github.com/grafana/pyroscope/pull/2391, a change was made to factor out a common ring config to reduce duplication of ring settings across components. In doing so, a change was added to set default port values if no value was provided:

https://github.com/grafana/pyroscope/commit/2c73692f18f99b00dfb336088b7211b953a9ae12#diff-e94eca41c9ef18ab2a324780565931df687280a46d570e6d08ebc54f73bf541dR167-R170

In doing so, this fouled up a separate process where (if no default was provided for instance-port) it would fallback to the http listen port.

This PR removes the change where a default port value would be used, allowing the fallback mechanism to work correctly.