### PR TITLE
fix: various bugs that occur when selection is too small

### DIFF
--- a/public/app/components/TimelineChart/TimelineChart.tsx
+++ b/public/app/components/TimelineChart/TimelineChart.tsx
@@ -24,10 +24,45 @@ class TimelineChart extends ReactFlot<TimelineChartProps> {
 
     // TODO: use ref
     $(`#${this.props.id}`).bind('plotselected', (event, ranges) => {
-      this.props.onSelect(
-        Math.round(ranges.xaxis.from / 1000).toString(),
-        Math.round(ranges.xaxis.to / 1000).toString()
-      );
+      // Before invoking the onselect, we ensure the selection is valid
+
+      if (ranges.xaxis == null) {
+        // Invalid range, do nothing.
+        return;
+      }
+
+      const {from, to} = ranges.xaxis;
+
+      let fromSeconds = Math.round(from / 1000);
+      let untilSeconds = Math.round(to / 1000);
+
+      if (fromSeconds === untilSeconds) {
+        // If the time ranges have a difference of zero seconds, we skip the zoom.
+        return;
+      }
+
+      let morePointsThanPixels = false;
+      let pointCount = 0;
+
+      for (const dataRange of this.props.data) {
+
+        if (morePointsThanPixels || (dataRange.data.length > event.currentTarget.clientWidth)) {
+          // We can assume there are some points in the selection, so we will short circuit out
+          morePointsThanPixels = true;
+          break;
+        }
+
+        dataRange.data.forEach(
+          (point: number[]) => pointCount += Number(point[0] > from && point[0] < to)
+        )
+      }
+
+      if (!morePointsThanPixels && pointCount < 3) {
+        // If we are zooming in and there are fewer than 3 points, we cancel the zoom.
+        return;
+      }
+
+      this.props.onSelect(fromSeconds.toString(), untilSeconds.toString());
     });
   }
 

--- a/public/app/components/TimelineChart/TimelineChart.tsx
+++ b/public/app/components/TimelineChart/TimelineChart.tsx
@@ -11,6 +11,7 @@ import '@pyroscope/components/TimelineChart/Tooltip.plugin';
 import '@pyroscope/components/TimelineChart/Annotations.plugin';
 import '@pyroscope/components/TimelineChart/ContextMenu.plugin';
 import '@pyroscope/components/TimelineChart/CrosshairSync.plugin';
+import { rangeIsAcceptableForZoom } from './util';
 
 interface TimelineChartProps {
   onSelect: (from: string, until: string) => void;
@@ -26,46 +27,13 @@ class TimelineChart extends ReactFlot<TimelineChartProps> {
     $(`#${this.props.id}`).bind('plotselected', (event, ranges) => {
       // Before invoking the onselect, we ensure the selection is valid
 
-      if (ranges.xaxis == null) {
-        // Invalid range, do nothing.
-        return;
+      const xAxisPixelsInChart = event.currentTarget.clientWidth;
+
+      if (rangeIsAcceptableForZoom(ranges.xaxis, this.props.data, xAxisPixelsInChart)) {
+        const fromSeconds = Math.round(ranges.xaxis.from / 1000);
+        const untilSeconds = Math.round(ranges.xaxis.to / 1000);
+        this.props.onSelect(fromSeconds.toString(), untilSeconds.toString());
       }
-
-      const { from, to } = ranges.xaxis;
-
-      let fromSeconds = Math.round(from / 1000);
-      let untilSeconds = Math.round(to / 1000);
-
-      if (fromSeconds === untilSeconds) {
-        // If the time ranges have a difference of zero seconds, we skip the zoom.
-        return;
-      }
-
-      let morePointsThanPixels = false;
-      let pointCount = 0;
-
-      for (const dataRange of this.props.data) {
-        if (
-          morePointsThanPixels ||
-          dataRange.data.length > event.currentTarget.clientWidth
-        ) {
-          // We can assume there are some points in the selection, so we will short circuit out
-          morePointsThanPixels = true;
-          break;
-        }
-
-        dataRange.data.forEach(
-          (point: number[]) =>
-            (pointCount += Number(point[0] > from && point[0] < to))
-        );
-      }
-
-      if (!morePointsThanPixels && pointCount < 3) {
-        // If we are zooming in and there are fewer than 3 points, we cancel the zoom.
-        return;
-      }
-
-      this.props.onSelect(fromSeconds.toString(), untilSeconds.toString());
     });
   }
 

--- a/public/app/components/TimelineChart/TimelineChart.tsx
+++ b/public/app/components/TimelineChart/TimelineChart.tsx
@@ -29,10 +29,17 @@ class TimelineChart extends ReactFlot<TimelineChartProps> {
 
       const xAxisPixelsInChart = event.currentTarget.clientWidth;
 
-      if (rangeIsAcceptableForZoom(ranges.xaxis, this.props.data, xAxisPixelsInChart)) {
-        const fromSeconds = Math.round(ranges.xaxis.from / 1000);
-        const untilSeconds = Math.round(ranges.xaxis.to / 1000);
-        this.props.onSelect(fromSeconds.toString(), untilSeconds.toString());
+      if (
+        rangeIsAcceptableForZoom(
+          ranges.xaxis,
+          this.props.data,
+          xAxisPixelsInChart
+        )
+      ) {
+        this.props.onSelect(
+          Math.round(ranges.xaxis.from / 1000).toString(),
+          Math.round(ranges.xaxis.to / 1000).toString()
+        );
       }
     });
   }

--- a/public/app/components/TimelineChart/TimelineChart.tsx
+++ b/public/app/components/TimelineChart/TimelineChart.tsx
@@ -31,7 +31,7 @@ class TimelineChart extends ReactFlot<TimelineChartProps> {
         return;
       }
 
-      const {from, to} = ranges.xaxis;
+      const { from, to } = ranges.xaxis;
 
       let fromSeconds = Math.round(from / 1000);
       let untilSeconds = Math.round(to / 1000);
@@ -45,16 +45,19 @@ class TimelineChart extends ReactFlot<TimelineChartProps> {
       let pointCount = 0;
 
       for (const dataRange of this.props.data) {
-
-        if (morePointsThanPixels || (dataRange.data.length > event.currentTarget.clientWidth)) {
+        if (
+          morePointsThanPixels ||
+          dataRange.data.length > event.currentTarget.clientWidth
+        ) {
           // We can assume there are some points in the selection, so we will short circuit out
           morePointsThanPixels = true;
           break;
         }
 
         dataRange.data.forEach(
-          (point: number[]) => pointCount += Number(point[0] > from && point[0] < to)
-        )
+          (point: number[]) =>
+            (pointCount += Number(point[0] > from && point[0] < to))
+        );
       }
 
       if (!morePointsThanPixels && pointCount < 3) {

--- a/public/app/components/TimelineChart/util.spec.tsx
+++ b/public/app/components/TimelineChart/util.spec.tsx
@@ -1,0 +1,56 @@
+import { TimelineVisibleData, rangeIsAcceptableForZoom } from './util'
+
+describe('TimelineChart.util', function () {
+
+  describe('rangeIsAcceptableForZoom', function () {
+
+    const xaxisRange = {from: 10, to: 20};
+    function makeData(timeValues: number[]) {
+      // The y value of 1 is used, but not actually read
+      return {data: timeValues.map(time => [time, 1])} as TimelineVisibleData[number]
+    }
+    
+
+    function executeOnData(data: TimelineVisibleData) {
+      const pixels = 100000; // Should not factor in for this kind of test
+      return rangeIsAcceptableForZoom(xaxisRange, data, pixels);
+    }
+
+    it("Rejects empty data", ()=>{
+      expect(executeOnData([])).toBe(false);
+      expect(executeOnData([makeData([]), makeData([])])).toBe(false);
+    });
+
+    it("Rejects if no points on xaxisrange", ()=>{
+      expect(executeOnData([makeData([1,2,3,4,5,6,7,8,9])])).toBe(false);
+    });
+
+    it("Rejects only one point on xaxisrange", ()=>{
+      expect(executeOnData([makeData([12])])).toBe(false);
+      expect(executeOnData([makeData([2, 12, 22])])).toBe(false);
+    });
+
+    it("Rejects only one point on xaxisrange even when multiple datasets", ()=>{
+      expect(executeOnData([makeData([12]), makeData([13]), makeData([14])])).toBe(false);
+      expect(executeOnData([makeData([2, 12, 22]), makeData([3, 13, 23]), makeData([4, 14, 24])])).toBe(false);
+    });
+
+    it("Accepts if at least two points within xaxisrange", ()=>{
+      expect(executeOnData([makeData([12, 13])])).toBe(true);
+    });
+
+    it("Accepts if at least one dataset has two points within xaxisrange", ()=>{
+      expect(executeOnData([makeData([12]), makeData([13]), makeData([14,15])])).toBe(true);
+    });
+
+    it ("Automatically accepts when more data than pixels", ()=> {
+      const pixels = 10;
+      const numPoints = 25;
+      const data = [] as number[];
+      for (let i = 0; i < numPoints; i++) {
+        data.push(i);
+      }
+      expect(rangeIsAcceptableForZoom(xaxisRange, [makeData(data)], pixels))
+    })
+  });
+});

--- a/public/app/components/TimelineChart/util.spec.tsx
+++ b/public/app/components/TimelineChart/util.spec.tsx
@@ -1,56 +1,67 @@
-import { TimelineVisibleData, rangeIsAcceptableForZoom } from './util'
+import { TimelineVisibleData, rangeIsAcceptableForZoom } from './util';
 
 describe('TimelineChart.util', function () {
-
   describe('rangeIsAcceptableForZoom', function () {
-
-    const xaxisRange = {from: 10, to: 20};
+    const xaxisRange = { from: 10, to: 20 };
     function makeData(timeValues: number[]) {
       // The y value of 1 is used, but not actually read
-      return {data: timeValues.map(time => [time, 1])} as TimelineVisibleData[number]
+      return {
+        data: timeValues.map((time) => [time, 1]),
+      } as TimelineVisibleData[number];
     }
-    
 
     function executeOnData(data: TimelineVisibleData) {
       const pixels = 100000; // Should not factor in for this kind of test
       return rangeIsAcceptableForZoom(xaxisRange, data, pixels);
     }
 
-    it("Rejects empty data", ()=>{
+    it('Rejects empty data', () => {
       expect(executeOnData([])).toBe(false);
       expect(executeOnData([makeData([]), makeData([])])).toBe(false);
     });
 
-    it("Rejects if no points on xaxisrange", ()=>{
-      expect(executeOnData([makeData([1,2,3,4,5,6,7,8,9])])).toBe(false);
+    it('Rejects if no points on xaxisrange', () => {
+      expect(executeOnData([makeData([1, 2, 3, 4, 5, 6, 7, 8, 9])])).toBe(
+        false
+      );
     });
 
-    it("Rejects only one point on xaxisrange", ()=>{
+    it('Rejects only one point on xaxisrange', () => {
       expect(executeOnData([makeData([12])])).toBe(false);
       expect(executeOnData([makeData([2, 12, 22])])).toBe(false);
     });
 
-    it("Rejects only one point on xaxisrange even when multiple datasets", ()=>{
-      expect(executeOnData([makeData([12]), makeData([13]), makeData([14])])).toBe(false);
-      expect(executeOnData([makeData([2, 12, 22]), makeData([3, 13, 23]), makeData([4, 14, 24])])).toBe(false);
+    it('Rejects only one point on xaxisrange even when multiple datasets', () => {
+      expect(
+        executeOnData([makeData([12]), makeData([13]), makeData([14])])
+      ).toBe(false);
+      expect(
+        executeOnData([
+          makeData([2, 12, 22]),
+          makeData([3, 13, 23]),
+          makeData([4, 14, 24]),
+        ])
+      ).toBe(false);
     });
 
-    it("Accepts if at least two points within xaxisrange", ()=>{
+    it('Accepts if at least two points within xaxisrange', () => {
       expect(executeOnData([makeData([12, 13])])).toBe(true);
     });
 
-    it("Accepts if at least one dataset has two points within xaxisrange", ()=>{
-      expect(executeOnData([makeData([12]), makeData([13]), makeData([14,15])])).toBe(true);
+    it('Accepts if at least one dataset has two points within xaxisrange', () => {
+      expect(
+        executeOnData([makeData([12]), makeData([13]), makeData([14, 15])])
+      ).toBe(true);
     });
 
-    it ("Automatically accepts when more data than pixels", ()=> {
+    it('Automatically accepts when more data than pixels', () => {
       const pixels = 10;
       const numPoints = 25;
       const data = [] as number[];
       for (let i = 0; i < numPoints; i++) {
         data.push(i);
       }
-      expect(rangeIsAcceptableForZoom(xaxisRange, [makeData(data)], pixels))
-    })
+      expect(rangeIsAcceptableForZoom(xaxisRange, [makeData(data)], pixels));
+    });
   });
 });

--- a/public/app/components/TimelineChart/util.ts
+++ b/public/app/components/TimelineChart/util.ts
@@ -1,31 +1,33 @@
-
 export type TimelineChartSelectionTimeRangeAxis = {
   from: number;
   to: number;
-
-}
+};
 
 export type TimelineAxisSelection = {
   from: number;
   to: number;
-}
+};
 
-export type TimelineVisibleData = {
+export type TimelineVisibleData = Array<{
   data: number[][];
-}[]
+}>;
 
 /**
  * Evaluates if a time range contains points suitable to zoom into.
  * The criteria is that there should be at least two points on the same data set.
  * If the number of xaxis pixels is smaller than number of points in a dataset,
  * we assume that no xaxisRange can be selected that won't contain at least two points.
- * 
+ *
  * @param xaxisRange mouse drag/drop selection range along the xaxis
- * @param datasets a collection of datasets that are currently visible on the chart 
+ * @param datasets a collection of datasets that are currently visible on the chart
  * @param xaxisPixels the width of the chart in pixels
- * @returns 
+ * @returns
  */
-export function rangeIsAcceptableForZoom(xaxisRange: TimelineAxisSelection, datasets: TimelineVisibleData, xaxisPixels: number) {
+export function rangeIsAcceptableForZoom(
+  xaxisRange: TimelineAxisSelection,
+  datasets: TimelineVisibleData,
+  xaxisPixels: number
+) {
   if (xaxisRange == null) {
     // Invalid range, do nothing.
     return false;

--- a/public/app/components/TimelineChart/util.ts
+++ b/public/app/components/TimelineChart/util.ts
@@ -1,0 +1,58 @@
+
+export type TimelineChartSelectionTimeRangeAxis = {
+  from: number;
+  to: number;
+
+}
+
+export type TimelineAxisSelection = {
+  from: number;
+  to: number;
+}
+
+export type TimelineVisibleData = {
+  data: number[][];
+}[]
+
+/**
+ * Evaluates if a time range contains points suitable to zoom into.
+ * The criteria is that there should be at least two points on the same data set.
+ * If the number of xaxis pixels is smaller than number of points in a dataset,
+ * we assume that no xaxisRange can be selected that won't contain at least two points.
+ * 
+ * @param xaxisRange mouse drag/drop selection range along the xaxis
+ * @param datasets a collection of datasets that are currently visible on the chart 
+ * @param xaxisPixels the width of the chart in pixels
+ * @returns 
+ */
+export function rangeIsAcceptableForZoom(xaxisRange: TimelineAxisSelection, datasets: TimelineVisibleData, xaxisPixels: number) {
+  if (xaxisRange == null) {
+    // Invalid range, do nothing.
+    return false;
+  }
+
+  const { from, to } = xaxisRange;
+
+  for (const dataset of datasets) {
+    const points = dataset.data;
+
+    if (points.length > xaxisPixels) {
+      // There are more points than pixels visible,
+      // so we can assume the range is safe.
+      return true;
+    }
+
+    let pointCount = 0;
+    for (const point of points) {
+      // If at least two points are on the range, it is acceptable.
+      if (point[0] > from && point[0] < to) {
+        pointCount++;
+        if (pointCount >= 2) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
It was detected that for very small selections on the timeline, the date range would be left in an invalid state. This is often due to there being no data points in the new selection, resulting in a corruption of subsequent range selection.

This PR avoids the issue by doing a few checks before accepting a range selection on the time line. If there are too few points in the new selection, it is aborted, thus preventing the resulting bugs.
