### PR TITLE
feat: add metric to track number of times a request fails to forward

### DIFF
--- a/pkg/frontend/frontend_scheduler_worker.go
+++ b/pkg/frontend/frontend_scheduler_worker.go
@@ -253,7 +253,7 @@ func newFrontendSchedulerWorker(conn *grpc.ClientConn, schedulerAddr string, fro
 		requestCh:                    requestCh,
 		cancelCh:                     make(chan uint64, schedulerWorkerCancelChanCapacity),
 		enqueuedRequests:             enqueuedRequests,
-		requestsForwardedFailedStats: usagestats.NewInt("pyroscope_query_frontend_requests_forwarded_failed"),
+		requestsForwardedFailedStats: usagestats.NewInt("query_frontend_forwarded_requests_failed"),
 		maxLoopDuration:              maxLoopDuration,
 	}
 	w.ctx, w.cancel = context.WithCancel(context.Background())


### PR DESCRIPTION
In https://github.com/grafana/pyroscope/pull/2391, a bug was introduced that stopped the scheduler from sending requests to the querier. This was reverted in https://github.com/grafana/pyroscope/pull/2398.

This PR adds metrics to track the number of times a frontend worker fails to forward a request to a querier. We can then create alerting based off those metrics to catch failures earlier.