### PR TITLE
Docs: Use the correct data source type

### DIFF
--- a/docs/sources/deploy-kubernetes/helm.md
+++ b/docs/sources/deploy-kubernetes/helm.md
@@ -154,7 +154,7 @@ datasources:
    apiVersion: 1
    datasources:
    - name: Pyroscope
-     type: pyroscope
+     type: grafana-pyroscope-datasource
      uid: pyroscope-test
      url: http://pyroscope-querier.pyroscope-test.svc.cluster.local.:4040/
 ```

--- a/examples/tracing/jaeger/grafana/provisioning/datasources/datasources.yml
+++ b/examples/tracing/jaeger/grafana/provisioning/datasources/datasources.yml
@@ -10,7 +10,7 @@ datasources:
     url: http://jaeger:16686
 
   - name: Pyroscope
-    type: pyroscope-datasource
+    type: grafana-pyroscope-datasource
     access: proxy
     orgId: 1
     uid: pyroscope


### PR DESCRIPTION
The only correct values are `phlare` and `grafana-pyroscope-datasource`