### PR TITLE
Handle pyroscope 0.37 modes more gracefully

### DIFF
--- a/cmd/pyroscope/main.go
+++ b/cmd/pyroscope/main.go
@@ -63,6 +63,23 @@ func main() {
 		return
 	}
 
+	if args := flag.Args(); len(args) > 0 {
+		switch args[0] {
+		// server mode is the pyroscope's only mode from 1.0
+		case "server":
+			break
+		case "agent", "ebpf":
+			fmt.Printf("%s mode is deprecated. Please use Grafana Agent instead.\n", args[0])
+			os.Exit(1)
+		case "connect", "exec":
+			fmt.Printf("%s mode is deprecated. Please use Pyroscope 0.37 or earlier.\n", args[0])
+			os.Exit(1)
+		default:
+			fmt.Printf("unknown mode: %s\n", args[0])
+			os.Exit(1)
+		}
+	}
+
 	f, err := phlare.New(flags.Config)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed creating pyroscope: %v\n", err)


### PR DESCRIPTION
I think the minimum we can do about https://github.com/grafana/pyroscope/issues/2421 is to use be explicit and error.