### PR TITLE
fix(helm): set correct namespace for all resources

### DIFF
--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: pyroscope-dev-distributor
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -24,6 +25,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: pyroscope-dev-ingester
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -44,6 +46,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: pyroscope-dev-querier
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -64,6 +67,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: pyroscope-dev-query-frontend
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -84,6 +88,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: pyroscope-dev-query-scheduler
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -104,6 +109,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: pyroscope-dev-store-gateway
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -143,6 +149,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: pyroscope-dev
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -489,6 +496,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-agent-config-pyroscope
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1292,6 +1300,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: pyroscope-dev-overrides-config
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1308,6 +1317,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: pyroscope-dev-config
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1411,6 +1421,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: default-pyroscope-dev
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1457,6 +1468,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: default-pyroscope-dev
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1596,6 +1608,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pyroscope-dev-memberlist
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1622,6 +1635,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pyroscope-dev-distributor
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1646,6 +1660,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pyroscope-dev-distributor-headless
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1671,6 +1686,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pyroscope-dev-ingester
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1695,6 +1711,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pyroscope-dev-ingester-headless
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1720,6 +1737,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pyroscope-dev-querier
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1744,6 +1762,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pyroscope-dev-querier-headless
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1769,6 +1788,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pyroscope-dev-query-frontend
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1793,6 +1813,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pyroscope-dev-query-frontend-headless
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1818,6 +1839,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pyroscope-dev-query-scheduler
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1842,6 +1864,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pyroscope-dev-query-scheduler-headless
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1867,6 +1890,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pyroscope-dev-store-gateway
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1891,6 +1915,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pyroscope-dev-store-gateway-headless
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1916,6 +1941,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pyroscope-dev-distributor
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1933,7 +1959,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 94032a81c0046878afc76b7c7a28f71649da6d44991149bdf763ad50dcf34527
+        checksum/config: 027360c7de6747514d4ecfafd152f3a01b26a673d9cce1ef8697a8c67d6d48d9
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2006,6 +2032,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pyroscope-dev-querier
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -2023,7 +2050,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 94032a81c0046878afc76b7c7a28f71649da6d44991149bdf763ad50dcf34527
+        checksum/config: 027360c7de6747514d4ecfafd152f3a01b26a673d9cce1ef8697a8c67d6d48d9
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2096,6 +2123,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pyroscope-dev-query-frontend
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -2113,7 +2141,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 94032a81c0046878afc76b7c7a28f71649da6d44991149bdf763ad50dcf34527
+        checksum/config: 027360c7de6747514d4ecfafd152f3a01b26a673d9cce1ef8697a8c67d6d48d9
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2186,6 +2214,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pyroscope-dev-query-scheduler
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -2203,7 +2232,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 94032a81c0046878afc76b7c7a28f71649da6d44991149bdf763ad50dcf34527
+        checksum/config: 027360c7de6747514d4ecfafd152f3a01b26a673d9cce1ef8697a8c67d6d48d9
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2453,6 +2482,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: pyroscope-dev-ingester
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -2472,7 +2502,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 94032a81c0046878afc76b7c7a28f71649da6d44991149bdf763ad50dcf34527
+        checksum/config: 027360c7de6747514d4ecfafd152f3a01b26a673d9cce1ef8697a8c67d6d48d9
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2546,6 +2576,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: pyroscope-dev-store-gateway
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -2565,7 +2596,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 94032a81c0046878afc76b7c7a28f71649da6d44991149bdf763ad50dcf34527
+        checksum/config: 027360c7de6747514d4ecfafd152f3a01b26a673d9cce1ef8697a8c67d6d48d9
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: pyroscope-dev
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -36,6 +37,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: pyroscope-dev
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -48,6 +50,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-agent-config-pyroscope
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -851,6 +854,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: pyroscope-dev-overrides-config
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -867,6 +871,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: pyroscope-dev-config
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -963,6 +968,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: default-pyroscope-dev
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1009,6 +1015,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: default-pyroscope-dev
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1080,6 +1087,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pyroscope-dev-memberlist
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1106,6 +1114,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pyroscope-dev
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1130,6 +1139,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pyroscope-dev-headless
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1237,6 +1247,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: pyroscope-dev
+  namespace: default
   labels:
     helm.sh/chart: pyroscope-1.0.3
     app.kubernetes.io/name: pyroscope
@@ -1256,7 +1267,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b11c7a3f7cb3527e9771a71b638c9653862052a29daca13986aad156d3d6da15
+        checksum/config: 076be65c67cf2c6720688fc274951f7aef8fdd570d7159ca08f7908a75317fd6
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/templates/configmap-agent.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/configmap-agent.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.agent.agent.configMap.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "pyroscope.labels" . | nindent 4 }}
 data:

--- a/operations/pyroscope/helm/pyroscope/templates/configmap-overrides.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/configmap-overrides.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "pyroscope.fullname" . }}-overrides-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "pyroscope.labels" . | nindent 4 }}
 data:

--- a/operations/pyroscope/helm/pyroscope/templates/configmap.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "pyroscope.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "pyroscope.labels" . | nindent 4 }}
 data:

--- a/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
@@ -7,6 +7,7 @@ apiVersion: apps/v1
 kind: {{ $cfg.kind }}
 metadata:
   name: {{ $cfg.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "pyroscope.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ $component | quote }}
@@ -166,6 +167,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ $cfg.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "pyroscope.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ $component | quote }}

--- a/operations/pyroscope/helm/pyroscope/templates/ingress.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "pyroscope.fullname" . }}-ingress
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "pyroscope.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/operations/pyroscope/helm/pyroscope/templates/memberlist-service.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/memberlist-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "pyroscope.fullname" . }}-memberlist
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "pyroscope.labels" . | nindent 4 }}
 spec:

--- a/operations/pyroscope/helm/pyroscope/templates/rbac.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/rbac.yaml
@@ -4,6 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Release.Namespace }}-{{ include "pyroscope.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "pyroscope.labels" . | nindent 4 }}
 rules:
@@ -25,6 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Release.Namespace }}-{{ include "pyroscope.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "pyroscope.labels" . | nindent 4 }}
 roleRef:

--- a/operations/pyroscope/helm/pyroscope/templates/serviceaccount.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "pyroscope.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "pyroscope.labels" . | nindent 4 }}
   {{- with .Values.pyroscope.serviceAccount.annotations }}

--- a/operations/pyroscope/helm/pyroscope/templates/services.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/services.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $cfg.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "pyroscope.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ $component | quote }}
@@ -28,6 +29,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $cfg.name }}-headless
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "pyroscope.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ $component | quote }}


### PR DESCRIPTION
This PR adds namespace values for each resource created by the helm chart. Previously, everything would be installed in the default namespace, e.g. `helm -n pyroscope-test install pyroscope grafana/pyroscope` would not install into the `pyroscope-test` namespace. 

Not sure if there was a specfic reason for this. 