### PR TITLE
f32 fixes

### DIFF
--- a/pkg/ingester/pyroscope/ingest_adapter.go
+++ b/pkg/ingester/pyroscope/ingest_adapter.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-kit/log/level"
 	"github.com/grafana/pyroscope/pkg/distributor/model"
+	"github.com/grafana/pyroscope/pkg/tenant"
 
 	"github.com/bufbuild/connect-go"
 	"github.com/go-kit/log"
@@ -31,12 +33,13 @@ type PushService interface {
 func NewPyroscopeIngestHandler(svc PushService, logger log.Logger) http.Handler {
 	return NewIngestHandler(
 		logger,
-		&pyroscopeIngesterAdapter{svc: svc},
+		&pyroscopeIngesterAdapter{svc: svc, log: logger},
 	)
 }
 
 type pyroscopeIngesterAdapter struct {
 	svc PushService
+	log log.Logger
 }
 
 func (p *pyroscopeIngesterAdapter) Ingest(ctx context.Context, in *ingestion.IngestInput) error {
@@ -163,6 +166,13 @@ func (p *pyroscopeIngesterAdapter) parseToPprof(ctx context.Context, in *ingesti
 	plainReq, err := pprofable.ParseToPprof(ctx, in.Metadata)
 	if err != nil {
 		return fmt.Errorf("parsing IngestInput-pprof failed %w", err)
+	}
+	if len(plainReq.Series) == 0 {
+		tenantID, _ := tenant.ExtractTenantIDFromContext(ctx)
+		_ = level.Debug(p.log).Log("msg", "empty profile",
+			"app", in.Metadata.Key.AppName(),
+			"orgID", tenantID)
+		return nil
 	}
 	_, err = p.svc.PushParsed(ctx, plainReq)
 	if err != nil {

--- a/pkg/ingester/pyroscope/ingest_handler.go
+++ b/pkg/ingester/pyroscope/ingest_handler.go
@@ -46,17 +46,17 @@ func NewIngestHandler(l log.Logger, p ingestion.Ingester) http.Handler {
 }
 
 func (h ingestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	tenantID, _ := tenant.ExtractTenantIDFromContext(r.Context())
 	input, err := h.ingestInputFromRequest(r)
 	if err != nil {
-		_ = h.log.Log("msg", "bad request", "err", err)
+		_ = h.log.Log("msg", "bad request", "err", err, "orgID", tenantID)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
-	tenantID, _ := tenant.ExtractTenantIDFromContext(r.Context())
 	err = h.ingester.Ingest(r.Context(), input)
 	if err != nil {
-		_ = h.log.Log("msg", "pyroscope ingest", "err", err, "tenant_id", tenantID)
+		_ = h.log.Log("msg", "pyroscope ingest", "err", err, "orgID", tenantID)
 		var connectErr *connect.Error
 		if ok := errors.As(err, &connectErr); ok {
 			w.WriteHeader(int(connectgrpc.CodeToHTTP(connectErr.Code())))

--- a/pkg/og/convert/jfr/pprof.go
+++ b/pkg/og/convert/jfr/pprof.go
@@ -35,11 +35,17 @@ const (
 func newJfrPprofBuilders(p *parser.Parser, jfrLabels *LabelsSnapshot, piOriginal *storage.PutInput) *jfrPprofBuilders {
 	st := piOriginal.StartTime.UnixNano()
 	et := piOriginal.EndTime.UnixNano()
+	var period int64
+	if piOriginal.SampleRate == 0 {
+		period = 0
+	} else {
+		period = 1e9 / int64(piOriginal.SampleRate)
+	}
 	res := &jfrPprofBuilders{
 		timeNanos:     st,
 		durationNanos: et - st,
 		labels:        make([]*v1.LabelPair, 0, len(piOriginal.Key.Labels())+5),
-		period:        1e9 / int64(piOriginal.SampleRate),
+		period:        period,
 		appName:       piOriginal.Key.AppName(),
 		spyName:       piOriginal.SpyName,
 

--- a/pkg/og/convert/pprof/profile.go
+++ b/pkg/og/convert/pprof/profile.go
@@ -63,7 +63,7 @@ func (p *RawProfile) ParseToPprof(_ context.Context, md ingestion.Metadata) (res
 
 	fixTime(profile, md)
 	FixFunctionNamesForScriptingLanguages(profile, md)
-	if md.SpyName == "dotnetspy" {
+	if p.isDotnetspy(md) {
 		FixFunctionIDForBrokenDotnet(profile.Profile)
 		fixSampleTypes(profile.Profile)
 	}
@@ -80,6 +80,14 @@ func (p *RawProfile) ParseToPprof(_ context.Context, md ingestion.Metadata) (res
 		}},
 	}
 	return
+}
+
+func (p *RawProfile) isDotnetspy(md ingestion.Metadata) bool {
+	if md.SpyName == "dotnetspy" {
+		return true
+	}
+	stc := p.getSampleTypes()
+	return stc != nil && stc["inuse-space"] != nil
 }
 
 func fixTime(profile *pprof.Profile, md ingestion.Metadata) {

--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -492,7 +492,7 @@ func initLogger(logFormat string, logLevel dslog.Level) log.Logger {
 }
 
 func (f *Phlare) initAPI() (services.Service, error) {
-	a, err := api.New(f.Cfg.API, f.Server, f.grpcGatewayMux, util.Logger)
+	a, err := api.New(f.Cfg.API, f.Server, f.grpcGatewayMux, f.Server.Log)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- enable logging in the /ingest - it was NoOpLogger
- fix division by zero panic leading to 422 for a jfr ingested with sampleRate=0 parameter
- detect old dotnetspy by looking into  sample type config. (these pprofs have function.id = 0, which lead to "function id is 0" error from the distributor validation
- do not try to push to distributor if profile has zero series (there is some tenant with misconfigured jfr producing zero profiles)