### PR TITLE
feature: prefer cpu app default if none selected

### DIFF
--- a/public/app/hooks/useAppNames.ts
+++ b/public/app/hooks/useAppNames.ts
@@ -20,8 +20,15 @@ export function useSelectFirstApp() {
       const apps = await dispatch(reloadAppNames()).unwrap();
 
       if (apps.length > 0 && query === '') {
-        // Select first app automatically if there is no query selected
-        dispatch(setQuery(appToQuery(apps[0])));
+        // Select a reasonable default app automatically if there is no query selected
+
+        // First, find a `cpu` type
+        const cpuApp = apps.find((app)=>app.__profile_type__.split(":")[1] === 'cpu')
+
+        // If we can't find a `cpu` type, just choose the top of the list
+        const app = cpuApp ? cpuApp : apps[0];
+
+        dispatch(setQuery(appToQuery(app)));
       }
     }
 

--- a/public/app/hooks/useAppNames.ts
+++ b/public/app/hooks/useAppNames.ts
@@ -26,9 +26,14 @@ export function useSelectFirstApp() {
         const cpuApp = apps.find(
           (app) => app.__profile_type__.split(':')[1] === 'cpu'
         );
+     
+        // If `cpu` type is not found, try to find an `.itimer` type for Java
+        const itimerApp = cpuApp ? null : apps.find(
+          (app) => app.__profile_type__.split(':')[1] === '.itimer'
+        );
 
-        // If we can't find a `cpu` type, just choose the top of the list
-        const app = cpuApp ? cpuApp : apps[0];
+        // If we can't find a `cpu` or `.itimer` type, just choose the top of the list
+        const app = cpuApp || itimerApp || apps[0];
 
         dispatch(setQuery(appToQuery(app)));
       }

--- a/public/app/hooks/useAppNames.ts
+++ b/public/app/hooks/useAppNames.ts
@@ -26,11 +26,13 @@ export function useSelectFirstApp() {
         const cpuApp = apps.find(
           (app) => app.__profile_type__.split(':')[1] === 'cpu'
         );
-     
+
         // If `cpu` type is not found, try to find an `.itimer` type for Java
-        const itimerApp = cpuApp ? null : apps.find(
-          (app) => app.__profile_type__.split(':')[1] === '.itimer'
-        );
+        const itimerApp = cpuApp
+          ? null
+          : apps.find(
+              (app) => app.__profile_type__.split(':')[1] === '.itimer'
+            );
 
         // If we can't find a `cpu` or `.itimer` type, just choose the top of the list
         const app = cpuApp || itimerApp || apps[0];

--- a/public/app/hooks/useAppNames.ts
+++ b/public/app/hooks/useAppNames.ts
@@ -23,7 +23,9 @@ export function useSelectFirstApp() {
         // Select a reasonable default app automatically if there is no query selected
 
         // First, find a `cpu` type
-        const cpuApp = apps.find((app)=>app.__profile_type__.split(":")[1] === 'cpu')
+        const cpuApp = apps.find(
+          (app) => app.__profile_type__.split(':')[1] === 'cpu'
+        );
 
         // If we can't find a `cpu` type, just choose the top of the list
         const app = cpuApp ? cpuApp : apps[0];


### PR DESCRIPTION
- If no app is selected, choose the first cpu option as default
- If it can't find a cpu app, just choose the first as it did before 