### PR TITLE
doc: use correct memory profile endpoint in Go pull example

### DIFF
--- a/docs/sources/configure-client/grafana-agent/go_pull.md
+++ b/docs/sources/configure-client/grafana-agent/go_pull.md
@@ -225,7 +225,7 @@ pyroscope.scrape "default_settings" {
     }
     profile.memory {
       enabled = false
-      path = "/debug/pprof/memory"
+      path = "/debug/pprof/heap"
       delta = false
     }
     profile.godeltaprof_mutex {


### PR DESCRIPTION
Hello there,

I believe the memory profile is available at `/debug/pprof/heap` and not `/debug/pprof/memory` on Golang applications.

This PR fixes a doc that would suggest otherwise (got stuck for a while on this haha).

https://cs.opensource.google/go/go/+/refs/tags/go1.21.1:src/runtime/pprof/pprof.go;l=189