### PR TITLE
profilecli: Add query series command

### DIFF
--- a/cmd/profilecli/main.go
+++ b/cmd/profilecli/main.go
@@ -49,9 +49,11 @@ func main() {
 	parquetInspectFiles := parquetInspectCmd.Arg("file", "parquet file path").Required().ExistingFiles()
 
 	queryCmd := app.Command("query", "Query profile store.")
-	queryParams := addQueryParams(queryCmd)
-	queryOutput := queryCmd.Flag("output", "How to output the result, examples: console, raw, pprof=./my.pprof").Default("console").String()
 	queryMergeCmd := queryCmd.Command("merge", "Request merged profile.")
+	queryMergeOutput := queryMergeCmd.Flag("output", "How to output the result, examples: console, raw, pprof=./my.pprof").Default("console").String()
+	queryMergeParams := addQueryMergeParams(queryMergeCmd)
+	querySeriesCmd := queryCmd.Command("series", "Request series labels.")
+	querySeriesParams := addQuerySeriesParams(querySeriesCmd)
 
 	uploadCmd := app.Command("upload", "Upload profile(s).")
 	uploadParams := addUploadParams(uploadCmd)
@@ -77,7 +79,11 @@ func main() {
 			}
 		}
 	case queryMergeCmd.FullCommand():
-		if err := queryMerge(ctx, queryParams, *queryOutput); err != nil {
+		if err := queryMerge(ctx, queryMergeParams, *queryMergeOutput); err != nil {
+			os.Exit(checkError(err))
+		}
+	case querySeriesCmd.FullCommand():
+		if err := querySeries(ctx, querySeriesParams); err != nil {
 			os.Exit(checkError(err))
 		}
 	case uploadCmd.FullCommand():

--- a/cmd/profilecli/query.go
+++ b/cmd/profilecli/query.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -20,8 +21,12 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 
+	ingestv1 "github.com/grafana/pyroscope/api/gen/proto/go/ingester/v1"
+	"github.com/grafana/pyroscope/api/gen/proto/go/ingester/v1/ingesterv1connect"
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	"github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect"
+	"github.com/grafana/pyroscope/api/gen/proto/go/storegateway/v1/storegatewayv1connect"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 )
 
 const (
@@ -92,12 +97,25 @@ func (c *phlareClient) queryClient() querierv1connect.QuerierServiceClient {
 	)
 }
 
+func (c *phlareClient) storeGatewayClient() storegatewayv1connect.StoreGatewayServiceClient {
+	return storegatewayv1connect.NewStoreGatewayServiceClient(
+		c.httpClient(),
+		c.URL,
+	)
+}
+
+func (c *phlareClient) ingesterClient() ingesterv1connect.IngesterServiceClient {
+	return ingesterv1connect.NewIngesterServiceClient(
+		c.httpClient(),
+		c.URL,
+	)
+}
+
 type queryParams struct {
 	*phlareClient
-	From        string
-	To          string
-	ProfileType string
-	Query       string
+	From  string
+	To    string
+	Query string
 }
 
 func (p *queryParams) parseFromTo() (from time.Time, to time.Time, err error) {
@@ -118,19 +136,28 @@ func (p *queryParams) parseFromTo() (from time.Time, to time.Time, err error) {
 }
 
 func addQueryParams(queryCmd commander) *queryParams {
-	var (
-		params = &queryParams{}
-	)
+	params := new(queryParams)
 	params.phlareClient = addPhlareClient(queryCmd)
 
 	queryCmd.Flag("from", "Beginning of the query.").Default("now-1h").StringVar(&params.From)
 	queryCmd.Flag("to", "End of the query.").Default("now").StringVar(&params.To)
-	queryCmd.Flag("profile-type", "Profile type to query.").Default("process_cpu:cpu:nanoseconds:cpu:nanoseconds").StringVar(&params.ProfileType)
 	queryCmd.Flag("query", "Label selector to query.").Default("{}").StringVar(&params.Query)
 	return params
 }
 
-func queryMerge(ctx context.Context, params *queryParams, outputFlag string) (err error) {
+type queryMergeParams struct {
+	*queryParams
+	ProfileType string
+}
+
+func addQueryMergeParams(queryCmd commander) *queryMergeParams {
+	params := new(queryMergeParams)
+	params.queryParams = addQueryParams(queryCmd)
+	queryCmd.Flag("profile-type", "Profile type to query.").Default("process_cpu:cpu:nanoseconds:cpu:nanoseconds").StringVar(&params.ProfileType)
+	return params
+}
+
+func queryMerge(ctx context.Context, params *queryMergeParams, outputFlag string) (err error) {
 	from, to, err := params.parseFromTo()
 	if err != nil {
 		return err
@@ -204,4 +231,86 @@ func queryMerge(ctx context.Context, params *queryParams, outputFlag string) (er
 	}
 
 	return errors.Errorf("unknown output %s", outputFlag)
+}
+
+type querySeriesParams struct {
+	*queryParams
+	LabelNames []string
+	APIType    string
+}
+
+func addQuerySeriesParams(queryCmd commander) *querySeriesParams {
+	params := new(querySeriesParams)
+	params.queryParams = addQueryParams(queryCmd)
+	queryCmd.Flag("label-names", "Filter returned labels to the supplied label names. Without any filter all labels are returned.").StringsVar(&params.LabelNames)
+	queryCmd.Flag("api-type", "Which API type to query (querier, ingester or store-gateway).").Default("querier").StringVar(&params.APIType)
+	return params
+}
+
+func querySeries(ctx context.Context, params *querySeriesParams) (err error) {
+	from, to, err := params.parseFromTo()
+	if err != nil {
+		return err
+	}
+
+	level.Info(logger).Log("msg", fmt.Sprintf("query series from %s", params.APIType), "url", params.URL, "from", from, "to", to, "labelNames", fmt.Sprintf("%q", params.LabelNames))
+
+	var result []*typesv1.Labels
+	switch params.APIType {
+	case "querier":
+		qc := params.phlareClient.queryClient()
+		resp, err := qc.Series(ctx, connect.NewRequest(&querierv1.SeriesRequest{
+			Start:      from.UnixMilli(),
+			End:        to.UnixMilli(),
+			Matchers:   []string{params.Query},
+			LabelNames: params.LabelNames,
+		}))
+		if err != nil {
+			return errors.Wrap(err, "failed to query")
+		}
+		result = resp.Msg.LabelsSet
+	case "ingester":
+		ic := params.phlareClient.ingesterClient()
+		resp, err := ic.Series(ctx, connect.NewRequest(&ingestv1.SeriesRequest{
+			Start:      from.UnixMilli(),
+			End:        to.UnixMilli(),
+			Matchers:   []string{params.Query},
+			LabelNames: params.LabelNames,
+		}))
+		if err != nil {
+			return errors.Wrap(err, "failed to query")
+		}
+		result = resp.Msg.LabelsSet
+	case "store-gateway":
+		sc := params.phlareClient.storeGatewayClient()
+		resp, err := sc.Series(ctx, connect.NewRequest(&ingestv1.SeriesRequest{
+			Start:      from.UnixMilli(),
+			End:        to.UnixMilli(),
+			Matchers:   []string{params.Query},
+			LabelNames: params.LabelNames,
+		}))
+		if err != nil {
+			return errors.Wrap(err, "failed to query")
+		}
+		result = resp.Msg.LabelsSet
+	default:
+		return errors.Errorf("unknown api type %s", params.APIType)
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	m := make(map[string]interface{})
+	for _, s := range result {
+		for k := range m {
+			delete(m, k)
+		}
+		for _, l := range s.Labels {
+			m[l.Name] = l.Value
+		}
+		if err := enc.Encode(m); err != nil {
+			return err
+		}
+	}
+
+	return nil
+
 }


### PR DESCRIPTION
This command allows to query the profile series available from pyroscope. It support querier/ingester/store-gateway APIs.

The results are written to stdout, so they e.g. can be processed further with `jq`.
