### PR TITLE
Preserve profile timestamp

### DIFF
--- a/pkg/test/integration/helper.go
+++ b/pkg/test/integration/helper.go
@@ -34,6 +34,9 @@ func (p *PyroscopeTest) Start(t *testing.T) {
 	require.NoError(t, err)
 	p.config.SelfProfiling.DisablePush = true
 	p.config.Analytics.Enabled = false // usage-stats terminating slow as hell
+	p.config.LimitsConfig.MaxQueryLength = 0
+	p.config.LimitsConfig.MaxQueryLookback = 0
+	p.config.LimitsConfig.RejectOlderThan = 0
 	_ = p.config.Server.LogLevel.Set("debug")
 	p.it, err = phlare.New(p.config)
 

--- a/pkg/test/integration/ingest_pprof_test.go
+++ b/pkg/test/integration/ingest_pprof_test.go
@@ -293,7 +293,7 @@ func selectMerge(t *testing.T, metric expectedMetric, name string, testdatum ppr
 	qc := queryClient()
 	resp, err := qc.SelectMergeProfile(context.Background(), connect.NewRequest(&querierv1.SelectMergeProfileRequest{
 		ProfileTypeID: metric.name,
-		Start:         time.Now().Add(-time.Hour).UnixMilli(),
+		Start:         time.Unix(0, 0).UnixMilli(),
 		End:           time.Now().UnixMilli(),
 		LabelSelector: fmt.Sprintf("{service_name=\"%s\"}", name),
 	}))
@@ -328,7 +328,7 @@ func selectMerge(t *testing.T, metric expectedMetric, name string, testdatum ppr
 func render(t *testing.T, metric expectedMetric, appName string, testdatum pprofTestData) {
 	fmt.Println(metric)
 
-	queryURL := "http://localhost:4040/pyroscope/render?query=" + metric.name + "{service_name=\"" + appName + "\"}&from=now-1h&until=now&format=collapsed"
+	queryURL := "http://localhost:4040/pyroscope/render?query=" + metric.name + "{service_name=\"" + appName + "\"}&from=946656000&until=now&format=collapsed"
 	fmt.Println(queryURL)
 	queryRes, err := http.Get(queryURL)
 	require.NoError(t, err)
@@ -441,7 +441,7 @@ func ingest(t *testing.T, testdatum pprofTestData) string {
 
 	res, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	assert.Equal(t, testdatum.expectStatusIngest, res.StatusCode, testdatum.profile)
+	require.Equal(t, testdatum.expectStatusIngest, res.StatusCode, testdatum.profile)
 	fmt.Printf("%+v %+v\n", testdatum, res)
 	return appName
 }


### PR DESCRIPTION
Overriding the profile time with the request `StartTime` causes precision loss since `pyroscope-go` specifies time in seconds, which triggers #2483. I'm not sure if we need to update our SDKs, but created PR for Go: https://github.com/grafana/pyroscope-go/pull/54.
