### PR TITLE
feat: 'ExportData' now respects the 'flamegraph.com' related prop

### DIFF
--- a/public/app/components/ExportData.spec.tsx
+++ b/public/app/components/ExportData.spec.tsx
@@ -71,6 +71,27 @@ describe('ExportData', () => {
       render(<ExportData exportHTML flamebearer={TestData} />);
       screen.getByRole('button', { name: /html/i });
     });
+
+    describe('the "flamegraph.com" export button', () => {
+      it('is enabled by default"', () => {
+        render(<ExportData flamebearer={TestData} />);
+        screen.getByRole('button', { name: /flamegraph\.com/i });
+      });
+
+      it('can be enabled"', () => {
+        render(<ExportData exportFlamegraphDotCom flamebearer={TestData} />);
+        screen.getByRole('button', { name: /flamegraph\.com/i });
+      });
+
+      it('can be disabled"', () => {
+        render(
+          <ExportData exportFlamegraphDotCom={false} flamebearer={TestData} />
+        );
+        expect(
+          screen.queryByRole('button', { name: /flamegraph\.com/i })
+        ).not.toBeInTheDocument();
+      });
+    });
   });
 
   describe('filename', () => {

--- a/public/app/components/ExportData.tsx
+++ b/public/app/components/ExportData.tsx
@@ -83,7 +83,7 @@ export class PprofRequest extends Message<PprofRequest> {
   end: number;
 }
 
-type ExportDataProps = {
+export type ExportDataProps = {
   buttonEl?: React.ComponentType<{
     onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
   }>;

--- a/public/app/components/ExportData.tsx
+++ b/public/app/components/ExportData.tsx
@@ -114,9 +114,8 @@ function buildPprofQuery(state: ContinuousState) {
 }
 
 function ExportData(props: ExportDataProps) {
-  const { exportJSON = false } = props;
+  const { exportJSON = false, exportFlamegraphDotCom = true } = props;
   let { exportPprof } = props;
-  const exportFlamegraphDotCom = true;
   const exportPNG = true;
   const exportHTML = false;
   const { pathname } = useLocation();

--- a/public/app/util/features.ts
+++ b/public/app/util/features.ts
@@ -8,7 +8,7 @@ const featuresSchema = z.object({
   internalAuthEnabled: z.boolean().default(false),
   signupEnabled: z.boolean().default(false),
   isAuthRequired: z.boolean().default(false),
-  exportToFlamegraphDotComEnabled: z.boolean().default(false),
+  exportToFlamegraphDotComEnabled: z.boolean().default(true),
   exemplarsPageEnabled: z.boolean().default(false),
 });
 


### PR DESCRIPTION
This PR to let `ExportData` honour the value of the `exportFlamegraphDotCom` prop.

This is needed for the work on the Grafana plugin, see https://github.com/grafana/pyroscope-app-plugin/pull/87