### PR TITLE
[packaging] Configure systemd to allow pyroscope to be reloaded via kill -HUP

### DIFF
--- a/tools/packaging/pyroscope.service
+++ b/tools/packaging/pyroscope.service
@@ -7,6 +7,7 @@ Type=simple
 User=pyroscope
 WorkingDirectory=/var/lib/pyroscope
 ExecStart=/usr/bin/pyroscope -config.file /etc/pyroscope/config.yml
+ExecReload=/bin/kill -HUP $MAINPID
 # Give a reasonable amount of time for the server to start up/shut down
 TimeoutSec = 120
 Restart = on-failure


### PR DESCRIPTION
This PR aim to fix the following error:

```
# systemctl reload pyroscope
Failed to reload pyroscope.service: Job type reload is not applicable for unit pyroscope.service.
```