### PR TITLE
refactor(Frontend): Extract the logic to determine the default app for continuous profiling pages

### DIFF
--- a/public/app/hooks/util/determineDefaultApp.spec.ts
+++ b/public/app/hooks/util/determineDefaultApp.spec.ts
@@ -1,0 +1,74 @@
+import { determineDefaultApp } from './determineDefaultApp';
+
+describe('async determineDefaultApp(apps)', () => {
+  it('should return the first "cpu app"', async () => {
+    const apps = [
+      {
+        name: 'pyroscope',
+        __profile_type__: 'block:contentions:count::',
+      },
+      {
+        name: 'nodejs-app',
+        __profile_type__: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds',
+      },
+      {
+        name: 'ride-sharing-app',
+        __profile_type__: 'memory:alloc_space:bytes::',
+      },
+      {
+        name: 'ride-sharing-app',
+        __profile_type__: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds',
+      },
+    ];
+
+    const result = await determineDefaultApp(apps);
+
+    expect(result).toBe(apps[1]);
+  });
+
+  describe('if no "cpu app" is found', () => {
+    it('should return the first ".itimer app"', async () => {
+      const apps = [
+        {
+          name: 'pyroscope',
+          __profile_type__: 'block:contentions:count::',
+        },
+        {
+          name: 'nodejs-app',
+          __profile_type__: 'foo:.itimer:bar',
+        },
+        {
+          name: 'ride-sharing-app',
+          __profile_type__: 'memory:alloc_space:bytes::',
+        },
+        {
+          name: 'ride-sharing-app',
+          __profile_type__: 'foo:.itimer:bar',
+        },
+      ];
+
+      const result = await determineDefaultApp(apps);
+
+      expect(result).toBe(apps[1]);
+    });
+  });
+
+  describe('otherwise', () => {
+    it('it should return the first app', async () => {
+      const apps = [
+        {
+          name: 'pyroscope',
+          __profile_type__: 'block:contentions:count::',
+        },
+        {
+          name: 'ride-sharing-app',
+          __profile_type__: 'memory:alloc_space:bytes::',
+        },
+      ];
+
+      const result = await determineDefaultApp(apps);
+
+      expect(result).toBe(apps[0]);
+    });
+  });
+});

--- a/public/app/hooks/util/determineDefaultApp.ts
+++ b/public/app/hooks/util/determineDefaultApp.ts
@@ -1,0 +1,21 @@
+// Async to support override in Grafana's app plugin
+export async function determineDefaultApp(apps: any[]) {
+  const cpuApp = apps.find(
+    (app) => app.__profile_type__.split(':')[1] === 'cpu'
+  );
+
+  if (cpuApp) {
+    return cpuApp;
+  }
+
+  // `.itimer` type for Java
+  const itimerApp = apps.find(
+    (app) => app.__profile_type__.split(':')[1] === '.itimer'
+  );
+
+  if (itimerApp) {
+    return itimerApp;
+  }
+
+  return apps[0];
+}


### PR DESCRIPTION
In this PR, we separate the business logic from the rest of the code to support code reusability and extensibility.