### PR TITLE
Improve flush spread

### DIFF
--- a/pkg/phlaredb/phlaredb.go
+++ b/pkg/phlaredb/phlaredb.go
@@ -138,7 +138,7 @@ func (f *PhlareDB) runBlockQuerierSync(ctx context.Context) {
 func (f *PhlareDB) loop() {
 	blockScanTicker := time.NewTicker(5 * time.Minute)
 	headSizeCheck := time.NewTicker(5 * time.Second)
-	staleHeadTicker := time.NewTicker(util.DurationWithJitter(1*time.Minute, 0.2))
+	staleHeadTicker := time.NewTimer(util.DurationWithJitter(10*time.Minute, 0.5))
 	maxBlockBytes := f.maxBlockBytes()
 	defer func() {
 		blockScanTicker.Stop()
@@ -161,6 +161,7 @@ func (f *PhlareDB) loop() {
 			}
 		case <-staleHeadTicker.C:
 			f.Flush(ctx, false, flushReasonMaxDuration)
+			staleHeadTicker.Reset(util.DurationWithJitter(10*time.Minute, 0.5))
 		case e := <-f.evictCh:
 			f.evictBlock(e)
 		}


### PR DESCRIPTION
This should improve the spread of flushes per ingester. Not only I've increase the jitter, but it's re-evaluated on each run, making it even more randomized.

We still need a flush queue for large multitenant cluster.