### PR TITLE
Tweak compaction configuration and performance.

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -16,7 +16,7 @@ Usage of ./pyroscope:
   -blocks-storage.bucket-store.tenant-sync-concurrency int
     	Maximum number of concurrent tenants synching blocks. (default 10)
   -compactor.block-ranges value
-    	List of compaction time ranges. (default 3h0m0s,6h0m0s,12h0m0s)
+    	List of compaction time ranges. (default 1h0m0s,4h0m0s,8h0m0s)
   -compactor.block-sync-concurrency int
     	Number of Go routines to use when downloading blocks for compaction and uploading resulting blocks. (default 8)
   -compactor.blocks-retention-period duration
@@ -50,7 +50,7 @@ Usage of ./pyroscope:
   -compactor.max-compaction-time duration
     	Max time for starting compactions for a single tenant. After this time no new compactions for the tenant are started before next compaction cycle. This can help in multi-tenant environments to avoid single tenant using all compaction time, but also in single-tenant environments to force new discovery of blocks more often. 0 = disabled. (default 1h0m0s)
   -compactor.max-opening-blocks-concurrency int
-    	Number of goroutines opening blocks before compaction. (default 1)
+    	Number of goroutines opening blocks before compaction. (default 4)
   -compactor.meta-sync-concurrency int
     	Number of Go routines to use when syncing block meta files from the long term storage. (default 20)
   -compactor.no-blocks-file-cleanup-enabled
@@ -464,7 +464,7 @@ Usage of ./pyroscope:
   -pyroscopedb.data-path string
     	Directory used for local storage. (default "./data")
   -pyroscopedb.max-block-duration duration
-    	Upper limit to the duration of a Pyroscope block. (default 3h0m0s)
+    	Upper limit to the duration of a Pyroscope block. (default 1h0m0s)
   -pyroscopedb.row-group-target-size uint
     	How big should a single row group be uncompressed (default 1342177280)
   -querier.client-cleanup-period duration

--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -16,7 +16,7 @@ Usage of ./pyroscope:
   -blocks-storage.bucket-store.tenant-sync-concurrency int
     	Maximum number of concurrent tenants synching blocks. (default 10)
   -compactor.block-ranges value
-    	List of compaction time ranges. (default 1h0m0s,4h0m0s,8h0m0s)
+    	List of compaction time ranges. (default 1h0m0s,2h0m0s,8h0m0s)
   -compactor.block-sync-concurrency int
     	Number of Go routines to use when downloading blocks for compaction and uploading resulting blocks. (default 8)
   -compactor.blocks-retention-period duration

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -122,7 +122,7 @@ Usage of ./pyroscope:
   -pyroscopedb.data-path string
     	Directory used for local storage. (default "./data")
   -pyroscopedb.max-block-duration duration
-    	Upper limit to the duration of a Pyroscope block. (default 3h0m0s)
+    	Upper limit to the duration of a Pyroscope block. (default 1h0m0s)
   -pyroscopedb.row-group-target-size uint
     	How big should a single row group be uncompressed (default 1342177280)
   -querier.client-cleanup-period duration

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -121,7 +121,7 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	cfg.ShardingRing.RegisterFlags(f, logger)
 
-	cfg.BlockRanges = DurationList{3 * time.Hour, 6 * time.Hour, 12 * time.Hour}
+	cfg.BlockRanges = DurationList{1 * time.Hour, 4 * time.Hour, 8 * time.Hour}
 	cfg.retryMinBackoff = 10 * time.Second
 	cfg.retryMaxBackoff = time.Minute
 
@@ -144,7 +144,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	// f.DurationVar(&cfg.TenantCleanupDelay, "compactor.tenant-cleanup-delay", 6*time.Hour, "For tenants marked for deletion, this is time between deleting of last block, and doing final cleanup (marker files, debug files) of the tenant.")
 	f.BoolVar(&cfg.NoBlocksFileCleanupEnabled, "compactor.no-blocks-file-cleanup-enabled", false, "If enabled, will delete the bucket-index, markers and debug files in the tenant bucket when there are no blocks left in the index.")
 	// compactor concurrency options
-	f.IntVar(&cfg.MaxOpeningBlocksConcurrency, "compactor.max-opening-blocks-concurrency", 1, "Number of goroutines opening blocks before compaction.")
+	f.IntVar(&cfg.MaxOpeningBlocksConcurrency, "compactor.max-opening-blocks-concurrency", 4, "Number of goroutines opening blocks before compaction.")
 
 	f.Var(&cfg.EnabledTenants, "compactor.enabled-tenants", "Comma separated list of tenants that can be compacted. If specified, only these tenants will be compacted by compactor, otherwise all tenants can be compacted. Subject to sharding.")
 	f.Var(&cfg.DisabledTenants, "compactor.disabled-tenants", "Comma separated list of tenants that cannot be compacted by this compactor. If specified, and compactor would normally pick given tenant for compaction (via -compactor.enabled-tenants or sharding), it will be ignored instead.")

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -121,7 +121,7 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	cfg.ShardingRing.RegisterFlags(f, logger)
 
-	cfg.BlockRanges = DurationList{1 * time.Hour, 4 * time.Hour, 8 * time.Hour}
+	cfg.BlockRanges = DurationList{1 * time.Hour, 2 * time.Hour, 8 * time.Hour}
 	cfg.retryMinBackoff = 10 * time.Second
 	cfg.retryMaxBackoff = time.Minute
 

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -99,7 +99,7 @@ func TestConfig_Validate(t *testing.T) {
 		"should pass with the default config": {
 			setup:    func(cfg *Config) {},
 			expected: "",
-			maxBlock: 3 * time.Hour,
+			maxBlock: 1 * time.Hour,
 		},
 		"should pass with only 1 block range period": {
 			setup: func(cfg *Config) {
@@ -120,12 +120,12 @@ func TestConfig_Validate(t *testing.T) {
 				cfg.CompactionJobsOrder = "everything-is-important"
 			},
 			expected: errInvalidCompactionOrder.Error(),
-			maxBlock: 3 * time.Hour,
+			maxBlock: 1 * time.Hour,
 		},
 		"should fail on invalid value of max-opening-blocks-concurrency": {
 			setup:    func(cfg *Config) { cfg.MaxOpeningBlocksConcurrency = 0 },
 			expected: errInvalidMaxOpeningBlocksConcurrency.Error(),
-			maxBlock: 3 * time.Hour,
+			maxBlock: 1 * time.Hour,
 		},
 		"should fail on first range not divisible by max block duration": {
 			setup: func(cfg *Config) {

--- a/pkg/phlaredb/compact.go
+++ b/pkg/phlaredb/compact.go
@@ -466,7 +466,7 @@ func newProfileRowIterator(s BlockReader) (*profileRowIterator, error) {
 	// todo close once https://github.com/grafana/pyroscope/issues/2172 is done.
 	reader := s.Profiles()
 	return &profileRowIterator{
-		profiles:         phlareparquet.NewBufferedRowReaderIterator(reader, 1024),
+		profiles:         phlareparquet.NewBufferedRowReaderIterator(reader, 32),
 		blockReader:      s,
 		closer:           reader,
 		index:            s.Index(),

--- a/pkg/phlaredb/phlaredb.go
+++ b/pkg/phlaredb/phlaredb.go
@@ -50,7 +50,7 @@ type ParquetConfig struct {
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.DataPath, "pyroscopedb.data-path", "./data", "Directory used for local storage.")
-	f.DurationVar(&cfg.MaxBlockDuration, "pyroscopedb.max-block-duration", 3*time.Hour, "Upper limit to the duration of a Pyroscope block.")
+	f.DurationVar(&cfg.MaxBlockDuration, "pyroscopedb.max-block-duration", 1*time.Hour, "Upper limit to the duration of a Pyroscope block.")
 	f.Uint64Var(&cfg.RowGroupTargetSize, "pyroscopedb.row-group-target-size", 10*128*1024*1024, "How big should a single row group be uncompressed") // This should roughly be 128MiB compressed
 }
 


### PR DESCRIPTION
This now set 1h the block duration default and compaction range to 1h, 2h, and 8h.

This should be much better default based on my overall experience with the compactor.


The commit also include a big performance improvement where compacting large amount of blocks. This is done by reducing the row buffer  from 1024 to 32.