### PR TITLE
Revert "fix: remove "Flamegraph" from timeline chart title (#2565)"

### DIFF
--- a/public/app/components/ChartTitle.tsx
+++ b/public/app/components/ChartTitle.tsx
@@ -15,8 +15,8 @@ const chartTitleKeys = {
   exceptions: 'Total number of exceptions thrown',
   unknown: '',
 
-  baseline: 'Baseline Flamegraph',
-  comparison: 'Comparison Flamegraph',
+  baseline: 'Baseline time range',
+  comparison: 'Comparison time range',
   selection_included: 'Selection-included Exemplar Flamegraph',
   selection_excluded: 'Selection-excluded Exemplar Flamegraph',
 };

--- a/public/app/components/ChartTitle.tsx
+++ b/public/app/components/ChartTitle.tsx
@@ -15,8 +15,8 @@ const chartTitleKeys = {
   exceptions: 'Total number of exceptions thrown',
   unknown: '',
 
-  baseline: 'Baseline',
-  comparison: 'Comparison',
+  baseline: 'Baseline Flamegraph',
+  comparison: 'Comparison Flamegraph',
   selection_included: 'Selection-included Exemplar Flamegraph',
   selection_excluded: 'Selection-excluded Exemplar Flamegraph',
 };


### PR DESCRIPTION
This reverts commit b4e6cef43718aef5ecee5ed555891e7be9cca3bf and applies recommendations from
- #2565 