### PR TITLE
Fixes compaction range block grouping

### DIFF
--- a/pkg/compactor/split_merge_grouper.go
+++ b/pkg/compactor/split_merge_grouper.go
@@ -289,7 +289,6 @@ func groupBlocksByRange(blocks []*block.Meta, tr int64) []blocksGroup {
 			group blocksGroup
 			m     = blocks[i]
 		)
-
 		group.rangeStart = getRangeStart(m, tr)
 		group.rangeEnd = group.rangeStart + tr
 
@@ -304,7 +303,7 @@ func groupBlocksByRange(blocks []*block.Meta, tr int64) []blocksGroup {
 		for ; i < len(blocks); i++ {
 			// If the block does not start within this group, then we should break the iteration
 			// and move it to the next group.
-			if int64(blocks[i].MinTime) > group.rangeEnd {
+			if int64(blocks[i].MinTime) >= group.rangeEnd {
 				break
 			}
 

--- a/pkg/compactor/split_merge_grouper_test.go
+++ b/pkg/compactor/split_merge_grouper_test.go
@@ -717,6 +717,21 @@ func TestGroupBlocksByRange(t *testing.T) {
 				}},
 			},
 		},
+		"block start at the end of the range": {
+			timeRange: 20,
+			blocks: []*block.Meta{
+				{MinTime: 10, MaxTime: 20},
+				{MinTime: 20, MaxTime: 40},
+			},
+			expected: []blocksGroup{
+				{rangeStart: 0, rangeEnd: 20, blocks: []*block.Meta{
+					{MinTime: 10, MaxTime: 20},
+				}},
+				{rangeStart: 20, rangeEnd: 40, blocks: []*block.Meta{
+					{MinTime: 20, MaxTime: 40},
+				}},
+			},
+		},
 		"only 1 block per range": {
 			timeRange: 20,
 			blocks: []*block.Meta{


### PR DESCRIPTION
This fixes an issue where if the minTime of a block would fall exactly on the end of a fixed range it would be considered overlapping (discarded).

In fact if that is the case it only means the block doesn't start within that range and we should move on to the next range.