### PR TITLE
Load symbols into memory at compaction

### DIFF
--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -356,6 +356,9 @@ func (c *BlockCompactor) CompactWithSplitting(ctx context.Context, dest string, 
 		if err := b.Open(ctx); err != nil {
 			return errors.Wrapf(err, "open block %s", meta.ULID)
 		}
+		if err = b.Symbols().Load(ctx); err != nil {
+			return errors.Wrapf(err, "error loading symbols")
+		}
 		readers[idx] = b
 		return nil
 	})

--- a/pkg/phlaredb/symdb/resolver_test.go
+++ b/pkg/phlaredb/symdb/resolver_test.go
@@ -137,3 +137,8 @@ func (m *mockSymbolsReader) Partition(ctx context.Context, partition uint64) (Pa
 	r, _ := args.Get(0).(PartitionReader)
 	return r, args.Error(1)
 }
+
+func (m *mockSymbolsReader) Load(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}

--- a/pkg/phlaredb/symdb/symdb.go
+++ b/pkg/phlaredb/symdb/symdb.go
@@ -15,6 +15,7 @@ import (
 // SymbolsReader provides access to a symdb partition.
 type SymbolsReader interface {
 	Partition(ctx context.Context, partition uint64) (PartitionReader, error)
+	Load(context.Context) error
 }
 
 type PartitionReader interface {
@@ -269,4 +270,9 @@ func (s *SymDB) Flush() error {
 
 func (s *SymDB) Files() []block.File {
 	return s.writer.files
+}
+
+func (s *SymDB) Load(context.Context) error {
+	// Already loaded into memory.
+	return nil
 }


### PR DESCRIPTION
When we compact blocks, it is preferable to load all symbols into memory

/cc @cyriltovena 