### PR TITLE
allow https health checks in the Helm chart

### DIFF
--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -2076,6 +2076,7 @@ spec:
             httpGet:
               path: /ready
               port: http2
+              scheme: http
           volumeMounts:
             - name: config
               mountPath: /etc/pyroscope/config.yaml
@@ -2168,6 +2169,7 @@ spec:
             httpGet:
               path: /ready
               port: http2
+              scheme: http
           volumeMounts:
             - name: config
               mountPath: /etc/pyroscope/config.yaml
@@ -2260,6 +2262,7 @@ spec:
             httpGet:
               path: /ready
               port: http2
+              scheme: http
           volumeMounts:
             - name: config
               mountPath: /etc/pyroscope/config.yaml
@@ -2352,6 +2355,7 @@ spec:
             httpGet:
               path: /ready
               port: http2
+              scheme: http
           volumeMounts:
             - name: config
               mountPath: /etc/pyroscope/config.yaml
@@ -2623,6 +2627,7 @@ spec:
             httpGet:
               path: /ready
               port: http2
+              scheme: http
           volumeMounts:
             - name: config
               mountPath: /etc/pyroscope/config.yaml
@@ -2721,6 +2726,7 @@ spec:
             httpGet:
               path: /ready
               port: http2
+              scheme: http
           volumeMounts:
             - name: config
               mountPath: /etc/pyroscope/config.yaml
@@ -2816,6 +2822,7 @@ spec:
             httpGet:
               path: /ready
               port: http2
+              scheme: http
           volumeMounts:
             - name: config
               mountPath: /etc/pyroscope/config.yaml

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
@@ -1312,6 +1312,7 @@ spec:
             httpGet:
               path: /ready
               port: http2
+              scheme: http
           volumeMounts:
             - name: config
               mountPath: /etc/pyroscope/config.yaml

--- a/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
@@ -95,6 +95,7 @@ spec:
             httpGet:
               path: /ready
               port: {{ $values.service.port_name }}
+              scheme: {{ $values.service.scheme }}
           volumeMounts:
             - name: config
               mountPath: /etc/pyroscope/config.yaml

--- a/operations/pyroscope/helm/pyroscope/values.yaml
+++ b/operations/pyroscope/helm/pyroscope/values.yaml
@@ -75,6 +75,7 @@ pyroscope:
     type: ClusterIP
     port: 4040
     port_name: http2
+    scheme: http
 
   memberlist:
     port: 7946

--- a/operations/pyroscope/jsonnet/values.json
+++ b/operations/pyroscope/jsonnet/values.json
@@ -115,6 +115,7 @@
     "service": {
       "port": 4040,
       "port_name": "http2",
+      "scheme": "http",
       "type": "ClusterIP"
     },
     "serviceAccount": {


### PR DESCRIPTION
Hi there, I added an additional field to be able to perform https readiness/health checks on Pyroscope when TLS is set up.