### PR TITLE
Cleanup failed segment before flushing.

### DIFF
--- a/pkg/phlaredb/profile_store.go
+++ b/pkg/phlaredb/profile_store.go
@@ -243,7 +243,7 @@ func (s *profileStore) cutRowGroup(count int) (err error) {
 	// Removes the file if it exists. This can happen if the previous
 	// cut attempt failed.
 	if err := os.Remove(path); err == nil {
-		level.Error(s.logger).Log("msg", "old rowgroup segment found", "path", path)
+		level.Warning(s.logger).Log("msg", "deleting row group segment of a failed previous attempt", "path", path)
 	}
 	f, err := s.prepareFile(path)
 	if err != nil {

--- a/pkg/phlaredb/profile_store.go
+++ b/pkg/phlaredb/profile_store.go
@@ -243,7 +243,7 @@ func (s *profileStore) cutRowGroup(count int) (err error) {
 	// Removes the file if it exists. This can happen if the previous
 	// cut attempt failed.
 	if err := os.Remove(path); err == nil {
-		level.Warning(s.logger).Log("msg", "deleting row group segment of a failed previous attempt", "path", path)
+		level.Warn(s.logger).Log("msg", "deleting row group segment of a failed previous attempt", "path", path)
 	}
 	f, err := s.prepareFile(path)
 	if err != nil {

--- a/pkg/phlaredb/profile_store.go
+++ b/pkg/phlaredb/profile_store.go
@@ -65,7 +65,7 @@ type profileStore struct {
 func newParquetProfileWriter(writer io.Writer, options ...parquet.WriterOption) *parquet.GenericWriter[*schemav1.Profile] {
 	options = append(options, parquet.PageBufferSize(3*1024*1024))
 	options = append(options, parquet.CreatedBy("github.com/grafana/pyroscope/", build.Version, build.Revision))
-	// options = append(options, parquet.ColumnPageBuffers(parquet.NewFileBufferPool(os.TempDir(), "pyroscopedb-parquet-buffers*")))
+	options = append(options, parquet.ColumnPageBuffers(parquet.NewFileBufferPool(os.TempDir(), "pyroscopedb-parquet-buffers*")))
 	options = append(options, schemav1.ProfilesSchema)
 	return parquet.NewGenericWriter[*schemav1.Profile](
 		writer, options...,
@@ -241,7 +241,7 @@ func (s *profileStore) cutRowGroup(count int) (err error) {
 		fmt.Sprintf("%s.%d%s", s.persister.Name(), s.rowsFlushed, block.ParquetSuffix),
 	)
 	// Removes the file if it exists. This can happen if the previous
-	// ingestion attempt failed.
+	// cut attempt failed.
 	if err := os.Remove(path); err == nil {
 		level.Error(s.logger).Log("msg", "old rowgroup segment found", "path", path)
 	}

--- a/pkg/phlaredb/profile_store_test.go
+++ b/pkg/phlaredb/profile_store_test.go
@@ -598,9 +598,10 @@ func TestProfileStore_Querying(t *testing.T) {
 
 func TestRemoveFailedSegment(t *testing.T) {
 	store := newProfileStore(testContext(t))
-	require.NoError(t, store.Init("", defaultParquetConfig, contextHeadMetrics(context.Background())))
+	dir := t.TempDir()
+	require.NoError(t, store.Init(dir, defaultParquetConfig, contextHeadMetrics(context.Background())))
 	// fake a failed segment
-	_, err := os.Create("profiles.0.parquet")
+	_, err := os.Create(dir + "/profiles.0.parquet")
 	require.NoError(t, store.ingest(context.Background(), []schemav1.InMemoryProfile{{}}, phlaremodel.LabelsFromStrings(), "memory"))
 	require.NoError(t, err)
 	err = store.cutRowGroup(1)

--- a/pkg/phlaredb/profile_store_test.go
+++ b/pkg/phlaredb/profile_store_test.go
@@ -595,3 +595,13 @@ func TestProfileStore_Querying(t *testing.T) {
 		)
 	})
 }
+
+func TestRemoveFailedSegment(t *testing.T) {
+	store := newProfileStore(testContext(t))
+	require.NoError(t, store.Init("", defaultParquetConfig, contextHeadMetrics(context.Background())))
+	// fake a failed segment
+	_, err := os.Create("profiles.0.parquet")
+	require.NoError(t, err)
+	err = store.cutRowGroup(0)
+	require.NoError(t, err)
+}

--- a/pkg/phlaredb/profile_store_test.go
+++ b/pkg/phlaredb/profile_store_test.go
@@ -601,7 +601,8 @@ func TestRemoveFailedSegment(t *testing.T) {
 	require.NoError(t, store.Init("", defaultParquetConfig, contextHeadMetrics(context.Background())))
 	// fake a failed segment
 	_, err := os.Create("profiles.0.parquet")
+	require.NoError(t, store.ingest(context.Background(), []schemav1.InMemoryProfile{{}}, phlaremodel.LabelsFromStrings(), "memory"))
 	require.NoError(t, err)
-	err = store.cutRowGroup(0)
+	err = store.cutRowGroup(1)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
We've found instances where if an error happens during cut of rowgroups, there will be a file left over that will make next attempts fail.

This PR adds a test for this and fixes this by removing the segment if it exist, it will also log an error.