### PR TITLE
Remove the usage of file buffer for parquet pages.

### DIFF
--- a/pkg/phlaredb/profile_store.go
+++ b/pkg/phlaredb/profile_store.go
@@ -65,7 +65,6 @@ type profileStore struct {
 func newParquetProfileWriter(writer io.Writer, options ...parquet.WriterOption) *parquet.GenericWriter[*schemav1.Profile] {
 	options = append(options, parquet.PageBufferSize(3*1024*1024))
 	options = append(options, parquet.CreatedBy("github.com/grafana/pyroscope/", build.Version, build.Revision))
-	options = append(options, parquet.ColumnPageBuffers(parquet.NewFileBufferPool(os.TempDir(), "pyroscopedb-parquet-buffers*")))
 	options = append(options, schemav1.ProfilesSchema)
 	return parquet.NewGenericWriter[*schemav1.Profile](
 		writer, options...,


### PR DESCRIPTION
Again we had an incident where crashlooping pods would fill up the disk with parquet file buffer pages.

Turns out this is more harmful than helpful.
We're actually compacting faster since we don't need to go through a file firsrt and ingesters are using less ressources without this.

<img width="1276" alt="image" src="https://github.com/grafana/pyroscope/assets/1053421/674222e6-eec1-4a4c-a3bf-24979a1d4fc4">


We should use file buffer page only if we consider that flushing a single rowgroups can't be done solely in-memory, but right now we actually have a way to flush intermediary row groups for this reason so this is not really helpul.
