### PR TITLE
fix(SyncBanner): Add 10% buffer on both sides of the timeline

### DIFF
--- a/public/app/components/TimelineChart/SyncTimelines/useSync.ts
+++ b/public/app/components/TimelineChart/SyncTimelines/useSync.ts
@@ -49,10 +49,8 @@ export function useSync({
   const [isIgnoring, setIgnoring] = useState(false);
 
   useEffect(() => {
-    if (isIgnoring) {
-      setIgnoring(false);
-    }
-  }, [isIgnoring, leftSelection, rightSelection, timeline]);
+    setIgnoring(false);
+  }, [leftSelection, rightSelection, timeline]);
 
   const { from: leftFrom, to: leftTo } = getSelectionBoundaries(
     leftSelection as Selection

--- a/public/app/components/TimelineChart/SyncTimelines/useSync.ts
+++ b/public/app/components/TimelineChart/SyncTimelines/useSync.ts
@@ -17,7 +17,6 @@ interface UseSyncParams {
   onSync: (from: string, until: string) => void;
 }
 
-const timeOffset = 5 * 60 * 1000;
 const selectionOffset = 5000;
 
 export const getTitle = (leftInRange: boolean, rightInRange: boolean) => {
@@ -36,6 +35,8 @@ const isInRange = (
   selectionFrom: number,
   selectionTo: number
 ) => {
+  const timeOffset = (to - from) * 0.1;
+
   return selectionFrom + timeOffset >= from && selectionTo - timeOffset <= to;
 };
 


### PR DESCRIPTION
Update on https://github.com/grafana/pyroscope/pull/1615: with a fixed value of 5m the user could end up in a situation where narrow selections wouldn't make the sync banner appear.

This PR:
- changes from fixed buffers (5m) to a dynamic buffers: we now allow 10% of the timeline duration on both sides of the timeline
- not related to the issue but... fixes the "Ignore" button that had no effect (the banner wouldn't disappear)

