### PR TITLE
Fallback to manual listing, when bucket index is not available

### DIFF
--- a/pkg/phlaredb/block/fetcher.go
+++ b/pkg/phlaredb/block/fetcher.go
@@ -146,6 +146,10 @@ type MetaFetcher struct {
 
 // NewMetaFetcher returns a MetaFetcher.
 func NewMetaFetcher(logger log.Logger, concurrency int, bkt objstore.BucketReader, dir string, reg prometheus.Registerer, filters []MetadataFilter) (*MetaFetcher, error) {
+	return NewMetaFetcherWithMetrics(logger, concurrency, bkt, dir, NewFetcherMetrics(reg, nil), filters)
+}
+
+func NewMetaFetcherWithMetrics(logger log.Logger, concurrency int, bkt objstore.BucketReader, dir string, metrics *FetcherMetrics, filters []MetadataFilter) (*MetaFetcher, error) {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
@@ -164,7 +168,7 @@ func NewMetaFetcher(logger log.Logger, concurrency int, bkt objstore.BucketReade
 		bkt:         bkt,
 		cacheDir:    cacheDir,
 		cached:      map[ulid.ULID]*Meta{},
-		metrics:     NewFetcherMetrics(reg, nil),
+		metrics:     metrics,
 		filters:     filters,
 	}, nil
 }

--- a/pkg/storegateway/bucket_index_metadata_fetcher_test.go
+++ b/pkg/storegateway/bucket_index_metadata_fetcher_test.go
@@ -115,7 +115,7 @@ func TestBucketIndexMetadataFetcher_Fetch_NoBucketIndex(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, metas)
 	assert.Empty(t, partials)
-	assert.Empty(t, logs)
+	assert.Contains(t, logs.String(), "no bucket index found, falling back to fetching directly from bucket")
 
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
 		# HELP blocks_meta_sync_failures_total Total blocks metadata synchronization failures


### PR DESCRIPTION
Since we merged the compactor, store-gateways rely on it to write the block index to quickly list blocks.

@cyriltovena not particularly pretty or performant, but I think might do its job