### PR TITLE
fix: Series query race condition

### DIFF
--- a/pkg/phlaredb/block_querier.go
+++ b/pkg/phlaredb/block_querier.go
@@ -1246,6 +1246,7 @@ func Series(ctx context.Context, req *ingestv1.SeriesRequest, blockGetter BlockG
 	group.SetLimit(concurrentQueryLimit)
 
 	for _, q := range queriers {
+		q := q
 		group.Go(util.RecoverPanic(func() error {
 			labels, err := q.Series(ctx, req)
 			if err != nil {


### PR DESCRIPTION
Discovered by accident while running Pyroscope built with `-race`. I checked other places (`errgroup.Go` arg capturing in a loop), it seems this is the only case