### PR TITLE
fix: prevent automatically setting blank query to url parameters

### DIFF
--- a/public/app/redux/store.ts
+++ b/public/app/redux/store.ts
@@ -121,7 +121,9 @@ ReduxQuerySync({
     query: {
       defaultvalue: '',
       selector: (state: RootState) => {
-        const {continuous: {query}} = state;
+        const {
+          continuous: { query },
+        } = state;
         // Only sync the query URL parameter if it is actually set to something
         // Otherwise `?query=` will always be appended to the URL
         if (query !== '') {

--- a/public/app/redux/store.ts
+++ b/public/app/redux/store.ts
@@ -120,7 +120,15 @@ ReduxQuerySync({
     },
     query: {
       defaultvalue: '',
-      selector: (state: RootState) => state.continuous.query,
+      selector: (state: RootState) => {
+        const {continuous: {query}} = state;
+        // Only sync the query URL parameter if it is actually set to something
+        // Otherwise `?query=` will always be appended to the URL
+        if (query !== '') {
+          return query;
+        }
+        return undefined;
+      },
       action: continuousActions.setQuery,
     },
     queryID: {


### PR DESCRIPTION
It was noted that `?query=` would automatically be appended to the URL.
Now, `query` will only be set if there is an actual change in the query.