### PR TITLE
Make rideshare golang-push memory configurable

### DIFF
--- a/examples/golang-push/rideshare/docker-compose.yml
+++ b/examples/golang-push/rideshare/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     environment:
       - REGION=us-east
       - PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040
+      - PARAMETERS_POOL_SIZE=1000
+      - PARAMETERS_POOL_BUFFER_SIZE_KB=1000
     build:
       context: .
 
@@ -37,3 +39,5 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.load-generator
+    environment:
+      - PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040

--- a/examples/golang-push/rideshare/main.go
+++ b/examples/golang-push/rideshare/main.go
@@ -10,6 +10,7 @@ import (
 	"rideshare/car"
 	"rideshare/rideshare"
 	"rideshare/scooter"
+	"rideshare/utility"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
@@ -64,6 +65,9 @@ func main() {
 	defer func() {
 		_ = p.Stop()
 	}()
+
+	cleanup := utility.InitWorkerPool(config)
+	defer cleanup()
 
 	rideshare.Log.Print(context.Background(), "started ride-sharing app")
 

--- a/examples/golang-push/rideshare/utility/utility.go
+++ b/examples/golang-push/rideshare/utility/utility.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"time"
 
+	"rideshare/rideshare"
+
 	"github.com/grafana/pyroscope-go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -12,7 +14,13 @@ import (
 
 const durationConstant = time.Duration(200 * time.Millisecond)
 
-var pool = newPool(1_000)
+var pool *workerPool
+
+// InitWorkPool initializes the worker pool and returns a clean up function.
+func InitWorkerPool(c rideshare.Config) func() {
+	pool = newPool(c)
+	return pool.Close
+}
 
 func mutexLock(n int64) {
 	var i int64 = 0


### PR DESCRIPTION
Adds some environment variables to help configure the "memory leak" in the Go rideshare example.

- `PARAMETERS_POOL_SIZE` sets the max size of the pool (aka the max number of goroutines that will hang before a reset)
- `PARAMETERS_POOL_BUFFER_SIZE_KB` sets the amount of memory each goroutine will allocate in kb