### PR TITLE
Helm: Fix persistence for compactor's data path

### DIFF
--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -2636,8 +2636,10 @@ spec:
               mountPath: /etc/pyroscope/overrides/
             - name: data
               mountPath: /data
-            - name: data-compactor
+              subPath: default
+            - name: data
               mountPath: /data-compactor
+              subPath: compactor
           resources:
             limits:
               memory: 16Gi

--- a/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
@@ -105,8 +105,10 @@ spec:
             - name: data
               mountPath: /data
             {{- if eq $component "compactor" }}
-            - name: data-compactor
+              subPath: default
+            - name: data
               mountPath: /data-compactor
+              subPath: compactor
             {{- end }}
             {{- with $values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
This will use a subvolume of volume `data` for the compactor instead of a separate volume. This will ensure we are able to handle persistence options in the same way for the compactor.
