### PR TITLE
fix: Reset pool slice

### DIFF
--- a/examples/golang-push/rideshare/utility/pool.go
+++ b/examples/golang-push/rideshare/utility/pool.go
@@ -58,7 +58,7 @@ func (c *workerPool) resetWithoutLock() {
 		c <- struct{}{}
 		close(c)
 	}
-	c.pool = c.pool[:]
+	c.pool = c.pool[:0]
 }
 
 func (c *workerPool) doWork(fn func(), stop <-chan struct{}, done chan<- struct{}) {


### PR DESCRIPTION
In https://github.com/grafana/pyroscope/pull/2632 I added a memory leak example, but didn't properly reset the pool, causing the slice to grow unbounded and create panics when we tried to close channels that were already closed.