### PR TITLE
Removes noisy span and adding block ULID inside span tags

### DIFF
--- a/pkg/phlaredb/block_querier.go
+++ b/pkg/phlaredb/block_querier.go
@@ -1352,6 +1352,8 @@ func retrieveStacktracePartition(buf [][]parquet.Value, pos int) uint64 {
 func (b *singleBlockQuerier) SelectMatchingProfiles(ctx context.Context, params *ingestv1.SelectProfilesRequest) (iter.Iterator[Profile], error) {
 	sp, ctx := opentracing.StartSpanFromContext(ctx, "SelectMatchingProfiles - Block")
 	defer sp.Finish()
+	sp.SetTag("block ULID", b.meta.ULID.String())
+
 	if err := b.Open(ctx); err != nil {
 		return nil, err
 	}

--- a/pkg/phlaredb/filter_profiles_bidi.go
+++ b/pkg/phlaredb/filter_profiles_bidi.go
@@ -61,6 +61,8 @@ type filterResponse interface {
 func filterProfiles[B BidiServerMerge[Res, Req], Res filterResponse, Req filterRequest](
 	ctx context.Context, profiles []iter.Iterator[Profile], batchProfileSize int, stream B,
 ) ([][]Profile, error) {
+	sp, _ := opentracing.StartSpanFromContext(ctx, "filterProfiles")
+	defer sp.Finish()
 	selection := make([][]Profile, len(profiles))
 	selectProfileResult := &ingestv1.ProfileSets{
 		Profiles:   make([]*ingestv1.SeriesProfile, 0, batchProfileSize),
@@ -78,12 +80,10 @@ func filterProfiles[B BidiServerMerge[Res, Req], Res filterResponse, Req filterR
 		Profile: maxBlockProfile,
 		Index:   0,
 	}, true, its...), batchProfileSize, func(ctx context.Context, batch []ProfileWithIndex) error {
-		sp, _ := opentracing.StartSpanFromContext(ctx, "filterProfiles - Filtering batch")
 		sp.LogFields(
 			otlog.Int("batch_len", len(batch)),
 			otlog.Int("batch_requested_size", batchProfileSize),
 		)
-		defer sp.Finish()
 
 		seriesByFP := map[model.Fingerprint]labelWithIndex{}
 		selectProfileResult.LabelsSets = selectProfileResult.LabelsSets[:0]

--- a/pkg/phlaredb/sample_merge.go
+++ b/pkg/phlaredb/sample_merge.go
@@ -23,6 +23,8 @@ import (
 func (b *singleBlockQuerier) MergeByStacktraces(ctx context.Context, rows iter.Iterator[Profile]) (*phlaremodel.Tree, error) {
 	sp, ctx := opentracing.StartSpanFromContext(ctx, "MergeByStacktraces - Block")
 	defer sp.Finish()
+	sp.SetTag("block ULID", b.meta.ULID.String())
+
 	r := symdb.NewResolver(ctx, b.symbols)
 	defer r.Release()
 	if err := mergeByStacktraces(ctx, b.profiles.file, rows, r); err != nil {
@@ -32,8 +34,10 @@ func (b *singleBlockQuerier) MergeByStacktraces(ctx context.Context, rows iter.I
 }
 
 func (b *singleBlockQuerier) MergePprof(ctx context.Context, rows iter.Iterator[Profile]) (*profile.Profile, error) {
-	sp, ctx := opentracing.StartSpanFromContext(ctx, "MergeByStacktraces - Block")
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "MergePprof - Block")
 	defer sp.Finish()
+	sp.SetTag("block ULID", b.meta.ULID.String())
+
 	r := symdb.NewResolver(ctx, b.symbols)
 	defer r.Release()
 	if err := mergeByStacktraces(ctx, b.profiles.file, rows, r); err != nil {


### PR DESCRIPTION
This PR attempts to improve our tracing integration.

Some span specially `filterProfiles` were noisy and moved up, outside of the batching, we don't need a span per batch a log is enough.

I've improve some span by adding the block ULID they touch as a tag.