### PR TITLE
Fix build tag, so ebpf/python tests can be run on darwin

### DIFF
--- a/ebpf/session_python.go
+++ b/ebpf/session_python.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package ebpfspy
 
 import (

--- a/ebpf/symtab/symbols.go
+++ b/ebpf/symtab/symbols.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package symtab
 
 import (


### PR DESCRIPTION
Not too sure about other side effects, but I am getting errors for `make test` for a while on darwin/arm64