### PR TITLE
Remove HashWithoutLabels

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -513,9 +513,10 @@ func (d *Distributor) maybeAggregate(tenantID string, labels phlaremodel.Labels,
 	if !ok {
 		return nil, false, nil
 	}
-
-	k, _ := labels.HashWithoutLabels(make([]byte, 0, 1024), phlaremodel.LabelNameSessionID)
-	r, ok, err := a.Aggregate(k, profile.TimeNanos, mergeProfile(profile))
+	if _, hasSessionID := labels.GetLabel(phlaremodel.LabelNameSessionID); hasSessionID {
+		labels = labels.Clone().Delete(phlaremodel.LabelNameSessionID)
+	}
+	r, ok, err := a.Aggregate(labels.Hash(), profile.TimeNanos, mergeProfile(profile))
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/model/labels.go
+++ b/pkg/model/labels.go
@@ -93,27 +93,6 @@ func (ls Labels) HashForLabels(b []byte, names ...string) (uint64, []byte) {
 	return xxhash.Sum64(b), b
 }
 
-// HashWithoutLabels returns a hash value for all labels except those matching
-// the provided names.
-// 'names' have to be sorted in ascending order.
-func (ls Labels) HashWithoutLabels(b []byte, names ...string) (uint64, []byte) {
-	b = b[:0]
-	j := 0
-	for i := range ls {
-		for j < len(names) && names[j] < ls[i].Name {
-			j++
-		}
-		if ls[i].Name == labels.MetricName || (j < len(names) && ls[i].Name == names[j]) {
-			continue
-		}
-		b = append(b, ls[i].Name...)
-		b = append(b, seps[0])
-		b = append(b, ls[i].Value...)
-		b = append(b, seps[0])
-	}
-	return xxhash.Sum64(b), b
-}
-
 // BytesWithLabels is just as Bytes(), but only for labels matching names.
 // 'names' have to be sorted in ascending order.
 // It uses an byte invalid character as a separator and so should not be used for printing.


### PR DESCRIPTION
https://github.com/grafana/pyroscope/pull/2656 introduced a regression caused by a bug in `HashWithoutLabels`: it ignores `__name__` label. I'm removing this function as it is not used anywhere and is misleading at best