### PR TITLE
fix: reduce redundant tag explorer fetches

### DIFF
--- a/public/app/pages/TagExplorerView.tsx
+++ b/public/app/pages/TagExplorerView.tsx
@@ -193,10 +193,10 @@ function TagExplorerView() {
       return () => fetchData.abort('cancel');
     }
     return undefined;
-  }, [from, until, query, groupByTagValue, dispatch]);
+  }, [from, until, query, groupByTagValue, refreshToken, dispatch]);
 
   useEffect(() => {
-    if (from && until && query) {
+    if (from && until && query && groupByTag) {
       const fetchData = dispatch(fetchTagExplorerView(null));
       return () => fetchData.abort('cancel');
     }


### PR DESCRIPTION
- Corrected the dependency list and boolean check for a useEffect which resulted in an additional fetch under certain conditions
  - The condition was when `groupBy` and `groupByValue` URL parameters are undefined (but everything else is defined)
