### PR TITLE
feat: compaction staging

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -131,10 +131,10 @@ Usage of ./pyroscope:
     	Minimum time to wait for ring stability at startup. 0 to disable.
   -compactor.split-and-merge-shards int
     	The number of shards to use when splitting blocks. 0 to disable splitting.
+  -compactor.split-and-merge-stage-size int
+    	Number of stages split shards will be written to. Number of output split shards is controlled by -compactor.split-and-merge-shards.
   -compactor.split-groups int
     	Number of groups that blocks for splitting should be grouped into. Each group of blocks is then split separately. Number of output split shards is controlled by -compactor.split-and-merge-shards. (default 1)
-  -compactor.stage-size int
-    	Number of stages split shards will be written to. Number of output split shards is controlled by -compactor.split-and-merge-shards.
   -config.expand-env
     	Expands ${var} in config according to the values of the environment variables.
   -config.file string

--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -133,6 +133,8 @@ Usage of ./pyroscope:
     	The number of shards to use when splitting blocks. 0 to disable splitting.
   -compactor.split-groups int
     	Number of groups that blocks for splitting should be grouped into. Each group of blocks is then split separately. Number of output split shards is controlled by -compactor.split-and-merge-shards. (default 1)
+  -compactor.stage-size int
+    	Number of stages split shards will be written to. Number of output split shards is controlled by -compactor.split-and-merge-shards.
   -config.expand-env
     	Expands ${var} in config according to the values of the environment variables.
   -config.file string

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -29,6 +29,8 @@ Usage of ./pyroscope:
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
   -compactor.split-and-merge-shards int
     	The number of shards to use when splitting blocks. 0 to disable splitting.
+  -compactor.split-and-merge-stage-size int
+    	Number of stages split shards will be written to. Number of output split shards is controlled by -compactor.split-and-merge-shards.
   -compactor.split-groups int
     	Number of groups that blocks for splitting should be grouped into. Each group of blocks is then split separately. Number of output split shards is controlled by -compactor.split-and-merge-shards. (default 1)
   -config.expand-env

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -576,6 +576,11 @@ compactor:
   # CLI flag: -compactor.compaction-concurrency
   [compaction_concurrency: <int> | default = 1]
 
+  # Number of stages split shards will be written to. Number of output split
+  # shards is controlled by -compactor.split-and-merge-shards.
+  # CLI flag: -compactor.stage-size
+  [compaction_stage_size: <int> | default = 0]
+
   # How long the compactor waits before compacting first-level blocks that are
   # uploaded by the ingesters. This configuration option allows for the
   # reduction of cases where the compactor begins to compact blocks before all

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -211,6 +211,11 @@ limits:
   # CLI flag: -compactor.split-and-merge-shards
   [compactor_split_and_merge_shards: <int> | default = 0]
 
+  # Number of stages split shards will be written to. Number of output split
+  # shards is controlled by -compactor.split-and-merge-shards.
+  # CLI flag: -compactor.split-and-merge-stage-size
+  [compactor_split_and_merge_stage_size: <int> | default = 0]
+
   # Number of groups that blocks for splitting should be grouped into. Each
   # group of blocks is then split separately. Number of output split shards is
   # controlled by -compactor.split-and-merge-shards.
@@ -575,11 +580,6 @@ compactor:
   # Max number of concurrent compactions running.
   # CLI flag: -compactor.compaction-concurrency
   [compaction_concurrency: <int> | default = 1]
-
-  # Number of stages split shards will be written to. Number of output split
-  # shards is controlled by -compactor.split-and-merge-shards.
-  # CLI flag: -compactor.stage-size
-  [compaction_stage_size: <int> | default = 0]
 
   # How long the compactor waits before compacting first-level blocks that are
   # uploaded by the ingesters. This configuration option allows for the

--- a/pkg/compactor/blocks_cleaner_test.go
+++ b/pkg/compactor/blocks_cleaner_test.go
@@ -1021,6 +1021,7 @@ type mockConfigProvider struct {
 	splitAndMergeShards          map[string]int
 	instancesShardSize           map[string]int
 	splitGroups                  map[string]int
+	splitAndMergeStageSize       map[string]int
 	blockUploadEnabled           map[string]bool
 	blockUploadValidationEnabled map[string]bool
 	blockUploadMaxBlockSizeBytes map[string]int64
@@ -1034,6 +1035,7 @@ func newMockConfigProvider() *mockConfigProvider {
 		userRetentionPeriods:         make(map[string]time.Duration),
 		splitAndMergeShards:          make(map[string]int),
 		splitGroups:                  make(map[string]int),
+		splitAndMergeStageSize:       make(map[string]int),
 		blockUploadEnabled:           make(map[string]bool),
 		blockUploadValidationEnabled: make(map[string]bool),
 		blockUploadMaxBlockSizeBytes: make(map[string]int64),
@@ -1052,6 +1054,13 @@ func (m *mockConfigProvider) CompactorBlocksRetentionPeriod(user string) time.Du
 
 func (m *mockConfigProvider) CompactorSplitAndMergeShards(user string) int {
 	if result, ok := m.splitAndMergeShards[user]; ok {
+		return result
+	}
+	return 0
+}
+
+func (m *mockConfigProvider) CompactorSplitAndMergeStageSize(user string) int {
+	if result, ok := m.splitAndMergeStageSize[user]; ok {
 		return result
 	}
 	return 0

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -245,6 +245,7 @@ func getCompactionSplitBy(name string) phlaredb.SplitByFunc {
 
 type BlockCompactor struct {
 	blockOpenConcurrency int
+	stageSize            int
 	splitBy              phlaredb.SplitByFunc
 	logger               log.Logger
 	metrics              *CompactorMetrics
@@ -383,7 +384,7 @@ func (c *BlockCompactor) CompactWithSplitting(ctx context.Context, dest string, 
 	c.metrics.Ran.WithLabelValues(fmt.Sprintf("%d", currentLevel)).Inc()
 	c.metrics.Split.WithLabelValues(fmt.Sprintf("%d", currentLevel)).Observe(float64(shardCount))
 
-	metas, err := phlaredb.CompactWithSplitting(ctx, readers, shardCount, dest, c.splitBy, 0)
+	metas, err := phlaredb.CompactWithSplitting(ctx, readers, shardCount, dest, c.splitBy, uint64(c.stageSize))
 	if err != nil {
 		return nil, errors.Wrapf(err, "compact blocks %v", dirs)
 	}

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -383,7 +383,7 @@ func (c *BlockCompactor) CompactWithSplitting(ctx context.Context, dest string, 
 	c.metrics.Ran.WithLabelValues(fmt.Sprintf("%d", currentLevel)).Inc()
 	c.metrics.Split.WithLabelValues(fmt.Sprintf("%d", currentLevel)).Observe(float64(shardCount))
 
-	metas, err := phlaredb.CompactWithSplitting(ctx, readers, shardCount, dest, c.splitBy)
+	metas, err := phlaredb.CompactWithSplitting(ctx, readers, shardCount, dest, c.splitBy, 0)
 	if err != nil {
 		return nil, errors.Wrapf(err, "compact blocks %v", dirs)
 	}

--- a/pkg/compactor/bucket_compactor_e2e_test.go
+++ b/pkg/compactor/bucket_compactor_e2e_test.go
@@ -154,7 +154,7 @@ func TestSyncer_GarbageCollect_e2e(t *testing.T) {
 		require.NoError(t, sy.GarbageCollect(ctx))
 
 		// Only the level 3 block, the last source block in both resolutions should be left.
-		grouper := NewSplitAndMergeGrouper("user-1", []int64{2 * time.Hour.Milliseconds()}, 0, 0, log.NewNopLogger())
+		grouper := NewSplitAndMergeGrouper("user-1", []int64{2 * time.Hour.Milliseconds()}, 0, 0, 0, log.NewNopLogger())
 		groups, err := grouper.Groups(sy.Metas())
 		require.NoError(t, err)
 
@@ -226,11 +226,10 @@ func TestGroupCompactE2E(t *testing.T) {
 		require.NoError(t, err)
 
 		planner := NewSplitAndMergePlanner([]int64{1000, 3000})
-		grouper := NewSplitAndMergeGrouper("user-1", []int64{1000, 3000}, 0, 0, logger)
+		grouper := NewSplitAndMergeGrouper("user-1", []int64{1000, 3000}, 0, 0, 0, logger)
 		metrics := NewBucketCompactorMetrics(blocksMarkedForDeletion, prometheus.NewPedanticRegistry())
 		bComp, err := NewBucketCompactor(logger, sy, grouper, planner, &BlockCompactor{
 			blockOpenConcurrency: 100,
-			stageSize:            4,
 			splitBy:              phlaredb.SplitByFingerprint,
 			logger:               logger,
 			metrics:              newCompactorMetrics(nil),

--- a/pkg/compactor/bucket_compactor_e2e_test.go
+++ b/pkg/compactor/bucket_compactor_e2e_test.go
@@ -229,8 +229,9 @@ func TestGroupCompactE2E(t *testing.T) {
 		grouper := NewSplitAndMergeGrouper("user-1", []int64{1000, 3000}, 0, 0, logger)
 		metrics := NewBucketCompactorMetrics(blocksMarkedForDeletion, prometheus.NewPedanticRegistry())
 		bComp, err := NewBucketCompactor(logger, sy, grouper, planner, &BlockCompactor{
-			splitBy:              phlaredb.SplitByFingerprint,
 			blockOpenConcurrency: 100,
+			stageSize:            4,
+			splitBy:              phlaredb.SplitByFingerprint,
 			logger:               logger,
 			metrics:              newCompactorMetrics(nil),
 		}, dir, userbkt, 2, ownAllJobs, sortJobsByNewestBlocksFirst, 0, 4, metrics)

--- a/pkg/compactor/bucket_compactor_test.go
+++ b/pkg/compactor/bucket_compactor_test.go
@@ -84,10 +84,10 @@ func TestGroupMaxMinTime(t *testing.T) {
 func TestBucketCompactor_FilterOwnJobs(t *testing.T) {
 	jobsFn := func() []*Job {
 		return []*Job{
-			NewJob("user", "key1", labels.EmptyLabels(), 0, false, 0, ""),
-			NewJob("user", "key2", labels.EmptyLabels(), 0, false, 0, ""),
-			NewJob("user", "key3", labels.EmptyLabels(), 0, false, 0, ""),
-			NewJob("user", "key4", labels.EmptyLabels(), 0, false, 0, ""),
+			NewJob("user", "key1", labels.EmptyLabels(), 0, false, 0, 0, ""),
+			NewJob("user", "key2", labels.EmptyLabels(), 0, false, 0, 0, ""),
+			NewJob("user", "key3", labels.EmptyLabels(), 0, false, 0, 0, ""),
+			NewJob("user", "key4", labels.EmptyLabels(), 0, false, 0, 0, ""),
 		}
 	}
 
@@ -134,13 +134,13 @@ func TestBucketCompactor_FilterOwnJobs(t *testing.T) {
 }
 
 func TestBlockMaxTimeDeltas(t *testing.T) {
-	j1 := NewJob("user", "key1", labels.EmptyLabels(), 0, false, 0, "")
+	j1 := NewJob("user", "key1", labels.EmptyLabels(), 0, false, 0, 0, "")
 	require.NoError(t, j1.AppendMeta(&block.Meta{
 		MinTime: 1500002700159,
 		MaxTime: 1500002800159,
 	}))
 
-	j2 := NewJob("user", "key2", labels.EmptyLabels(), 0, false, 0, "")
+	j2 := NewJob("user", "key2", labels.EmptyLabels(), 0, false, 0, 0, "")
 	require.NoError(t, j2.AppendMeta(&block.Meta{
 		MinTime: 1500002600159,
 		MaxTime: 1500002700159,

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -85,7 +85,6 @@ type Config struct {
 	CompactionInterval         time.Duration `yaml:"compaction_interval" category:"advanced"`
 	CompactionRetries          int           `yaml:"compaction_retries" category:"advanced"`
 	CompactionConcurrency      int           `yaml:"compaction_concurrency" category:"advanced"`
-	CompactionStageSize        int           `yaml:"compaction_stage_size" category:"advanced"`
 	CompactionWaitPeriod       time.Duration `yaml:"first_level_compaction_wait_period"`
 	CleanupInterval            time.Duration `yaml:"cleanup_interval" category:"advanced"`
 	CleanupConcurrency         int           `yaml:"cleanup_concurrency" category:"advanced"`
@@ -134,7 +133,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.DurationVar(&cfg.MaxCompactionTime, "compactor.max-compaction-time", time.Hour, "Max time for starting compactions for a single tenant. After this time no new compactions for the tenant are started before next compaction cycle. This can help in multi-tenant environments to avoid single tenant using all compaction time, but also in single-tenant environments to force new discovery of blocks more often. 0 = disabled.")
 	f.IntVar(&cfg.CompactionRetries, "compactor.compaction-retries", 3, "How many times to retry a failed compaction within a single compaction run.")
 	f.IntVar(&cfg.CompactionConcurrency, "compactor.compaction-concurrency", 1, "Max number of concurrent compactions running.")
-	f.IntVar(&cfg.CompactionStageSize, "compactor.stage-size", 0, "Number of stages split shards will be written to. Number of output split shards is controlled by -compactor.split-and-merge-shards.")
 	f.DurationVar(&cfg.CompactionWaitPeriod, "compactor.first-level-compaction-wait-period", 25*time.Minute, "How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters. This configuration option allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage.")
 	f.DurationVar(&cfg.CleanupInterval, "compactor.cleanup-interval", 15*time.Minute, "How frequently compactor should run blocks cleanup and maintenance, as well as update the bucket index.")
 	f.IntVar(&cfg.CleanupConcurrency, "compactor.cleanup-concurrency", 20, "Max number of tenants for which blocks cleanup and maintenance should run concurrently.")
@@ -187,6 +185,9 @@ type ConfigProvider interface {
 
 	// CompactorSplitAndMergeShards returns the number of shards to use when splitting blocks.
 	CompactorSplitAndMergeShards(userID string) int
+
+	// CompactorSplitAndMergeStageSize returns the number of stages split shards will be written to.
+	CompactorSplitAndMergeStageSize(userID string) int
 
 	// CompactorSplitGroups returns the number of groups that blocks used for splitting should
 	// be grouped into. Different groups are then split by different jobs.

--- a/pkg/compactor/compactor.go
+++ b/pkg/compactor/compactor.go
@@ -85,6 +85,7 @@ type Config struct {
 	CompactionInterval         time.Duration `yaml:"compaction_interval" category:"advanced"`
 	CompactionRetries          int           `yaml:"compaction_retries" category:"advanced"`
 	CompactionConcurrency      int           `yaml:"compaction_concurrency" category:"advanced"`
+	CompactionStageSize        int           `yaml:"compaction_stage_size" category:"advanced"`
 	CompactionWaitPeriod       time.Duration `yaml:"first_level_compaction_wait_period"`
 	CleanupInterval            time.Duration `yaml:"cleanup_interval" category:"advanced"`
 	CleanupConcurrency         int           `yaml:"cleanup_concurrency" category:"advanced"`
@@ -133,6 +134,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	f.DurationVar(&cfg.MaxCompactionTime, "compactor.max-compaction-time", time.Hour, "Max time for starting compactions for a single tenant. After this time no new compactions for the tenant are started before next compaction cycle. This can help in multi-tenant environments to avoid single tenant using all compaction time, but also in single-tenant environments to force new discovery of blocks more often. 0 = disabled.")
 	f.IntVar(&cfg.CompactionRetries, "compactor.compaction-retries", 3, "How many times to retry a failed compaction within a single compaction run.")
 	f.IntVar(&cfg.CompactionConcurrency, "compactor.compaction-concurrency", 1, "Max number of concurrent compactions running.")
+	f.IntVar(&cfg.CompactionStageSize, "compactor.stage-size", 0, "Number of stages split shards will be written to. Number of output split shards is controlled by -compactor.split-and-merge-shards.")
 	f.DurationVar(&cfg.CompactionWaitPeriod, "compactor.first-level-compaction-wait-period", 25*time.Minute, "How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters. This configuration option allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage.")
 	f.DurationVar(&cfg.CleanupInterval, "compactor.cleanup-interval", 15*time.Minute, "How frequently compactor should run blocks cleanup and maintenance, as well as update the bucket index.")
 	f.IntVar(&cfg.CleanupConcurrency, "compactor.cleanup-concurrency", 20, "Max number of tenants for which blocks cleanup and maintenance should run concurrently.")

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1703,8 +1703,8 @@ type blockCompactorMock struct {
 	mock.Mock
 }
 
-func (m *blockCompactorMock) CompactWithSplitting(ctx context.Context, dest string, dirs []string, shardCount uint64) (result []ulid.ULID, _ error) {
-	args := m.Called(ctx, dest, dirs, shardCount)
+func (m *blockCompactorMock) CompactWithSplitting(ctx context.Context, dest string, dirs []string, shardCount, stageSize uint64) (result []ulid.ULID, _ error) {
+	args := m.Called(ctx, dest, dirs, shardCount, stageSize)
 	return args.Get(0).([]ulid.ULID), args.Error(1)
 }
 

--- a/pkg/compactor/job.go
+++ b/pkg/compactor/job.go
@@ -33,10 +33,11 @@ type Job struct {
 
 	// The number of shards to split compacted block into. Not used if splitting is disabled.
 	splitNumShards uint32
+	splitStageSize uint32
 }
 
 // NewJob returns a new compaction Job.
-func NewJob(userID string, key string, lset labels.Labels, resolution int64, useSplitting bool, splitNumShards uint32, shardingKey string) *Job {
+func NewJob(userID string, key string, lset labels.Labels, resolution int64, useSplitting bool, splitNumShards, splitStageSize uint32, shardingKey string) *Job {
 	return &Job{
 		userID:         userID,
 		key:            key,
@@ -44,6 +45,7 @@ func NewJob(userID string, key string, lset labels.Labels, resolution int64, use
 		resolution:     resolution,
 		useSplitting:   useSplitting,
 		splitNumShards: splitNumShards,
+		splitStageSize: splitStageSize,
 		shardingKey:    shardingKey,
 	}
 }
@@ -143,6 +145,11 @@ func (job *Job) UseSplitting() bool {
 // SplittingShards returns the number of output shards to build if splitting is enabled.
 func (job *Job) SplittingShards() uint32 {
 	return job.splitNumShards
+}
+
+// SplitStageSize returns the number of stages split shards will be written to.
+func (job *Job) SplitStageSize() uint32 {
+	return job.splitStageSize
 }
 
 // ShardingKey returns the key used to shard this job across multiple instances.

--- a/pkg/compactor/job_test.go
+++ b/pkg/compactor/job_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestJob_MinCompactionLevel(t *testing.T) {
-	job := NewJob("user-1", "group-1", labels.EmptyLabels(), 0, true, 2, "shard-1")
+	job := NewJob("user-1", "group-1", labels.EmptyLabels(), 0, true, 2, 0, "shard-1")
 	require.NoError(t, job.AppendMeta(&block.Meta{ULID: ulid.MustNew(1, nil), Compaction: block.BlockMetaCompaction{Level: 2}}))
 	assert.Equal(t, 2, job.MinCompactionLevel())
 
@@ -108,7 +108,7 @@ func TestJobWaitPeriodElapsed(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			job := NewJob("user-1", "group-1", labels.EmptyLabels(), 0, true, 2, "shard-1")
+			job := NewJob("user-1", "group-1", labels.EmptyLabels(), 0, true, 2, 0, "shard-1")
 			for _, b := range testData.jobBlocks {
 				require.NoError(t, job.AppendMeta(b.meta))
 			}

--- a/pkg/compactor/split_merge_compactor.go
+++ b/pkg/compactor/split_merge_compactor.go
@@ -20,7 +20,7 @@ func splitAndMergeGrouperFactory(_ context.Context, cfg Config, cfgProvider Conf
 		logger)
 }
 
-func splitAndMergeCompactorFactory(ctx context.Context, cfg Config, logger log.Logger, reg prometheus.Registerer) (Compactor, Planner, error) {
+func splitAndMergeCompactorFactory(_ context.Context, cfg Config, logger log.Logger, reg prometheus.Registerer) (Compactor, Planner, error) {
 	splitBy := getCompactionSplitBy(cfg.CompactionSplitBy)
 	if splitBy == nil {
 		return nil, nil, errInvalidCompactionSplitBy
@@ -28,6 +28,7 @@ func splitAndMergeCompactorFactory(ctx context.Context, cfg Config, logger log.L
 
 	return &BlockCompactor{
 		blockOpenConcurrency: cfg.MaxOpeningBlocksConcurrency,
+		stageSize:            cfg.CompactionStageSize,
 		splitBy:              splitBy,
 		logger:               logger,
 		metrics:              newCompactorMetrics(reg),

--- a/pkg/compactor/split_merge_compactor.go
+++ b/pkg/compactor/split_merge_compactor.go
@@ -16,6 +16,7 @@ func splitAndMergeGrouperFactory(_ context.Context, cfg Config, cfgProvider Conf
 		userID,
 		cfg.BlockRanges.ToMilliseconds(),
 		uint32(cfgProvider.CompactorSplitAndMergeShards(userID)),
+		uint32(cfgProvider.CompactorSplitAndMergeStageSize(userID)),
 		uint32(cfgProvider.CompactorSplitGroups(userID)),
 		logger)
 }
@@ -28,7 +29,6 @@ func splitAndMergeCompactorFactory(_ context.Context, cfg Config, logger log.Log
 
 	return &BlockCompactor{
 		blockOpenConcurrency: cfg.MaxOpeningBlocksConcurrency,
-		stageSize:            cfg.CompactionStageSize,
 		splitBy:              splitBy,
 		logger:               logger,
 		metrics:              newCompactorMetrics(reg),

--- a/pkg/compactor/split_merge_grouper.go
+++ b/pkg/compactor/split_merge_grouper.go
@@ -28,6 +28,9 @@ type SplitAndMergeGrouper struct {
 	// Number of shards to split source blocks into.
 	shardCount uint32
 
+	// Number of stages to split shards into.
+	splitStageSize uint32
+
 	// Number of groups that blocks used for splitting are grouped into.
 	splitGroupsCount uint32
 }
@@ -38,6 +41,7 @@ func NewSplitAndMergeGrouper(
 	userID string,
 	ranges []int64,
 	shardCount uint32,
+	splitStageSize uint32,
 	splitGroupsCount uint32,
 	logger log.Logger,
 ) *SplitAndMergeGrouper {
@@ -45,6 +49,7 @@ func NewSplitAndMergeGrouper(
 		userID:           userID,
 		ranges:           ranges,
 		shardCount:       shardCount,
+		splitStageSize:   splitStageSize,
 		splitGroupsCount: splitGroupsCount,
 		logger:           logger,
 	}
@@ -83,6 +88,7 @@ func (g *SplitAndMergeGrouper) Groups(blocks map[ulid.ULID]*block.Meta) (res []*
 			resolution,
 			job.stage == stageSplit,
 			g.shardCount,
+			g.splitStageSize,
 			job.shardingKey(),
 		)
 

--- a/pkg/phlaredb/compact.go
+++ b/pkg/phlaredb/compact.go
@@ -40,14 +40,14 @@ type BlockReader interface {
 }
 
 func Compact(ctx context.Context, src []BlockReader, dst string) (meta block.Meta, err error) {
-	metas, err := CompactWithSplitting(ctx, src, 1, dst, SplitByFingerprint, 0)
+	metas, err := CompactWithSplitting(ctx, src, 1, 0, dst, SplitByFingerprint)
 	if err != nil {
 		return block.Meta{}, err
 	}
 	return metas[0], nil
 }
 
-func CompactWithSplitting(ctx context.Context, src []BlockReader, splitCount uint64, dst string, splitBy SplitByFunc, stageSize uint64) (
+func CompactWithSplitting(ctx context.Context, src []BlockReader, splitCount, stageSize uint64, dst string, splitBy SplitByFunc) (
 	[]block.Meta, error,
 ) {
 	if len(src) <= 1 && splitCount == 1 {

--- a/pkg/phlaredb/compact_test.go
+++ b/pkg/phlaredb/compact_test.go
@@ -108,7 +108,7 @@ func TestCompactWithSplitting(t *testing.T) {
 		)
 	})
 	dst := t.TempDir()
-	compacted, err := CompactWithSplitting(ctx, []BlockReader{b1, b2, b2, b1}, 16, dst, SplitByFingerprint, 2)
+	compacted, err := CompactWithSplitting(ctx, []BlockReader{b1, b2, b2, b1}, 16, 8, dst, SplitByFingerprint)
 	require.NoError(t, err)
 
 	// 4 shards one per series.
@@ -496,7 +496,7 @@ func TestCompactOldBlock(t *testing.T) {
 	br := NewSingleBlockQuerierFromMeta(context.Background(), bkt, meta)
 	require.NoError(t, br.Open(ctx))
 	_, err = CompactWithSplitting(ctx,
-		[]BlockReader{br}, 2, dst, SplitByFingerprint, 0)
+		[]BlockReader{br}, 2, 0, dst, SplitByFingerprint)
 	require.NoError(t, err)
 }
 

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -72,6 +72,7 @@ type Limits struct {
 	// Compactor.
 	CompactorBlocksRetentionPeriod     model.Duration `yaml:"compactor_blocks_retention_period" json:"compactor_blocks_retention_period"`
 	CompactorSplitAndMergeShards       int            `yaml:"compactor_split_and_merge_shards" json:"compactor_split_and_merge_shards"`
+	CompactorSplitAndMergeStageSize    int            `yaml:"compactor_split_and_merge_stage_size" json:"compactor_split_and_merge_stage_size"`
 	CompactorSplitGroups               int            `yaml:"compactor_split_groups" json:"compactor_split_groups"`
 	CompactorTenantShardSize           int            `yaml:"compactor_tenant_shard_size" json:"compactor_tenant_shard_size"`
 	CompactorPartialBlockDeletionDelay model.Duration `yaml:"compactor_partial_block_deletion_delay" json:"compactor_partial_block_deletion_delay"`
@@ -136,6 +137,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	f.Var(&l.CompactorBlocksRetentionPeriod, "compactor.blocks-retention-period", "Delete blocks containing samples older than the specified retention period. 0 to disable.")
 	f.IntVar(&l.CompactorSplitAndMergeShards, "compactor.split-and-merge-shards", 0, "The number of shards to use when splitting blocks. 0 to disable splitting.")
+	f.IntVar(&l.CompactorSplitAndMergeStageSize, "compactor.split-and-merge-stage-size", 0, "Number of stages split shards will be written to. Number of output split shards is controlled by -compactor.split-and-merge-shards.")
 	f.IntVar(&l.CompactorSplitGroups, "compactor.split-groups", 1, "Number of groups that blocks for splitting should be grouped into. Each group of blocks is then split separately. Number of output split shards is controlled by -compactor.split-and-merge-shards.")
 	f.IntVar(&l.CompactorTenantShardSize, "compactor.compactor-tenant-shard-size", 0, "Max number of compactors that can compact blocks for single tenant. 0 to disable the limit and use all compactors.")
 	_ = l.CompactorPartialBlockDeletionDelay.Set("1d")
@@ -346,6 +348,11 @@ func (o *Overrides) CompactorBlocksRetentionPeriod(userID string) time.Duration 
 // CompactorSplitAndMergeShards returns the number of shards to use when splitting blocks.
 func (o *Overrides) CompactorSplitAndMergeShards(userID string) int {
 	return o.getOverridesForTenant(userID).CompactorSplitAndMergeShards
+}
+
+// CompactorSplitAndMergeStageSize returns the number of stages split shards will be written to.
+func (o *Overrides) CompactorSplitAndMergeStageSize(userID string) int {
+	return o.getOverridesForTenant(userID).CompactorSplitAndMergeStageSize
 }
 
 // CompactorSplitGroups returns the number of groups that blocks for splitting should be grouped into.


### PR DESCRIPTION
Number of compactor split shards is limited to the number of blocks we can write concurrently. There are two significant factors:
 - Symbols size in memory. Varies depending on the sharding key.
 - Memory utilized by parquet writer / row group buffer. Varies depending on the row group size and contents.

I propose to compact blocks in stages to circumvent these limitations. Potentially, we can mitigate them (and we will, I believe), however we can't eliminate them.

There are multiple ways to implement staging. The PR contains the simplest of them: at compaction, we only populate limited number of output blocks (stage size), and re-read source blocks as many times as many stages specified. For example, if we have 16 blocks at input, 64 split shards, and stage size is 8, we re-read (re-reprocess) source blocks 8 times, but only 8 output blocks are being populated at any point in time.

The work is not complete and has not been tested. I'd like to discuss the subject before investing more efforts.

/cc @cyriltovena @simonswine 