### PR TITLE
Fix symbols resolver race condition

### DIFF
--- a/pkg/phlaredb/symdb/block_reader.go
+++ b/pkg/phlaredb/symdb/block_reader.go
@@ -189,7 +189,6 @@ func (r *Reader) partition(ctx context.Context, partition uint64) (*partition, e
 		return nil, ErrPartitionNotFound
 	}
 	if err := p.init(ctx); err != nil {
-		p.Release()
 		return nil, err
 	}
 	return p, nil
@@ -205,20 +204,22 @@ type partition struct {
 	strings          parquetTableRange[string, *schemav1.StringPersister]
 }
 
-func (p *partition) init(ctx context.Context) error {
-	g, ctx := errgroup.WithContext(ctx)
+func (p *partition) init(ctx context.Context) (err error) { return p.tx().fetch(ctx) }
+
+func (p *partition) Release() { p.tx().release() }
+
+func (p *partition) tx() *fetchTx {
+	tx := make(fetchTx, 0, len(p.stacktraceChunks)+4)
 	for _, c := range p.stacktraceChunks {
-		c := c
-		g.Go(func() error { return c.fetch(ctx) })
+		tx.append(c)
 	}
 	if p.reader.index.Header.Version > FormatV1 {
-		g.Go(func() error { return p.locations.fetch(ctx) })
-		g.Go(func() error { return p.mappings.fetch(ctx) })
-		g.Go(func() error { return p.functions.fetch(ctx) })
-		g.Go(func() error { return p.strings.fetch(ctx) })
+		tx.append(&p.locations)
+		tx.append(&p.mappings)
+		tx.append(&p.functions)
+		tx.append(&p.strings)
 	}
-	err := g.Wait()
-	return err
+	return &tx
 }
 
 func (p *partition) Symbols() *Symbols {
@@ -229,26 +230,6 @@ func (p *partition) Symbols() *Symbols {
 		Functions:   p.functions.s,
 		Strings:     p.strings.s,
 	}
-}
-
-func (p *partition) Release() {
-	var wg sync.WaitGroup
-	wg.Add(len(p.stacktraceChunks))
-	for _, c := range p.stacktraceChunks {
-		c := c
-		go func() {
-			c.release()
-			wg.Done()
-		}()
-	}
-	if p.reader.index.Header.Version > FormatV1 {
-		wg.Add(4)
-		go func() { p.locations.release(); wg.Done() }()
-		go func() { p.mappings.release(); wg.Done() }()
-		go func() { p.functions.release(); wg.Done() }()
-		go func() { p.strings.release(); wg.Done() }()
-	}
-	wg.Wait()
 }
 
 func (p *partition) WriteStats(s *PartitionStats) {
@@ -481,4 +462,51 @@ func (t *parquetTableRange[M, P]) release() {
 	t.r.Dec(func() {
 		t.s = nil
 	})
+}
+
+// fetchTx facilitates fetching multiple objects in a transactional manner:
+// if one of the objects has failed, all the remaining ones are released.
+type fetchTx []fetch
+
+type fetch interface {
+	fetch(context.Context) error
+	release()
+}
+
+func (tx *fetchTx) append(x fetch) { *tx = append(*tx, x) }
+
+func (tx *fetchTx) fetch(ctx context.Context) (err error) {
+	defer func() {
+		if err != nil {
+			tx.release()
+		}
+	}()
+	g, ctx := errgroup.WithContext(ctx)
+	for i, x := range *tx {
+		i := i
+		x := x
+		g.Go(func() error {
+			fErr := x.fetch(ctx)
+			if fErr != nil {
+				(*tx)[i] = nil
+			}
+			return fErr
+		})
+	}
+	return g.Wait()
+}
+
+func (tx *fetchTx) release() {
+	var wg sync.WaitGroup
+	wg.Add(len(*tx))
+	for _, x := range *tx {
+		x := x
+		go func() {
+			defer wg.Done()
+			if x != nil {
+				x.release()
+			}
+		}()
+	}
+	wg.Wait()
 }

--- a/pkg/phlaredb/symdb/resolver_test.go
+++ b/pkg/phlaredb/symdb/resolver_test.go
@@ -3,6 +3,8 @@ package symdb
 import (
 	"context"
 	"io"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -130,6 +132,40 @@ func Test_Resolver_Error_Propagation(t *testing.T) {
 	r.Release()
 }
 
+func Test_Resolver_Cancellation(t *testing.T) {
+	s := newBlockSuite(t, [][]string{{"testdata/profile.pb.gz"}})
+	defer s.teardown()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const (
+		workers    = 10
+		iterations = 10
+		depth      = 5
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				for d := 0; d < depth; d++ {
+					func() {
+						r := NewResolver(contextCancelAfter(ctx, int64(d)), s.reader)
+						defer r.Release()
+						r.AddSamples(0, s.indexed[0][0].Samples)
+						_, _ = r.Tree()
+					}()
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
 type mockSymbolsReader struct{ mock.Mock }
 
 func (m *mockSymbolsReader) Partition(ctx context.Context, partition uint64) (PartitionReader, error) {
@@ -141,4 +177,36 @@ func (m *mockSymbolsReader) Partition(ctx context.Context, partition uint64) (Pa
 func (m *mockSymbolsReader) Load(ctx context.Context) error {
 	args := m.Called(ctx)
 	return args.Error(0)
+}
+
+type fakeContext struct {
+	context.Context
+	once sync.Once
+	ch   chan struct{}
+	c    atomic.Int64
+	n    int64
+}
+
+func contextCancelAfter(ctx context.Context, n int64) context.Context {
+	return &fakeContext{
+		ch:      make(chan struct{}),
+		Context: ctx,
+		n:       n,
+	}
+}
+
+func (f *fakeContext) Done() <-chan struct{} {
+	if f.c.Add(1) > f.n {
+		f.once.Do(func() {
+			close(f.ch)
+		})
+	}
+	return f.ch
+}
+
+func (f *fakeContext) Err() error {
+	if f.c.Load() > f.n {
+		return context.Canceled
+	}
+	return f.Context.Err()
 }

--- a/pkg/util/refctr/refctr.go
+++ b/pkg/util/refctr/refctr.go
@@ -34,6 +34,9 @@ func (r *Counter) Inc(init func() error) (err error) {
 // if this is the last reference.
 func (r *Counter) Dec(release func()) {
 	r.m.Lock()
+	if r.c < 0 {
+		panic("bug: negative reference counter")
+	}
 	if r.c--; r.c < 1 {
 		release()
 	}


### PR DESCRIPTION
Fixes https://github.com/grafana/pyroscope/issues/2644: the problem was that, on context cancellation, a partition could be released while still being used by resolver. 