### PR TITLE
fix FQDN to short names

### DIFF
--- a/operations/pyroscope/helm/pyroscope/Chart.yaml
+++ b/operations/pyroscope/helm/pyroscope/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pyroscope
 description: 🔥 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 type: application
-version: 1.3.3
+version: 1.3.4
 appVersion: 1.2.1
 dependencies:
   - name: grafana-agent

--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -15,6 +15,7 @@
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| cluster_domain | string | `cluster.local.` | Override k8s cluster domain to internal DNS name resolution |
 | agent | object | `{"agent":{"clustering":{"enabled":true},"configMap":{"create":false,"name":"grafana-agent-config-pyroscope"}},"controller":{"podAnnotations":{"profiles.grafana.com/cpu.port_name":"http-metrics","profiles.grafana.com/cpu.scrape":"true","profiles.grafana.com/goroutine.port_name":"http-metrics","profiles.grafana.com/goroutine.scrape":"true","profiles.grafana.com/memory.port_name":"http-metrics","profiles.grafana.com/memory.scrape":"true"},"replicas":1,"type":"statefulset"},"enabled":true}` | ----------------------------------- |
 | ingress.className | string | `""` |  |
 | ingress.enabled | bool | `false` |  |

--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -1,6 +1,6 @@
 # pyroscope
 
-![Version: 1.3.3](https://img.shields.io/badge/Version-1.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.1](https://img.shields.io/badge/AppVersion-1.2.1-informational?style=flat-square)
+![Version: 1.3.4](https://img.shields.io/badge/Version-1.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.1](https://img.shields.io/badge/AppVersion-1.2.1-informational?style=flat-square)
 
 🔥 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 

--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -15,12 +15,12 @@
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| cluster_domain | string | `cluster.local.` | Override k8s cluster domain to internal DNS name resolution |
 | agent | object | `{"agent":{"clustering":{"enabled":true},"configMap":{"create":false,"name":"grafana-agent-config-pyroscope"}},"controller":{"podAnnotations":{"profiles.grafana.com/cpu.port_name":"http-metrics","profiles.grafana.com/cpu.scrape":"true","profiles.grafana.com/goroutine.port_name":"http-metrics","profiles.grafana.com/goroutine.scrape":"true","profiles.grafana.com/memory.port_name":"http-metrics","profiles.grafana.com/memory.scrape":"true"},"replicas":1,"type":"statefulset"},"enabled":true}` | ----------------------------------- |
 | ingress.className | string | `""` |  |
 | ingress.enabled | bool | `false` |  |
 | minio | object | `{"buckets":[{"name":"grafana-pyroscope-data","policy":"none","purge":false}],"drivesPerNode":2,"enabled":false,"persistence":{"size":"5Gi"},"podAnnotations":{"phlare.grafana.com/port":"9000","phlare.grafana.com/scrape":"true"},"replicas":1,"resources":{"requests":{"cpu":"100m","memory":"128Mi"}},"rootPassword":"supersecret","rootUser":"grafana-pyroscope"}` | ----------------------------------- |
 | pyroscope.affinity | object | `{}` |  |
+| pyroscope.cluster_domain | string | `".cluster.local."` | Kubernetes cluster domain suffix for DNS discovery |
 | pyroscope.components | object | `{}` |  |
 | pyroscope.config | string | The config depends on other values been set, details can be found in [`values.yaml`](./values.yaml) | Contains Phlare's configuration as a string. |
 | pyroscope.dnsPolicy | string | `"ClusterFirst"` |  |

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -27,7 +27,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -48,7 +48,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -69,7 +69,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -90,7 +90,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -111,7 +111,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -132,7 +132,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -153,7 +153,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -193,7 +193,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -540,7 +540,7 @@ metadata:
   name: grafana-agent-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1344,7 +1344,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1361,7 +1361,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1465,7 +1465,7 @@ metadata:
   name: default-pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1512,7 +1512,7 @@ metadata:
   name: default-pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1652,7 +1652,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1679,7 +1679,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1704,7 +1704,7 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1730,7 +1730,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1755,7 +1755,7 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1781,7 +1781,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1806,7 +1806,7 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1832,7 +1832,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1857,7 +1857,7 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1883,7 +1883,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1908,7 +1908,7 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1934,7 +1934,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1959,7 +1959,7 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1985,7 +1985,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -2010,7 +2010,7 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -2036,7 +2036,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -2061,7 +2061,7 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -2087,7 +2087,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -2103,7 +2103,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 077734baeb84a90bc054b9f8c8bca810bc0b8c770ad8838257ddbbf249b7ff9e
+        checksum/config: 73ee410b751eff68ce1e40efae63c961c9e68b22809bdde76497d302daf8f0a6
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2181,7 +2181,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -2197,7 +2197,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 077734baeb84a90bc054b9f8c8bca810bc0b8c770ad8838257ddbbf249b7ff9e
+        checksum/config: 73ee410b751eff68ce1e40efae63c961c9e68b22809bdde76497d302daf8f0a6
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2275,7 +2275,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -2291,7 +2291,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 077734baeb84a90bc054b9f8c8bca810bc0b8c770ad8838257ddbbf249b7ff9e
+        checksum/config: 73ee410b751eff68ce1e40efae63c961c9e68b22809bdde76497d302daf8f0a6
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2369,7 +2369,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -2385,7 +2385,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 077734baeb84a90bc054b9f8c8bca810bc0b8c770ad8838257ddbbf249b7ff9e
+        checksum/config: 73ee410b751eff68ce1e40efae63c961c9e68b22809bdde76497d302daf8f0a6
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2463,7 +2463,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -2479,7 +2479,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 077734baeb84a90bc054b9f8c8bca810bc0b8c770ad8838257ddbbf249b7ff9e
+        checksum/config: 73ee410b751eff68ce1e40efae63c961c9e68b22809bdde76497d302daf8f0a6
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2734,7 +2734,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -2752,7 +2752,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 077734baeb84a90bc054b9f8c8bca810bc0b8c770ad8838257ddbbf249b7ff9e
+        checksum/config: 73ee410b751eff68ce1e40efae63c961c9e68b22809bdde76497d302daf8f0a6
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2834,7 +2834,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -2852,7 +2852,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 077734baeb84a90bc054b9f8c8bca810bc0b8c770ad8838257ddbbf249b7ff9e
+        checksum/config: 73ee410b751eff68ce1e40efae63c961c9e68b22809bdde76497d302daf8f0a6
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2931,7 +2931,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -2949,7 +2949,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 077734baeb84a90bc054b9f8c8bca810bc0b8c770ad8838257ddbbf249b7ff9e
+        checksum/config: 73ee410b751eff68ce1e40efae63c961c9e68b22809bdde76497d302daf8f0a6
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -39,7 +39,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -52,7 +52,7 @@ metadata:
   name: grafana-agent-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -856,7 +856,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -873,7 +873,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -970,7 +970,7 @@ metadata:
   name: default-pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1017,7 +1017,7 @@ metadata:
   name: default-pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1089,7 +1089,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1116,7 +1116,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1141,7 +1141,7 @@ metadata:
   name: pyroscope-dev-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1249,7 +1249,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.3.3
+    helm.sh/chart: pyroscope-1.3.4
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.2.1"
@@ -1267,7 +1267,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e1429505643e7d88726345ec48abd0a3ab8616fcff98a669ab5718e7cfd5387f
+        checksum/config: c87d7804dfaa22b651b5141f315ef6524dbe6cd169cd6f4c670439aeb7d1ce50
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/templates/NOTES.txt
+++ b/operations/pyroscope/helm/pyroscope/templates/NOTES.txt
@@ -22,9 +22,9 @@ The in-cluster query URL for the data source in Grafana is:
 ```
 {{- if hasKey .Values.pyroscope.components "query-frontend" }}
 {{- $port := ((index .Values.pyroscope.components "query-frontend").service).port | default .Values.pyroscope.service.port }}
-http://{{ include "pyroscope.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc.cluster.local.:{{ $port }}
+http://{{ include "pyroscope.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc:{{ $port }}
 {{- else }}
-http://{{ include "pyroscope.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local.:{{ .Values.pyroscope.service.port }}
+http://{{ include "pyroscope.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.pyroscope.service.port }}
 {{- end }}
 ```
 

--- a/operations/pyroscope/helm/pyroscope/templates/NOTES.txt
+++ b/operations/pyroscope/helm/pyroscope/templates/NOTES.txt
@@ -22,9 +22,9 @@ The in-cluster query URL for the data source in Grafana is:
 ```
 {{- if hasKey .Values.pyroscope.components "query-frontend" }}
 {{- $port := ((index .Values.pyroscope.components "query-frontend").service).port | default .Values.pyroscope.service.port }}
-http://{{ include "pyroscope.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc:{{ $port }}
+http://{{ include "pyroscope.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc.{{ include "cluster.domain" . }}:{{ $port }}
 {{- else }}
-http://{{ include "pyroscope.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.pyroscope.service.port }}
+http://{{ include "pyroscope.fullname" . }}.{{ .Release.Namespace }}.svc.{{ include "cluster.domain" . }}:{{ .Values.pyroscope.service.port }}
 {{- end }}
 ```
 

--- a/operations/pyroscope/helm/pyroscope/templates/NOTES.txt
+++ b/operations/pyroscope/helm/pyroscope/templates/NOTES.txt
@@ -22,9 +22,9 @@ The in-cluster query URL for the data source in Grafana is:
 ```
 {{- if hasKey .Values.pyroscope.components "query-frontend" }}
 {{- $port := ((index .Values.pyroscope.components "query-frontend").service).port | default .Values.pyroscope.service.port }}
-http://{{ include "pyroscope.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc.{{ include "cluster.domain" . }}:{{ $port }}
+http://{{ include "pyroscope.fullname" . }}-query-frontend.{{ .Release.Namespace }}.svc{{ .Values.pyroscope.cluster_domain }}:{{ $port }}
 {{- else }}
-http://{{ include "pyroscope.fullname" . }}.{{ .Release.Namespace }}.svc.{{ include "cluster.domain" . }}:{{ .Values.pyroscope.service.port }}
+http://{{ include "pyroscope.fullname" . }}.{{ .Release.Namespace }}.svc{{ .Values.pyroscope.cluster_domain }}:{{ .Values.pyroscope.service.port }}
 {{- end }}
 ```
 

--- a/operations/pyroscope/helm/pyroscope/templates/_helpers.tpl
+++ b/operations/pyroscope/helm/pyroscope/templates/_helpers.tpl
@@ -91,3 +91,16 @@ If no components are defined fall back to single binary statefulset
 all: {kind: "StatefulSet", name: "{{$full_name}}"}
 {{- end }}
 {{- end }}
+
+
+{{- define "cluster.domain" }}
+{{- if .Values.cluster_domain  }}
+{{- if hasSuffix "." .Values.cluster_domain }}
+{{- .Values.cluster_domain | replace " " "" -}}
+{{- else }}
+{{- cat .Values.cluster_domain "." | replace " " "" -}}
+{{- end }}
+{{- else }}
+{{- printf "cluster.local." -}}
+{{- end }}
+{{- end }}

--- a/operations/pyroscope/helm/pyroscope/templates/_helpers.tpl
+++ b/operations/pyroscope/helm/pyroscope/templates/_helpers.tpl
@@ -91,16 +91,3 @@ If no components are defined fall back to single binary statefulset
 all: {kind: "StatefulSet", name: "{{$full_name}}"}
 {{- end }}
 {{- end }}
-
-
-{{- define "cluster.domain" }}
-{{- if .Values.cluster_domain  }}
-{{- if hasSuffix "." .Values.cluster_domain }}
-{{- .Values.cluster_domain | replace " " "" -}}
-{{- else }}
-{{- cat .Values.cluster_domain "." | replace " " "" -}}
-{{- end }}
-{{- else }}
-{{- printf "cluster.local." -}}
-{{- end }}
-{{- end }}

--- a/operations/pyroscope/helm/pyroscope/templates/configmap-agent.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/configmap-agent.yaml
@@ -177,9 +177,9 @@ data:
     pyroscope.write "pyroscope_write" {
     	endpoint {
         {{- if hasKey .Values.pyroscope.components "distributor" }}
-    		url = "http://{{ include "pyroscope.fullname" . }}-distributor.{{ .Release.Namespace }}.svc:{{ (.Values.pyroscope.components.distributor.service).port | default .Values.pyroscope.service.port}}"
+    		url = "http://{{ include "pyroscope.fullname" . }}-distributor.{{ .Release.Namespace }}.svc.{{ include "cluster.domain" . }}:{{ (.Values.pyroscope.components.distributor.service).port | default .Values.pyroscope.service.port}}"
         {{- else }}
-    		url = "http://{{ include "pyroscope.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.pyroscope.service.port }}"
+    		url = "http://{{ include "pyroscope.fullname" . }}.{{ .Release.Namespace }}.svc.{{ include "cluster.domain" . }}:{{ .Values.pyroscope.service.port }}"
         {{- end }}
     	}
     }

--- a/operations/pyroscope/helm/pyroscope/templates/configmap-agent.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/configmap-agent.yaml
@@ -177,9 +177,9 @@ data:
     pyroscope.write "pyroscope_write" {
     	endpoint {
         {{- if hasKey .Values.pyroscope.components "distributor" }}
-    		url = "http://{{ include "pyroscope.fullname" . }}-distributor.{{ .Release.Namespace }}.svc.{{ include "cluster.domain" . }}:{{ (.Values.pyroscope.components.distributor.service).port | default .Values.pyroscope.service.port}}"
+    		url = "http://{{ include "pyroscope.fullname" . }}-distributor.{{ .Release.Namespace }}.svc{{ .Values.pyroscope.cluster_domain }}:{{ (.Values.pyroscope.components.distributor.service).port | default .Values.pyroscope.service.port}}"
         {{- else }}
-    		url = "http://{{ include "pyroscope.fullname" . }}.{{ .Release.Namespace }}.svc.{{ include "cluster.domain" . }}:{{ .Values.pyroscope.service.port }}"
+    		url = "http://{{ include "pyroscope.fullname" . }}.{{ .Release.Namespace }}.svc{{ .Values.pyroscope.cluster_domain }}:{{ .Values.pyroscope.service.port }}"
         {{- end }}
     	}
     }

--- a/operations/pyroscope/helm/pyroscope/templates/configmap-agent.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/configmap-agent.yaml
@@ -177,9 +177,9 @@ data:
     pyroscope.write "pyroscope_write" {
     	endpoint {
         {{- if hasKey .Values.pyroscope.components "distributor" }}
-    		url = "http://{{ include "pyroscope.fullname" . }}-distributor.{{ .Release.Namespace }}.svc.cluster.local.:{{ (.Values.pyroscope.components.distributor.service).port | default .Values.pyroscope.service.port}}"
+    		url = "http://{{ include "pyroscope.fullname" . }}-distributor.{{ .Release.Namespace }}.svc:{{ (.Values.pyroscope.components.distributor.service).port | default .Values.pyroscope.service.port}}"
         {{- else }}
-    		url = "http://{{ include "pyroscope.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local.:{{ .Values.pyroscope.service.port }}"
+    		url = "http://{{ include "pyroscope.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.pyroscope.service.port }}"
         {{- end }}
     	}
     }

--- a/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
@@ -64,7 +64,7 @@ spec:
             - "-self-profiling.disable-push=true"
             - "-server.http-listen-port={{ $values.service.port }}"
             - "-memberlist.cluster-label={{ .Release.Namespace }}-{{ include "pyroscope.fullname" .}}"
-            - "-memberlist.join=dns+{{ include "pyroscope.fullname" .}}-memberlist.{{ .Release.Namespace }}.svc:{{ .Values.pyroscope.memberlist.port }}"
+            - "-memberlist.join=dns+{{ include "pyroscope.fullname" .}}-memberlist.{{ .Release.Namespace }}.svc.{{ include "cluster.domain" . }}:{{ .Values.pyroscope.memberlist.port }}"
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
           {{- range $key, $value := $extraArgs }}

--- a/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
@@ -64,7 +64,7 @@ spec:
             - "-self-profiling.disable-push=true"
             - "-server.http-listen-port={{ $values.service.port }}"
             - "-memberlist.cluster-label={{ .Release.Namespace }}-{{ include "pyroscope.fullname" .}}"
-            - "-memberlist.join=dns+{{ include "pyroscope.fullname" .}}-memberlist.{{ .Release.Namespace }}.svc.cluster.local.:{{ .Values.pyroscope.memberlist.port }}"
+            - "-memberlist.join=dns+{{ include "pyroscope.fullname" .}}-memberlist.{{ .Release.Namespace }}.svc:{{ .Values.pyroscope.memberlist.port }}"
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
           {{- range $key, $value := $extraArgs }}

--- a/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
@@ -64,7 +64,7 @@ spec:
             - "-self-profiling.disable-push=true"
             - "-server.http-listen-port={{ $values.service.port }}"
             - "-memberlist.cluster-label={{ .Release.Namespace }}-{{ include "pyroscope.fullname" .}}"
-            - "-memberlist.join=dns+{{ include "pyroscope.fullname" .}}-memberlist.{{ .Release.Namespace }}.svc.{{ include "cluster.domain" . }}:{{ .Values.pyroscope.memberlist.port }}"
+            - "-memberlist.join=dns+{{ include "pyroscope.fullname" .}}-memberlist.{{ .Release.Namespace }}.svc{{ .Values.pyroscope.cluster_domain }}:{{ .Values.pyroscope.memberlist.port }}"
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
           {{- range $key, $value := $extraArgs }}

--- a/operations/pyroscope/helm/pyroscope/values.yaml
+++ b/operations/pyroscope/helm/pyroscope/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Override default K8S cluster domain for DNS discovery
+# cluster_domain:
+
 pyroscope:
   replicaCount: 1
 

--- a/operations/pyroscope/helm/pyroscope/values.yaml
+++ b/operations/pyroscope/helm/pyroscope/values.yaml
@@ -2,11 +2,12 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# Override default K8S cluster domain for DNS discovery
-# cluster_domain:
 
 pyroscope:
   replicaCount: 1
+
+  # -- Kubernetes cluster domain suffix for DNS discovery
+  cluster_domain: .cluster.local.
 
   image:
     repository: grafana/pyroscope

--- a/operations/pyroscope/jsonnet/values.json
+++ b/operations/pyroscope/jsonnet/values.json
@@ -56,6 +56,7 @@
   },
   "pyroscope": {
     "affinity": {},
+    "cluster_domain": ".cluster.local.",
     "components": {},
     "config": "{{- if .Values.minio.enabled }}\nstorage:\n  backend: s3\n  s3:\n    endpoint: \"{{ include \"pyroscope.fullname\" . }}-minio:9000\"\n    bucket_name: {{(index .Values.minio.buckets 0).name | quote }}\n    access_key_id: {{ .Values.minio.rootUser | quote }}\n    secret_access_key: {{ .Values.minio.rootPassword | quote }}\n    insecure: true\n{{- end }}\n",
     "dnsPolicy": "ClusterFirst",


### PR DESCRIPTION
Hello grafana pyroscope team!

This PR fix used FQDN with hardcoded domain `cluster.local`.  
Main idea - don't use FQDN if you deploy resources, use svc short names.  