### PR TITLE
Handle block plans correctly when splitToStores

### DIFF
--- a/pkg/querier/ingester_querier.go
+++ b/pkg/querier/ingester_querier.go
@@ -65,7 +65,7 @@ func forAllIngesters[T any](ctx context.Context, ingesterQuerier *IngesterQuerie
 }
 
 // forAllPlannedIngesters runs f, in parallel, for all ingesters part of the plan
-func forAllPlannedIngesters[T any](ctx context.Context, ingesterQuerier *IngesterQuerier, plan map[string]*ingestv1.BlockHints, f QueryReplicaWithHintsFn[T, IngesterQueryClient]) ([]ResponseFromReplica[T], error) {
+func forAllPlannedIngesters[T any](ctx context.Context, ingesterQuerier *IngesterQuerier, plan blockPlan, f QueryReplicaWithHintsFn[T, IngesterQueryClient]) ([]ResponseFromReplica[T], error) {
 	replicationSet, err := ingesterQuerier.ring.GetReplicationSetForOperation(readNoExtend)
 	if err != nil {
 		return nil, err
@@ -80,7 +80,7 @@ func forAllPlannedIngesters[T any](ctx context.Context, ingesterQuerier *Ingeste
 	}, replicationSet, f)
 }
 
-func (q *Querier) selectTreeFromIngesters(ctx context.Context, req *querierv1.SelectMergeStacktracesRequest, plan map[string]*ingestv1.BlockHints) (*phlaremodel.Tree, error) {
+func (q *Querier) selectTreeFromIngesters(ctx context.Context, req *querierv1.SelectMergeStacktracesRequest, plan blockPlan) (*phlaremodel.Tree, error) {
 	sp, ctx := opentracing.StartSpanFromContext(ctx, "SelectTree Ingesters")
 	defer sp.Finish()
 	profileType, err := phlaremodel.ParseProfileTypeSelector(req.ProfileTypeID)

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -941,6 +941,7 @@ func Test_splitQueryToStores(t *testing.T) {
 		now             model.Time
 		start, end      model.Time
 		queryStoreAfter time.Duration
+		plan            blockPlan
 
 		expected storeQueries
 	}{
@@ -1132,6 +1133,28 @@ func Test_splitQueryToStores(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:            "with a plan we touch all stores at full time window and eleminate later based on the plan",
+			now:             model.TimeFromUnixNano(int64(4 * time.Hour)),
+			start:           model.TimeFromUnixNano(int64(30 * time.Minute)),
+			end:             model.TimeFromUnixNano(int64(45*time.Minute) + int64(3*time.Hour)),
+			queryStoreAfter: 30 * time.Minute,
+			plan:            blockPlan{"replica-a": &ingestv1.BlockHints{Ulids: []string{"block-a", "block-b"}}},
+
+			expected: storeQueries{
+				queryStoreAfter: 0,
+				storeGateway: storeQuery{
+					shouldQuery: true,
+					start:       model.TimeFromUnixNano(int64(30 * time.Minute)),
+					end:         model.TimeFromUnixNano(int64(45*time.Minute) + int64(3*time.Hour)),
+				},
+				ingester: storeQuery{
+					shouldQuery: true,
+					start:       model.TimeFromUnixNano(int64(30 * time.Minute)),
+					end:         model.TimeFromUnixNano(int64(45*time.Minute) + int64(3*time.Hour)),
+				},
+			},
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -1139,7 +1162,9 @@ func Test_splitQueryToStores(t *testing.T) {
 				tc.start,
 				tc.end,
 				tc.now,
-				tc.queryStoreAfter)
+				tc.queryStoreAfter,
+				tc.plan,
+			)
 			require.Equal(t, tc.expected, actual)
 		})
 	}

--- a/pkg/querier/replication.go
+++ b/pkg/querier/replication.go
@@ -309,9 +309,9 @@ func (r *replicasPerBlockID) pruneSupersededBlocks() {
 	}
 }
 
-type jsonPlan map[string]*ingestv1.BlockHints
+type blockPlan map[string]*ingestv1.BlockHints
 
-func (p jsonPlan) String() string {
+func (p blockPlan) String() string {
 	data, _ := json.Marshal(p)
 	return string(data)
 }
@@ -421,7 +421,7 @@ func (r *replicasPerBlockID) blockPlan(ctx context.Context) map[string]*ingestv1
 		"smallest_compaction_level", smallestCompactionLevel,
 		"planned_blocks_ingesters", plannedIngesterBlocks,
 		"planned_blocks_store_gateways", plannedStoreGatwayBlocks,
-		"plan", jsonPlan(plan),
+		"plan", blockPlan(plan),
 	)
 
 	return plan


### PR DESCRIPTION
When a plan has been acquired, we need to make sure we do query all underlying stores. If a particular replica from one store is not part of the plan, we will eliminate this later in `forPlannedIngesters|StoreGateways(...)`.
