### PR TITLE
Allow service.Type="LoadBalancer"

### DIFF
--- a/operations/pyroscope/helm/pyroscope/templates/services.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/services.yaml
@@ -34,7 +34,7 @@ metadata:
     {{- include "pyroscope.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ $component | quote }}
 spec:
-  type: {{ .Values.pyroscope.service.type }}
+  type: ClusterIP
   clusterIP: None
   ports:
     - port: {{ .Values.pyroscope.service.port }}


### PR DESCRIPTION
Closes https://github.com/grafana/pyroscope/issues/2689 by statically encoding the type to ClusterIP

This allows us to set service.Type="LoadBalancer" such that we can expose the service (and send profiles from non-Kube services)

NOTE(s):
- This PR has NOT been tested! If someone can point me to an "idiots guide to testing helm packages", rather just some way to import them locally, would be happy to
- This PR doesn't resolve my other issue of serviceAnnotations (to add the GCP LB annotations to make it an internal LB), but I'll follow that up with a separate PR and issue