### PR TITLE
fix(Units): Fix incorrect units in the UI

### DIFF
--- a/public/app/components/ChartTitle.tsx
+++ b/public/app/components/ChartTitle.tsx
@@ -3,16 +3,15 @@ import Color from 'color';
 import clsx from 'clsx';
 import styles from './ChartTitle.module.scss';
 
+import profileMetrics from '../constants/profile-metrics.json';
+
+const typeToDescriptionMap: Record<string, string> = Object.values(
+  profileMetrics
+).reduce((acc, { type, description }) => ({ ...acc, [type]: description }), {});
+
 const chartTitleKeys = {
-  objects: 'Total number of objects in RAM',
-  goroutines: 'Total number of goroutines',
-  bytes: 'Total amount of RAM',
-  samples: 'Total CPU time',
-  lock_nanoseconds: 'Total time spent waiting on locks',
-  lock_samples: 'Total number of contended locks',
-  diff: 'Baseline vs. Comparison Diff',
-  trace_samples: 'Total aggregated span duration',
-  exceptions: 'Total number of exceptions thrown',
+  ...typeToDescriptionMap,
+  exception: typeToDescriptionMap.exceptions, // alias
   unknown: '',
 
   baseline: 'Baseline time range',

--- a/public/app/constants/profile-metrics.json
+++ b/public/app/constants/profile-metrics.json
@@ -1,0 +1,135 @@
+{
+  "block:contentions:count:contentions:count": {
+    "id": "block:contentions:count:contentions:count",
+    "description": "Total count of blocking contentions",
+    "type": "contentions",
+    "group": "block",
+    "unit": "short"
+  },
+  "block:delay:nanoseconds:contentions:count": {
+    "id": "block:delay:nanoseconds:contentions:count",
+    "description": "Total nanoseconds spent in blocking delays",
+    "type": "delay",
+    "group": "block",
+    "unit": "ns"
+  },
+  "goroutine:goroutine:count:goroutine:count": {
+    "id": "goroutine:goroutine:count:goroutine:count",
+    "description": "Current number of goroutines",
+    "type": "goroutine",
+    "group": "goroutine",
+    "unit": "short"
+  },
+  "memory:alloc_in_new_tlab_bytes:bytes::": {
+    "id": "memory:alloc_in_new_tlab_bytes:bytes::",
+    "description": "Total bytes allocated inside Thread-Local Allocation Buffers (TLAB)",
+    "type": "alloc_in_new_tlab_bytes",
+    "group": "memory",
+    "unit": "bytes"
+  },
+  "memory:alloc_in_new_tlab_objects:count::": {
+    "id": "memory:alloc_in_new_tlab_objects:count::",
+    "description": "Number of objects allocated inside Thread-Local Allocation Buffers (TLAB)",
+    "type": "alloc_in_new_tlab_objects",
+    "group": "memory",
+    "unit": "short"
+  },
+  "memory:alloc_objects:count:space:bytes": {
+    "id": "memory:alloc_objects:count:space:bytes",
+    "description": "Total objects allocated, represented in bytes",
+    "type": "alloc_objects",
+    "group": "memory",
+    "unit": "count"
+  },
+  "memory:alloc_space:bytes:space:bytes": {
+    "id": "memory:alloc_space:bytes:space:bytes",
+    "description": "Total bytes allocated in the heap",
+    "type": "alloc_space",
+    "group": "memory",
+    "unit": "bytes"
+  },
+  "memory:inuse_objects:count:space:bytes": {
+    "id": "memory:inuse_objects:count:space:bytes",
+    "description": "Count of objects currently in use",
+    "type": "inuse_objects",
+    "group": "memory",
+    "unit": "short"
+  },
+  "memory:inuse_space:bytes:space:bytes": {
+    "id": "memory:inuse_space:bytes:space:bytes",
+    "description": "Total bytes of memory currently in use",
+    "type": "inuse_space",
+    "group": "memory",
+    "unit": "bytes"
+  },
+  "mutex:contentions:count:contentions:count": {
+    "id": "mutex:contentions:count:contentions:count",
+    "description": "Number of observed mutex contentions",
+    "type": "contentions",
+    "group": "mutex",
+    "unit": "short"
+  },
+  "mutex:delay:nanoseconds:contentions:count": {
+    "id": "mutex:delay:nanoseconds:contentions:count",
+    "description": "Total time spent waiting due to mutex contentions",
+    "type": "delay",
+    "group": "mutex",
+    "unit": "ns"
+  },
+  "process_cpu:alloc_samples:count:cpu:nanoseconds": {
+    "id": "process_cpu:alloc_samples:count:cpu:nanoseconds",
+    "description": "Count of memory allocation samples during CPU time",
+    "type": "alloc_samples",
+    "group": "memory",
+    "unit": "short"
+  },
+  "process_cpu:alloc_size:bytes:cpu:nanoseconds": {
+    "id": "process_cpu:alloc_size:bytes:cpu:nanoseconds",
+    "description": "Total bytes allocated during CPU time",
+    "type": "alloc_size",
+    "group": "alloc_size",
+    "unit": "bytes"
+  },
+  "process_cpu:cpu:nanoseconds:cpu:nanoseconds": {
+    "id": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+    "description": "Total nanoseconds of CPU time consumed",
+    "type": "cpu",
+    "group": "process_cpu",
+    "unit": "ns"
+  },
+  "process_cpu:exception:count:cpu:nanoseconds": {
+    "id": "process_cpu:exception:count:cpu:nanoseconds",
+    "description": "Number of exceptions within the sampled CPU time",
+    "type": "exceptions",
+    "group": "exceptions",
+    "unit": "short"
+  },
+  "process_cpu:lock_count:count:cpu:nanoseconds": {
+    "id": "process_cpu:lock_count:count:cpu:nanoseconds",
+    "description": "Count of lock acquisitions attempted during CPU time",
+    "type": "lock_count",
+    "group": "locks",
+    "unit": "short"
+  },
+  "process_cpu:lock_time:nanoseconds:cpu:nanoseconds": {
+    "id": "process_cpu:lock_time:nanoseconds:cpu:nanoseconds",
+    "description": "Cumulative time spent acquiring locks, in nanoseconds",
+    "type": "lock_time",
+    "group": "locks",
+    "unit": "ns"
+  },
+  "process_cpu:samples:count::milliseconds": {
+    "id": "process_cpu:samples:count::milliseconds",
+    "description": "Total number of process samples collected",
+    "type": "samples",
+    "group": "process_cpu",
+    "unit": "short"
+  },
+  "process_cpu:samples:count:cpu:nanoseconds": {
+    "id": "process_cpu:samples:count:cpu:nanoseconds",
+    "description": "Count of samples collected over CPU time",
+    "type": "samples",
+    "group": "process_cpu",
+    "unit": "short"
+  }
+}

--- a/public/app/legacy/flamegraph/FlameGraph/FlameGraphComponent/Header.tsx
+++ b/public/app/legacy/flamegraph/FlameGraph/FlameGraphComponent/Header.tsx
@@ -12,10 +12,9 @@ interface HeaderProps {
   setPalette: (p: FlamegraphPalette) => void;
   toolbarVisible?: boolean;
 }
-export default function Header(props: HeaderProps) {
-  const { format, units, palette, setPalette, toolbarVisible } = props;
 
-  const unitsToFlamegraphTitle = {
+const unitsToFlamegraphTitle = new Map(
+  Object.entries({
     objects: 'number of objects in RAM per function',
     goroutines: 'number of goroutines',
     bytes: 'amount of RAM per function',
@@ -25,7 +24,11 @@ export default function Header(props: HeaderProps) {
     trace_samples: 'aggregated span duration',
     exceptions: 'number of exceptions thrown',
     unknown: '',
-  };
+  })
+);
+
+export default function Header(props: HeaderProps) {
+  const { format, units, palette, setPalette, toolbarVisible } = props;
 
   const getTitle = () => {
     switch (format) {
@@ -37,8 +40,8 @@ export default function Header(props: HeaderProps) {
               role="heading"
               aria-level={2}
             >
-              {unitsToFlamegraphTitle[units] && (
-                <>Frame width represents {unitsToFlamegraphTitle[units]}</>
+              {unitsToFlamegraphTitle.has(units) && (
+                <>Frame width represents {unitsToFlamegraphTitle.get(units)}</>
               )}
             </div>
           </div>

--- a/public/app/legacy/flamegraph/Tooltip/Tooltip.tsx
+++ b/public/app/legacy/flamegraph/Tooltip/Tooltip.tsx
@@ -208,6 +208,11 @@ const tooltipTitles: Record<
     formattedValue: 'Time',
     total: '% of total seconds',
   },
+  nanoseconds: {
+    percent: '% of Time spent',
+    formattedValue: 'Time',
+    total: '% of total seconds',
+  },
   lock_samples: {
     percent: '% of contended locks',
     formattedValue: 'Contended locks',

--- a/public/app/legacy/models/units.ts
+++ b/public/app/legacy/models/units.ts
@@ -9,16 +9,13 @@ export const units = [
   'lock_nanoseconds',
   'trace_samples',
   'exceptions',
-];
+  'nanoseconds',
+] as const;
 
-export const UnitsSchema = z.preprocess((u) => {
-  if (typeof u === 'string') {
-    if (units.includes(u)) {
-      return u;
-    }
-  }
-  return 'unknown';
-}, z.enum(['samples', 'objects', 'goroutines', 'bytes', 'lock_samples', 'lock_nanoseconds', 'trace_samples', 'exceptions', 'unknown']));
+export const UnitsSchema = z.preprocess(
+  (u) => units.find((knownUnit) => u === knownUnit) || 'unknown',
+  z.enum([...units, 'unknown'])
+);
 
 export type UnitsType = (typeof units)[number];
 export type Units = z.infer<typeof UnitsSchema>;

--- a/public/app/pages/ContinuousComparisonView.tsx
+++ b/public/app/pages/ContinuousComparisonView.tsx
@@ -180,7 +180,9 @@ function ComparisonApp() {
           title={
             <ChartTitle
               titleKey={
-                isSidesHasSameUnits ? leftSide.metadata.units : undefined
+                isSidesHasSameUnits
+                  ? (leftSide.metadata.name as any)
+                  : undefined
               }
             />
           }

--- a/public/app/pages/ContinuousDiffView.tsx
+++ b/public/app/pages/ContinuousDiffView.tsx
@@ -220,7 +220,7 @@ function ComparisonDiffApp() {
             />
           </Panel>
         </div>
-        <Panel isLoading={isLoading} title={<ChartTitle titleKey="diff" />}>
+        <Panel isLoading={isLoading}>
           <FlameGraphWrapper profile={diffView.profile} diff={true} />
         </Panel>
       </PageContentWrapper>

--- a/public/app/pages/ContinuousDiffView.tsx
+++ b/public/app/pages/ContinuousDiffView.tsx
@@ -97,7 +97,9 @@ function ComparisonDiffApp() {
         />
         <Panel
           isLoading={isLoading}
-          title={<ChartTitle titleKey={diffView.profile?.metadata.units} />}
+          title={
+            <ChartTitle titleKey={diffView.profile?.metadata.name as any} />
+          }
         >
           <TimelineChartWrapper
             data-testid="timeline-main"

--- a/public/app/pages/ContinuousSingleView.tsx
+++ b/public/app/pages/ContinuousSingleView.tsx
@@ -121,6 +121,7 @@ function ContinuousSingleView() {
       </ContextMenu>
     );
   };
+
   return (
     <div>
       <PageTitle title={formatTitle('Single', query)} />
@@ -145,7 +146,7 @@ function ContinuousSingleView() {
           title={
             <ChartTitle
               className="singleView-timeline-title"
-              titleKey={singleView?.profile?.metadata.units}
+              titleKey={singleView?.profile?.metadata.name as any}
             />
           }
         >

--- a/public/app/util/flamebearer.ts
+++ b/public/app/util/flamebearer.ts
@@ -116,6 +116,7 @@ export function flamebearerToDataFrameDTO(
     case 'samples':
     case 'trace_samples':
     case 'lock_nanoseconds':
+    case 'nanoseconds':
       valueUnit = 'ns';
       break;
     case 'bytes':


### PR DESCRIPTION
In the case of (e.g.) `lock_time` profiles, the units were incorrect (count instead of ns). This is because the backend service returns `nanoseconds` as a unit, but the UI doesn't recognize it.

This PR introduces a static JSON file for describing all profile metrics and starts using it in:
- the header of the timeline
- the flamegraph

Note that a lot more work would be needed to ensure that all units/names/descriptions are always properly displayed across the application. 

|Before|After|
|---|---|
| <img width="1455" alt="Screenshot 2023-11-20 at 16 30 19" src="https://github.com/grafana/pyroscope/assets/146180665/c8f33e51-7732-4f83-a472-1d4ec8312d86">|<img width="1457" alt="Screenshot 2023-11-20 at 16 29 15" src="https://github.com/grafana/pyroscope/assets/146180665/c50f46a6-9e75-4cc5-b0ad-caeeda603219">|
