### PR TITLE
Improve SelectMatchingProfiles performance

### DIFF
--- a/pkg/phlaredb/block_querier.go
+++ b/pkg/phlaredb/block_querier.go
@@ -1210,7 +1210,6 @@ func MergeProfilesPprof(ctx context.Context, stream *connect.BidiStream[ingestv1
 		for _, querier := range queriers {
 			querier := querier
 			g.Go(util.RecoverPanic(func() error {
-
 				iters, err := querier.SelectMatchingProfiles(ctx, request)
 				if err != nil {
 					return err
@@ -1546,18 +1545,16 @@ func (b *singleBlockQuerier) SelectMatchingProfiles(ctx context.Context, params 
 		if err != nil {
 			return nil, err
 		}
-		if lblsExisting, exists := lblsPerRef[int64(chks[0].SeriesIndex)]; exists {
-			// Compare to check if there is a clash
-			if phlaremodel.CompareLabelPairs(lbls, lblsExisting.lbs) != 0 {
-				panic("label hash conflict")
-			}
-		} else {
-			lblsPerRef[int64(chks[0].SeriesIndex)] = labelsInfo{
-				fp:  model.Fingerprint(fp),
-				lbs: lbls,
-			}
-			lbls = make(phlaremodel.Labels, 0, 6)
+		if _, exists := lblsPerRef[int64(chks[0].SeriesIndex)]; exists {
+			continue
 		}
+		info := labelsInfo{
+			fp:  model.Fingerprint(fp),
+			lbs: make(phlaremodel.Labels, len(lbls)),
+		}
+		copy(info.lbs, lbls)
+		lblsPerRef[int64(chks[0].SeriesIndex)] = info
+
 	}
 
 	var buf [][]parquet.Value


### PR DESCRIPTION
This will avoid to grow the `lbls` on every runs and instead copy the slice.

I also removed the safety guard which shouldn't be there and is very expensive to run.