### PR TITLE
Refactor Azure bucket configs

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -814,9 +814,11 @@ Usage of ./pyroscope:
   -server.tls-min-version string
     	Minimum TLS version to use. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13. If blank, the Go TLS minimum version is used.
   -storage.azure.account-key string
-    	Azure storage account key
+    	Azure storage account key. If unset, Azure managed identities will be used for authentication instead.
   -storage.azure.account-name string
     	Azure storage account name
+  -storage.azure.connection-string string
+    	If `connection-string` is set, the value of `endpoint-suffix` will not be used. Use this method over `account-key` if you need to authenticate via a SAS token. Or if you use the Azurite emulator.
   -storage.azure.container-name string
     	Azure storage container name
   -storage.azure.endpoint-suffix string
@@ -824,7 +826,7 @@ Usage of ./pyroscope:
   -storage.azure.max-retries int
     	Number of retries for recoverable errors (default 20)
   -storage.azure.user-assigned-id string
-    	User assigned identity. If empty, then System assigned identity is used.
+    	User assigned managed identity. If empty, then System assigned identity is used.
   -storage.backend string
     	Backend storage to use. Supported backends are: s3, gcs, azure, swift, filesystem, cos.
   -storage.cos.app-id string

--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -824,7 +824,7 @@ Usage of ./pyroscope:
   -storage.azure.endpoint-suffix string
     	Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN. If set to empty string, default endpoint suffix is used.
   -storage.azure.max-retries int
-    	Number of retries for recoverable errors (default 20)
+    	Number of retries for recoverable errors (default 3)
   -storage.azure.user-assigned-id string
     	User assigned managed identity. If empty, then System assigned identity is used.
   -storage.backend string

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -262,9 +262,11 @@ Usage of ./pyroscope:
   -server.tls-min-version string
     	Minimum TLS version to use. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13. If blank, the Go TLS minimum version is used.
   -storage.azure.account-key string
-    	Azure storage account key
+    	Azure storage account key. If unset, Azure managed identities will be used for authentication instead.
   -storage.azure.account-name string
     	Azure storage account name
+  -storage.azure.connection-string string
+    	If `connection-string` is set, the value of `endpoint-suffix` will not be used. Use this method over `account-key` if you need to authenticate via a SAS token. Or if you use the Azurite emulator.
   -storage.azure.container-name string
     	Azure storage container name
   -storage.azure.endpoint-suffix string

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -2078,7 +2078,7 @@ The `azure_storage_backend` block configures the connection to Azure object stor
 
 # Number of retries for recoverable errors
 # CLI flag: -storage.azure.max-retries
-[max_retries: <int> | default = 20]
+[max_retries: <int> | default = 3]
 
 # User assigned managed identity. If empty, then System assigned identity is
 # used.

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -2055,9 +2055,16 @@ The `azure_storage_backend` block configures the connection to Azure object stor
 # CLI flag: -storage.azure.account-name
 [account_name: <string> | default = ""]
 
-# Azure storage account key
+# Azure storage account key. If unset, Azure managed identities will be used for
+# authentication instead.
 # CLI flag: -storage.azure.account-key
 [account_key: <string> | default = ""]
+
+# If `connection-string` is set, the value of `endpoint-suffix` will not be
+# used. Use this method over `account-key` if you need to authenticate via a SAS
+# token. Or if you use the Azurite emulator.
+# CLI flag: -storage.azure.connection-string
+[connection_string: <string> | default = ""]
 
 # Azure storage container name
 # CLI flag: -storage.azure.container-name
@@ -2073,7 +2080,8 @@ The `azure_storage_backend` block configures the connection to Azure object stor
 # CLI flag: -storage.azure.max-retries
 [max_retries: <int> | default = 20]
 
-# User assigned identity. If empty, then System assigned identity is used.
+# User assigned managed identity. If empty, then System assigned identity is
+# used.
 # CLI flag: -storage.azure.user-assigned-id
 [user_assigned_id: <string> | default = ""]
 ```

--- a/pkg/objstore/client/config.go
+++ b/pkg/objstore/client/config.go
@@ -77,7 +77,7 @@ func (cfg *StorageBackendConfig) RegisterFlags(f *flag.FlagSet, logger log.Logge
 func (cfg *StorageBackendConfig) RegisterFlagsWithPrefixAndDefaultDirectory(prefix, dir string, f *flag.FlagSet, logger log.Logger) {
 	cfg.S3.RegisterFlagsWithPrefix(prefix, f)
 	cfg.GCS.RegisterFlagsWithPrefix(prefix, f)
-	cfg.Azure.RegisterFlagsWithPrefix(prefix, f, logger)
+	cfg.Azure.RegisterFlagsWithPrefix(prefix, f)
 	cfg.Swift.RegisterFlagsWithPrefix(prefix, f)
 	cfg.Filesystem.RegisterFlagsWithPrefixAndDefaultDirectory(prefix, dir, f)
 	cfg.COS.RegisterFlagsWithPrefix(prefix, f)

--- a/pkg/objstore/providers/azure/bucket_client.go
+++ b/pkg/objstore/providers/azure/bucket_client.go
@@ -26,6 +26,9 @@ func newBucketClient(cfg Config, name string, logger log.Logger, factory func(lo
 	bucketConfig.MaxRetries = cfg.MaxRetries
 	bucketConfig.UserAssignedID = cfg.UserAssignedID
 
+	// do not delay retries
+	bucketConfig.PipelineConfig.RetryDelay = -1
+
 	if cfg.Endpoint != "" {
 		// azure.DefaultConfig has the default Endpoint, overwrite it only if a different one was explicitly provided.
 		bucketConfig.Endpoint = cfg.Endpoint

--- a/pkg/objstore/providers/azure/bucket_client.go
+++ b/pkg/objstore/providers/azure/bucket_client.go
@@ -9,26 +9,27 @@ import (
 	"github.com/go-kit/log"
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/providers/azure"
-	"gopkg.in/yaml.v3"
 )
 
 func NewBucketClient(cfg Config, name string, logger log.Logger) (objstore.Bucket, error) {
+	return newBucketClient(cfg, name, logger, azure.NewBucketWithConfig)
+}
+
+func newBucketClient(cfg Config, name string, logger log.Logger, factory func(log.Logger, azure.Config, string) (*azure.Bucket, error)) (objstore.Bucket, error) {
 	// Start with default config to make sure that all parameters are set to sensible values, especially
 	// HTTP Config field.
 	bucketConfig := azure.DefaultConfig
 	bucketConfig.StorageAccountName = cfg.StorageAccountName
 	bucketConfig.StorageAccountKey = cfg.StorageAccountKey.String()
+	bucketConfig.StorageConnectionString = cfg.StorageConnectionString.String()
 	bucketConfig.ContainerName = cfg.ContainerName
-	bucketConfig.Endpoint = cfg.Endpoint
 	bucketConfig.MaxRetries = cfg.MaxRetries
 	bucketConfig.UserAssignedID = cfg.UserAssignedID
 
-	// Thanos currently doesn't support passing the config as is, but expects a YAML,
-	// so we're going to serialize it.
-	serialized, err := yaml.Marshal(bucketConfig)
-	if err != nil {
-		return nil, err
+	if cfg.Endpoint != "" {
+		// azure.DefaultConfig has the default Endpoint, overwrite it only if a different one was explicitly provided.
+		bucketConfig.Endpoint = cfg.Endpoint
 	}
 
-	return azure.NewBucket(logger, serialized, name)
+	return factory(logger, bucketConfig, name)
 }

--- a/pkg/objstore/providers/azure/config.go
+++ b/pkg/objstore/providers/azure/config.go
@@ -34,6 +34,6 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.Var(&cfg.StorageConnectionString, prefix+"azure.connection-string", "If `connection-string` is set, the value of `endpoint-suffix` will not be used. Use this method over `account-key` if you need to authenticate via a SAS token. Or if you use the Azurite emulator.")
 	f.StringVar(&cfg.ContainerName, prefix+"azure.container-name", "", "Azure storage container name")
 	f.StringVar(&cfg.Endpoint, prefix+"azure.endpoint-suffix", "", "Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN. If set to empty string, default endpoint suffix is used.")
-	f.IntVar(&cfg.MaxRetries, prefix+"azure.max-retries", 20, "Number of retries for recoverable errors")
+	f.IntVar(&cfg.MaxRetries, prefix+"azure.max-retries", 3, "Number of retries for recoverable errors")
 	f.StringVar(&cfg.UserAssignedID, prefix+"azure.user-assigned-id", "", "User assigned managed identity. If empty, then System assigned identity is used.")
 }

--- a/pkg/objstore/providers/azure/config.go
+++ b/pkg/objstore/providers/azure/config.go
@@ -8,33 +8,32 @@ package azure
 import (
 	"flag"
 
-	"github.com/go-kit/log"
 	"github.com/grafana/dskit/flagext"
 )
 
 // Config holds the config options for an Azure backend
 type Config struct {
-	StorageAccountName string         `yaml:"account_name"`
-	StorageAccountKey  flagext.Secret `yaml:"account_key"`
-	ContainerName      string         `yaml:"container_name"`
-	Endpoint           string         `yaml:"endpoint_suffix"`
-	MaxRetries         int            `yaml:"max_retries" category:"advanced"`
-	MSIResource        string         `yaml:"msi_resource" category:"advanced" doc:"hidden"` // TODO Remove in Mimir 2.7.
-	UserAssignedID     string         `yaml:"user_assigned_id" category:"advanced"`
+	StorageAccountName      string         `yaml:"account_name"`
+	StorageAccountKey       flagext.Secret `yaml:"account_key"`
+	StorageConnectionString flagext.Secret `yaml:"connection_string"`
+	ContainerName           string         `yaml:"container_name"`
+	Endpoint                string         `yaml:"endpoint_suffix"`
+	MaxRetries              int            `yaml:"max_retries" category:"advanced"`
+	UserAssignedID          string         `yaml:"user_assigned_id" category:"advanced"`
 }
 
 // RegisterFlags registers the flags for Azure storage
-func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
-	cfg.RegisterFlagsWithPrefix("", f, logger)
+func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+	cfg.RegisterFlagsWithPrefix("", f)
 }
 
 // RegisterFlagsWithPrefix registers the flags for Azure storage
-func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet, logger log.Logger) {
+func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.StorageAccountName, prefix+"azure.account-name", "", "Azure storage account name")
-	f.Var(&cfg.StorageAccountKey, prefix+"azure.account-key", "Azure storage account key")
+	f.Var(&cfg.StorageAccountKey, prefix+"azure.account-key", "Azure storage account key. If unset, Azure managed identities will be used for authentication instead.")
+	f.Var(&cfg.StorageConnectionString, prefix+"azure.connection-string", "If `connection-string` is set, the value of `endpoint-suffix` will not be used. Use this method over `account-key` if you need to authenticate via a SAS token. Or if you use the Azurite emulator.")
 	f.StringVar(&cfg.ContainerName, prefix+"azure.container-name", "", "Azure storage container name")
 	f.StringVar(&cfg.Endpoint, prefix+"azure.endpoint-suffix", "", "Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN. If set to empty string, default endpoint suffix is used.")
 	f.IntVar(&cfg.MaxRetries, prefix+"azure.max-retries", 20, "Number of retries for recoverable errors")
-	flagext.DeprecatedFlag(f, prefix+"azure.msi-resource", "Deprecated: this setting was used for obtaining ServicePrincipalToken from MSI. The Azure SDK now chooses the address.", logger)
-	f.StringVar(&cfg.UserAssignedID, prefix+"azure.user-assigned-id", "", "User assigned identity. If empty, then System assigned identity is used.")
+	f.StringVar(&cfg.UserAssignedID, prefix+"azure.user-assigned-id", "", "User assigned managed identity. If empty, then System assigned identity is used.")
 }


### PR DESCRIPTION
This PR fixes #2412 #2680 

It does that by refactoring the config to align with mimir's azure config.

It also avoids retrying for too often and too long, by lowering MaxRetries and making sure retries are done without exponential backoff. 

This depends on #2741 
