### PR TITLE
fix(ebpf): prefer pid targets over container targets

### DIFF
--- a/ebpf/sd/procfs.go
+++ b/ebpf/sd/procfs.go
@@ -8,9 +8,7 @@ import (
 
 var (
 	// cgroupContainerIDRe matches a container ID from a /proc/{pid}}/cgroup
-	// 12:cpuset:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod471203d1_984f_477e_9c35_db96487ffe5e.slice/cri-containerd-a534eb629135e43beb13213976e37bb2ab95cba4c0d1d0b4e27c6bc4d8091b83.scope"
-	// 11:devices:/kubepods/besteffort/pod85adbef3-622f-4ef2-8f60-a8bdf3eb6c72/7edda1de1e0d1d366351e478359cf5fa16bb8ab53063a99bb119e56971bfb7e2
-	cgroupContainerIDRe = regexp.MustCompile(`^.*/(?:.*-)?([0-9a-f]+)(?:\.|\s*$)`)
+	cgroupContainerIDRe = regexp.MustCompile(`^.*/(?:.*-)?([0-9a-f]{64})(?:\.|\s*$)`)
 )
 
 func (tf *targetFinder) getContainerIDFromPID(pid uint32) containerID {

--- a/ebpf/sd/target.go
+++ b/ebpf/sd/target.go
@@ -181,16 +181,16 @@ func (tf *targetFinder) setTargets(opts TargetsOptions) {
 	containerID2Target := make(map[containerID]*Target)
 	pid2Target := make(map[uint32]*Target)
 	for _, target := range opts.Targets {
-		if cid := containerIDFromTarget(target); cid != "" {
-			t := NewTarget(cid, 0, target)
-			containerID2Target[cid] = t
-		} else if pid := pidFromTarget(target); pid != 0 {
+		if pid := pidFromTarget(target); pid != 0 {
 			t := NewTarget("", pid, target)
 			pid2Target[pid] = t
+		} else if cid := containerIDFromTarget(target); cid != "" {
+			t := NewTarget(cid, 0, target)
+			containerID2Target[cid] = t
 		}
 	}
-	if len(opts.Targets) > 0 && len(containerID2Target) == 0 {
-		_ = level.Warn(tf.l).Log("msg", "No container IDs found in targets")
+	if len(opts.Targets) > 0 && len(containerID2Target) == 0 && len(pid2Target) == 0 {
+		_ = level.Warn(tf.l).Log("msg", "No targets found")
 	}
 	tf.cid2target = containerID2Target
 	tf.pid2target = pid2Target

--- a/ebpf/sd/target_test.go
+++ b/ebpf/sd/target_test.go
@@ -2,11 +2,12 @@ package sd
 
 import (
 	"fmt"
-	"github.com/grafana/pyroscope/ebpf/util"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/grafana/pyroscope/ebpf/util"
 
 	"github.com/stretchr/testify/require"
 )
@@ -48,6 +49,11 @@ func TestCGroupMatching(t *testing.T) {
 			cgroup: "11:devices:/kubepods/besteffort/pod85adbef3-622f-4ef2-8f60-a8bdf3eb6c72/" +
 				"7edda1de1e0d1d366351e478359cf5fa16bb8ab53063a99bb119e56971bfb7e2",
 			expectedID: "7edda1de1e0d1d366351e478359cf5fa16bb8ab53063a99bb119e56971bfb7e2",
+		},
+		{
+			containerID: "",
+			cgroup:      "0::/../../user.slice/user-501.slice/session-3.scope",
+			expectedID:  "",
 		},
 	}
 	for i, tc := range testcases {


### PR DESCRIPTION
if we have a target specific to process, we should use, even if it is in a container(instead of creating a generic container target)