### PR TITLE
fix(ebpf): start profiling after attaching perf reader

### DIFF
--- a/ebpf/session.go
+++ b/ebpf/session.go
@@ -163,15 +163,15 @@ func (s *session) Start() error {
 
 	btf.FlushKernelSpec() // save some memory
 
-	s.perfEvents, err = attachPerfEvents(s.options.SampleRate, s.bpf.DoPerfEvent)
-	if err != nil {
-		s.stopLocked()
-		return fmt.Errorf("attach perf events: %w", err)
-	}
 	eventsReader, err := perf.NewReader(s.bpf.ProfileMaps.Events, 4*os.Getpagesize())
 	if err != nil {
 		s.stopLocked()
 		return fmt.Errorf("perf new reader for events map: %w", err)
+	}
+	s.perfEvents, err = attachPerfEvents(s.options.SampleRate, s.bpf.DoPerfEvent)
+	if err != nil {
+		s.stopLocked()
+		return fmt.Errorf("attach perf events: %w", err)
 	}
 
 	err = s.linkKProbes()


### PR DESCRIPTION
There was  a tiny time window when we already attach ebpf program to perf event (start profiling) and not yet attached a reader for pid info requests.

So this line some times return 2 (ENOENT) instead of 0, causing userspace program miss some processes to profile.
https://github.com/grafana/pyroscope/blob/8dc366aa5027608f62510faaa871a4f5a6397c7f/ebpf/bpf/profile.bpf.c#L50

This PR changes order of enabling profiling - start reading events first, then start profiling