### PR TITLE
Improve language detection performance

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -239,6 +239,10 @@ func (d *Distributor) GetProfileLanguage(series *distributormodel.ProfileSeries)
 	if len(series.Samples) == 0 {
 		return "unknown"
 	}
+	lang := series.GetLanguage()
+	if lang != "" {
+		return lang
+	}
 	return pprof.GetLanguage(series.Samples[0].Profile, d.logger)
 }
 

--- a/pkg/distributor/model/push.go
+++ b/pkg/distributor/model/push.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	v1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	phlaremodel "github.com/grafana/pyroscope/pkg/model"
 	"github.com/grafana/pyroscope/pkg/pprof"
 )
 
@@ -29,4 +30,38 @@ type ProfileSample struct {
 type ProfileSeries struct {
 	Labels  []*v1.LabelPair
 	Samples []*ProfileSample
+}
+
+func (p *ProfileSeries) GetLanguage() string {
+	spyName := phlaremodel.Labels(p.Labels).Get(phlaremodel.LabelNamePyroscopeSpy)
+	if spyName != "" {
+		lang := getProfileLanguageFromSpy(spyName)
+		if lang != "" {
+			return lang
+		}
+	}
+	return ""
+}
+
+func getProfileLanguageFromSpy(spyName string) string {
+	switch spyName {
+	default:
+		return ""
+	case "dotnetspy":
+		return "dotnet"
+	case "gospy":
+		return "go"
+	case "phpspy":
+		return "php"
+	case "pyspy":
+		return "python"
+	case "rbspy":
+		return "ruby"
+	case "nodespy":
+		return "nodejs"
+	case "javaspy":
+		return "java"
+	case "pyroscope-rs":
+		return "rust"
+	}
 }

--- a/pkg/distributor/model/push_test.go
+++ b/pkg/distributor/model/push_test.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"testing"
+
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+)
+
+func TestProfileSeries_GetLanguage(t *testing.T) {
+	tests := []struct {
+		labels []*typesv1.LabelPair
+		want   string
+	}{
+		{labels: []*typesv1.LabelPair{{Name: "pyroscope_spy", Value: "gospy"}}, want: "go"},
+		{labels: []*typesv1.LabelPair{{Name: "pyroscope_spy", Value: "javaspy"}}, want: "java"},
+		{labels: []*typesv1.LabelPair{{Name: "pyroscope_spy", Value: "dotnetspy"}}, want: "dotnet"},
+		{labels: []*typesv1.LabelPair{{Name: "pyroscope_spy", Value: ""}}, want: ""},
+	}
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			p := &ProfileSeries{
+				Labels: tt.labels,
+			}
+			if got := p.GetLanguage(); got != tt.want {
+				t.Errorf("GetLanguage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/ingester/pyroscope/ingest_adapter.go
+++ b/pkg/ingester/pyroscope/ingest_adapter.go
@@ -118,7 +118,7 @@ func (p *pyroscopeIngesterAdapter) Put(ctx context.Context, pi *storage.PutInput
 	})
 	if pi.SpyName != "" {
 		series.Labels = append(series.Labels, &typesv1.LabelPair{
-			Name:  "pyroscope_spy",
+			Name:  phlaremodel.LabelNamePyroscopeSpy,
 			Value: pi.SpyName,
 		})
 	}

--- a/pkg/ingester/pyroscope/ingest_handler_test.go
+++ b/pkg/ingester/pyroscope/ingest_handler_test.go
@@ -395,7 +395,7 @@ func TestIngestPPROFFixtures(t *testing.T) {
 				ls := phlaremodel.Labels(actualReq.Labels)
 				require.Equal(t, testdatum.expectMetric, ls.Get(labels.MetricName))
 				require.Equal(t, "asd", ls.Get("qwe"))
-				require.Equal(t, spyName, ls.Get("pyroscope_spy"))
+				require.Equal(t, spyName, ls.Get(phlaremodel.LabelNamePyroscopeSpy))
 				require.Equal(t, "pprof.test", ls.Get("service_name"))
 				require.Equal(t, "false", ls.Get("__delta__"))
 				require.Equal(t, profile, actualReq.RawProfile)

--- a/pkg/model/labels.go
+++ b/pkg/model/labels.go
@@ -22,15 +22,16 @@ import (
 var seps = []byte{'\xff'}
 
 const (
-	LabelNameProfileType = "__profile_type__"
-	LabelNameType        = "__type__"
-	LabelNameUnit        = "__unit__"
-	LabelNamePeriodType  = "__period_type__"
-	LabelNamePeriodUnit  = "__period_unit__"
-	LabelNameDelta       = "__delta__"
-	LabelNameProfileName = pmodel.MetricNameLabel
-	LabelNameServiceName = "service_name"
-	LabelNameSessionID   = "__session_id__"
+	LabelNameProfileType  = "__profile_type__"
+	LabelNameType         = "__type__"
+	LabelNameUnit         = "__unit__"
+	LabelNamePeriodType   = "__period_type__"
+	LabelNamePeriodUnit   = "__period_unit__"
+	LabelNameDelta        = "__delta__"
+	LabelNameProfileName  = pmodel.MetricNameLabel
+	LabelNameServiceName  = "service_name"
+	LabelNamePyroscopeSpy = "pyroscope_spy"
+	LabelNameSessionID    = "__session_id__"
 
 	LabelNameServiceNameK8s = "__meta_kubernetes_pod_annotation_pyroscope_io_service_name"
 

--- a/pkg/og/convert/jfr/parser_suite_test.go
+++ b/pkg/og/convert/jfr/parser_suite_test.go
@@ -3,7 +3,6 @@ package jfr
 import (
 	"encoding/json"
 	"fmt"
-	model2 "github.com/grafana/pyroscope/pkg/distributor/model"
 	"os"
 	"strings"
 	"testing"
@@ -11,6 +10,7 @@ import (
 
 	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 	v1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	distributormodel "github.com/grafana/pyroscope/pkg/distributor/model"
 	phlaremodel "github.com/grafana/pyroscope/pkg/model"
 	"github.com/grafana/pyroscope/pkg/og/convert/pprof/bench"
 	"github.com/grafana/pyroscope/pkg/og/storage"
@@ -84,7 +84,7 @@ func TestParseCompareExpectedData(t *testing.T) {
 	}
 }
 
-func compareWithJson(t *testing.T, req *model2.PushRequest, file string) error {
+func compareWithJson(t *testing.T, req *distributormodel.PushRequest, file string) error {
 	type flatProfileSeries struct {
 		Labels  []*v1.LabelPair
 		Profile *profilev1.Profile
@@ -181,7 +181,7 @@ func compareWithJson(t *testing.T, req *model2.PushRequest, file string) error {
 				return err
 			}
 			for _, label := range profile.Labels {
-				if strings.HasPrefix(label.Name, "__") || label.Name == "service_name" || label.Name == "jfr_event" || label.Name == "pyroscope_spy" {
+				if strings.HasPrefix(label.Name, "__") || label.Name == phlaremodel.LabelNameServiceName || label.Name == "jfr_event" || label.Name == phlaremodel.LabelNamePyroscopeSpy {
 					continue
 				}
 				parseKey.Add(label.Name, label.Value)

--- a/pkg/og/convert/jfr/pprof.go
+++ b/pkg/og/convert/jfr/pprof.go
@@ -227,7 +227,7 @@ func (b *jfrPprofBuilders) build(event string) *model.PushRequest {
 				Name:  "jfr_event",
 				Value: event,
 			}, &v1.LabelPair{
-				Name:  "pyroscope_spy",
+				Name:  phlaremodel.LabelNamePyroscopeSpy,
 				Value: b.spyName,
 			})
 			for _, v := range b.labels {

--- a/pkg/og/convert/pprof/profile.go
+++ b/pkg/og/convert/pprof/profile.go
@@ -211,7 +211,7 @@ func (p *RawProfile) createLabels(profile *pprof.Profile, md ingestion.Metadata)
 		Name:  "service_name",
 		Value: md.Key.AppName(),
 	}, &v1.LabelPair{
-		Name:  "pyroscope_spy",
+		Name:  phlaremodel.LabelNamePyroscopeSpy,
 		Value: md.SpyName,
 	})
 	for k, v := range md.Key.Labels() {

--- a/pkg/pprof/pprof_test.go
+++ b/pkg/pprof/pprof_test.go
@@ -1101,3 +1101,31 @@ func Test_GetProfileLanguage_rust_profile(t *testing.T) {
 	language := GetLanguage(p, log.NewNopLogger())
 	assert.Equal(t, "rust", language)
 }
+
+func Benchmark_GetProfileLanguage(b *testing.B) {
+	tests := []string{
+		"testdata/go.cpu.labels.pprof",
+		"testdata/heap",
+		"testdata/dotnet.labels.pprof",
+		"testdata/profile_java",
+		"testdata/profile_nodejs",
+		"testdata/profile_python",
+		"testdata/profile_ruby",
+		"testdata/profile_rust",
+	}
+
+	for _, testdata := range tests {
+		f := testdata
+		b.Run(testdata, func(b *testing.B) {
+			p, err := OpenFile(f)
+			require.NoError(b, err)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				language := GetLanguage(p, log.NewNopLogger())
+				if language == "unknown" {
+					b.Fatal()
+				}
+			}
+		})
+	}
+}

--- a/pkg/pprof/pprof_test.go
+++ b/pkg/pprof/pprof_test.go
@@ -1120,6 +1120,7 @@ func Benchmark_GetProfileLanguage(b *testing.B) {
 			p, err := OpenFile(f)
 			require.NoError(b, err)
 			b.ResetTimer()
+			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				language := GetLanguage(p, log.NewNopLogger())
 				if language == "unknown" {


### PR DESCRIPTION
Closes #2777 

1. If the profile has the `pyroscope_spy` label, we use it to determine the language
2. If we do need to look into the string table, we use prefix and suffix matching instead of regular expressions

Here is a summary of the gains with 2:

Regexp:
```
go.cpu.labels.pprof-10         	  330040	     10853 ns/op
heap-10                        	  195819	     18407 ns/op
dotnet.labels.pprof-10         	  143966	     24949 ns/op
profile_java-10                	   61840	     58016 ns/op
profile_nodejs-10              	  109437	     32871 ns/op
profile_python-10              	  391418	      9156 ns/op
profile_ruby-10                	  307896	     11783 ns/op
profile_rust-10                	  636633	      5668 ns/op
```

String matching (prefix or suffix):
```
go.cpu.labels.pprof-10         	 3418387	      1060 ns/op
heap-10                        	 2446440	      1483 ns/op
dotnet.labels.pprof-10         	 1751536	      2057 ns/op
profile_java-10                	 2333244	      1541 ns/op
profile_nodejs-10              	 1722144	      2083 ns/op
profile_python-10              	 4395427	       821 ns/op
profile_ruby-10                	 4546932	       793 ns/op
profile_rust-10                	 2960469	      1221 ns/op
```

benchstat:

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/pyroscope/pkg/pprof
                                                    │    old.txt    │               new.txt               │
                                                    │    sec/op     │   sec/op     vs base                │
_GetProfileLanguage/testdata/go.cpu.labels.pprof-10    10.589µ ± 0%   1.016µ ± 0%  -90.40% (p=0.000 n=10)
_GetProfileLanguage/testdata/heap-10                   18.034µ ± 1%   1.411µ ± 0%  -92.18% (p=0.000 n=10)
_GetProfileLanguage/testdata/dotnet.labels.pprof-10    24.765µ ± 1%   1.981µ ± 1%  -92.00% (p=0.000 n=10)
_GetProfileLanguage/testdata/profile_java-10           57.873µ ± 1%   1.473µ ± 0%  -97.46% (p=0.000 n=10)
_GetProfileLanguage/testdata/profile_nodejs-10         32.770µ ± 0%   2.010µ ± 1%  -93.87% (p=0.000 n=10)
_GetProfileLanguage/testdata/profile_python-10         9125.0n ± 1%   790.8n ± 0%  -91.33% (p=0.000 n=10)
_GetProfileLanguage/testdata/profile_ruby-10          11754.5n ± 1%   772.7n ± 1%  -93.43% (p=0.000 n=10)
_GetProfileLanguage/testdata/profile_rust-10            5.679µ ± 1%   1.184µ ± 0%  -79.16% (p=0.000 n=10)
geomean                                                 16.49µ        1.253µ       -92.40%
```

As before, there is a chance of false detection - though this is only used for statistics for now.
