### PR TITLE
Avoid loading all symbols for each partition destination

### DIFF
--- a/pkg/phlaredb/symdb/block_reader.go
+++ b/pkg/phlaredb/symdb/block_reader.go
@@ -31,9 +31,10 @@ type Reader struct {
 
 	chunkFetchBufferSize int
 
-	index         IndexFile
-	partitions    []*partition
-	partitionsMap map[uint64]*partition
+	index            IndexFile
+	partitions       []*partition
+	partitionsMap    map[uint64]*partition
+	partitionsLoaded bool
 
 	locations parquetobj.File
 	mappings  parquetobj.File
@@ -188,8 +189,10 @@ func (r *Reader) partition(ctx context.Context, partition uint64) (*partition, e
 	if !ok {
 		return nil, ErrPartitionNotFound
 	}
-	if err := p.init(ctx); err != nil {
-		return nil, err
+	if !r.partitionsLoaded {
+		if err := p.init(ctx); err != nil {
+			return nil, err
+		}
 	}
 	return p, nil
 }

--- a/pkg/phlaredb/symdb/block_reader_load.go
+++ b/pkg/phlaredb/symdb/block_reader_load.go
@@ -27,7 +27,11 @@ func (r *Reader) Load(ctx context.Context) error {
 	if r.index.Header.Version > FormatV1 {
 		r.loadParquetTables(g)
 	}
-	return g.Wait()
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	r.partitionsLoaded = true
+	return nil
 }
 
 func (r *Reader) loadStacktraces(ctx context.Context) error {


### PR DESCRIPTION
Sounds like `partition.init` doesn't care and will always load all symbols for the current partition.

It seems like an oversight.