### PR TITLE
Fixes span name for BlockSelect from store-gateway

### DIFF
--- a/pkg/querier/store_gateway_querier.go
+++ b/pkg/querier/store_gateway_querier.go
@@ -487,7 +487,7 @@ func (q *Querier) selectSpanProfileFromStoreGateway(ctx context.Context, req *qu
 }
 
 func (q *Querier) blockSelectFromStoreGateway(ctx context.Context, req *ingestv1.BlockMetadataRequest) ([]ResponseFromReplica[[]*typesv1.BlockInfo], error) {
-	sp, ctx := opentracing.StartSpanFromContext(ctx, "Series StoreGateway")
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "blockSelect StoreGateway")
 	defer sp.Finish()
 
 	tenantID, err := tenant.ExtractTenantIDFromContext(ctx)


### PR DESCRIPTION
I was looking at a trace and  thought we have a bug selecting Series when asking for Flamegraph.

In fact the span name was incorrect probably from copy-pasta.

<img width="2550" alt="image" src="https://github.com/grafana/pyroscope/assets/1053421/afec62a8-7317-4486-bd32-c2f2eb90047f">
