### PR TITLE
Fix query split logic for LabelNames, LabelValues and ProfileTypes

### DIFF
--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -155,10 +155,7 @@ func (q *Querier) ProfileTypes(ctx context.Context, req *connect.Request[querier
 
 	if storeQueries.ingester.shouldQuery {
 		group.Go(func() error {
-			ir, err := q.profileTypesFromIngesters(ctx, &ingestv1.ProfileTypesRequest{
-				Start: req.Msg.Start,
-				End:   req.Msg.End,
-			})
+			ir, err := q.profileTypesFromIngesters(ctx, storeQueries.ingester.ProfileTypesRequest(req.Msg))
 			if err != nil {
 				return err
 			}
@@ -172,10 +169,7 @@ func (q *Querier) ProfileTypes(ctx context.Context, req *connect.Request[querier
 
 	if storeQueries.storeGateway.shouldQuery {
 		group.Go(func() error {
-			ir, err := q.profileTypesFromStoreGateway(ctx, &ingestv1.ProfileTypesRequest{
-				Start: req.Msg.Start,
-				End:   req.Msg.End,
-			})
+			ir, err := q.profileTypesFromStoreGateway(ctx, storeQueries.storeGateway.ProfileTypesRequest(req.Msg))
 			if err != nil {
 				return err
 			}
@@ -232,7 +226,7 @@ func (q *Querier) LabelValues(ctx context.Context, req *connect.Request[typesv1.
 
 	if storeQueries.ingester.shouldQuery {
 		group.Go(func() error {
-			ir, err := q.labelValuesFromIngesters(ctx, req.Msg)
+			ir, err := q.labelValuesFromIngesters(ctx, storeQueries.ingester.LabelValuesRequest(req.Msg))
 			if err != nil {
 				return err
 			}
@@ -246,7 +240,7 @@ func (q *Querier) LabelValues(ctx context.Context, req *connect.Request[typesv1.
 
 	if storeQueries.storeGateway.shouldQuery {
 		group.Go(func() error {
-			ir, err := q.labelValuesFromStoreGateway(ctx, req.Msg)
+			ir, err := q.labelValuesFromStoreGateway(ctx, storeQueries.storeGateway.LabelValuesRequest(req.Msg))
 			if err != nil {
 				return err
 			}
@@ -302,7 +296,7 @@ func (q *Querier) LabelNames(ctx context.Context, req *connect.Request[typesv1.L
 
 	if storeQueries.ingester.shouldQuery {
 		group.Go(func() error {
-			ir, err := q.labelNamesFromIngesters(ctx, req.Msg)
+			ir, err := q.labelNamesFromIngesters(ctx, storeQueries.ingester.LabelNamesRequest(req.Msg))
 			if err != nil {
 				return err
 			}
@@ -316,7 +310,7 @@ func (q *Querier) LabelNames(ctx context.Context, req *connect.Request[typesv1.L
 
 	if storeQueries.storeGateway.shouldQuery {
 		group.Go(func() error {
-			ir, err := q.labelNamesFromStoreGateway(ctx, req.Msg)
+			ir, err := q.labelNamesFromStoreGateway(ctx, storeQueries.storeGateway.LabelNamesRequest(req.Msg))
 			if err != nil {
 				return err
 			}
@@ -694,6 +688,30 @@ func (sq storeQuery) SeriesRequest(req *querierv1.SeriesRequest) *ingestv1.Serie
 		End:        int64(sq.end),
 		Matchers:   req.Matchers,
 		LabelNames: req.LabelNames,
+	}
+}
+
+func (sq storeQuery) LabelNamesRequest(req *typesv1.LabelNamesRequest) *typesv1.LabelNamesRequest {
+	return &typesv1.LabelNamesRequest{
+		Matchers: req.Matchers,
+		Start:    int64(sq.start),
+		End:      int64(sq.end),
+	}
+}
+
+func (sq storeQuery) LabelValuesRequest(req *typesv1.LabelValuesRequest) *typesv1.LabelValuesRequest {
+	return &typesv1.LabelValuesRequest{
+		Name:     req.Name,
+		Matchers: req.Matchers,
+		Start:    int64(sq.start),
+		End:      int64(sq.end),
+	}
+}
+
+func (sq storeQuery) ProfileTypesRequest(req *querierv1.ProfileTypesRequest) *ingestv1.ProfileTypesRequest {
+	return &ingestv1.ProfileTypesRequest{
+		Start: int64(sq.start),
+		End:   int64(sq.end),
 	}
 }
 


### PR DESCRIPTION
While looking at the ingesters memory usage in a high-load environment I noticed that a big portion of it came from `(*singleBlockQuerier) openTSDBIndex`. 

Looking at the `pyroscopedb_blocks_currently_open` metric, many ingesters have a large number of opened blocks (300+ in some cases). Narrowing that further with traces, the large number of open blocks came from requests to `LabelNames` and `LabelValues` with long query intervals. Currently these requests are served entirely by ingesters because until recently such requests didn't contain a `start` and `end` in the body (the client didn't send the range).

With https://github.com/grafana/grafana/pull/78861, clients started sending a `start` and `end` for the LabelNames and LabelValues APIs. This means we can now properly split the queries between ingesters and store gateways which should in theory reduce the memory pressure on ingesters as described above.

Notes:
- The ProfileTypes API is covered here but the behavior for this endpoint won't change until the clients start sending `start` and `end` for those requests (a separate Grafana PR to follow)
- The issue could also be solved with block plans but I've opted for a simple incremental change for now. If this works we could switch entirely to block plans and simplify queriers.
- Ingesters are currently not closing old blocks that they've opened, making this problem worse over time. If needed we could also add periodic eviction of blocks from memory, though I don't think this will make a big impact following the change done here