### PR TITLE
feat: Run compactor stages in parallel.

### DIFF
--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -222,7 +222,7 @@ type Compactor interface {
 	// CompactWithSplitting merges and splits the source blocks into shardCount number of compacted blocks,
 	// and returns slice of block IDs.
 	// If given compacted block has no series, corresponding block ID will not be returned.
-	CompactWithSplitting(ctx context.Context, dst string, dirs []string, shardCount, stageSize uint64) (result []ulid.ULID, _ error)
+	CompactWithSplitting(ctx context.Context, dst string, dirs []string, shardCount, stageIndex, stageSize uint64) (result []ulid.ULID, _ error)
 }
 
 const (
@@ -316,7 +316,7 @@ func newCompactorMetrics(r prometheus.Registerer) *CompactorMetrics {
 	return m
 }
 
-func (c *BlockCompactor) CompactWithSplitting(ctx context.Context, dest string, dirs []string, shardCount, stageSize uint64) ([]ulid.ULID, error) {
+func (c *BlockCompactor) CompactWithSplitting(ctx context.Context, dest string, dirs []string, shardCount, stageIndex, stageSize uint64) ([]ulid.ULID, error) {
 	defer func() {
 		if err := recover(); err != nil {
 			level.Error(c.logger).Log("msg", "panic during compaction", "err", err, "dirs", strings.Join(dirs, ","))
@@ -383,7 +383,7 @@ func (c *BlockCompactor) CompactWithSplitting(ctx context.Context, dest string, 
 	c.metrics.Ran.WithLabelValues(fmt.Sprintf("%d", currentLevel)).Inc()
 	c.metrics.Split.WithLabelValues(fmt.Sprintf("%d", currentLevel)).Observe(float64(shardCount))
 
-	metas, err := phlaredb.CompactWithSplitting(ctx, readers, shardCount, stageSize, dest, c.splitBy)
+	metas, err := phlaredb.CompactWithSplitting(ctx, readers, shardCount, stageIndex, stageSize, dest, c.splitBy)
 	if err != nil {
 		return nil, errors.Wrapf(err, "compact blocks %v", dirs)
 	}
@@ -475,9 +475,9 @@ func (c *BucketCompactor) runCompactionJob(ctx context.Context, job *Job) (shoul
 	compactionBegin := time.Now()
 
 	if job.UseSplitting() {
-		compIDs, err = c.comp.CompactWithSplitting(ctx, subDir, blocksToCompactDirs, uint64(job.SplittingShards()), uint64(job.SplitStageSize()))
+		compIDs, err = c.comp.CompactWithSplitting(ctx, subDir, blocksToCompactDirs, uint64(job.SplittingShards()), uint64(job.SplitStageIndex()), uint64(job.SplitStageSize()))
 	} else {
-		compIDs, err = c.comp.CompactWithSplitting(ctx, subDir, blocksToCompactDirs, 1, 0)
+		compIDs, err = c.comp.CompactWithSplitting(ctx, subDir, blocksToCompactDirs, 1, 0, 0)
 	}
 	if err != nil {
 		return false, nil, errors.Wrapf(err, "compact blocks %v", blocksToCompactDirs)

--- a/pkg/compactor/bucket_compactor_test.go
+++ b/pkg/compactor/bucket_compactor_test.go
@@ -84,10 +84,10 @@ func TestGroupMaxMinTime(t *testing.T) {
 func TestBucketCompactor_FilterOwnJobs(t *testing.T) {
 	jobsFn := func() []*Job {
 		return []*Job{
-			NewJob("user", "key1", labels.EmptyLabels(), 0, false, 0, 0, ""),
-			NewJob("user", "key2", labels.EmptyLabels(), 0, false, 0, 0, ""),
-			NewJob("user", "key3", labels.EmptyLabels(), 0, false, 0, 0, ""),
-			NewJob("user", "key4", labels.EmptyLabels(), 0, false, 0, 0, ""),
+			NewJob("user", "key1", labels.EmptyLabels(), 0, false, 0, "", ""),
+			NewJob("user", "key2", labels.EmptyLabels(), 0, false, 0, "", ""),
+			NewJob("user", "key3", labels.EmptyLabels(), 0, false, 0, "", ""),
+			NewJob("user", "key4", labels.EmptyLabels(), 0, false, 0, "", ""),
 		}
 	}
 
@@ -134,13 +134,13 @@ func TestBucketCompactor_FilterOwnJobs(t *testing.T) {
 }
 
 func TestBlockMaxTimeDeltas(t *testing.T) {
-	j1 := NewJob("user", "key1", labels.EmptyLabels(), 0, false, 0, 0, "")
+	j1 := NewJob("user", "key1", labels.EmptyLabels(), 0, false, 0, "", "")
 	require.NoError(t, j1.AppendMeta(&block.Meta{
 		MinTime: 1500002700159,
 		MaxTime: 1500002800159,
 	}))
 
-	j2 := NewJob("user", "key2", labels.EmptyLabels(), 0, false, 0, 0, "")
+	j2 := NewJob("user", "key2", labels.EmptyLabels(), 0, false, 0, "", "")
 	require.NoError(t, j2.AppendMeta(&block.Meta{
 		MinTime: 1500002600159,
 		MaxTime: 1500002700159,

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1703,8 +1703,8 @@ type blockCompactorMock struct {
 	mock.Mock
 }
 
-func (m *blockCompactorMock) CompactWithSplitting(ctx context.Context, dest string, dirs []string, shardCount, stageSize uint64) (result []ulid.ULID, _ error) {
-	args := m.Called(ctx, dest, dirs, shardCount, stageSize)
+func (m *blockCompactorMock) CompactWithSplitting(ctx context.Context, dest string, dirs []string, shardCount, stageIndex, stageSize uint64) (result []ulid.ULID, _ error) {
+	args := m.Called(ctx, dest, dirs, shardCount, stageIndex, stageSize)
 	return args.Get(0).([]ulid.ULID), args.Error(1)
 }
 

--- a/pkg/compactor/job_test.go
+++ b/pkg/compactor/job_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestJob_MinCompactionLevel(t *testing.T) {
-	job := NewJob("user-1", "group-1", labels.EmptyLabels(), 0, true, 2, 0, "shard-1")
+	job := NewJob("user-1", "group-1", labels.EmptyLabels(), 0, true, 2, "", "shard-1")
 	require.NoError(t, job.AppendMeta(&block.Meta{ULID: ulid.MustNew(1, nil), Compaction: block.BlockMetaCompaction{Level: 2}}))
 	assert.Equal(t, 2, job.MinCompactionLevel())
 
@@ -108,7 +108,7 @@ func TestJobWaitPeriodElapsed(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			job := NewJob("user-1", "group-1", labels.EmptyLabels(), 0, true, 2, 0, "shard-1")
+			job := NewJob("user-1", "group-1", labels.EmptyLabels(), 0, true, 2, "", "shard-1")
 			for _, b := range testData.jobBlocks {
 				require.NoError(t, job.AppendMeta(b.meta))
 			}

--- a/pkg/compactor/split_merge_grouper_test.go
+++ b/pkg/compactor/split_merge_grouper_test.go
@@ -35,6 +35,7 @@ func TestPlanCompaction(t *testing.T) {
 		ranges      []int64
 		shardCount  uint32
 		splitGroups uint32
+		stageSize   uint32
 		blocks      []*block.Meta
 		expected    []*job
 	}{
@@ -513,7 +514,7 @@ func TestPlanCompaction(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			actual := planCompaction(userID, testData.blocks, testData.ranges, testData.shardCount, testData.splitGroups)
+			actual := planCompaction(userID, testData.blocks, testData.ranges, testData.shardCount, testData.splitGroups, testData.stageSize)
 
 			// Print the actual jobs (useful for debugging if tests fail).
 			t.Logf("got %d jobs:", len(actual))
@@ -538,6 +539,7 @@ func TestPlanSplitting(t *testing.T) {
 	tests := map[string]struct {
 		blocks      blocksGroup
 		splitGroups uint32
+		stageID     string
 		expected    []*job
 	}{
 		"should return nil if the input group is empty": {
@@ -595,6 +597,7 @@ func TestPlanSplitting(t *testing.T) {
 				},
 			},
 			splitGroups: 2,
+			stageID:     "1_of_2",
 			expected: []*job{
 				{
 					blocksGroup: blocksGroup{
@@ -607,6 +610,7 @@ func TestPlanSplitting(t *testing.T) {
 					userID:  userID,
 					stage:   stageSplit,
 					shardID: "1_of_2",
+					stageID: "1_of_2",
 				}, {
 					blocksGroup: blocksGroup{
 						rangeStart: 10,
@@ -619,6 +623,7 @@ func TestPlanSplitting(t *testing.T) {
 					userID:  userID,
 					stage:   stageSplit,
 					shardID: "2_of_2",
+					stageID: "1_of_2",
 				},
 			},
 		},
@@ -626,7 +631,7 @@ func TestPlanSplitting(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			assert.ElementsMatch(t, testData.expected, planSplitting(userID, testData.blocks, testData.splitGroups))
+			assert.ElementsMatch(t, testData.expected, planSplitting(userID, testData.blocks, testData.splitGroups, testData.stageID))
 		})
 	}
 }


### PR DESCRIPTION
The idea is to add the stage index as part of the job shard key.

As suggested in https://github.com/grafana/pyroscope/issues/2730

However now that I did it, I realized that each jobs refers to the same group of blocks and they all will want to delete that group of block under completions which will be problematic.

Not sure how to solve this yet. cc @kolesnikovae  wdyt