### PR TITLE
bugfix: Properly cleanup dst folder on compaction

### DIFF
--- a/pkg/phlaredb/compact.go
+++ b/pkg/phlaredb/compact.go
@@ -77,6 +77,7 @@ func CompactWithSplitting(ctx context.Context, src []BlockReader, splitCount, st
 	}
 
 	symbolsCompactor := newSymbolsCompactor(dst)
+	defer runutil.CloseWithLogOnErr(util.Logger, symbolsCompactor, "close symbols compactor")
 
 	outMeta := compactMetas(srcMetas...)
 	for _, stage := range splitStages(len(writers), int(stageSize)) {
@@ -697,7 +698,7 @@ func (s *symbolsRewriter) ReWriteRow(profile profileRow) error {
 }
 
 func (s *symbolsRewriter) Close() (uint64, error) {
-	if err := s.symbolsCompactor.Close(); err != nil {
+	if err := s.symbolsCompactor.Flush(); err != nil {
 		return 0, err
 	}
 	return s.numSamples, util.CopyDir(s.symbolsCompactor.dst, filepath.Join(s.dst, symdb.DefaultDirName))
@@ -730,7 +731,7 @@ func (s *symbolsCompactor) ReWriteRow(profile profileRow) (uint64, error) {
 	return rewrittenSamples, nil
 }
 
-func (s *symbolsCompactor) Close() error {
+func (s *symbolsCompactor) Flush() error {
 	if s.flushed {
 		return nil
 	}
@@ -739,6 +740,10 @@ func (s *symbolsCompactor) Close() error {
 	}
 	s.flushed = true
 	return nil
+}
+
+func (s *symbolsCompactor) Close() error {
+	return os.RemoveAll(s.dst)
 }
 
 func (s *symbolsCompactor) loadStacktracesID(values []parquet.Value) {

--- a/pkg/phlaredb/compact_test.go
+++ b/pkg/phlaredb/compact_test.go
@@ -27,6 +27,7 @@ import (
 	phlarecontext "github.com/grafana/pyroscope/pkg/phlare/context"
 	"github.com/grafana/pyroscope/pkg/phlaredb/block"
 	"github.com/grafana/pyroscope/pkg/phlaredb/sharding"
+	"github.com/grafana/pyroscope/pkg/phlaredb/symdb"
 	"github.com/grafana/pyroscope/pkg/phlaredb/tsdb/index"
 	"github.com/grafana/pyroscope/pkg/pprof/testhelper"
 )
@@ -112,6 +113,8 @@ func TestCompactWithSplitting(t *testing.T) {
 	dst := t.TempDir()
 	compacted, err := CompactWithSplitting(ctx, []BlockReader{b1, b2, b2, b1}, 16, 8, dst, SplitByFingerprint)
 	require.NoError(t, err)
+
+	require.NoDirExists(t, filepath.Join(dst, symdb.DefaultDirName))
 
 	// 4 shards one per series.
 	require.Equal(t, 4, len(compacted))


### PR DESCRIPTION
The file is hardlinked or fully copied and so the original file is safe to delete.