### PR TITLE
feat: Only load all symbols when splitting

### DIFF
--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -356,8 +356,11 @@ func (c *BlockCompactor) CompactWithSplitting(ctx context.Context, dest string, 
 		if err := b.Open(ctx); err != nil {
 			return errors.Wrapf(err, "open block %s", meta.ULID)
 		}
-		if err = b.Symbols().Load(ctx); err != nil {
-			return errors.Wrapf(err, "error loading symbols")
+		// Only load symbols if we are splitting.
+		if shardCount > 1 {
+			if err = b.Symbols().Load(ctx); err != nil {
+				return errors.Wrapf(err, "error loading symbols")
+			}
 		}
 		readers[idx] = b
 		return nil


### PR DESCRIPTION
I want to give a try to this in our largest cluster.

load vs fetch

<img width="2183" alt="image" src="https://github.com/grafana/pyroscope/assets/1053421/a2d78bd4-14ef-4b98-a171-d128ca446697">
