### PR TITLE
bugfix: Warn only when deleting twice during compaction

### DIFF
--- a/pkg/compactor/blocks_cleaner.go
+++ b/pkg/compactor/blocks_cleaner.go
@@ -553,7 +553,7 @@ func (c *BlocksCleaner) cleanUserPartialBlocks(ctx context.Context, partials map
 			}
 			if !lastModified.IsZero() {
 				level.Info(userLogger).Log("msg", "stale partial block found: marking block for deletion", "block", blockID, "last modified", lastModified)
-				if err := block.MarkForDeletion(ctx, userLogger, userBucket, blockID, "stale partial block", c.partialBlocksMarkedForDeletion); err != nil {
+				if err := block.MarkForDeletion(ctx, userLogger, userBucket, blockID, "stale partial block", false, c.partialBlocksMarkedForDeletion); err != nil {
 					level.Warn(userLogger).Log("msg", "failed to mark partial block for deletion", "block", blockID, "err", err)
 				}
 			}
@@ -574,7 +574,7 @@ func (c *BlocksCleaner) applyUserRetentionPeriod(ctx context.Context, idx *bucke
 	// the cleaner will retry applying the retention in its next cycle.
 	for _, b := range blocks {
 		level.Info(userLogger).Log("msg", "applied retention: marking block for deletion", "block", b.ID, "maxTime", b.MaxTime)
-		if err := block.MarkForDeletion(ctx, userLogger, userBucket, b.ID, fmt.Sprintf("block exceeding retention of %v", retention), c.blocksMarkedForDeletion); err != nil {
+		if err := block.MarkForDeletion(ctx, userLogger, userBucket, b.ID, fmt.Sprintf("block exceeding retention of %v", retention), false, c.blocksMarkedForDeletion); err != nil {
 			level.Warn(userLogger).Log("msg", "failed to mark block for deletion", "block", b.ID, "err", err)
 		}
 	}

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -146,7 +146,7 @@ func (s *Syncer) GarbageCollect(ctx context.Context) error {
 		delCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 
 		level.Info(s.logger).Log("msg", "marking outdated block for deletion", "block", id)
-		err := block.MarkForDeletion(delCtx, s.logger, s.bkt, id, "outdated block", s.metrics.blocksMarkedForDeletion)
+		err := block.MarkForDeletion(delCtx, s.logger, s.bkt, id, "outdated block", false, s.metrics.blocksMarkedForDeletion)
 		cancel()
 		if err != nil {
 			s.metrics.garbageCollectionFailures.Inc()
@@ -596,7 +596,7 @@ func deleteBlock(bkt objstore.Bucket, id ulid.ULID, bdir string, logger log.Logg
 	delCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 	level.Info(logger).Log("msg", "marking compacted block for deletion", "old_block", id)
-	if err := block.MarkForDeletion(delCtx, logger, bkt, id, "source of compacted block", blocksMarkedForDeletion); err != nil {
+	if err := block.MarkForDeletion(delCtx, logger, bkt, id, "source of compacted block", true, blocksMarkedForDeletion); err != nil {
 		return errors.Wrapf(err, "mark block %s for deletion from bucket", id)
 	}
 	return nil

--- a/pkg/phlaredb/block/block.go
+++ b/pkg/phlaredb/block/block.go
@@ -154,13 +154,13 @@ func cleanUp(logger log.Logger, bkt objstore.Bucket, id ulid.ULID, err error) er
 }
 
 // MarkForDeletion creates a file which stores information about when the block was marked for deletion.
-func MarkForDeletion(ctx context.Context, logger log.Logger, bkt objstore.Bucket, id ulid.ULID, details string, markedForDeletion prometheus.Counter) error {
+func MarkForDeletion(ctx context.Context, logger log.Logger, bkt objstore.Bucket, id ulid.ULID, details string, warnExist bool, markedForDeletion prometheus.Counter) error {
 	deletionMarkFile := path.Join(id.String(), DeletionMarkFilename)
 	deletionMarkExists, err := bkt.Exists(ctx, deletionMarkFile)
 	if err != nil {
 		return errors.Wrapf(err, "check exists %s in bucket", deletionMarkFile)
 	}
-	if deletionMarkExists {
+	if deletionMarkExists && warnExist {
 		level.Warn(logger).Log("msg", "requested to mark for deletion, but file already exists; this should not happen; investigate", "err", errors.Errorf("file %s already exists in bucket", deletionMarkFile))
 		return nil
 	}

--- a/pkg/phlaredb/block/block.go
+++ b/pkg/phlaredb/block/block.go
@@ -160,8 +160,10 @@ func MarkForDeletion(ctx context.Context, logger log.Logger, bkt objstore.Bucket
 	if err != nil {
 		return errors.Wrapf(err, "check exists %s in bucket", deletionMarkFile)
 	}
-	if deletionMarkExists && warnExist {
-		level.Warn(logger).Log("msg", "requested to mark for deletion, but file already exists; this should not happen; investigate", "err", errors.Errorf("file %s already exists in bucket", deletionMarkFile))
+	if deletionMarkExists {
+		if warnExist {
+			level.Warn(logger).Log("msg", "requested to mark for deletion, but file already exists; this should not happen; investigate", "err", errors.Errorf("file %s already exists in bucket", deletionMarkFile))
+		}
 		return nil
 	}
 

--- a/pkg/phlaredb/block/block_test.go
+++ b/pkg/phlaredb/block/block_test.go
@@ -99,7 +99,7 @@ func TestDelete(t *testing.T) {
 			require.Equal(t, 9, len(objects(t, bkt, meta.ULID)))
 
 			markedForDeletion := promauto.With(prometheus.NewRegistry()).NewCounter(prometheus.CounterOpts{Name: "test"})
-			require.NoError(t, block.MarkForDeletion(ctx, log.NewNopLogger(), bkt, meta.ULID, "", markedForDeletion))
+			require.NoError(t, block.MarkForDeletion(ctx, log.NewNopLogger(), bkt, meta.ULID, "", false, markedForDeletion))
 
 			// Full delete.
 			require.NoError(t, block.Delete(ctx, log.NewNopLogger(), bkt, meta.ULID))
@@ -260,7 +260,7 @@ func TestMarkForDeletion(t *testing.T) {
 			require.NoError(t, block.Upload(ctx, log.NewNopLogger(), bkt, path.Join(tmpDir, id.String())))
 
 			c := promauto.With(nil).NewCounter(prometheus.CounterOpts{})
-			err := block.MarkForDeletion(ctx, log.NewNopLogger(), bkt, id, "", c)
+			err := block.MarkForDeletion(ctx, log.NewNopLogger(), bkt, id, "", false, c)
 			require.NoError(t, err)
 			require.Equal(t, float64(tcase.blocksMarked), promtest.ToFloat64(c))
 		})

--- a/pkg/phlaredb/block/fetcher_test.go
+++ b/pkg/phlaredb/block/fetcher_test.go
@@ -110,7 +110,7 @@ func TestMetaFetcher_Fetch_ShouldReturnDiscoveredBlocksIncludingMarkedForDeletio
 	// Upload a block and mark it for deletion.
 	block3ID, block3Dir := createTestBlock(t)
 	require.NoError(t, block.Upload(ctx, logger, bkt, block3Dir))
-	require.NoError(t, block.MarkForDeletion(ctx, logger, bkt, block3ID, "", promauto.With(nil).NewCounter(prometheus.CounterOpts{})))
+	require.NoError(t, block.MarkForDeletion(ctx, logger, bkt, block3ID, "", false, promauto.With(nil).NewCounter(prometheus.CounterOpts{})))
 
 	t.Run("should include blocks marked for deletion", func(t *testing.T) {
 		actualMetas, actualPartials, actualErr := f.Fetch(ctx)
@@ -231,7 +231,7 @@ func TestMetaFetcher_FetchWithoutMarkedForDeletion_ShouldReturnDiscoveredBlocksE
 	// Upload a block and mark it for deletion.
 	block3ID, block3Dir := createTestBlock(t)
 	require.NoError(t, block.Upload(ctx, logger, bkt, block3Dir))
-	require.NoError(t, block.MarkForDeletion(ctx, logger, bkt, block3ID, "", promauto.With(nil).NewCounter(prometheus.CounterOpts{})))
+	require.NoError(t, block.MarkForDeletion(ctx, logger, bkt, block3ID, "", false, promauto.With(nil).NewCounter(prometheus.CounterOpts{})))
 
 	t.Run("should include blocks marked for deletion", func(t *testing.T) {
 		actualMetas, actualPartials, actualErr := f.FetchWithoutMarkedForDeletion(ctx)

--- a/pkg/phlaredb/block/global_markers_bucket_client_test.go
+++ b/pkg/phlaredb/block/global_markers_bucket_client_test.go
@@ -348,7 +348,7 @@ func TestPhlareDBGlobalMarker(t *testing.T) {
 
 	id := generateULID()
 
-	err := MarkForDeletion(context.Background(), log.NewLogfmtLogger(os.Stderr), bkt, id, "foo", prometheus.NewCounter(prometheus.CounterOpts{}))
+	err := MarkForDeletion(context.Background(), log.NewLogfmtLogger(os.Stderr), bkt, id, "foo", false, prometheus.NewCounter(prometheus.CounterOpts{}))
 	require.NoError(t, err)
 
 	ok, err := bkt.Exists(context.Background(), DeletionMarkFilepath(id))


### PR DESCRIPTION
We often log this error:

```

  | ts=2023-12-21T09:46:56.652203687Z caller=block.go:164 level=warn component=compactor component=compactor tenant=27821 msg="requested to mark for deletion, but file already exists; this should not happen; investigate" err="file 01HJ5FB5R2Z145HJPBYQB0ZBMN/deletion-mark.json already exists in bucket" |  
-- | -- | --
```

This is confusing when it's actually from recurring cleanup this is fine that multiple compactor does try to delete the same file.