### PR TITLE
Listen on 127.0.0.1 in tests to avoid firewall popups on MacOS

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -368,7 +368,6 @@ func TestSchedulerForwardsErrorToFrontend(t *testing.T) {
 	_, frontendClient, querierClient := setupScheduler(t, nil)
 
 	fm := &frontendMock{resp: map[uint64]*httpgrpc.HTTPResponse{}}
-
 	frontendAddress := ""
 
 	// Setup frontend grpc server

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -368,6 +368,7 @@ func TestSchedulerForwardsErrorToFrontend(t *testing.T) {
 	_, frontendClient, querierClient := setupScheduler(t, nil)
 
 	fm := &frontendMock{resp: map[uint64]*httpgrpc.HTTPResponse{}}
+
 	frontendAddress := ""
 
 	// Setup frontend grpc server
@@ -375,7 +376,7 @@ func TestSchedulerForwardsErrorToFrontend(t *testing.T) {
 		frontendGrpcServer := grpc.NewServer()
 		frontendpb.RegisterFrontendForQuerierServer(frontendGrpcServer, fm)
 
-		l, err := net.Listen("tcp", "")
+		l, err := net.Listen("tcp", "127.0.0.1:")
 		require.NoError(t, err)
 
 		frontendAddress = l.Addr().String()

--- a/pkg/test/integration/helper.go
+++ b/pkg/test/integration/helper.go
@@ -26,7 +26,7 @@ func getFreePorts(len int) (ports []int, err error) {
 	ports = make([]int, len)
 	for i := 0; i < len; i++ {
 		var a *net.TCPAddr
-		if a, err = net.ResolveTCPAddr("tcp", "localhost:0"); err == nil {
+		if a, err = net.ResolveTCPAddr("tcp", "127.0.0.1:0"); err == nil {
 			var l *net.TCPListener
 			if l, err = net.ListenTCP("tcp", a); err != nil {
 				return nil, err
@@ -63,10 +63,16 @@ func (p *PyroscopeTest) Start(t *testing.T) {
 	err = cfg.DynamicUnmarshal(&p.config, []string{"pyroscope"}, flag.NewFlagSet("pyroscope", flag.ContinueOnError))
 	require.NoError(t, err)
 
-	// set free ports
+	// set addresses and ports
+	p.config.Server.HTTPListenAddress = "127.0.0.1"
 	p.config.Server.HTTPListenPort = p.httpPort
+	p.config.Server.GRPCListenAddress = "127.0.0.1"
+	p.config.Worker.SchedulerAddress = "127.0.0.1"
 	p.config.MemberlistKV.AdvertisePort = p.memberlistPort
 	p.config.MemberlistKV.TCPTransport.BindPort = p.memberlistPort
+	p.config.Ingester.LifecyclerConfig.Addr = "127.0.0.1"
+	p.config.QueryScheduler.ServiceDiscovery.SchedulerRing.InstanceAddr = "127.0.0.1"
+	p.config.Frontend.Addr = "127.0.0.1"
 
 	// heartbeat more often
 	p.config.Distributor.DistributorRing.HeartbeatPeriod = time.Second
@@ -116,7 +122,7 @@ func (p *PyroscopeTest) ringActive() bool {
 	return httpBodyContains(p.URL()+"/ring", "ACTIVE")
 }
 func (p *PyroscopeTest) URL() string {
-	return fmt.Sprintf("http://localhost:%d", p.httpPort)
+	return fmt.Sprintf("http://127.0.0.1:%d", p.httpPort)
 }
 
 func (p *PyroscopeTest) queryClient() querierv1connect.QuerierServiceClient {

--- a/pkg/test/integration/helper.go
+++ b/pkg/test/integration/helper.go
@@ -48,6 +48,7 @@ type PyroscopeTest struct {
 	memberlistPort int
 }
 
+const address = "127.0.0.1"
 const storeInMemory = "inmemory"
 
 func (p *PyroscopeTest) Start(t *testing.T) {
@@ -64,15 +65,15 @@ func (p *PyroscopeTest) Start(t *testing.T) {
 	require.NoError(t, err)
 
 	// set addresses and ports
-	p.config.Server.HTTPListenAddress = "127.0.0.1"
+	p.config.Server.HTTPListenAddress = address
 	p.config.Server.HTTPListenPort = p.httpPort
-	p.config.Server.GRPCListenAddress = "127.0.0.1"
-	p.config.Worker.SchedulerAddress = "127.0.0.1"
+	p.config.Server.GRPCListenAddress = address
+	p.config.Worker.SchedulerAddress = address
 	p.config.MemberlistKV.AdvertisePort = p.memberlistPort
 	p.config.MemberlistKV.TCPTransport.BindPort = p.memberlistPort
-	p.config.Ingester.LifecyclerConfig.Addr = "127.0.0.1"
-	p.config.QueryScheduler.ServiceDiscovery.SchedulerRing.InstanceAddr = "127.0.0.1"
-	p.config.Frontend.Addr = "127.0.0.1"
+	p.config.Ingester.LifecyclerConfig.Addr = address
+	p.config.QueryScheduler.ServiceDiscovery.SchedulerRing.InstanceAddr = address
+	p.config.Frontend.Addr = address
 
 	// heartbeat more often
 	p.config.Distributor.DistributorRing.HeartbeatPeriod = time.Second
@@ -122,7 +123,7 @@ func (p *PyroscopeTest) ringActive() bool {
 	return httpBodyContains(p.URL()+"/ring", "ACTIVE")
 }
 func (p *PyroscopeTest) URL() string {
-	return fmt.Sprintf("http://127.0.0.1:%d", p.httpPort)
+	return fmt.Sprintf("http://%s:%d", address, p.httpPort)
 }
 
 func (p *PyroscopeTest) queryClient() querierv1connect.QuerierServiceClient {


### PR DESCRIPTION
When the firewall is enabled in MacOS, some tests that involve networking will trigger the firewall popups. Allowing or denying the connections has a temporary effect, once the binary changes the popups are back.

This change makes it so that we listen to 127.0.0.1 in networking tests, which should avoid the popups entirely for most developers.

<img width="360" alt="Screenshot 2024-01-02 at 09 14 35" src="https://github.com/grafana/pyroscope/assets/8142643/462203bf-9ea9-41e8-a4e9-7db19b2fcdc0">
