### PR TITLE
[WIP] feat: Persist settings in bucket storage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/valyala/bytebufferpool v1.0.0
 	github.com/xlab/treeprint v1.2.0
+	go.etcd.io/bbolt v1.3.8
 	go.uber.org/atomic v1.11.0
 	go.uber.org/goleak v1.2.1
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa

--- a/go.sum
+++ b/go.sum
@@ -726,6 +726,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+go.etcd.io/bbolt v1.3.8 h1:xs88BrvEv273UsB79e0hcVrlUWmS0a8upikMFhSyAtA=
+go.etcd.io/bbolt v1.3.8/go.mod h1:N9Mkw9X8x5fupy0IKsmuqVtoGDyxsaDlbk4Rd05IAQw=
 go.etcd.io/etcd/api/v3 v3.5.7 h1:sbcmosSVesNrWOJ58ZQFitHMdncusIifYcrBfwrlJSY=
 go.etcd.io/etcd/api/v3 v3.5.7/go.mod h1:9qew1gCdDDLu+VwmeG+iFpL+QlpHTo7iubavdVDgCAA=
 go.etcd.io/etcd/client/pkg/v3 v3.5.7 h1:y3kf5Gbp4e4q7egZdn5T7W9TSHUvkClN6u+Rq9mEOmg=

--- a/pkg/phlare/modules.go
+++ b/pkg/phlare/modules.go
@@ -135,12 +135,12 @@ func (f *Phlare) initRuntimeConfig() (services.Service, error) {
 }
 
 func (f *Phlare) initTenantSettings() (services.Service, error) {
-	mem, err := settings.NewMemoryStore()
+	store, err := settings.NewPersistentStore(nil, f.Cfg.PhlareDB.DataPath)
 	if err != nil {
 		return nil, err
 	}
 
-	settings, err := settings.New(mem)
+	settings, err := settings.New(store)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to init %s", TenantSettings)
 	}

--- a/pkg/settings/memory.go
+++ b/pkg/settings/memory.go
@@ -61,3 +61,8 @@ func (s *memoryStore) Set(ctx context.Context, tenantID string, setting *setting
 
 	return setting, nil
 }
+
+func (s *memoryStore) Sync(ctx context.Context) error {
+	// In-memory store does not have on-disk storage.
+	return nil
+}

--- a/pkg/settings/persistent.go
+++ b/pkg/settings/persistent.go
@@ -1,0 +1,115 @@
+package settings
+
+import (
+	"context"
+	"encoding/json"
+	"path"
+
+	"github.com/pkg/errors"
+	"github.com/thanos-io/objstore"
+	"go.etcd.io/bbolt"
+
+	settingsv1 "github.com/grafana/pyroscope/api/gen/proto/go/settings/v1"
+)
+
+const (
+	settingsFilename = "settings.bolt"
+)
+
+func NewPersistentStore(bucket objstore.Bucket, dataPath string) (Store, error) {
+	db, err := bbolt.Open(path.Join(dataPath, settingsFilename), 0755, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	store := &persistentStore{
+		bucket: bucket,
+		db:     db,
+	}
+
+	return store, nil
+}
+
+type persistentStore struct {
+	bucket objstore.Bucket
+	db     *bbolt.DB
+}
+
+func (s *persistentStore) Get(ctx context.Context, tenantID string) ([]*settingsv1.Setting, error) {
+	settings := make([]*settingsv1.Setting, 0)
+
+	err := s.db.View(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket([]byte(tenantID))
+		if bucket == nil {
+			return nil
+		}
+
+		err := bucket.ForEach(func(k []byte, v []byte) error {
+			setting := &settingsv1.Setting{}
+			err := json.Unmarshal(v, setting)
+			if err != nil {
+				return err
+			}
+
+			settings = append(settings, setting)
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return settings, nil
+}
+
+func (s *persistentStore) Set(ctx context.Context, tenantID string, setting *settingsv1.Setting) (*settingsv1.Setting, error) {
+	err := s.db.Update(func(tx *bbolt.Tx) error {
+		// Get or create the bucket for this tenant.
+		bucket, err := tx.CreateBucketIfNotExists([]byte(tenantID))
+		if err != nil {
+			return err
+		}
+
+		// Check if there is an existing setting with this key.
+		value := bucket.Get([]byte(setting.Name))
+		if value != nil {
+			// An existing setting was found, make sure we don't overwrite it if
+			// its newer.
+			oldSetting := &settingsv1.Setting{}
+			err = json.Unmarshal(value, oldSetting)
+			if err != nil {
+				return errors.Wrapf(err, "failed to update %s", setting.Name)
+			}
+
+			if oldSetting.ModifiedAt > setting.ModifiedAt {
+				return errors.Wrapf(oldSettingErr, "failed to update %s", setting.Name)
+			}
+		}
+
+		// Encode the new setting.
+		value, err = json.Marshal(setting)
+		if err != nil {
+			return errors.Wrapf(err, "failed to update %s", setting.Name)
+		}
+
+		// Insert the new setting.
+		err = bucket.Put([]byte(setting.Name), value)
+		if err != nil {
+			return errors.Wrapf(err, "failed to update %s", setting.Name)
+		}
+
+		// TODO(bryan) Sync the db with object storage.
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return setting, nil
+}

--- a/pkg/settings/persistent.go
+++ b/pkg/settings/persistent.go
@@ -113,3 +113,7 @@ func (s *persistentStore) Set(ctx context.Context, tenantID string, setting *set
 
 	return setting, nil
 }
+
+func (s *persistentStore) Sync(ctx context.Context) error {
+	panic("unimplemented")
+}

--- a/pkg/settings/store.go
+++ b/pkg/settings/store.go
@@ -12,4 +12,7 @@ type Store interface {
 
 	// Set a setting for a tenant.
 	Set(ctx context.Context, tenantID string, setting *settingsv1.Setting) (*settingsv1.Setting, error)
+
+	// Trigger the store to resync with the underlying storage.
+	Sync(ctx context.Context) error
 }


### PR DESCRIPTION
WIP

Related: https://github.com/grafana/pyroscope-app-plugin/issues/43

Leverages bbolt to create an on-disk kv store which we can sync to bucket storage with every write. We can reuse the same bucket profiles are written to. We should refresh the blob in bucket storage every 24 hours or so to make sure the file doesn't expire.