### PR TITLE
Fix compactor metrics registration

### DIFF
--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1647,7 +1647,7 @@ func prepareWithConfigProvider(t *testing.T, compactorCfg Config, bucketClient o
 	logger := &componentLogger{component: "compactor", log: log.NewLogfmtLogger(logs)}
 	registry := prometheus.NewRegistry()
 
-	blocksCompactorFactory := func(ctx context.Context, cfg Config, cfgProvider ConfigProvider, userID string, logger log.Logger, reg prometheus.Registerer) (Compactor, error) {
+	blocksCompactorFactory := func(ctx context.Context, cfg Config, cfgProvider ConfigProvider, userID string, logger log.Logger, metrics *CompactorMetrics) (Compactor, error) {
 		return blockCompactor, nil
 	}
 

--- a/pkg/compactor/split_merge_compactor.go
+++ b/pkg/compactor/split_merge_compactor.go
@@ -25,7 +25,7 @@ func splitAndMergePlannerFactory(cfg Config) Planner {
 	return NewSplitAndMergePlanner(cfg.BlockRanges.ToMilliseconds())
 }
 
-func splitAndMergeCompactorFactory(_ context.Context, cfg Config, cfgProvider ConfigProvider, userID string, logger log.Logger, reg prometheus.Registerer) (Compactor, error) {
+func splitAndMergeCompactorFactory(_ context.Context, cfg Config, cfgProvider ConfigProvider, userID string, logger log.Logger, metrics *CompactorMetrics) (Compactor, error) {
 	splitBy := getCompactionSplitBy(cfg.CompactionSplitBy)
 	if splitBy == nil {
 		return nil, errInvalidCompactionSplitBy
@@ -35,7 +35,7 @@ func splitAndMergeCompactorFactory(_ context.Context, cfg Config, cfgProvider Co
 		downsamplerEnabled:   cfg.DownsamplerEnabled && cfgProvider.CompactorDownsamplerEnabled(userID),
 		splitBy:              splitBy,
 		logger:               logger,
-		metrics:              newCompactorMetrics(reg),
+		metrics:              metrics,
 	}, nil
 }
 


### PR DESCRIPTION
Fixes an issue introduced in #2880 where some compactor metrics are initialized multiple times. Verified in a dev environment. 