### PR TITLE
feat: Improve compaction shutdown

### DIFF
--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -2817,6 +2817,7 @@ spec:
             requests:
               cpu: 1
               memory: 8Gi
+      terminationGracePeriodSeconds: 1200
       volumes:
         - name: config
           configMap:

--- a/operations/pyroscope/helm/pyroscope/values-micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/values-micro-services.yaml
@@ -55,6 +55,7 @@ pyroscope:
     compactor:
       kind: StatefulSet
       replicaCount: 3
+      terminationGracePeriodSeconds: 1200
       persistence:
         enabled: false
       resources:
@@ -67,8 +68,8 @@ pyroscope:
       kind: StatefulSet
       replicaCount: 3
       persistence:
-      # The store-gateway needs not need persistent storage, but we still run it as a StatefulSet
-      # This is to avoid having blocks of data being
+        # The store-gateway needs not need persistent storage, but we still run it as a StatefulSet
+        # This is to avoid having blocks of data being
         enabled: false
       resources:
         limits:

--- a/operations/pyroscope/jsonnet/values-micro-services.json
+++ b/operations/pyroscope/jsonnet/values-micro-services.json
@@ -18,7 +18,8 @@
             "cpu": 1,
             "memory": "8Gi"
           }
-        }
+        },
+        "terminationGracePeriodSeconds": 1200
       },
       "distributor": {
         "kind": "Deployment",

--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -537,7 +537,7 @@ func (c *BucketCompactor) runCompactionJob(ctx context.Context, job *Job) (shoul
 	}
 
 	if err = verifyCompactedBlocksTimeRanges(compIDs, toCompactMinTime.UnixMilli(), toCompactMaxTime.UnixMilli(), subDir); err != nil {
-		level.Warn(jobLogger).Log("msg", "compacted blocks verification failed", "err", err)
+		level.Error(jobLogger).Log("msg", "compacted blocks verification failed", "err", err)
 		c.metrics.compactionBlocksVerificationFailed.Inc()
 		return false, nil, err
 	}


### PR DESCRIPTION
I've seen traces where it took 10m to compact. When we rollout a new version  it can get cancelled in the upload and deletion which is usually less than 2m.

I think we should leave a grace period for uploads and marking blocks deleted.