### PR TITLE
Use LabelValues for ProfileTypes call in querier

### DIFF
--- a/api/gen/proto/go/ingester/v1/ingester_vtproto.pb.go
+++ b/api/gen/proto/go/ingester/v1/ingester_vtproto.pb.go
@@ -1545,6 +1545,8 @@ type IngesterServiceClient interface {
 	Push(ctx context.Context, in *v11.PushRequest, opts ...grpc.CallOption) (*v11.PushResponse, error)
 	LabelValues(ctx context.Context, in *v1.LabelValuesRequest, opts ...grpc.CallOption) (*v1.LabelValuesResponse, error)
 	LabelNames(ctx context.Context, in *v1.LabelNamesRequest, opts ...grpc.CallOption) (*v1.LabelNamesResponse, error)
+	// Deprecated: ProfileType call is deprecated in the store components
+	// TODO: Remove this call in release v1.4
 	ProfileTypes(ctx context.Context, in *ProfileTypesRequest, opts ...grpc.CallOption) (*ProfileTypesResponse, error)
 	Series(ctx context.Context, in *SeriesRequest, opts ...grpc.CallOption) (*SeriesResponse, error)
 	Flush(ctx context.Context, in *FlushRequest, opts ...grpc.CallOption) (*FlushResponse, error)
@@ -1757,6 +1759,8 @@ type IngesterServiceServer interface {
 	Push(context.Context, *v11.PushRequest) (*v11.PushResponse, error)
 	LabelValues(context.Context, *v1.LabelValuesRequest) (*v1.LabelValuesResponse, error)
 	LabelNames(context.Context, *v1.LabelNamesRequest) (*v1.LabelNamesResponse, error)
+	// Deprecated: ProfileType call is deprecated in the store components
+	// TODO: Remove this call in release v1.4
 	ProfileTypes(context.Context, *ProfileTypesRequest) (*ProfileTypesResponse, error)
 	Series(context.Context, *SeriesRequest) (*SeriesResponse, error)
 	Flush(context.Context, *FlushRequest) (*FlushResponse, error)

--- a/api/gen/proto/go/ingester/v1/ingesterv1connect/ingester.connect.go
+++ b/api/gen/proto/go/ingester/v1/ingesterv1connect/ingester.connect.go
@@ -88,6 +88,8 @@ type IngesterServiceClient interface {
 	Push(context.Context, *connect.Request[v11.PushRequest]) (*connect.Response[v11.PushResponse], error)
 	LabelValues(context.Context, *connect.Request[v12.LabelValuesRequest]) (*connect.Response[v12.LabelValuesResponse], error)
 	LabelNames(context.Context, *connect.Request[v12.LabelNamesRequest]) (*connect.Response[v12.LabelNamesResponse], error)
+	// Deprecated: ProfileType call is deprecated in the store components
+	// TODO: Remove this call in release v1.4
 	ProfileTypes(context.Context, *connect.Request[v1.ProfileTypesRequest]) (*connect.Response[v1.ProfileTypesResponse], error)
 	Series(context.Context, *connect.Request[v1.SeriesRequest]) (*connect.Response[v1.SeriesResponse], error)
 	Flush(context.Context, *connect.Request[v1.FlushRequest]) (*connect.Response[v1.FlushResponse], error)
@@ -252,6 +254,8 @@ type IngesterServiceHandler interface {
 	Push(context.Context, *connect.Request[v11.PushRequest]) (*connect.Response[v11.PushResponse], error)
 	LabelValues(context.Context, *connect.Request[v12.LabelValuesRequest]) (*connect.Response[v12.LabelValuesResponse], error)
 	LabelNames(context.Context, *connect.Request[v12.LabelNamesRequest]) (*connect.Response[v12.LabelNamesResponse], error)
+	// Deprecated: ProfileType call is deprecated in the store components
+	// TODO: Remove this call in release v1.4
 	ProfileTypes(context.Context, *connect.Request[v1.ProfileTypesRequest]) (*connect.Response[v1.ProfileTypesResponse], error)
 	Series(context.Context, *connect.Request[v1.SeriesRequest]) (*connect.Response[v1.SeriesResponse], error)
 	Flush(context.Context, *connect.Request[v1.FlushRequest]) (*connect.Response[v1.FlushResponse], error)

--- a/api/gen/proto/go/storegateway/v1/storegateway_vtproto.pb.go
+++ b/api/gen/proto/go/storegateway/v1/storegateway_vtproto.pb.go
@@ -34,6 +34,8 @@ type StoreGatewayServiceClient interface {
 	MergeProfilesLabels(ctx context.Context, opts ...grpc.CallOption) (StoreGatewayService_MergeProfilesLabelsClient, error)
 	MergeProfilesPprof(ctx context.Context, opts ...grpc.CallOption) (StoreGatewayService_MergeProfilesPprofClient, error)
 	MergeSpanProfile(ctx context.Context, opts ...grpc.CallOption) (StoreGatewayService_MergeSpanProfileClient, error)
+	// Deprecated: ProfileType call is deprecated in the store components
+	// TODO: Remove this call in release v1.4
 	ProfileTypes(ctx context.Context, in *v1.ProfileTypesRequest, opts ...grpc.CallOption) (*v1.ProfileTypesResponse, error)
 	LabelValues(ctx context.Context, in *v11.LabelValuesRequest, opts ...grpc.CallOption) (*v11.LabelValuesResponse, error)
 	LabelNames(ctx context.Context, in *v11.LabelNamesRequest, opts ...grpc.CallOption) (*v11.LabelNamesResponse, error)
@@ -226,6 +228,8 @@ type StoreGatewayServiceServer interface {
 	MergeProfilesLabels(StoreGatewayService_MergeProfilesLabelsServer) error
 	MergeProfilesPprof(StoreGatewayService_MergeProfilesPprofServer) error
 	MergeSpanProfile(StoreGatewayService_MergeSpanProfileServer) error
+	// Deprecated: ProfileType call is deprecated in the store components
+	// TODO: Remove this call in release v1.4
 	ProfileTypes(context.Context, *v1.ProfileTypesRequest) (*v1.ProfileTypesResponse, error)
 	LabelValues(context.Context, *v11.LabelValuesRequest) (*v11.LabelValuesResponse, error)
 	LabelNames(context.Context, *v11.LabelNamesRequest) (*v11.LabelNamesResponse, error)

--- a/api/gen/proto/go/storegateway/v1/storegatewayv1connect/storegateway.connect.go
+++ b/api/gen/proto/go/storegateway/v1/storegatewayv1connect/storegateway.connect.go
@@ -84,6 +84,8 @@ type StoreGatewayServiceClient interface {
 	MergeProfilesLabels(context.Context) *connect.BidiStreamForClient[v11.MergeProfilesLabelsRequest, v11.MergeProfilesLabelsResponse]
 	MergeProfilesPprof(context.Context) *connect.BidiStreamForClient[v11.MergeProfilesPprofRequest, v11.MergeProfilesPprofResponse]
 	MergeSpanProfile(context.Context) *connect.BidiStreamForClient[v11.MergeSpanProfileRequest, v11.MergeSpanProfileResponse]
+	// Deprecated: ProfileType call is deprecated in the store components
+	// TODO: Remove this call in release v1.4
 	ProfileTypes(context.Context, *connect.Request[v11.ProfileTypesRequest]) (*connect.Response[v11.ProfileTypesResponse], error)
 	LabelValues(context.Context, *connect.Request[v12.LabelValuesRequest]) (*connect.Response[v12.LabelValuesResponse], error)
 	LabelNames(context.Context, *connect.Request[v12.LabelNamesRequest]) (*connect.Response[v12.LabelNamesResponse], error)
@@ -223,6 +225,8 @@ type StoreGatewayServiceHandler interface {
 	MergeProfilesLabels(context.Context, *connect.BidiStream[v11.MergeProfilesLabelsRequest, v11.MergeProfilesLabelsResponse]) error
 	MergeProfilesPprof(context.Context, *connect.BidiStream[v11.MergeProfilesPprofRequest, v11.MergeProfilesPprofResponse]) error
 	MergeSpanProfile(context.Context, *connect.BidiStream[v11.MergeSpanProfileRequest, v11.MergeSpanProfileResponse]) error
+	// Deprecated: ProfileType call is deprecated in the store components
+	// TODO: Remove this call in release v1.4
 	ProfileTypes(context.Context, *connect.Request[v11.ProfileTypesRequest]) (*connect.Response[v11.ProfileTypesResponse], error)
 	LabelValues(context.Context, *connect.Request[v12.LabelValuesRequest]) (*connect.Response[v12.LabelValuesResponse], error)
 	LabelNames(context.Context, *connect.Request[v12.LabelNamesRequest]) (*connect.Response[v12.LabelNamesResponse], error)

--- a/api/ingester/v1/ingester.proto
+++ b/api/ingester/v1/ingester.proto
@@ -10,6 +10,8 @@ service IngesterService {
   rpc Push(push.v1.PushRequest) returns (push.v1.PushResponse) {}
   rpc LabelValues(types.v1.LabelValuesRequest) returns (types.v1.LabelValuesResponse) {}
   rpc LabelNames(types.v1.LabelNamesRequest) returns (types.v1.LabelNamesResponse) {}
+  // Deprecated: ProfileType call is deprecated in the store components
+  // TODO: Remove this call in release v1.4
   rpc ProfileTypes(ProfileTypesRequest) returns (ProfileTypesResponse) {}
   rpc Series(SeriesRequest) returns (SeriesResponse) {}
   rpc Flush(FlushRequest) returns (FlushResponse) {}

--- a/api/storegateway/v1/storegateway.proto
+++ b/api/storegateway/v1/storegateway.proto
@@ -12,6 +12,8 @@ service StoreGatewayService {
   rpc MergeProfilesLabels(stream ingester.v1.MergeProfilesLabelsRequest) returns (stream ingester.v1.MergeProfilesLabelsResponse) {}
   rpc MergeProfilesPprof(stream ingester.v1.MergeProfilesPprofRequest) returns (stream ingester.v1.MergeProfilesPprofResponse) {}
   rpc MergeSpanProfile(stream ingester.v1.MergeSpanProfileRequest) returns (stream ingester.v1.MergeSpanProfileResponse) {}
+  // Deprecated: ProfileType call is deprecated in the store components
+  // TODO: Remove this call in release v1.4
   rpc ProfileTypes(ingester.v1.ProfileTypesRequest) returns (ingester.v1.ProfileTypesResponse) {}
   rpc LabelValues(types.v1.LabelValuesRequest) returns (types.v1.LabelValuesResponse) {}
   rpc LabelNames(types.v1.LabelNamesRequest) returns (types.v1.LabelNamesResponse) {}

--- a/pkg/querier/ingester_querier.go
+++ b/pkg/querier/ingester_querier.go
@@ -236,23 +236,6 @@ func (q *Querier) selectSeriesFromIngesters(ctx context.Context, req *ingesterv1
 	return responses, nil
 }
 
-func (q *Querier) profileTypesFromIngesters(ctx context.Context, req *ingesterv1.ProfileTypesRequest) ([]ResponseFromReplica[*ingesterv1.ProfileTypesResponse], error) {
-	sp, ctx := opentracing.StartSpanFromContext(ctx, "ProfileTypes Ingesters")
-	defer sp.Finish()
-
-	responses, err := forAllIngesters(ctx, q.ingesterQuerier, func(childCtx context.Context, ic IngesterQueryClient) (*ingesterv1.ProfileTypesResponse, error) {
-		res, err := ic.ProfileTypes(childCtx, connect.NewRequest(req))
-		if err != nil {
-			return nil, err
-		}
-		return res.Msg, nil
-	})
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
-	}
-	return responses, nil
-}
-
 func (q *Querier) labelValuesFromIngesters(ctx context.Context, req *typesv1.LabelValuesRequest) ([]ResponseFromReplica[[]string], error) {
 	sp, ctx := opentracing.StartSpanFromContext(ctx, "LabelValues Ingesters")
 	defer sp.Finish()

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -51,27 +51,27 @@ func Test_QuerySampleType(t *testing.T) {
 		q := newFakeQuerier()
 		switch addr {
 		case "1":
-			q.On("ProfileTypes", mock.Anything, mock.Anything).
-				Return(connect.NewResponse(&ingestv1.ProfileTypesResponse{
-					ProfileTypes: []*typesv1.ProfileType{
-						{ID: "foo"},
-						{ID: "bar"},
+			q.On("LabelValues", mock.Anything, mock.Anything).
+				Return(connect.NewResponse(&typesv1.LabelValuesResponse{
+					Names: []string{
+						"foo::::",
+						"bar::::",
 					},
 				}), nil)
 		case "2":
-			q.On("ProfileTypes", mock.Anything, mock.Anything).
-				Return(connect.NewResponse(&ingestv1.ProfileTypesResponse{
-					ProfileTypes: []*typesv1.ProfileType{
-						{ID: "bar"},
-						{ID: "buzz"},
+			q.On("LabelValues", mock.Anything, mock.Anything).
+				Return(connect.NewResponse(&typesv1.LabelValuesResponse{
+					Names: []string{
+						"bar::::",
+						"buzz::::",
 					},
 				}), nil)
 		case "3":
-			q.On("ProfileTypes", mock.Anything, mock.Anything).
-				Return(connect.NewResponse(&ingestv1.ProfileTypesResponse{
-					ProfileTypes: []*typesv1.ProfileType{
-						{ID: "buzz"},
-						{ID: "foo"},
+			q.On("LabelValues", mock.Anything, mock.Anything).
+				Return(connect.NewResponse(&typesv1.LabelValuesResponse{
+					Names: []string{
+						"buzz::::",
+						"foo::::",
 					},
 				}), nil)
 		}
@@ -85,7 +85,7 @@ func Test_QuerySampleType(t *testing.T) {
 		ids = append(ids, pt.ID)
 	}
 	require.NoError(t, err)
-	require.Equal(t, []string{"bar", "buzz", "foo"}, ids)
+	require.Equal(t, []string{"bar::::", "buzz::::", "foo::::"}, ids)
 }
 
 func Test_QueryLabelValues(t *testing.T) {

--- a/pkg/querier/store_gateway_querier.go
+++ b/pkg/querier/store_gateway_querier.go
@@ -336,28 +336,6 @@ func (q *Querier) selectSeriesFromStoreGateway(ctx context.Context, req *ingeste
 	return responses, nil
 }
 
-func (q *Querier) profileTypesFromStoreGateway(ctx context.Context, req *ingesterv1.ProfileTypesRequest) ([]ResponseFromReplica[*ingesterv1.ProfileTypesResponse], error) {
-	sp, ctx := opentracing.StartSpanFromContext(ctx, "ProfileTypes StoreGateway")
-	defer sp.Finish()
-
-	tenantID, err := tenant.ExtractTenantIDFromContext(ctx)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
-	}
-
-	responses, err := forAllStoreGateways(ctx, tenantID, q.storeGatewayQuerier, func(ctx context.Context, ic StoreGatewayQueryClient) (*ingesterv1.ProfileTypesResponse, error) {
-		res, err := ic.ProfileTypes(ctx, connect.NewRequest(req))
-		if err != nil {
-			return nil, err
-		}
-		return res.Msg, nil
-	})
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
-	}
-	return responses, nil
-}
-
 func (q *Querier) labelValuesFromStoreGateway(ctx context.Context, req *typesv1.LabelValuesRequest) ([]ResponseFromReplica[[]string], error) {
 	sp, ctx := opentracing.StartSpanFromContext(ctx, "LabelValues StoreGateway")
 	defer sp.Finish()


### PR DESCRIPTION
This will allow us to remove the ProfileType endpoints from Ingesters and store-gateways in release v1.4 or later
