### PR TITLE
bugfix: Fixes panic in compaction benchmark

### DIFF
--- a/pkg/phlaredb/compact_test.go
+++ b/pkg/phlaredb/compact_test.go
@@ -916,6 +916,7 @@ func Benchmark_CompactSplit(b *testing.B) {
 			StageSize:          32,
 			SplitBy:            SplitByFingerprint,
 			DownsamplerEnabled: true,
+			Logger:             log.NewNopLogger(),
 		})
 		require.NoError(b, err)
 	}


### PR DESCRIPTION
Trying to run it today and found a panic, logger was missing, probably during a refactoring