### PR TITLE
Fix deploying `make deploy-micro-services` after `make deploy`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -398,6 +398,8 @@ deploy: $(BIN)/kind $(BIN)/helm docker-image/pyroscope/build
 
 .PHONY: deploy-micro-services
 deploy-micro-services: $(BIN)/kind $(BIN)/helm docker-image/pyroscope/build
+	# Ensure to delete existing service, that has been created manually by the deploy target
+	kubectl delete svc --field-selector metadata.name=pyroscope-micro-services-query-frontend -l app.kubernetes.io/managed-by!=Helm
 	$(call deploy,pyroscope-micro-services,--values=operations/pyroscope/helm/pyroscope/values-micro-services.yaml --set pyroscope.components.querier.resources=null --set pyroscope.components.distributor.resources=null --set pyroscope.components.ingester.resources=null --set pyroscope.components.store-gateway.resources=null --set pyroscope.components.compactor.resources=null --set pyroscope.components.tenant-settings.resources=null)
 
 .PHONY: deploy-monitoring


### PR DESCRIPTION
Make deploy manually creates a service to have the same endpoint for
single-binary and micro-services, which then interferes with the next
deployment of microservces.
