### PR TITLE
Increase parquet read buffer size

### DIFF
--- a/pkg/phlaredb/block_querier.go
+++ b/pkg/phlaredb/block_querier.go
@@ -49,8 +49,14 @@ import (
 )
 
 const (
-	defaultBatchSize      = 4096
-	parquetReadBufferSize = 256 << 10 // 256KB
+	defaultBatchSize = 4096
+
+	// This controls the buffer size for reads to a parquet io.Reader. This value should be small for memory or
+	// disk backed readers, but when the reader is backed by network storage a larger size will be advantageous.
+	//
+	// The chosen value should be larger than the page size. Page sizes depend on the write buffer size as well as
+	// on how well the data is encoded. In practice, they tend to be around 1MB.
+	parquetReadBufferSize = 2 << 20
 )
 
 type tableReader interface {

--- a/pkg/phlaredb/profile_store.go
+++ b/pkg/phlaredb/profile_store.go
@@ -26,6 +26,10 @@ import (
 	"github.com/grafana/pyroscope/pkg/util/build"
 )
 
+const (
+	parquetWriteBufferSize = 3 << 20 // 3MB
+)
+
 type profileStore struct {
 	size      atomic.Uint64
 	totalSize atomic.Uint64
@@ -63,7 +67,7 @@ type profileStore struct {
 }
 
 func newParquetProfileWriter(writer io.Writer, options ...parquet.WriterOption) *parquet.GenericWriter[*schemav1.Profile] {
-	options = append(options, parquet.PageBufferSize(3*1024*1024))
+	options = append(options, parquet.PageBufferSize(parquetWriteBufferSize))
 	options = append(options, parquet.CreatedBy("github.com/grafana/pyroscope/", build.Version, build.Revision))
 	options = append(options, schemav1.ProfilesSchema)
 	return parquet.NewGenericWriter[*schemav1.Profile](


### PR DESCRIPTION
Page sizes for parquet files tent to be larger than the current read buffer which results in more page reads than ideal. This change increases the size from 256KB to 2MB. In tests against a GCS backed storage this yields around 5-10% improved response time for the `SelectMergeByStacktraces` API and in a synthetic test with higher latencies towards the object store gains of up to 20% can be observed.

@cyriltovena 