### PR TITLE
docs(lambda): AWS Lambda extension SDK support

### DIFF
--- a/docs/sources/configure-client/aws-lambda.md
+++ b/docs/sources/configure-client/aws-lambda.md
@@ -62,6 +62,18 @@ Configure the extension with the following environment variables:
 
 ### Integrate the Pyroscope SDK
 
+The Pyroscope AWS Lambda extension is compatible with all existing Pyroscope SDKs. Here are some key considerations:
+ - Initialize the SDK before setting up the AWS Lambda handler.
+ - Ensure that the Pyroscope server address is configured to http://localhost:4040.
+
+Note that the SDK packages are not automatically included in the extension layer. For Java, Python, Node.js, and Ruby,
+you must either include the SDK package in the function deployment package or add it as a Lambda layer. Refer to the
+detailed guide in the AWS Lambda documentation for your specific runtime for further instructions:
+ - [Java](https://docs.aws.amazon.com/lambda/latest/dg/java-package.html#java-package-layers)
+ - [Python](https://docs.aws.amazon.com/lambda/latest/dg/python-package.html#python-package-dependencies)
+ - [Ruby](https://docs.aws.amazon.com/lambda/latest/dg/ruby-package.html#ruby-package-runtime-dependencies)
+ - [Node.js](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-package.html#nodejs-package-dependencies)
+
 For a Golang Lambda function, integrate the Pyroscope SDK as follows:
 
 ```go
@@ -78,7 +90,7 @@ func main() {
 }
 ```
 
-Replace `simple.golang.lambda` with your application name. The `ServerAddress` must be `http://localhost:4040`.
+Replace `simple.golang.lambda` with your application name.
 
 ## Use cases
 

--- a/docs/sources/configure-client/aws-lambda.md
+++ b/docs/sources/configure-client/aws-lambda.md
@@ -66,9 +66,7 @@ The Pyroscope AWS Lambda extension is compatible with all existing Pyroscope SDK
  - Initialize the SDK before setting up the AWS Lambda handler.
  - Ensure that the Pyroscope server address is configured to http://localhost:4040.
 
-Note that the SDK packages are not automatically included in the extension layer. For Java, Python, Node.js, and Ruby,
-you must either include the SDK package in the function deployment package or add it as a Lambda layer. Refer to the
-detailed guide in the AWS Lambda documentation for your specific runtime for further instructions:
+Note that the SDK packages are not automatically included in the extension layer. For Java, Python, Node.js, and Ruby, you must either include the SDK package in the function deployment package or add it as a Lambda layer. Refer to the detailed guide in the AWS Lambda documentation for your specific runtime for further instructions:
  - [Java](https://docs.aws.amazon.com/lambda/latest/dg/java-package.html#java-package-layers)
  - [Python](https://docs.aws.amazon.com/lambda/latest/dg/python-package.html#python-package-dependencies)
  - [Ruby](https://docs.aws.amazon.com/lambda/latest/dg/ruby-package.html#ruby-package-runtime-dependencies)


### PR DESCRIPTION
Presently, we don't distribute Lambda layers tailored to specific runtimes, therefore users have to manage SDK dependency on their own.

While AWS offers comprehensive guidance on this, it might be worthwhile for us to consider packaging our SDKs as layers. Please refer to [AWS Distro for OpenTelemetry](https://aws-otel.github.io/docs/getting-started/lambda) (ADOT) for example. Created a separate issue: https://github.com/grafana/pyroscope-lambda-extension/issues/34

/cc @Rperry2174 @knylander-grafana 