### PR TITLE
Correct river config in go_pull.md

### DIFF
--- a/docs/sources/configure-client/grafana-agent/go_pull.md
+++ b/docs/sources/configure-client/grafana-agent/go_pull.md
@@ -122,11 +122,13 @@ grafana.com. On this same page, create a token and use it as the Basic authentic
 pyroscope.write "write_job_name" {
         endpoint {
                 url = "<Grafana Cloud URL>"
+
+                basic_auth {
+                        username = "<Grafana Cloud User>"
+                        password = "<Grafana Cloud Password>"
+                }
         }
-        basic_auth {
-                username = "<Grafana Cloud User>"
-                password = "<Grafana Cloud Password>"
-        }
+        
 }
 ```
 


### PR DESCRIPTION
The Pyroscope.write block in the river config didn't next the `basic_auth` block within the endpoint block.