### PR TITLE
Improve block grouping in admin block viewer

### DIFF
--- a/pkg/operations/admin.go
+++ b/pkg/operations/admin.go
@@ -3,6 +3,7 @@ package operations
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/services"
@@ -16,12 +17,13 @@ type Admin struct {
 	handlers *Handlers
 }
 
-func NewAdmin(bucketClient objstore.Bucket, logger log.Logger) (*Admin, error) {
+func NewAdmin(bucketClient objstore.Bucket, logger log.Logger, maxBlockDuration time.Duration) (*Admin, error) {
 	a := &Admin{
 		logger: logger,
 		handlers: &Handlers{
-			Logger: logger,
-			Bucket: bucketClient,
+			Logger:           logger,
+			Bucket:           bucketClient,
+			MaxBlockDuration: maxBlockDuration,
 		},
 	}
 	a.Service = services.NewBasicService(nil, a.running, nil)

--- a/pkg/operations/handlers.go
+++ b/pkg/operations/handlers.go
@@ -99,13 +99,14 @@ func (h *Handlers) filterAndGroupBlocks(index *bucketindex.Index, query *blockQu
 				blockGroups = append(blockGroups, blkGroup)
 			}
 			blockDetails := &blockDetails{
-				ID:               blk.ID.String(),
-				MinTime:          minTime.Format(time.RFC3339),
-				MaxTime:          blk.MaxTime.Time().UTC().Format(time.RFC3339),
-				Duration:         int(math.Round(blk.MaxTime.Sub(blk.MinTime).Minutes())),
-				UploadedAt:       blk.GetUploadedAt().UTC().Format(time.RFC3339),
-				CompactionLevel:  blk.CompactionLevel,
-				CompactorShardID: blk.CompactorShardID,
+				ID:                blk.ID.String(),
+				MinTime:           minTime.Format(time.RFC3339),
+				MaxTime:           blk.MaxTime.Time().UTC().Format(time.RFC3339),
+				Duration:          int(math.Round(blk.MaxTime.Sub(blk.MinTime).Minutes())),
+				FormattedDuration: blk.MaxTime.Sub(blk.MinTime).Round(time.Minute).String(),
+				UploadedAt:        blk.GetUploadedAt().UTC().Format(time.RFC3339),
+				CompactionLevel:   blk.CompactionLevel,
+				CompactorShardID:  blk.CompactorShardID,
 			}
 			blkGroup.Blocks = append(blkGroup.Blocks, blockDetails)
 			if blockDetails.Duration > blkGroup.MaxBlockDurationMinutes {

--- a/pkg/operations/handlers.go
+++ b/pkg/operations/handlers.go
@@ -119,7 +119,7 @@ func postProcessBlockGroups(blockGroups []*blockGroup) *blockListResult {
 	maxBlocksPerGroup := 0
 	for i := 0; i < len(blockGroups); i += 1 {
 		blockGroup := blockGroups[i]
-		if i < len(blockGroups)-1 && !strings.Contains(blockGroup.FormattedMinTime, "0:00Z") {
+		if i < len(blockGroups)-1 && !strings.Contains(blockGroup.FormattedMinTime, ":00:") {
 			nextGroup := blockGroups[i+1]
 			nextGroup.Blocks = append(nextGroup.Blocks, blockGroup.Blocks...)
 			blockGroup.Blocks = make([]*blockDetails, 0)

--- a/pkg/operations/handlers.go
+++ b/pkg/operations/handlers.go
@@ -119,7 +119,7 @@ func postProcessBlockGroups(blockGroups []*blockGroup) *blockListResult {
 	maxBlocksPerGroup := 0
 	for i := 0; i < len(blockGroups); i += 1 {
 		blockGroup := blockGroups[i]
-		if i < len(blockGroups)-1 && !strings.Contains(blockGroup.FormattedMinTime, ":00:") {
+		if i < len(blockGroups)-1 && shouldAddToNextGroup(blockGroup.FormattedMinTime) {
 			nextGroup := blockGroups[i+1]
 			nextGroup.Blocks = append(nextGroup.Blocks, blockGroup.Blocks...)
 			blockGroup.Blocks = make([]*blockDetails, 0)
@@ -149,6 +149,10 @@ func postProcessBlockGroups(blockGroups []*blockGroup) *blockListResult {
 		MaxBlocksPerGroup: maxBlocksPerGroup,
 		GroupDuration:     groupDuration,
 	}
+}
+
+func shouldAddToNextGroup(blockMinTime string) bool {
+	return !strings.Contains(blockMinTime, ":00:") && !strings.Contains(blockMinTime, ":30:")
 }
 
 func (h *Handlers) CreateBlockDetailsHandler() func(http.ResponseWriter, *http.Request) {

--- a/pkg/operations/handlers.go
+++ b/pkg/operations/handlers.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"strings"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -25,8 +24,9 @@ import (
 )
 
 type Handlers struct {
-	Bucket objstore.Bucket
-	Logger log.Logger
+	Bucket           objstore.Bucket
+	Logger           log.Logger
+	MaxBlockDuration time.Duration
 }
 
 func (h *Handlers) CreateIndexHandler() func(http.ResponseWriter, *http.Request) {
@@ -61,7 +61,7 @@ func (h *Handlers) CreateBlocksHandler() func(http.ResponseWriter, *http.Request
 			User:           tenantId,
 			Query:          query,
 			Now:            time.Now().UTC().Format(time.RFC3339),
-			SelectedBlocks: filterAndGroupBlocks(index, query),
+			SelectedBlocks: h.filterAndGroupBlocks(index, query),
 		})
 		if err != nil {
 			httputil.Error(w, err)
@@ -70,10 +70,10 @@ func (h *Handlers) CreateBlocksHandler() func(http.ResponseWriter, *http.Request
 	}
 }
 
-func filterAndGroupBlocks(index *bucketindex.Index, query *blockQuery) *blockListResult {
+func (h *Handlers) filterAndGroupBlocks(index *bucketindex.Index, query *blockQuery) *blockListResult {
 	queryFrom := model.TimeFromUnix(query.parsedFrom.UnixMilli() / 1000)
 	queryTo := model.TimeFromUnix(query.parsedTo.UnixMilli() / 1000)
-	blockGroupMap := make(map[string]*blockGroup)
+	blockGroupMap := make(map[time.Time]*blockGroup)
 	blockGroups := make([]*blockGroup, 0)
 
 	deletedBlocks := make(map[ulid.ULID]int64)
@@ -86,12 +86,12 @@ func filterAndGroupBlocks(index *bucketindex.Index, query *blockQuery) *blockLis
 	for _, blk := range index.Blocks {
 		if _, deleted := deletedBlocks[blk.ID]; !deleted && blk.Within(queryFrom, queryTo) {
 			minTime := blk.MinTime.Time().UTC()
-			formattedMinTime := minTime.Format(time.RFC3339)
-			blkGroup, ok := blockGroupMap[formattedMinTime]
+			truncatedMinTime := minTime.Truncate(h.MaxBlockDuration)
+			blkGroup, ok := blockGroupMap[truncatedMinTime]
 			if !ok {
 				blkGroup = &blockGroup{
-					MinTime:          minTime,
-					FormattedMinTime: formattedMinTime,
+					MinTime:          truncatedMinTime,
+					FormattedMinTime: truncatedMinTime.Format(time.RFC3339),
 					Blocks:           make([]*blockDetails, 0),
 					MinTimeAge:       humanize.RelTime(blk.MinTime.Time(), time.Now(), "ago", ""),
 				}
@@ -99,60 +99,32 @@ func filterAndGroupBlocks(index *bucketindex.Index, query *blockQuery) *blockLis
 			}
 			blkGroup.Blocks = append(blkGroup.Blocks, &blockDetails{
 				ID:               blk.ID.String(),
-				MinTime:          formattedMinTime,
+				MinTime:          minTime.Format(time.RFC3339),
 				MaxTime:          blk.MaxTime.Time().UTC().Format(time.RFC3339),
 				Duration:         int(math.Round(blk.MaxTime.Sub(blk.MinTime).Minutes())),
 				UploadedAt:       blk.GetUploadedAt().UTC().Format(time.RFC3339),
 				CompactionLevel:  blk.CompactionLevel,
 				CompactorShardID: blk.CompactorShardID,
 			})
-			blockGroupMap[formattedMinTime] = blkGroup
+			blockGroupMap[truncatedMinTime] = blkGroup
 		}
 	}
 
 	sortBlockGroupsByMinTimeDec(blockGroups)
 
-	return postProcessBlockGroups(blockGroups)
-}
-
-func postProcessBlockGroups(blockGroups []*blockGroup) *blockListResult {
 	maxBlocksPerGroup := 0
-	for i := 0; i < len(blockGroups); i += 1 {
-		blockGroup := blockGroups[i]
-		if i < len(blockGroups)-1 && shouldAddToNextGroup(blockGroup.FormattedMinTime) {
-			nextGroup := blockGroups[i+1]
-			nextGroup.Blocks = append(nextGroup.Blocks, blockGroup.Blocks...)
-			blockGroup.Blocks = make([]*blockDetails, 0)
-		}
-
+	for _, blockGroup := range blockGroups {
 		sortBlockDetailsByMinTimeDec(blockGroup.Blocks)
-
 		if len(blockGroup.Blocks) > maxBlocksPerGroup {
 			maxBlocksPerGroup = len(blockGroup.Blocks)
 		}
 	}
 
-	finalBlockGroups := make([]*blockGroup, 0)
-	for _, blockGroup := range blockGroups {
-		if len(blockGroup.Blocks) > 0 {
-			finalBlockGroups = append(finalBlockGroups, blockGroup)
-		}
-	}
-	groupDuration := 60
-	if len(finalBlockGroups) > 1 {
-		groupOne := finalBlockGroups[len(finalBlockGroups)-2]
-		groupTwo := finalBlockGroups[len(finalBlockGroups)-1]
-		groupDuration = int(math.Round(groupOne.MinTime.Sub(groupTwo.MinTime).Minutes()))
-	}
 	return &blockListResult{
-		BlockGroups:       finalBlockGroups,
-		MaxBlocksPerGroup: maxBlocksPerGroup,
-		GroupDuration:     groupDuration,
+		BlockGroups:          blockGroups,
+		MaxBlocksPerGroup:    maxBlocksPerGroup,
+		GroupDurationMinutes: int(h.MaxBlockDuration.Minutes()),
 	}
-}
-
-func shouldAddToNextGroup(blockMinTime string) bool {
-	return !strings.Contains(blockMinTime, ":00:") && !strings.Contains(blockMinTime, ":30:")
 }
 
 func (h *Handlers) CreateBlockDetailsHandler() func(http.ResponseWriter, *http.Request) {

--- a/pkg/operations/handlers_test.go
+++ b/pkg/operations/handlers_test.go
@@ -189,18 +189,20 @@ func Test_filterAndGroupBlocks(t *testing.T) {
 						FormattedMinTime: block2.MinTime.Time().Truncate(time.Hour).UTC().Format(time.RFC3339),
 						Blocks: []*blockDetails{
 							{
-								ID:         block3.ID.String(), // block 3 is newer so it goes first
-								MinTime:    block3.MinTime.Time().UTC().Format(time.RFC3339),
-								MaxTime:    block3.MaxTime.Time().UTC().Format(time.RFC3339),
-								Duration:   59,
-								UploadedAt: time.UnixMilli(0).UTC().Format(time.RFC3339),
+								ID:                block3.ID.String(), // block 3 is newer so it goes first
+								MinTime:           block3.MinTime.Time().UTC().Format(time.RFC3339),
+								MaxTime:           block3.MaxTime.Time().UTC().Format(time.RFC3339),
+								Duration:          59,
+								FormattedDuration: "59m0s",
+								UploadedAt:        time.UnixMilli(0).UTC().Format(time.RFC3339),
 							},
 							{
-								ID:         block2.ID.String(),
-								MinTime:    block2.MinTime.Time().UTC().Format(time.RFC3339),
-								MaxTime:    block2.MaxTime.Time().UTC().Format(time.RFC3339),
-								Duration:   60,
-								UploadedAt: time.UnixMilli(0).UTC().Format(time.RFC3339),
+								ID:                block2.ID.String(),
+								MinTime:           block2.MinTime.Time().UTC().Format(time.RFC3339),
+								MaxTime:           block2.MaxTime.Time().UTC().Format(time.RFC3339),
+								Duration:          60,
+								FormattedDuration: "1h0m0s",
+								UploadedAt:        time.UnixMilli(0).UTC().Format(time.RFC3339),
 							},
 						},
 						MinTimeAge:              "4 hours ago",

--- a/pkg/operations/handlers_test.go
+++ b/pkg/operations/handlers_test.go
@@ -165,7 +165,7 @@ func Test_filterAndGroupBlocks(t *testing.T) {
 				}, query: &blockQuery{}},
 			want: &blockListResult{
 				BlockGroups:          []*blockGroup{},
-				GroupDurationMinutes: 60,
+				GroupDurationMinutes: 0,
 			},
 		},
 		{
@@ -203,7 +203,8 @@ func Test_filterAndGroupBlocks(t *testing.T) {
 								UploadedAt: time.UnixMilli(0).UTC().Format(time.RFC3339),
 							},
 						},
-						MinTimeAge: "4 hours ago",
+						MinTimeAge:              "4 hours ago",
+						MaxBlockDurationMinutes: 60,
 					},
 				},
 				GroupDurationMinutes: 60,

--- a/pkg/operations/model.go
+++ b/pkg/operations/model.go
@@ -47,16 +47,17 @@ func readQuery(r *http.Request) *blockQuery {
 }
 
 type blockDetails struct {
-	ID               string
-	MinTime          string
-	MaxTime          string
-	Duration         int
-	UploadedAt       string
-	CompactorShardID string
-	CompactionLevel  int
-	Size             string
-	Stats            block.BlockStats
-	Labels           map[string]string
+	ID                string
+	MinTime           string
+	MaxTime           string
+	Duration          int
+	FormattedDuration string
+	UploadedAt        string
+	CompactorShardID  string
+	CompactionLevel   int
+	Size              string
+	Stats             block.BlockStats
+	Labels            map[string]string
 }
 
 type blockGroup struct {

--- a/pkg/operations/model.go
+++ b/pkg/operations/model.go
@@ -67,9 +67,9 @@ type blockGroup struct {
 }
 
 type blockListResult struct {
-	BlockGroups       []*blockGroup
-	MaxBlocksPerGroup int
-	GroupDuration     int
+	BlockGroups          []*blockGroup
+	MaxBlocksPerGroup    int
+	GroupDurationMinutes int
 }
 
 // Sorts a slice of block groups by MinTime in descending order.

--- a/pkg/operations/model.go
+++ b/pkg/operations/model.go
@@ -60,10 +60,11 @@ type blockDetails struct {
 }
 
 type blockGroup struct {
-	MinTime          time.Time
-	FormattedMinTime string
-	Blocks           []*blockDetails
-	MinTimeAge       string
+	MinTime                 time.Time
+	FormattedMinTime        string
+	Blocks                  []*blockDetails
+	MinTimeAge              string
+	MaxBlockDurationMinutes int
 }
 
 type blockListResult struct {

--- a/pkg/operations/tool.blocks.list.gohtml
+++ b/pkg/operations/tool.blocks.list.gohtml
@@ -123,7 +123,7 @@
             </div>
             {{ else }}
                 <hr/>
-                {{ $groupDuration := .SelectedBlocks.GroupDuration}}
+                {{ $groupDuration := .SelectedBlocks.GroupDurationMinutes}}
                 {{ $blockWidth := 20 }}
                 {{ $blockSpacing := 2 }}
                 {{ if gt .SelectedBlocks.MaxBlocksPerGroup 32 }}

--- a/pkg/operations/tool.blocks.list.gohtml
+++ b/pkg/operations/tool.blocks.list.gohtml
@@ -108,7 +108,7 @@
                                             <td class="font-monospace small">{{ $v.UploadedAt }}</td>
                                             <td class="font-monospace small">{{ $v.MinTime }}</td>
                                             <td class="font-monospace small">{{ $v.MaxTime }}</td>
-                                            <td class="font-monospace small">{{ $v.Duration }}</td>
+                                            <td class="font-monospace small">{{ $v.FormattedDuration }}</td>
                                             <td class="font-monospace small">{{ $v.CompactionLevel }}</td>
                                             <td class="font-monospace small">{{ $v.CompactorShardID }}</td>
                                         </tr>

--- a/pkg/phlare/modules.go
+++ b/pkg/phlare/modules.go
@@ -527,7 +527,7 @@ func (f *Phlare) initAdmin() (services.Service, error) {
 		return nil, nil
 	}
 
-	a, err := operations.NewAdmin(f.storageBucket, f.logger)
+	a, err := operations.NewAdmin(f.storageBucket, f.logger, f.Cfg.PhlareDB.MaxBlockDuration)
 	if err != nil {
 		level.Info(f.logger).Log("msg", "failed to initialize admin", "err", err)
 		return nil, nil


### PR DESCRIPTION
The code assumed MinTime is aligned to 0 seconds, but we've found a case where this is not the case. This could happen due to clock-skew on a node, or code-related factors. 

The assumption is now changed to be aligned to either 0 or 30 minutes instead. 

cc. @cyriltovena 