### PR TITLE
[DOC] Add 1.3 release notes for docs (#2949)

### DIFF
--- a/docs/sources/release-notes/v1-2.md
+++ b/docs/sources/release-notes/v1-2.md
@@ -20,7 +20,7 @@ We've invested substantial effort in optimizing the read path and refining query
 Trace to profiles integrations
 ![image](https://github.com/grafana/pyroscope/assets/23323466/d10bfb66-a40f-4b35-9f24-d2ec515b68c6)
 
-Notable changes are listed below for more details check out the **Full 1.2.0 Changelog**: https://github.com/grafana/pyroscope/compare/v1.1.5...v1.2.0
+Notable changes are listed below. For more details, check out the **Full 1.2.0 Changelog**: https://github.com/grafana/pyroscope/compare/v1.1.5...v1.2.0
 
 Version 1.2.x changelogs:
 
@@ -29,7 +29,7 @@ Version 1.2.x changelogs:
 
 ## Features and enhancements
 
-All new features and enhancements for version 1.2.x are listed in this section.
+This section lists all new features and enhancements for version 1.2.x.
 
 ### Version 1.2.1
 
@@ -43,7 +43,7 @@ Features and enhancements for version 1.2.1:
 * Develop optimized pprof symbolication and pprof truncation ([#2679](https://github.com/grafana/pyroscope/pull/2679), [#2754](https://github.com/grafana/pyroscope/pull/2754))
 * Add the first iteration of the blocks viewer cli tool ([#2697](https://github.com/grafana/pyroscope/pull/2697))
 
-In addition, the followin improvements and updates for version 1.2.1:
+In addition, the following improvements and updates for version 1.2.1:
 
 * Improve `SelectMatchingProfiles` performance ([#2734](https://github.com/grafana/pyroscope/pull/2734))
 * Enhance language detection performance ([#2823](https://github.com/grafana/pyroscope/pull/2823))

--- a/docs/sources/release-notes/v1-3.md
+++ b/docs/sources/release-notes/v1-3.md
@@ -1,0 +1,68 @@
+---
+title: Version 1.3 release notes
+menuTitle: V1.3
+description: Release notes for Grafana Pyroscope 1.3
+weight: 750
+---
+
+# Version 1.3 release notes
+
+We are excited to present Grafana Pyroscope 1.3.
+
+This release focuses on improving stability and interoperability to make Pyroscope more reliable and easier to use.
+
+Several major improvements were made to the compaction process:
+
+* Improved performance and storage efficiency of the symbol compaction process.
+* Optimized data processing by adding support for time-based down-sampling during the compaction process.
+* Added tracing integration to compaction for better observability.
+* Improved system stability during compaction shutdown
+* Added a `profilecli compact` command
+
+Notable changes are listed below. For more details, check out the **Full 1.3.0 Changelog**: https://github.com/grafana/pyroscope/compare/v1.2.1...v1.3.0
+
+## Features and enhancements
+
+Features and enhancements for version 1.3 include:
+
+* Enhanced symbol compaction process: Improved performance and storage efficiency with the new symbol compaction process ([#2864](https://github.com/grafana/pyroscope/pull/2864)).
+* Introduced function selector in pprof query: More precise profiling with the addition of a function selector ([#2878](https://github.com/grafana/pyroscope/pull/2878)).
+* Support for time-based downsampling during compaction: Optimized data processing with time-based strategies ([#2880](https://github.com/grafana/pyroscope/pull/2880)).
+* Added tracing integrations to compaction: Better observability in the compaction process ([#2876](https://github.com/grafana/pyroscope/pull/2876)).
+* Added language mapping for Grafana Agent in Java: Expanded profiling capabilities ([#2866](https://github.com/grafana/pyroscope/pull/2866)).
+
+### Improvements and updates
+
+Version 1.3 includes the following improvements and updates:
+
+* Updated Alpine and Golang versions: Enhanced security and performance with the latest versions of Alpine (3.18.5) and Golang (1.21.5) ([#2901](https://github.com/grafana/pyroscope/pull/2901), [#2902](https://github.com/grafana/pyroscope/pull/2902)).
+* Injected JFR labels into pprof: Enriched profiling data for better insights ([#2868](https://github.com/grafana/pyroscope/pull/2868)).
+* Streamlined Makefile and `go.mod`: Better build process with updated Makefile and tidied `go.mod` ([#2900](https://github.com/grafana/pyroscope/pull/2900)).
+* Updated agent configuration in Helm: More flexible deployments in Kubernetes environments ([#2879](https://github.com/grafana/pyroscope/pull/2879)).
+* Refactored eBPF installation documentation: Improved clarity and usability in eBPF documentation ([#2849](https://github.com/grafana/pyroscope/pull/2849)).
+* Upgraded connect-go, protobuf, and buf: Improved system interoperability ([#2909](https://github.com/grafana/pyroscope/pull/2909)).
+* Enhanced compaction shutdown process: Improved system stability during shutdowns ([#2903](https://github.com/grafana/pyroscope/pull/2903)).
+* Implemented profilecli compact command: Efficient data management with the new command ([#2869](https://github.com/grafana/pyroscope/pull/2869)).
+
+## Fixes
+
+Version 1.3 includes the following fixes:
+
+* Fixed panic in compaction benchmark: Addressed issues causing system instability ([#2918](https://github.com/grafana/pyroscope/pull/2918)).
+* Resolved block cleanup process issues: Ensured system integrity and stability ([#2916](https://github.com/grafana/pyroscope/pull/2916)).
+* Fixed pprof profile builder panics: Enhanced system stability ([#2917](https://github.com/grafana/pyroscope/pull/2917)).
+* Corrected profile types call handling: Better data management without bucket store ([#2910](https://github.com/grafana/pyroscope/pull/2910)).
+* Removed delta reserved labels from storage: Optimized the storage system ([#2920](https://github.com/grafana/pyroscope/pull/2920)).
+* Increased parquet read buffer size: Improved data processing efficiency ([#2924](https://github.com/grafana/pyroscope/pull/2924)).
+
+
+## Documentation improvements
+
+Version 1.3 includes the following documentation updates:
+
+* Enhanced memory overhead documentation: Deeper insights into system performance ([#2895](https://github.com/grafana/pyroscope/pull/2895)).
+* Updated NodeJS documentation: Fixed Markdown link issues for better clarity ([#2890](https://github.com/grafana/pyroscope/pull/2890)).
+* Expanded java.md documentation: Comprehensive Java profiling guidance ([#2904](https://github.com/grafana/pyroscope/pull/2904)).
+* Removed dependency on Grafana Agent: Streamlined Pyroscope architecture ([#2913](https://github.com/grafana/pyroscope/pull/2913)).
+* Updated various sections: Intro, analyze, sampling, and SDK pages now offer clearer and more detailed information ([#2855](https://github.com/grafana/pyroscope/pull/2855), [#2844](https://github.com/grafana/pyroscope/pull/2844), [#2854](https://github.com/grafana/pyroscope/pull/2854), [#2851](https://github.com/grafana/pyroscope/pull/2851), [#2861](https://github.com/grafana/pyroscope/pull/2861)).
+* Launched a 1-minute YouTube short on eBPF: Providing a quick and informative overview of eBPF ([#2893](https://github.com/grafana/pyroscope/pull/2893)).


### PR DESCRIPTION
Cherrypick https://github.com/grafana/pyroscope/pull/2949 release notes from main to the v1.3 branch. 