### PR TITLE
feat: async profile row iterator

### DIFF
--- a/pkg/iter/batch_async.go
+++ b/pkg/iter/batch_async.go
@@ -81,6 +81,9 @@ func (x *AsyncBatchIterator[T, N]) loadBatch() bool {
 	var b batch[N]
 	select {
 	case b = <-x.c:
+		if b.done != nil {
+			defer close(b.done)
+		}
 	case <-x.done:
 	}
 	if len(b.buffered) == 0 {
@@ -91,7 +94,6 @@ func (x *AsyncBatchIterator[T, N]) loadBatch() bool {
 	// immediately start filling the buffer.
 	x.buffered, x.batch = x.batch, b.buffered
 	x.idx = -1
-	close(b.done)
 	return true
 }
 

--- a/pkg/phlaredb/block_querier.go
+++ b/pkg/phlaredb/block_querier.go
@@ -1668,7 +1668,7 @@ func (b *singleBlockQuerier) SelectMergeByLabels(ctx context.Context, params *in
 	buf := make([][]parquet.Value, 2)
 
 	rows := iter.NewAsyncBatchIterator[*query.IteratorResult, Profile](
-		it, 256,
+		it, 1<<10,
 		func(r *query.IteratorResult) Profile {
 			buf = r.Columns(buf, "SeriesIndex", "TimeNanos")
 			seriesIndex := buf[0][0].Int64()


### PR DESCRIPTION
The PR addresses one of the issues with data streaming in the block read path: when we select profile rows for filtering (by profile series ID and the query time range) we synchronously collect the list of filtered profiles, blocking the data flow. This behaviour has been changed so that filtered profiles are passed down to the stream in batches, asynchronously.

It's not expected that the overall query performance will improve in all cases. Usually the delay caused by the described blocking is very small and does not have impact on the overall query latency and/or resource consumption. However, it may be helpful with huge datasets of high cardinality.