### PR TITLE
fix: Use correct field in `mappingsKey`

### DIFF
--- a/pkg/phlaredb/symdb/dedup_slice.go
+++ b/pkg/phlaredb/symdb/dedup_slice.go
@@ -501,7 +501,7 @@ func (*mappingsHelper) key(m *schemav1.InMemoryMapping) mappingsKey {
 		BuildId:         m.BuildId,
 		HasFunctions:    m.HasFunctions,
 		HasFilenames:    m.HasFilenames,
-		HasLineNumbers:  m.HasFunctions,
+		HasLineNumbers:  m.HasLineNumbers,
 		HasInlineFrames: m.HasInlineFrames,
 	}
 }


### PR DESCRIPTION
Previously `HasLineNumber` in `mappingsKey` used the value of `HasFunctions`. This appears to not have caused correctness problems, but this PR fixes it anyways to avoid subtle bugs in the future.