### PR TITLE
fix: Double scraping with servicemonitor due to headless service

### DIFF
--- a/operations/pyroscope/helm/pyroscope/templates/servicemonitor.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/servicemonitor.yaml
@@ -31,6 +31,10 @@ spec:
       app.kubernetes.io/component: {{ $component | quote }}
     {{- with $serviceMonitor.matchExpressions }}
     matchExpressions:
+      - key: prometheus.io/service-monitor
+        operator: NotIn
+        values:
+          - "false"
       {{- toYaml . | nindent 6 }}
     {{- end }}
   endpoints:

--- a/operations/pyroscope/helm/pyroscope/templates/servicemonitor.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/servicemonitor.yaml
@@ -29,12 +29,12 @@ spec:
     matchLabels:
       {{- include "pyroscope.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: {{ $component | quote }}
-    {{- with $serviceMonitor.matchExpressions }}
     matchExpressions:
       - key: prometheus.io/service-monitor
         operator: NotIn
         values:
           - "false"
+    {{- with $serviceMonitor.matchExpressions }}
       {{- toYaml . | nindent 6 }}
     {{- end }}
   endpoints:

--- a/operations/pyroscope/helm/pyroscope/templates/services.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/services.yaml
@@ -34,6 +34,9 @@ metadata:
   labels:
     {{- include "pyroscope.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ $component | quote }}
+    {{- if .Values.serviceMonitor.enabled }}
+    prometheus.io/service-monitor: "false"
+    {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None


### PR DESCRIPTION
Add label to headless service fix double scraping of metrics with service monitor