### PR TITLE
fix: disable Go names decoration

### DIFF
--- a/pkg/frontend/frontend_select_merge_span_profile.go
+++ b/pkg/frontend/frontend_select_merge_span_profile.go
@@ -83,7 +83,6 @@ func (f *Frontend) SelectMergeSpanProfile(ctx context.Context,
 	}
 
 	t := m.Tree()
-	t.FormatNodeNames(phlaremodel.DropGoTypeParameters)
 	return connect.NewResponse(&querierv1.SelectMergeSpanProfileResponse{
 		Flamegraph: phlaremodel.NewFlameGraph(t, c.Msg.GetMaxNodes()),
 	}), nil

--- a/pkg/frontend/frontend_select_merge_stacktraces.go
+++ b/pkg/frontend/frontend_select_merge_stacktraces.go
@@ -82,7 +82,6 @@ func (f *Frontend) SelectMergeStacktraces(ctx context.Context,
 	}
 
 	t := m.Tree()
-	t.FormatNodeNames(phlaremodel.DropGoTypeParameters)
 	return connect.NewResponse(&querierv1.SelectMergeStacktracesResponse{
 		Flamegraph: phlaremodel.NewFlameGraph(t, c.Msg.GetMaxNodes()),
 	}), nil


### PR DESCRIPTION
Starting from Go 1.21.0, type parameters are part of the function name in pprof, which often makes them unreadable

![image](https://github.com/grafana/pyroscope/assets/12090599/782c4eeb-2c1e-4d55-a963-af4a086a3d1f)

The change reverts https://github.com/grafana/pyroscope/pull/2343 (replaces Go type parameters with ellipses `[...]`) as it makes it impossible to find the selected node in the source profile in backend (needed for #2228, and #2727 and https://github.com/grafana/pyroscope-app-plugin/issues/207).

The presentation aspects are to be managed on the frontend. Ideally, there should be an option for user to disable all the decorations. Note that a function name change usually causes changes in the tree/flamegraph structure, which we used to [fix](https://github.com/grafana/pyroscope/blob/main/pkg/model/tree.go#L161). I believe we don't have to do this.