### PR TITLE
Fix missing icon assets

### DIFF
--- a/public/app/app.tsx
+++ b/public/app/app.tsx
@@ -23,6 +23,17 @@ const root = ReactDOM.createRoot(container);
 
 setupReduxQuerySync();
 
+declare global {
+  interface Window {
+    __grafana_public_path__: string;
+  }
+}
+
+if (typeof window !== 'undefined') {
+  // Set the root path for icons to load them from Grafana's CDN instead of bundling locally
+  window.__grafana_public_path__ = 'https://grafana-assets.grafana.net/grafana/10.3.0/public/';
+}
+
 function App() {
   useSelectFirstApp();
 

--- a/public/app/app.tsx
+++ b/public/app/app.tsx
@@ -30,7 +30,7 @@ declare global {
 }
 
 if (typeof window !== 'undefined') {
-  // Set the root path for icons to load them from Grafana's CDN instead of bundling locally
+  // Icons from @grafana/ui are not bundled, this forces them to be loaded via a CDN instead.
   window.__grafana_public_path__ = 'https://grafana-assets.grafana.net/grafana/10.3.0/public/';
 }
 

--- a/public/app/app.tsx
+++ b/public/app/app.tsx
@@ -31,7 +31,7 @@ declare global {
 
 if (typeof window !== 'undefined') {
   // Icons from @grafana/ui are not bundled, this forces them to be loaded via a CDN instead.
-  window.__grafana_public_path__ = 'https://grafana-assets.grafana.net/grafana/10.3.0/public/';
+  window.__grafana_public_path__ = 'https://grafana-assets.grafana.net/grafana/public/';
 }
 
 function App() {

--- a/public/app/app.tsx
+++ b/public/app/app.tsx
@@ -31,7 +31,7 @@ declare global {
 
 if (typeof window !== 'undefined') {
   // Icons from @grafana/ui are not bundled, this forces them to be loaded via a CDN instead.
-  window.__grafana_public_path__ = 'https://grafana-assets.grafana.net/grafana/public/';
+  window.__grafana_public_path__ = 'assets/grafana/';
 }
 
 function App() {

--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -3,7 +3,6 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
-
 module.exports = {
   target: 'web',
   entry: {

--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -1,17 +1,8 @@
-const HtmlWebpackPlugin = require('html-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+
 const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-//const { dependencies: pyroOSSDeps } = require('../../og/package.json');
-const webpack = require('webpack');
-const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
-// this is so that we don't import dependencies twice, once from pyroscope-oss and another from here
-// const deps = Object.entries(pyroOSSDeps).reduce((prev, [name]) => {
-//   return {
-//     ...prev,
-//     [name]: path.resolve(__dirname, `../../node_modules/${name}`),
-//   };
-// }, {});
 
 module.exports = {
   target: 'web',
@@ -57,6 +48,14 @@ module.exports = {
   plugins: [
     new MiniCssExtractPlugin({
       filename: '[name].[contenthash].css',
+    }),
+    new CopyWebpackPlugin({
+      patterns: [
+        {
+          from: 'node_modules/@grafana/ui/dist/public/img/icons',
+          to: 'grafana/img/icons/',
+        },
+      ],
     }),
   ],
   module: {

--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -16,8 +16,8 @@ module.exports = merge(common, {
       '/assets/grafana/*': {
         target: 'http://localhost:4041',
         pathRewrite: { '^/assets': '' },
-        logLevel: 'debug'
-      }
+        logLevel: 'debug',
+      },
     },
   },
   optimization: {

--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -13,6 +13,11 @@ module.exports = merge(common, {
     proxy: {
       '/pyroscope': 'http://localhost:4040',
       '/querier.v1.QuerierService': 'http://localhost:4040',
+      '/assets/grafana/*': {
+        target: 'http://localhost:4041',
+        pathRewrite: { '^/assets': '' },
+        logLevel: 'debug'
+      }
     },
   },
   optimization: {


### PR DESCRIPTION
Fixes #2978

This was made possible with https://github.com/grafana/grafana/pull/76191. Alternatively we could just point to the Grafana CDN, but icons take longer to load and we it adds a runtime dependency. 