### PR TITLE
Fix invalid php-fpm host

### DIFF
--- a/examples/php/php-fpm/docker-compose.yml
+++ b/examples/php/php-fpm/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     build:
       context: .
       dockerfile: client-cgi/Dockerfile
-    command: cgi-fcgi -bind -connect pyroscope_php-fpm:9000
+    command: cgi-fcgi -bind -connect php:9000
     depends_on:
       - php
     environment:


### PR DESCRIPTION
According to docker-compose file host for php-fpm should be `php` instead of `pyroscope_php-fpm`.