### PR TITLE
Fix downsampler debug log message

### DIFF
--- a/pkg/phlaredb/downsample/downsample.go
+++ b/pkg/phlaredb/downsample/downsample.go
@@ -161,8 +161,8 @@ func NewDownsampler(path string, logger log.Logger) (*Downsampler, error) {
 func (d *Downsampler) flush(s *state, w *profilesWriter, c downsampleConfig) error {
 	level.Debug(d.logger).Log(
 		"msg", "flushing downsampled profile",
-		"interval", c.interval,
-		"aggregation", c.aggregation,
+		"interval", c.interval.shortName,
+		"aggregation", c.aggregation.name,
 		"sourceProfileCount", s.profileCount,
 		"sampleCount", len(s.values))
 	outputSamplesHistogram.WithLabelValues(c.interval.shortName).Observe(float64(len(s.values)))


### PR DESCRIPTION
Addresses "unsupported value type" in 

`ts=2024-02-09T13:13:02.072918921Z caller=downsample.go:162 level=debug component=compactor component=compactor msg="flushing downsampled profile" interval="unsupported value type" aggregation="unsupported value type" sourceProfileCount=20 sampleCount=250`