### PR TITLE
fix: Fix makefile `help` rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ HELM_ARGS =
 
 .PHONY: help
 help: ## Describe useful make targets
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "%-30s %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_/-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ": .*?## "}; {printf "%-50s %s\n", $$1, $$2}'
 
 .PHONY: all
 all: lint test build ## Build, test, and lint (default)


### PR DESCRIPTION
Previously, running `make help` would display:

```
Makefile                       Build, test, and lint (default)
Makefile                       Do a dev build (without requiring the frontend)
Makefile                       Do a production build (requiring the frontend build to be present)
Makefile                       Delete intermediate build artifacts
Makefile                       Automatically fix some lint errors
Makefile                       Regenerate protobuf
Makefile                       Describe useful make targets
Makefile                       Lint Go, Helm and protobuf
Makefile                       Generates the reference help documentation.
Makefile                       Create a release
Makefile                       Run the pyroscope binary (pass parameters with 'make run PARAMS=-myparam')
Makefile                       Run unit tests

```

This is caused by a second makefile `Makefile.examples` adding another file to grep in `MAKEFILE_LIST`. Now running `make help` will display:

```
Makefile:all                                       Build, test, and lint (default)
Makefile:build-dev                                 Do a dev build (without requiring the frontend)
Makefile:build                                     Do a production build (requiring the frontend build to be present)
Makefile:clean                                     Delete intermediate build artifacts
Makefile:fmt                                       Automatically fix some lint errors
Makefile:frontend/build                            Do a production build for the frontend
Makefile:generate                                  Regenerate protobuf
Makefile:help                                      Describe useful make targets
Makefile:lint                                      Lint Go, Helm and protobuf
Makefile:reference-help                            Generates the reference help documentation.
Makefile:release/build/all                         Build all release binaries
Makefile:release/build                             Build current platform release binaries
Makefile:release/prepare                           Prepare a release
Makefile:release/prereq                            Ensure release pre requesites are met
Makefile:release                                   Create a release
Makefile:run                                       Run the pyroscope binary (pass parameters with 'make run PARAMS=-myparam')
Makefile:test                                      Run unit tests
```

And if help text is added to rules in `Makefile.examples`, it would look like this:

```
Makefile.examples:tools/update_examples            Updates example projects
Makefile:all                                       Build, test, and lint (default)
Makefile:build-dev                                 Do a dev build (without requiring the frontend)
Makefile:build                                     Do a production build (requiring the frontend build to be present)
Makefile:clean                                     Delete intermediate build artifacts
Makefile:fmt                                       Automatically fix some lint errors
Makefile:frontend/build                            Do a production build for the frontend
Makefile:generate                                  Regenerate protobuf
Makefile:help                                      Describe useful make targets
Makefile:lint                                      Lint Go, Helm and protobuf
Makefile:reference-help                            Generates the reference help documentation.
Makefile:release/build/all                         Build all release binaries
Makefile:release/build                             Build current platform release binaries
Makefile:release/prepare                           Prepare a release
Makefile:release/prereq                            Ensure release pre requesites are met
Makefile:release                                   Create a release
Makefile:run                                       Run the pyroscope binary (pass parameters with 'make run PARAMS=-myparam')
Makefile:test                                      Run unit tests

```