### PR TITLE
fix: wait for ongoing queries to finish at close

### DIFF
--- a/pkg/phlaredb/sample_merge.go
+++ b/pkg/phlaredb/sample_merge.go
@@ -24,6 +24,13 @@ func (b *singleBlockQuerier) MergeByStacktraces(ctx context.Context, rows iter.I
 	sp, ctx := opentracing.StartSpanFromContext(ctx, "MergeByStacktraces - Block")
 	defer sp.Finish()
 	sp.SetTag("block ULID", b.meta.ULID.String())
+
+	if err := b.Open(ctx); err != nil {
+		return nil, err
+	}
+	b.queries.Add(1)
+	defer b.queries.Done()
+
 	ctx = query.AddMetricsToContext(ctx, b.metrics.query)
 	r := symdb.NewResolver(ctx, b.symbols)
 	defer r.Release()
@@ -37,6 +44,13 @@ func (b *singleBlockQuerier) MergePprof(ctx context.Context, rows iter.Iterator[
 	sp, ctx := opentracing.StartSpanFromContext(ctx, "MergePprof - Block")
 	defer sp.Finish()
 	sp.SetTag("block ULID", b.meta.ULID.String())
+
+	if err := b.Open(ctx); err != nil {
+		return nil, err
+	}
+	b.queries.Add(1)
+	defer b.queries.Done()
+
 	ctx = query.AddMetricsToContext(ctx, b.metrics.query)
 	r := symdb.NewResolver(ctx, b.symbols,
 		symdb.WithResolverMaxNodes(maxNodes),
@@ -52,6 +66,13 @@ func (b *singleBlockQuerier) MergeByLabels(ctx context.Context, rows iter.Iterat
 	sp, ctx := opentracing.StartSpanFromContext(ctx, "MergeByLabels - Block")
 	defer sp.Finish()
 	sp.SetTag("block ULID", b.meta.ULID.String())
+
+	if err := b.Open(ctx); err != nil {
+		return nil, err
+	}
+	b.queries.Add(1)
+	defer b.queries.Done()
+
 	ctx = query.AddMetricsToContext(ctx, b.metrics.query)
 	if len(sts.GetCallSite()) == 0 {
 		columnName := "TotalValue"
@@ -70,6 +91,13 @@ func (b *singleBlockQuerier) MergeBySpans(ctx context.Context, rows iter.Iterato
 	sp, _ := opentracing.StartSpanFromContext(ctx, "MergeBySpans - Block")
 	defer sp.Finish()
 	sp.SetTag("block ULID", b.meta.ULID.String())
+
+	if err := b.Open(ctx); err != nil {
+		return nil, err
+	}
+	b.queries.Add(1)
+	defer b.queries.Done()
+
 	ctx = query.AddMetricsToContext(ctx, b.metrics.query)
 	r := symdb.NewResolver(ctx, b.symbols)
 	defer r.Release()


### PR DESCRIPTION
This change forces block querier to wait until all outgoing queries to finish at `Close` call. Resolves https://github.com/grafana/pyroscope/issues/2845

The solution does not completely address the issue of block ownership. Since our queries involve stateful processes (block iteration + series iteration + deduplication + merge), and our replicas (ingesters and store gateways) lack awareness of the query context, there is a possibility that a block may be closed while the query is still running. This occurs because replicas may not retain any references to the block in-between query stages.

For instance, if a block is evicted immediately after the list of replica blocks has been returned to the querier, attempting to retrieve profiling data from the block will result in an empty response. This is to be solved in a separate PR. I plan to introduce a graceful period for block eviction. Instead of immediate eviction, the plan is to mark the block and initiate eviction only after a reasonable grace period, such as 5 minutes, has expired.