### PR TITLE
Fixes merge of empty samples in pprof

### DIFF
--- a/pkg/pprof/merge.go
+++ b/pkg/pprof/merge.go
@@ -37,8 +37,10 @@ func (m *ProfileMerge) merge(p *profilev1.Profile, clone bool) error {
 		return nil
 	}
 	ConvertIDsToIndices(p)
+	var initial bool
 	if m.profile == nil {
 		m.init(p, clone)
+		initial = true
 	}
 
 	// We rewrite strings first in order to compare
@@ -46,7 +48,7 @@ func (m *ProfileMerge) merge(p *profilev1.Profile, clone bool) error {
 	m.tmp = slices.GrowLen(m.tmp, len(p.StringTable))
 	m.stringTable.Index(m.tmp, p.StringTable)
 	RewriteStrings(p, m.tmp)
-	if len(m.profile.StringTable) == 0 {
+	if initial {
 		// Right after initialisation we need to make
 		// sure that the string identifiers are normalized
 		// among profiles.

--- a/pkg/pprof/merge_test.go
+++ b/pkg/pprof/merge_test.go
@@ -368,3 +368,60 @@ func Test_Merge_Sample(t *testing.T) {
 
 	testhelper.EqualProto(t, expected, m.Profile())
 }
+
+func TestMergeEmpty(t *testing.T) {
+	var m ProfileMerge
+
+	err := m.Merge(&profilev1.Profile{
+		SampleType: []*profilev1.ValueType{
+			{
+				Type: 2,
+				Unit: 1,
+			},
+		},
+		PeriodType: &profilev1.ValueType{
+			Type: 2,
+			Unit: 1,
+		},
+		StringTable: []string{"", "nanoseconds", "cpu"},
+	})
+	require.NoError(t, err)
+	err = m.Merge(&profilev1.Profile{
+		Sample: []*profilev1.Sample{
+			{
+				LocationId: []uint64{1},
+				Value:      []int64{1},
+			},
+		},
+		Location: []*profilev1.Location{
+			{
+				Id:        1,
+				MappingId: 1,
+				Line:      []*profilev1.Line{{FunctionId: 1, Line: 1}},
+			},
+		},
+		Function: []*profilev1.Function{
+			{
+				Id:   1,
+				Name: 1,
+			},
+		},
+		SampleType: []*profilev1.ValueType{
+			{
+				Type: 3,
+				Unit: 2,
+			},
+		},
+		PeriodType: &profilev1.ValueType{
+			Type: 3,
+			Unit: 2,
+		},
+		Mapping: []*profilev1.Mapping{
+			{
+				Id: 1,
+			},
+		},
+		StringTable: []string{"", "bar", "nanoseconds", "cpu"},
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Introduced in https://github.com/grafana/pyroscope/pull/3010/files#diff-1716fbe09b95462c58b96e3abdc3b60585159cad6f026e731598ca62859ea5e5R49

When we insert an empty profile we still would consider the next one as new and rewrite string from the original twice.

This has caused the pprof API to fail recently.

cc @bryanhuhta @grafakus 

Sneaky one !