### PR TITLE
fix: disable vt proto pools

### DIFF
--- a/api/gen/proto/go/querier/v1/querier_vtproto.pb.go
+++ b/api/gen/proto/go/querier/v1/querier_vtproto.pb.go
@@ -1073,7 +1073,7 @@ func (c *querierServiceClient) SelectMergeSpanProfile(ctx context.Context, in *S
 }
 
 func (c *querierServiceClient) SelectMergeProfile(ctx context.Context, in *SelectMergeProfileRequest, opts ...grpc.CallOption) (*v11.Profile, error) {
-	out := v11.ProfileFromVTPool()
+	out := new(v11.Profile)
 	err := c.cc.Invoke(ctx, "/querier.v1.QuerierService/SelectMergeProfile", in, out, opts...)
 	if err != nil {
 		return nil, err

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -649,7 +649,7 @@ func Test_SampleLabels(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.description, func(t *testing.T) {
-			series, _ := extractSampleSeries(tc.pushReq)
+			series := extractSampleSeries(tc.pushReq)
 			require.Len(t, series, len(tc.series))
 			for i, actualSeries := range series {
 				expectedSeries := tc.series[i]

--- a/pkg/ingester/pyroscope/ingest_adapter.go
+++ b/pkg/ingester/pyroscope/ingest_adapter.go
@@ -165,22 +165,6 @@ func (p *pyroscopeIngesterAdapter) Evaluate(input *storage.PutInput) (storage.Sa
 
 func (p *pyroscopeIngesterAdapter) parseToPprof(ctx context.Context, in *ingestion.IngestInput, pprofable ingestion.ParseableToPprof) error {
 	plainReq, err := pprofable.ParseToPprof(ctx, in.Metadata)
-	// ParseToPprof allocates pprof.Profile that have to be closed after use.
-	defer func() {
-		if plainReq == nil {
-			return
-		}
-		for _, s := range plainReq.Series {
-			if s == nil {
-				continue
-			}
-			for _, x := range s.Samples {
-				if x != nil && x.Profile != nil {
-					x.Profile.Close()
-				}
-			}
-		}
-	}()
 	if err != nil {
 		return fmt.Errorf("parsing IngestInput-pprof failed %w", err)
 	}

--- a/pkg/ingester/pyroscope/ingest_handler_test.go
+++ b/pkg/ingester/pyroscope/ingest_handler_test.go
@@ -374,7 +374,6 @@ func TestIngestPPROFFixtures(t *testing.T) {
 func comparePPROF(t *testing.T, actual *profilev1.Profile, profile2 []byte) {
 	expected, err := pprof.RawFromBytes(profile2)
 	require.NoError(t, err)
-	defer expected.Close()
 
 	require.Equal(t, len(expected.SampleType), len(actual.SampleType))
 	for i := range actual.SampleType {

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -79,32 +79,20 @@ func (r *gzipReader) openBytes(input []byte) (io.Reader, error) {
 }
 
 func NewProfile() *Profile {
-	return RawFromProto(profilev1.ProfileFromVTPool())
+	return RawFromProto(new(profilev1.Profile))
 }
 
 func RawFromProto(pbp *profilev1.Profile) *Profile {
-	buf := bufPool.Get().(*bytes.Buffer)
-	return &Profile{Profile: pbp, buf: buf}
+	return &Profile{Profile: pbp}
 }
 
-// Read RawProfile from bytes
 func RawFromBytes(input []byte) (_ *Profile, err error) {
 	gzipReader := gzipReaderPool.Get().(*gzipReader)
-	// We borrow all the necessary objects from respective pools in advance.
-	// If an error happens before the function returns, we ensure that these
-	// are returned to their pools. Otherwise, the ownership is transferred to
-	// the caller: Profile.Close must be called to dispose the resources
-	// allocated.
 	buf := bufPool.Get().(*bytes.Buffer)
-	pbp := profilev1.ProfileFromVTPool()
 	defer func() {
-		// Note that gzip reader should be returned unconditionally.
 		gzipReaderPool.Put(gzipReader)
-		if err != nil {
-			buf.Reset()
-			bufPool.Put(buf)
-			pbp.ReturnToVTPool()
-		}
+		buf.Reset()
+		bufPool.Put(buf)
 	}()
 
 	r, err := gzipReader.openBytes(input)
@@ -116,29 +104,28 @@ func RawFromBytes(input []byte) (_ *Profile, err error) {
 		return nil, errors.Wrap(err, "copy to buffer")
 	}
 
+	rawSize := buf.Len()
+	pbp := new(profilev1.Profile)
 	if err = pbp.UnmarshalVT(buf.Bytes()); err != nil {
 		return nil, err
 	}
 
-	return &Profile{Profile: pbp, buf: buf}, nil
+	return &Profile{
+		Profile: pbp,
+		rawSize: rawSize,
+	}, nil
 }
 
-// Read Profile from Bytes
 func FromBytes(input []byte, fn func(*profilev1.Profile, int) error) error {
 	p, err := RawFromBytes(input)
 	if err != nil {
 		return err
 	}
-	uncompressedSize := p.buf.Len()
-	p.buf.Reset()
-	bufPool.Put(p.buf)
-	err = fn(p.Profile, uncompressedSize)
-	p.ReturnToVTPool()
-	return err
+	return fn(p.Profile, p.rawSize)
 }
 
 func FromProfile(p *profile.Profile) (*profilev1.Profile, error) {
-	r := profilev1.ProfileFromVTPool()
+	var r profilev1.Profile
 	strings := make(map[string]int)
 
 	r.Sample = make([]*profilev1.Sample, 0, len(p.Sample))
@@ -276,7 +263,7 @@ func FromProfile(p *profile.Profile) (*profilev1.Profile, error) {
 	for s, i := range strings {
 		r.StringTable[i] = s
 	}
-	return r, nil
+	return &r, nil
 }
 
 func addString(strings map[string]int, s string) int64 {
@@ -299,28 +286,19 @@ func OpenFile(path string) (*Profile, error) {
 
 type Profile struct {
 	*profilev1.Profile
-	// raw []byte
-	buf *bytes.Buffer
-
-	hasher SampleHasher
-}
-
-func (p *Profile) Close() {
-	p.Profile.ReturnToVTPool()
-	p.buf.Reset()
-	bufPool.Put(p.buf)
-}
-
-func (p *Profile) SizeBytes() int {
-	return p.buf.Len()
+	hasher  SampleHasher
+	rawSize int
 }
 
 // WriteTo writes the profile to the given writer.
 func (p *Profile) WriteTo(w io.Writer) (int64, error) {
-	// reuse the data buffer if possible
-	p.buf.Reset()
-	p.buf.Grow(p.SizeVT())
-	data := p.buf.Bytes()
+	buf := bufPool.Get().(*bytes.Buffer)
+	defer func() {
+		buf.Reset()
+		bufPool.Put(buf)
+	}()
+	buf.Grow(p.SizeVT())
+	data := buf.Bytes()
 	n, err := p.MarshalToVT(data)
 	if err != nil {
 		return 0, err
@@ -342,10 +320,6 @@ func (p *Profile) WriteTo(w io.Writer) (int64, error) {
 	if err := gzipWriter.Close(); err != nil {
 		return 0, errors.Wrap(err, "gzip close")
 	}
-
-	// reset buffer
-	p.buf.Reset()
-
 	return int64(written), nil
 }
 

--- a/pkg/pprof/testhelper/profile_builder.go
+++ b/pkg/pprof/testhelper/profile_builder.go
@@ -41,7 +41,7 @@ func NewProfileBuilder(ts int64) *ProfileBuilder {
 
 // NewProfileBuilderWithLabels creates a new ProfileBuilder with the given nanoseconds timestamp and labels.
 func NewProfileBuilderWithLabels(ts int64, labels []*typesv1.LabelPair) *ProfileBuilder {
-	profile := profilev1.ProfileFromVTPool()
+	profile := new(profilev1.Profile)
 	profile.TimeNanos = ts
 	profile.Mapping = append(profile.Mapping, &profilev1.Mapping{
 		Id: 1, HasFunctions: true,


### PR DESCRIPTION
Should fix #3024 

I tested distributors without VT protobuf pools and I think that it's probably better to disable them altogether:
 - We do not benefit from reduced allocs as it's compensated by the cost of sync pools and resets.
 - Memory consumption is 10-15% lower without pools.
 - Code is simpler. I suspect that #3024 is caused by wrong handling of pooled items. By removing the pools we eliminate this factor. 

<img width="1406" alt="image" src="https://github.com/grafana/pyroscope/assets/12090599/c85df0f7-46a1-44ac-a7b3-a0e2be4e0ae8">

The impact on GC is understood and expected:

<img width="1315" alt="image" src="https://github.com/grafana/pyroscope/assets/12090599/08837d3f-7324-4bec-9200-b7002158cfb7">
