### PR TITLE
ebpf: Public PID and EXE labels for debugging

### DIFF
--- a/ebpf/cmd/playground/main.go
+++ b/ebpf/cmd/playground/main.go
@@ -335,6 +335,8 @@ func getProcessTargets() []sd.DiscoveryTarget {
 			"__meta_process_exe":    exe,
 			"__meta_process_comm":   string(comm),
 			"__meta_process_cgroup": string(cgroup),
+			"pid":                   spid,
+			"exe":                   exe,
 		}
 		res = append(res, target)
 	}


### PR DESCRIPTION
Find this quite useful, when debugging things.