### PR TITLE
[release/v1.4] docs: Add additional span profiles docs

### DIFF
--- a/docs/sources/configure-client/trace-span-profiles/_index.md
+++ b/docs/sources/configure-client/trace-span-profiles/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Linking tracing and profiling with span profiles"
+menuTitle: "Linking traces and profiles"
+description: "Learn how to configure the client to Link tracing and profiling with span profiles."
+weight: 35
+---
+
+# Linking tracing and profiling with span profiles
+
+Span Profiles are a powerful feature that further enhances the value of continuous profiling. Span Profiles offer a novel approach to profiling by providing detailed insights into specific execution scopes of applications, moving beyond the traditional system-wide analysis to offer a more dynamic, focused analysis of individual requests or trace spans. 
+
+This method enhances understanding of application behavior by directly linking traces with profiling data, enabling engineering teams to pinpoint and resolve performance bottlenecks with precision.
+
+Key benefits and features:
+
+- Deep analysis: Understand the specifics of code execution within particular time frames, offering granular insights into application performance
+- Seamless integration: Smoothly transition from a high-level trace overview to detailed profiling of specific trace spans within Grafana’s trace view
+- Efficiency and cost savings: Quickly identify and address performance issues, reducing troubleshooting time and operational costs
+
+Get started:
+
+- Configure Pyroscope: Begin sending profiling data to unlock the full potential of Span Profiles
+- Client-Side Packages: Easily link traces and profiles using available packages for Go, Ruby, and Java
+  - Go: [Span profiles with Traces to profiles (Go)]({{< relref "./go-span-profiles" >}})
+  - Java: [Span profiles with Traces to profiles (Java)]({{< relref "./java-span-profiles" >}})
+  - Ruby: [Span profiles with Traces to profiles (Ruby)]({{< relref "./ruby-span-profiles" >}})
+- Grafana Tempo: Visualize and analyze Span Profiles within the Grafana Tempo UI
+
+To learn more check out our product announcement blog introducing the [span profiles feature](/blog/2024/02/06/combining-tracing-and-profiling-for-enhanced-observability-introducing-span-profiles/)

--- a/docs/sources/configure-client/trace-span-profiles/go-span-profiles.md
+++ b/docs/sources/configure-client/trace-span-profiles/go-span-profiles.md
@@ -2,6 +2,9 @@
 title: Span profiles with Traces to profiles for Go
 menuTitle: Span profiles with Traces to profiles (Go)
 description: Learn about and configure Span profiles with Traces to profiles in Grafana for the Go language.
+aliases:
+  - /docs/pyroscope/next/configure-client/go-span-profiles/
+  - /docs/pyroscope/latest/configure-client/go-span-profiles/
 weight: 100
 ---
 
@@ -19,15 +22,15 @@ To learn more about Span Profiles, refer to [Combining tracing and profiling for
 
 To use Span Profiles, you need to:
 
-* [Configure Pyroscope to send profiling data]({{< relref "../configure-client" >}})
-* Configure a client-side package to link traces and profiles: [Go](https://github.com/grafana/otel-profiling-go), [Ruby](https://github.com/grafana/otel-profiling-ruby), and [Java](https://github.com/grafana/otel-profiling-java)
+* [Configure Pyroscope to send profiling data]({{< relref "../../configure-client" >}})
+* Configure a client-side package to link traces and profiles: [Go](https://github.com/grafana/otel-profiling-go)
 * [Configure Tempo data source in Grafana or Grafana Cloud to discover linked traces and profiles](/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/)
 
 ## Before you begin
 
 Your applications must be instrumented for profiling and tracing before you can use span profiles.
 
-* Profiling: Your application must be instrumented with Pyroscopes Go SDK. If you haven't done this yet, please refer to the [Go (push mode)]({{< relref "../configure-client/language-sdks/go_push" >}}) guide.
+* Profiling: Your application must be instrumented with Pyroscopes Go SDK. If you haven't done this yet, please refer to the [Go (push mode)]({{< relref "../language-sdks/go_push" >}}) guide.
 * Tracing: Your application must be instrumented with OpenTelemetry traces. If you haven't done this yet, please refer to the [OpenTelemetry](https://opentelemetry.io/docs/go/getting-started/) guide.
 
 ### OpenTelemetry support
@@ -91,12 +94,12 @@ defer span.End()
 To view the span profiles in Grafana Tempo, you need to have a Grafana instance with a Tempo data source configured to link trace spans and profiles.
 Refer to the configuration documentation for [Grafana](/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source) or [Grafana Cloud](/docs/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source).
 
-To learn how to set up Traces to profiles and view the span profiles, refer to [Traces to profiles]({{< relref "../view-and-analyze-profile-data/profile-tracing/traces-to-profiles" >}}).
+To learn how to set up Traces to profiles and view the span profiles, refer to [Traces to profiles]({{< relref "../../view-and-analyze-profile-data/profile-tracing/traces-to-profiles" >}}).
 
 
 ## Examples
 
-Check out the [examples](https://github.com/grafana/pyroscope/tree/release/v1.4/examples/tracing/tempo) directory in the Pyroscope GitHub repository to
+Check out the [examples directory](https://github.com/grafana/pyroscope/tree/main/examples/tracing/tempo) in the Pyroscope GitHub repository to
 find a complete example application that demonstrates tracing integration features.
 
 <!-- ## Using tracing exemplars manually

--- a/docs/sources/configure-client/trace-span-profiles/java-span-profiles.md
+++ b/docs/sources/configure-client/trace-span-profiles/java-span-profiles.md
@@ -1,0 +1,100 @@
+---
+title: Span profiles with Traces to profiles for Java
+menuTitle: Span profiles with Traces to profiles (Java)
+description: Learn about and configure Span profiles with Traces to profiles in Grafana for the Java language.
+weight: 100
+---
+
+# Span profiles with Traces to profiles for Java
+
+![span-profiles screenshot](https://grafana.com/static/img/docs/tempo/profiles/tempo-profiles-Span-link-profile-data-source.png)
+
+## Before you begin
+
+Your applications must be instrumented for profiling and tracing before you can use span profiles. 
+
+* Profiling: Your application must be instrumented with Pyroscopes Java client SDK. If you haven't done this yet, please refer to the [Java ()]({{< relref "../language-sdks/java" >}}) guide.
+* Tracing: Your application must be instrumented with OpenTelemetry traces. If you haven't done this yet, please refer to the [OpenTelemetry](https://opentelemetry.io/docs/java/getting-started/) guide.
+
+## OpenTelemetry support
+
+Pyroscope can integrate with distributed tracing systems supporting [**OpenTelemetry**](https://opentelemetry.io/docs/instrumentation/java/getting-started/) standard which allows you to
+link traces with the profiling data, and find resource usage for specific lines of code for your trace spans
+
+{{< admonition type="note" >}}
+ * Only CPU profiling is supported at the moment.
+ * Because of how sampling profilers work, spans shorter than the sample interval may not be captured. Java CPU profiler probes stack traces 100 times per second, meaning that spans shorter than 10ms may not be captured.
+{{< /admonition >}}
+
+
+## Configure the otel-profiling-java package
+
+To start collecting Span Profiles for your Java application, you need to include [otel-profiling-java](https://github.com/pyroscope-io/otel-profiling-java) in your code. 
+
+This package is a `TracerProvider` implementation, that labels profiling data with span IDs which makes it possible to query for span-specific profiling data in Grafana Tempo UI. 
+
+```shell
+java -jar ./build/libs/rideshare-1.0-SNAPSHOT.jar \
+    -javaagent:./opentelemetry-javaagent.jar \
+    -Dotel.javaagent.extensions=./pyroscope-otel.jar \
+    -Dotel.pyroscope.start.profiling=true \
+    -Dpyroscope.application.name=ride-sharing-app-java-instrumentation  \
+    -Dpyroscope.format=jfr \
+    -Dpyroscope.profiler.event=itimer \
+    -Dpyroscope.server.address=$PYROSCOPE_SERVER_ADDRESS \
+    # rest of your otel-java-instrumentation configuration
+
+```
+
+Next, you need to create and configure the tracer provider:
+```java
+implementation("io.pyroscope:otel:0.10.1.1")
+
+// obtain SdkTracerProviderBuilder
+SdkTracerProviderBuilder tpBuilder = ... 
+
+// Add PyroscopeOtelSpanProcessor to SdkTracerProviderBuilder
+PyroscopeOtelConfiguration pyroscopeTelemetryConfig = new PyroscopeOtelConfiguration.Builder()
+  .setAddSpanName(true)
+  .setRootSpanOnly(true)
+  .build();
+tpBuilder.addSpanProcessor(new PyroscopeOtelSpanProcessor(pyroscopeOtelConfig));
+
+```
+
+Now that we set up the tracer, we can create a new trace from anywhere and the profiler will automatically capture profiles for it.
+```java
+Span span = tracer.spanBuilder("findNearestVehicle").startSpan();
+try (Scope s = span.makeCurrent()){
+    // Your code goes here.
+} finally {
+    span.end();
+}
+
+// Your code goes here.
+```
+
+## View the span profiles in Grafana Tempo
+
+To view the span profiles in Grafana Tempo, you need to have a Grafana instance running and a data source configured to link trace spans and profiles.
+
+Refer to the [data source configuration documentation](/docs/grafana/datasources/tempo/configure-tempo-data-source) to see how to configure the visualization to link trace spans with profiles.
+
+To use a simple configuration, follow these steps:
+
+1. Select a Pyroscope data source from the Data source drop-down.
+
+2. Optional: Choose any tags to use in the query. If left blank, the default values of service.name and service.namespace are used.
+
+The tags you configure must be present in the spans attributes or resources for a trace to profiles span link to appear. You can optionally configure a new name for the tag. This is useful for example if the tag has dots in the name and the target data source doesn’t allow using dots in labels. In that case you can for example remap service.name to service_name.
+
+3. Select one or more profile types to use in the query. Select the drop-down and choose options from the menu.
+
+The profile type or app must be selected for the query to be valid. Grafana doesn’t show any data if the profile type or app isn’t selected when a query runs.
+
+![span-profiles configuration](https://grafana.com/static/img/docs/tempo/profiles/Tempo-data-source-profiles-Settings.png)
+
+## Examples
+
+Check out the [examples](https://github.com/grafana/pyroscope/tree/main/examples/tracing/tempo) directory in our repository to
+find a complete example application that demonstrates tracing integration features.

--- a/docs/sources/configure-client/trace-span-profiles/ruby-span-profiles.md
+++ b/docs/sources/configure-client/trace-span-profiles/ruby-span-profiles.md
@@ -1,0 +1,79 @@
+---
+title: Span profiles with Traces to profiles for Ruby
+menuTitle: Span profiles with Traces to profiles (Ruby)
+description: Learn about and configure Span profiles with Traces to profiles in Grafana for the Ruby language.
+weight: 100
+---
+
+# Span profiles with Traces to profiles for Ruby
+
+![span-profiles screenshot](https://grafana.com/static/img/docs/tempo/profiles/tempo-profiles-Span-link-profile-data-source.png)
+
+## Before you begin
+
+Your applications must be instrumented for profiling and tracing before you can use span profiles. 
+
+* Profiling: Your application must be instrumented with Pyroscopes Ruby SDK. If you haven't done this yet, please refer to the [Ruby (push mode)]({{< relref "../language-sdks/ruby" >}}) guide.
+* Tracing: Your application must be instrumented with OpenTelemetry traces. If you haven't done this yet, please refer to the [OpenTelemetry](https://opentelemetry.io/docs/ruby/getting-started/) guide.
+
+## OpenTelemetry support
+
+Pyroscope can integrate with distributed tracing systems supporting [**OpenTelemetry**](https://opentelemetry.io/docs/instrumentation/ruby/getting-started/) standard which allows you to
+link traces with the profiling data, and find resource usage for specific lines of code for your trace spans
+
+{{< admonition type="note" >}}
+ * Only CPU profiling is supported at the moment.
+ * Because of how sampling profilers work, spans shorter than the sample interval may not be captured. Ruby CPU profiler probes stack traces 100 times per second, meaning that spans shorter than 10ms may not be captured.
+{{< /admonition >}}
+
+
+## Configure the otel-profiling-ruby package
+
+To start collecting Span Profiles for your Ruby application, you need to include [otel-profiling-ruby](https://github.com/pyroscope-io/otel-profiling-ruby) in your code. 
+
+This package is a `TracerProvider` implementation, that labels profiling data with span IDs which makes it possible to query for span-specific profiling data in Grafana Tempo UI. 
+
+```shell
+# Add to your Gemfile
+gem install pyroscope-otel
+```
+
+Next, you need to create and configure the tracer provider:
+```ruby
+Pyroscope.configure do |config|
+  # Configure pyroscope as described https://pyroscope.io/docs/ruby/
+end
+
+OpenTelemetry::SDK.configure do |config|
+  config.add_span_processor Pyroscope::Otel::SpanProcessor.new(
+    "#{app_name}.cpu", # your app name with ".cpu" suffix, for example rideshare-ruby.cpu
+    pyroscope_endpoint # link to your pyroscope server, for example "http://localhost:4040"
+  )
+  # Configure the rest of opentelemetry as described  https://github.com/open-telemetry/opentelemetry-ruby
+end
+```
+
+## View the span profiles in Grafana Tempo
+
+To view the span profiles in Grafana Tempo, you need to have a Grafana instance running and a data source configured to link trace spans and profiles.
+
+Refer to the [data source configuration documentation](/docs/grafana/datasources/tempo/configure-tempo-data-source) to see how to configure the visualization to link trace spans with profiles.
+
+To use a simple configuration, follow these steps:
+
+1. Select a Pyroscope data source from the Data source drop-down.
+
+2. Optional: Choose any tags to use in the query. If left blank, the default values of service.name and service.namespace are used.
+
+The tags you configure must be present in the spans attributes or resources for a trace to profiles span link to appear. You can optionally configure a new name for the tag. This is useful for example if the tag has dots in the name and the target data source doesn’t allow using dots in labels. In that case you can for example remap service.name to service_name.
+
+3. Select one or more profile types to use in the query. Select the drop-down and choose options from the menu.
+
+The profile type or app must be selected for the query to be valid. Grafana doesn’t show any data if the profile type or app isn’t selected when a query runs.
+
+![span-profiles configuration](https://grafana.com/static/img/docs/tempo/profiles/Tempo-data-source-profiles-Settings.png)
+
+## Examples
+
+Check out the [examples](https://github.com/grafana/pyroscope/tree/main/examples/tracing/tempo) directory in our repository to
+find a complete example application that demonstrates tracing integration features.

--- a/docs/sources/view-and-analyze-profile-data/profile-tracing/traces-to-profiles.md
+++ b/docs/sources/view-and-analyze-profile-data/profile-tracing/traces-to-profiles.md
@@ -13,7 +13,7 @@ keywords:
 
 {{< admonition type="note" >}}
 
-Your application must be instrumented for profiles and traces. For more information, refer to [Span profiles for Traces to profiles]({{< relref "../../configure-client/go-span-profiles" >}}).
+Your application must be instrumented for profiles and traces. For more information, refer to [Span profiles for Traces to profiles]({{< relref "../../configure-client/trace-span-profiles" >}}).
 
 {{< /admonition >}}
 


### PR DESCRIPTION
Backport 91df6b0691211416a5e3a274dce906939258af90 from #3063

---

Adds span profiles docs for java and ruby. Also first attempt at nesting them under a folde
