### PR TITLE
fix: query plan optimisation

### DIFF
--- a/pkg/ingester/retention.go
+++ b/pkg/ingester/retention.go
@@ -290,6 +290,9 @@ func (dc *diskCleaner) CleanupBlocksWhenHighDiskUtilization(ctx context.Context)
 
 // isBlockDeletable returns true if this block can be deleted.
 func (dc *diskCleaner) isBlockDeletable(block *tenantBlock) bool {
+	// TODO(kolesnikovae):
+	//  Expiry defaults to -querier.query-store-after which should be deprecated,
+	//  blocks-storage.bucket-store.ignore-blocks-within can be used instead.
 	expiryTs := time.Now().Add(-dc.policy.Expiry)
 	return block.Uploaded && ulid.Time(block.ID.Time()).Before(expiryTs)
 }

--- a/pkg/phlaredb/block_querier.go
+++ b/pkg/phlaredb/block_querier.go
@@ -285,11 +285,6 @@ type BlockInfo struct {
 	Series      uint64
 }
 
-func (b *BlockQuerier) BlockInfo() []BlockInfo {
-	result := make([]BlockInfo, len(b.queriers))
-	return result
-}
-
 type singleBlockQuerier struct {
 	logger  log.Logger
 	metrics *BlocksMetrics

--- a/pkg/querier/replication.go
+++ b/pkg/querier/replication.go
@@ -345,8 +345,8 @@ func (r *replicasPerBlockID) blockPlan(ctx context.Context) map[string]*ingestv1
 	}
 
 	// Depending on whether split sharding is used, the compaction level at
-	// which we the data gets deduplicated differs: if split sharding is
-	// enabled, we deduplicate at level 3, and at level 2 otherwise.
+	// which the data gets deduplicated differs: if split sharding is enabled,
+	// we deduplicate at level 3, and at level 2 otherwise.
 	var deduplicationLevel int32 = 2
 	if sharded {
 		deduplicationLevel = 3


### PR DESCRIPTION
Fixes #3088.

The problem manifests when compactor does not keep up with the ingestion rate, and store-gateways load sharded L2 blocks (with duplicates).

Normally, L3 blocks supersede all the parent blocks in the query plan, and presence of L2 blocks does not pose any issues. However, when an L3 shard is incomplete, all its blocks are removed from the plan before this step, preserving L2 shards in the query plan (partial shards are ignored in the plan). This happens, when L3 compaction delay exceeds `blocks-storage.bucket-store.ignore-blocks-within`. The way query plan is built expects that L2 blocks do not contain duplicate series, which is not true if blocks are shared. As a result, query returns duplicated data.