### PR TITLE
chore: use pyroscope:latest in tracing integration demo

### DIFF
--- a/examples/tracing/tempo/README.md
+++ b/examples/tracing/tempo/README.md
@@ -14,8 +14,7 @@ Pyroscope and Tempo datasources are provisioned automatically.
 The project can be run locally with the following commands:
 
 ```shell
-GOOS=linux GOARCH=amd64 make build -C ../../..
-docker-compose up --build
+docker-compose up
 ```
 
 Navigate to the [Explore page](http://localhost:3000/explore?schemaVersion=1&panes=%7B%22yM9%22:%7B%22datasource%22:%22tempo%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22tempo%22,%22uid%22:%22tempo%22%7D,%22queryType%22:%22traceqlSearch%22,%22limit%22:20,%22tableType%22:%22traces%22,%22filters%22:%5B%7B%22id%22:%22e73a615e%22,%22operator%22:%22%3D%22,%22scope%22:%22span%22%7D,%7B%22id%22:%22service-name%22,%22tag%22:%22service.name%22,%22operator%22:%22%3D%22,%22scope%22:%22resource%22,%22value%22:%5B%22ride-sharing-app%22%5D,%22valueType%22:%22string%22%7D%5D%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1), select a trace and click on one of its spans

--- a/examples/tracing/tempo/docker-compose.yml
+++ b/examples/tracing/tempo/docker-compose.yml
@@ -80,6 +80,7 @@ services:
       - "9411:9411"   # zipkin
 
   pyroscope:
+    image: grafana/pyroscope:latest
     environment:
       JAEGER_AGENT_HOST: tempo
       JAEGER_SAMPLER_TYPE: const
@@ -89,6 +90,3 @@ services:
       - '4040:4040'
     volumes:
       - ./pyroscope/pyroscope.yml:/etc/pyroscope.yml
-    build:
-      context: '../../../'
-      dockerfile: cmd/pyroscope/Dockerfile


### PR DESCRIPTION
The tracing integration feature has been released a long time ago, but in the demo we're still building the pyroscope image locally, which might be challenging for users