### PR TITLE
feat: Add flag to disable printing banner

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -143,6 +143,8 @@ Usage of ./pyroscope:
     	Expands ${var} in config according to the values of the environment variables.
   -config.file string
     	yaml file to load
+  -config.show_banner
+    	Prints the application banner at startup. (default true)
   -consul.acl-token string
     	ACL Token used to interact with Consul.
   -consul.cas-retry-delay duration

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -39,6 +39,8 @@ Usage of ./pyroscope:
     	Expands ${var} in config according to the values of the environment variables.
   -config.file string
     	yaml file to load
+  -config.show_banner
+    	Prints the application banner at startup. (default true)
   -consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")
   -distributor.aggregation-period duration

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -53,7 +53,7 @@ Each variable reference is replaced at startup by the value of the environment v
 The replacement is case-sensitive and occurs before the YAML file is parsed.
 References to undefined variables are replaced by empty strings unless you specify a default value or custom error text.
 
-To specify a default value, use `${VAR:default_value}`,
+To specify a default value, use `${VAR:-default_value}`,
 where `default_value` is the value to use if the environment variable is undefined.
 
 ## Configuration parameters

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -53,7 +53,7 @@ Each variable reference is replaced at startup by the value of the environment v
 The replacement is case-sensitive and occurs before the YAML file is parsed.
 References to undefined variables are replaced by empty strings unless you specify a default value or custom error text.
 
-To specify a default value, use `${VAR:-default_value}`,
+To specify a default value, use `${VAR:default_value}`,
 where `default_value` is the value to use if the environment variable is undefined.
 
 ## Configuration parameters
@@ -264,6 +264,10 @@ analytics:
   # Enable anonymous usage reporting.
   # CLI flag: -usage-stats.enabled
   [reporting_enabled: <boolean> | default = true]
+
+# Prints the application banner at startup.
+# CLI flag: -config.show_banner
+[show_banner: <boolean> | default = true]
 ```
 
 ### server
@@ -616,10 +620,6 @@ lifecycler:
         # values:
         # 
         # Secure Ciphers:
-        # - TLS_RSA_WITH_AES_128_CBC_SHA
-        # - TLS_RSA_WITH_AES_256_CBC_SHA
-        # - TLS_RSA_WITH_AES_128_GCM_SHA256
-        # - TLS_RSA_WITH_AES_256_GCM_SHA384
         # - TLS_AES_128_GCM_SHA256
         # - TLS_AES_256_GCM_SHA384
         # - TLS_CHACHA20_POLY1305_SHA256
@@ -637,7 +637,11 @@ lifecycler:
         # Insecure Ciphers:
         # - TLS_RSA_WITH_RC4_128_SHA
         # - TLS_RSA_WITH_3DES_EDE_CBC_SHA
+        # - TLS_RSA_WITH_AES_128_CBC_SHA
+        # - TLS_RSA_WITH_AES_256_CBC_SHA
         # - TLS_RSA_WITH_AES_128_CBC_SHA256
+        # - TLS_RSA_WITH_AES_128_GCM_SHA256
+        # - TLS_RSA_WITH_AES_256_GCM_SHA384
         # - TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
         # - TLS_ECDHE_RSA_WITH_RC4_128_SHA
         # - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
@@ -973,10 +977,6 @@ sharding_ring:
       # values:
       # 
       # Secure Ciphers:
-      # - TLS_RSA_WITH_AES_128_CBC_SHA
-      # - TLS_RSA_WITH_AES_256_CBC_SHA
-      # - TLS_RSA_WITH_AES_128_GCM_SHA256
-      # - TLS_RSA_WITH_AES_256_GCM_SHA384
       # - TLS_AES_128_GCM_SHA256
       # - TLS_AES_256_GCM_SHA384
       # - TLS_CHACHA20_POLY1305_SHA256
@@ -994,7 +994,11 @@ sharding_ring:
       # Insecure Ciphers:
       # - TLS_RSA_WITH_RC4_128_SHA
       # - TLS_RSA_WITH_3DES_EDE_CBC_SHA
+      # - TLS_RSA_WITH_AES_128_CBC_SHA
+      # - TLS_RSA_WITH_AES_256_CBC_SHA
       # - TLS_RSA_WITH_AES_128_CBC_SHA256
+      # - TLS_RSA_WITH_AES_128_GCM_SHA256
+      # - TLS_RSA_WITH_AES_256_GCM_SHA384
       # - TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
       # - TLS_ECDHE_RSA_WITH_RC4_128_SHA
       # - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
@@ -1322,10 +1326,6 @@ sharding_ring:
       # values:
       # 
       # Secure Ciphers:
-      # - TLS_RSA_WITH_AES_128_CBC_SHA
-      # - TLS_RSA_WITH_AES_256_CBC_SHA
-      # - TLS_RSA_WITH_AES_128_GCM_SHA256
-      # - TLS_RSA_WITH_AES_256_GCM_SHA384
       # - TLS_AES_128_GCM_SHA256
       # - TLS_AES_256_GCM_SHA384
       # - TLS_CHACHA20_POLY1305_SHA256
@@ -1343,7 +1343,11 @@ sharding_ring:
       # Insecure Ciphers:
       # - TLS_RSA_WITH_RC4_128_SHA
       # - TLS_RSA_WITH_3DES_EDE_CBC_SHA
+      # - TLS_RSA_WITH_AES_128_CBC_SHA
+      # - TLS_RSA_WITH_AES_256_CBC_SHA
       # - TLS_RSA_WITH_AES_128_CBC_SHA256
+      # - TLS_RSA_WITH_AES_128_GCM_SHA256
+      # - TLS_RSA_WITH_AES_256_GCM_SHA384
       # - TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
       # - TLS_ECDHE_RSA_WITH_RC4_128_SHA
       # - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
@@ -1530,10 +1534,6 @@ backoff_config:
 # Override the default cipher suite list (separated by commas). Allowed values:
 # 
 # Secure Ciphers:
-# - TLS_RSA_WITH_AES_128_CBC_SHA
-# - TLS_RSA_WITH_AES_256_CBC_SHA
-# - TLS_RSA_WITH_AES_128_GCM_SHA256
-# - TLS_RSA_WITH_AES_256_GCM_SHA384
 # - TLS_AES_128_GCM_SHA256
 # - TLS_AES_256_GCM_SHA384
 # - TLS_CHACHA20_POLY1305_SHA256
@@ -1551,7 +1551,11 @@ backoff_config:
 # Insecure Ciphers:
 # - TLS_RSA_WITH_RC4_128_SHA
 # - TLS_RSA_WITH_3DES_EDE_CBC_SHA
+# - TLS_RSA_WITH_AES_128_CBC_SHA
+# - TLS_RSA_WITH_AES_256_CBC_SHA
 # - TLS_RSA_WITH_AES_128_CBC_SHA256
+# - TLS_RSA_WITH_AES_128_GCM_SHA256
+# - TLS_RSA_WITH_AES_256_GCM_SHA384
 # - TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
 # - TLS_ECDHE_RSA_WITH_RC4_128_SHA
 # - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
@@ -1743,10 +1747,6 @@ The `memberlist` block configures the Gossip memberlist.
 # Override the default cipher suite list (separated by commas). Allowed values:
 # 
 # Secure Ciphers:
-# - TLS_RSA_WITH_AES_128_CBC_SHA
-# - TLS_RSA_WITH_AES_256_CBC_SHA
-# - TLS_RSA_WITH_AES_128_GCM_SHA256
-# - TLS_RSA_WITH_AES_256_GCM_SHA384
 # - TLS_AES_128_GCM_SHA256
 # - TLS_AES_256_GCM_SHA384
 # - TLS_CHACHA20_POLY1305_SHA256
@@ -1764,7 +1764,11 @@ The `memberlist` block configures the Gossip memberlist.
 # Insecure Ciphers:
 # - TLS_RSA_WITH_RC4_128_SHA
 # - TLS_RSA_WITH_3DES_EDE_CBC_SHA
+# - TLS_RSA_WITH_AES_128_CBC_SHA
+# - TLS_RSA_WITH_AES_256_CBC_SHA
 # - TLS_RSA_WITH_AES_128_CBC_SHA256
+# - TLS_RSA_WITH_AES_128_GCM_SHA256
+# - TLS_RSA_WITH_AES_256_GCM_SHA384
 # - TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
 # - TLS_ECDHE_RSA_WITH_RC4_128_SHA
 # - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA

--- a/docs/sources/configure-server/reference-configuration-parameters/index.template
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.template
@@ -53,7 +53,7 @@ Each variable reference is replaced at startup by the value of the environment v
 The replacement is case-sensitive and occurs before the YAML file is parsed.
 References to undefined variables are replaced by empty strings unless you specify a default value or custom error text.
 
-To specify a default value, use `${VAR:default_value}`,
+To specify a default value, use `${VAR:-default_value}`,
 where `default_value` is the value to use if the environment variable is undefined.
 
 ## Configuration parameters

--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -87,6 +87,7 @@ type Config struct {
 
 	MultitenancyEnabled bool              `yaml:"multitenancy_enabled,omitempty"`
 	Analytics           usagestats.Config `yaml:"analytics"`
+	ShowBanner          bool              `yaml:"show_banner,omitempty"`
 
 	ConfigFile      string `yaml:"-"`
 	ConfigExpandEnv bool   `yaml:"-"`
@@ -133,6 +134,7 @@ func (c *Config) RegisterFlagsWithContext(ctx context.Context, f *flag.FlagSet) 
 		"The alias 'all' can be used in the list to load a number of core modules and will enable single-binary mode. ")
 	f.BoolVar(&c.MultitenancyEnabled, "auth.multitenancy-enabled", false, "When set to true, incoming HTTP requests must specify tenant ID in HTTP X-Scope-OrgId header. When set to false, tenant ID anonymous is used instead.")
 	f.BoolVar(&c.ConfigExpandEnv, "config.expand-env", false, "Expands ${var} in config according to the values of the environment variables.")
+	f.BoolVar(&c.ShowBanner, "config.show_banner", true, "Prints the application banner at startup.")
 
 	c.registerServerFlagsWithChangedDefaultValues(f)
 	c.MemberlistKV.RegisterFlags(f)
@@ -354,7 +356,9 @@ var banner = `
  `
 
 func (f *Phlare) Run() error {
-	_ = cli.GradientBanner(banner, os.Stderr)
+	if f.Cfg.ShowBanner {
+		_ = cli.GradientBanner(banner, os.Stderr)
+	}
 
 	serviceMap, err := f.ModuleManager.InitModuleServices(f.Cfg.Target...)
 	if err != nil {


### PR DESCRIPTION
In production environments, users may not want the banner to be printed because doesn't conform to any logging format, which can muddle logs. This PR adds a flag which allows users to disable printing the banner.