### PR TITLE
[documentation] update config.river sample for k8s ebpf use case

### DIFF
--- a/examples/grafana-agent-auto-instrumentation/ebpf/k8s/config.river
+++ b/examples/grafana-agent-auto-instrumentation/ebpf/k8s/config.river
@@ -55,7 +55,7 @@ discovery.relabel "specific_pods" {
 
 pyroscope.ebpf "instance" {
     forward_to = [pyroscope.write.endpoint.receiver]
-    targets = discovery.relabel.specific_pods.targets
+    targets = discovery.relabel.specific_pods.output
 }
 
 pyroscope.write "endpoint" {

--- a/examples/grafana-agent-auto-instrumentation/ebpf/k8s/config.river
+++ b/examples/grafana-agent-auto-instrumentation/ebpf/k8s/config.river
@@ -59,10 +59,12 @@ pyroscope.ebpf "instance" {
 }
 
 pyroscope.write "endpoint" {
-    url = "http://pyroscope:4040"
-    // url = "<Grafana Cloud URL>"
-    // basic_auth {
-    //  username = "<Grafana Cloud User>"
-    //  password = "<Grafana Cloud Password>"
-    // }
+    endpoint {
+      url = "http://pyroscope:4040"
+      // url = "<Grafana Cloud URL>"
+      // basic_auth {
+      //  username = "<Grafana Cloud User>"
+      //  password = "<Grafana Cloud Password>"
+      // }
+    }
 }


### PR DESCRIPTION
```
Error: /etc/agent/config.river:61:47: field "targets" does not exist

60 |     forward_to = [pyroscope.write.endpoint.receiver]
61 |     targets = discovery.relabel.specific_pods.targets
   |                                               ^^^^^^^
62 | }

ts=2024-03-21T16:17:33.064918553Z level=error msg="failed to start reporter" err="context canceled"
interrupt received
Error: could not perform the initial load successfully
```