### PR TITLE
Adapt disk util to FreeBSD

### DIFF
--- a/pkg/util/disk/disk.go
+++ b/pkg/util/disk/disk.go
@@ -24,14 +24,30 @@ func (v *volumeChecker) HasHighDiskUtilization(path string) (*VolumeStats, error
 		return nil, err
 	}
 
+  // Convert [stat.Bavail] to uint64 safely, considering it can be negative, and represented
+  // as an int64 on BSD systems.
+  //
+  // See https://cs.opensource.google/go/x/sys/+/refs/tags/v0.18.0:unix/ztypes_freebsd_arm64.go;l=96
+  var bytesAvailable uint64
+  if stat.Bavail < 0 {
+    bytesAvailable = 0
+  } else {
+    bytesAvailable = uint64(stat.Bavail) * uint64(stat.Bsize)
+  }
+
 	// available means accessible to the current user, while free means bytes
 	// for privileged users. (Linux sometimes reserves some space for root)
 	var (
 		stats = VolumeStats{
-			BytesAvailable: stat.Bavail * uint64(stat.Bsize),
+			BytesAvailable: bytesAvailable,
 		}
-		percentageAvailable = float64(stat.Bavail) / float64(stat.Blocks)
+		percentageAvailable = 0.0
 	)
+
+  // Ensure [stat.Blocks] is greater than zero to avoid division by zero.
+  if stat.Blocks > 0 {  
+    percentageAvailable = float64(bytesAvailable) / float64(uint64(stat.Blocks) * uint64(stat.Bsize))
+  }
 
 	// if bytes available is bigger than minFreeDisk => not in high disk utilization
 	if stats.BytesAvailable >= v.minFreeDisk {


### PR DESCRIPTION
Hi folks 👋🏻 

I was looking into putting together a FreeBSD port of Pyroscope, and encountered the following compilation issue as I was building it. I hope you find this useful 🙇🏻 

On FreeBSD, the struct returned by the [fstat syscall](https://man.freebsd.org/cgi/man.cgi?statfs(2))'s `f_bavail` field is represented as an `int64`, rather than a `uint64` like on linux and macos platforms.

As a result, comparisons such as ` stat.Bavail * uint64(stat.Bsize)` won't compile on FreeBSD, as it would lead to applying a multiplication between a signed and unsigned 64-bit integer.

This commit refactors the logic of computing the disk available bytes and the percentage available to cater to OS differences. Note that I chose this approach as opposed to having a dedicated `disk_freebsd.go` file with a conditional build flag to avoid repeating logic, but I'm not hung up on my solution and would like to hear your thoughts about this approach.

I also want to acknowledge that modifying this code might be a good candidate for silently breaking everything (there are currently no tests). I could hear the argument of not wanting to fix this for an unsupported OS.

Let me know what you think 🙇🏻  