### PR TITLE
Include documentation updates in generated changelogs

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -180,7 +180,6 @@ changelog:
   sort: asc
   filters:
     exclude:
-      - "^docs:"
       - "^test:"
 release:
   draft: true


### PR DESCRIPTION
The last release (https://github.com/grafana/pyroscope/releases/tag/v1.5.0) had some documentation updates included in its changelog . This happened because we exclude commits that start with `docs:` and this exclusion didn't cover all documentation updates.

I personally don't mind having documentation updates in release changelogs but would be curious to see how others feel. 

Thanks @simonswine for pointing out the root cause.