### PR TITLE
Update golang version to 1.21.9

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.21.8"
+          go-version: "1.21.9"
           cache: true
       - run: yarn --frozen-lockfile
       - run: make build
@@ -55,7 +55,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.21.8"
+          go-version: "1.21.9"
           cache: true
       - run: yarn --frozen-lockfile
       - run: make build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.21.8"
+          go-version: "1.21.9"
           cache: true
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.8
+          go-version: 1.21.9
       - name: Format
         run: make fmt check/unstaged-changes
   test:
@@ -33,7 +33,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.8
+          go-version: 1.21.9
       - name: Go Mod
         run: make check/go/mod
       - name: Test
@@ -46,7 +46,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.8
+          go-version: 1.21.9
       - name: Run linter
         run: make lint
       - name: Check helm manifests
@@ -96,7 +96,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.21.8
+          go-version: 1.21.9
       - uses: actions/setup-node@v3
         with:
           node-version: lts/hydrogen
@@ -118,7 +118,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.21.8
+          go-version: 1.21.9
       - uses: actions/setup-node@v3
         with:
           node-version: lts/hydrogen

--- a/.github/workflows/test_ebpf.yml
+++ b/.github/workflows/test_ebpf.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.8
+          go-version: 1.21.9
       - name: Test
         run: sudo make -C ./ebpf go/test/amd64
   test_ebpf_qemu:
@@ -82,7 +82,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.8
+          go-version: 1.21.9
       - name: Install qemu
         run: sudo apt-get update && sudo apt-get -y install qemu-system-x86 qemu-system-aarch64
       - name: Build tests

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -25,7 +25,7 @@ jobs:
           git tag "$WEEKLY_IMAGE_TAG"
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.21.8"
+          go-version: "1.21.9"
           cache: true
       # setup docker buildx
       - name: Set up QEMU

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,7 +2,7 @@ project_name: pyroscope
 before:
   hooks:
     # This hook ensures that goreleaser uses the correct go version for a Pyroscope release
-    - sh -euc "go version | grep "go version go1.21.8 " || { echo "Unexpected go version"; exit 1; }"
+    - sh -euc "go version | grep "go version go1.21.9 " || { echo "Unexpected go version"; exit 1; }"
 builds:
   - env:
       - CGO_ENABLED=0

--- a/examples/golang-pgo/Dockerfile
+++ b/examples/golang-pgo/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.8
+FROM golang:1.21.9
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/language-sdk-instrumentation/golang-push/rideshare/Dockerfile
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.8
+FROM golang:1.21.9
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/language-sdk-instrumentation/golang-push/rideshare/Dockerfile.load-generator
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare/Dockerfile.load-generator
@@ -1,4 +1,4 @@
-FROM golang:1.21.8
+FROM golang:1.21.9
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/language-sdk-instrumentation/golang-push/simple/Dockerfile
+++ b/examples/language-sdk-instrumentation/golang-push/simple/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.8
+FROM golang:1.21.9
 
 WORKDIR /go/src/app
 


### PR DESCRIPTION
```
http2: close connections when receiving too many headers

Maintaining HPACK state requires that we parse and process all HEADERS and CONTINUATION frames on a connection. When a request's headers exceed MaxHeaderBytes, we don't allocate memory to store the excess headers but we do parse them. This permits an attacker to cause an HTTP/2 endpoint to read arbitrary amounts of header data, all associated with a request which is going to be rejected. These headers can include Huffman-encoded data which is significantly more expensive for the receiver to decode than for an attacker to send.

Set a limit on the amount of excess header frames we will process before closing a connection.

Thanks to Bartek Nowotarski (https://nowotarski.info/) for reporting this issue.

This is CVE-2023-45288 and Go issue https://go.dev/issue/65051.
```

https://go.dev/doc/devel/release#go1.21.minor