### PR TITLE
integration: Check distributor health before push

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/parquet-go/parquet-go v0.18.1-0.20231004061202-cde8189c4c26
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.17.0
+	github.com/prometheus/client_model v0.5.0
 	github.com/prometheus/common v0.45.0
 	github.com/prometheus/prometheus v1.99.0
 	github.com/samber/lo v1.38.1
@@ -188,7 +189,6 @@ require (
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/alertmanager v0.26.0 // indirect
-	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common/sigv4 v0.1.0 // indirect
 	github.com/prometheus/exporter-toolkit v0.10.1-0.20230714054209-2f4150c63f97 // indirect
 	github.com/prometheus/procfs v0.11.1 // indirect

--- a/pkg/test/integration/cluster/cluster.go
+++ b/pkg/test/integration/cluster/cluster.go
@@ -362,6 +362,7 @@ type gatherCheck struct {
 	conditions []gatherCoditions
 }
 
+//nolint:unparam
 func (c *gatherCheck) addExpectValue(value float64, metricName string, labelPairs ...string) *gatherCheck {
 	c.conditions = append(c.conditions, gatherCoditions{
 		metricName:    metricName,


### PR DESCRIPTION
This adds a health check for the write path before pushing profiles. (Saw flakes based on this)

It also moves listening to `127.0.0.1` in order to avoid this dialogue: 
![image](https://github.com/grafana/pyroscope/assets/223048/2834536a-706c-42fe-9a94-63280518721a)
 