### PR TITLE
Example to trigger eBPF vm timezone problem

### DIFF
--- a/ebpf/perf_event.go
+++ b/ebpf/perf_event.go
@@ -19,15 +19,15 @@ type perfEvent struct {
 
 func newPerfEvent(cpu int, sampleRate int) (*perfEvent, error) {
 	var (
-		fd  int
-		err error
+		fd   int
+		err  error
+		attr = unix.PerfEventAttr{
+			Type:   unix.PERF_TYPE_SOFTWARE,
+			Config: unix.PERF_COUNT_SW_CPU_CLOCK,
+			Bits:   unix.PerfBitFreq,
+			Sample: uint64(sampleRate),
+		}
 	)
-	attr := unix.PerfEventAttr{
-		Type:   unix.PERF_TYPE_SOFTWARE,
-		Config: unix.PERF_COUNT_SW_CPU_CLOCK,
-		Bits:   unix.PerfBitFreq,
-		Sample: uint64(sampleRate),
-	}
 	fd, err = unix.PerfEventOpen(&attr, -1, cpu, -1, unix.PERF_FLAG_FD_CLOEXEC)
 	if err != nil {
 		return nil, fmt.Errorf("open perf event: %w", err)


### PR DESCRIPTION
```
test=TestEBPFPythonProfiler/korniltsev/ebpf-testdata-rideshare:3.13-rc-slim component=docker cmd="/usr/bin/docker pull korniltsev/ebpf-testdata-rideshare:3.13-rc-slim" output="Error response from daemon: Get \"[https://registry-1.docker.io/v2/\](https://registry-1.docker.io/v2//)": tls: failed to verify certificate: x509: certificate has expired or is not yet valid: current time 2024-01-26T21:49:05Z is before 2024-04-04T00:00:00Z\n" err="exit status 1"
```

@korniltsev I think we need to set the correct time within before we run any other command