### PR TITLE
chore: Move mock struct to test file

### DIFF
--- a/ebpf/symtab/table.go
+++ b/ebpf/symtab/table.go
@@ -4,42 +4,6 @@ import (
 	"sort"
 )
 
-type SymTab struct {
-	Symbols []Sym
-	base    uint64
-}
-
-type Sym struct {
-	Start uint64
-	Name  string
-}
-
-func NewSymTab(symbols []Sym) *SymTab {
-	return &SymTab{Symbols: symbols}
-}
-
-func (t *SymTab) Rebase(base uint64) {
-	t.base = base
-}
-
-func (t *SymTab) Resolve(addr uint64) *Sym {
-	if len(t.Symbols) == 0 {
-		return nil
-	}
-	addr -= t.base
-	if addr < t.Symbols[0].Start {
-		return nil
-	}
-	i := sort.Search(len(t.Symbols), func(i int) bool {
-		return addr < t.Symbols[i].Start
-	})
-	i--
-	return &t.Symbols[i]
-}
-func (t *SymTab) Length() int {
-	return len(t.Symbols)
-}
-
 type SymbolTab struct {
 	symbols []Symbol
 	base    uint64

--- a/ebpf/symtab/table_test.go
+++ b/ebpf/symtab/table_test.go
@@ -1,13 +1,51 @@
 package symtab
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
+type MockSymTab struct {
+	Symbols []MockSym
+	base    uint64
+}
+
+type MockSym struct {
+	Start uint64
+	Name  string
+}
+
+func NewSymTab(symbols []MockSym) *MockSymTab {
+	return &MockSymTab{Symbols: symbols}
+}
+
+func (t *MockSymTab) Rebase(base uint64) {
+	t.base = base
+}
+
+func (t *MockSymTab) Resolve(addr uint64) *MockSym {
+	if len(t.Symbols) == 0 {
+		return nil
+	}
+	addr -= t.base
+	if addr < t.Symbols[0].Start {
+		return nil
+	}
+	i := sort.Search(len(t.Symbols), func(i int) bool {
+		return addr < t.Symbols[i].Start
+	})
+	i--
+	return &t.Symbols[i]
+}
+
+func (t *MockSymTab) Length() int {
+	return len(t.Symbols)
+}
+
 func TestSymTab(t *testing.T) {
-	sym := NewSymTab([]Sym{
+	sym := NewSymTab([]MockSym{
 		{0x1000, "0x1000"},
 		{0x1200, "0x1200"},
 		{0x1300, "0x1300"},


### PR DESCRIPTION
It is more appropriate for `SymTab` and `Sym` structures to be separated into test files since they are only used in tests, not in general code.  Additionally, adding the `Mock` prefix will clearly indicate to other developers that these structures are intended for testing purposes only, reducing the potential for confusion.

Therefore, I propose moving these two structures to test files and renaming them.