### PR TITLE
feat: CallGraph API

### DIFF
--- a/api/querier/v1/querier.proto
+++ b/api/querier/v1/querier.proto
@@ -154,12 +154,10 @@ message SelectSeriesResponse {
 message CallGraph {
   repeated CallGraphNode nodes = 1;
   repeated CallGraphEdge edges = 2;
-  // The total weight of the graph, used to compute percentages.
+  // The total weight of the graph before truncation, used to compute percentages.
   uint64 total_value = 3;
-  // The total number of nodes in the source full graph.
+  // The total number of nodes in the source graph before truncation.
   uint64 nodes_total = 4;
-  // The number of nodes not present in the graph.
-  uint64 nodes_dropped = 5;
 }
 
 message CallGraphNode {

--- a/api/querier/v1/querier.proto
+++ b/api/querier/v1/querier.proto
@@ -150,3 +150,36 @@ message SelectSeriesRequest {
 message SelectSeriesResponse {
   repeated types.v1.Series series = 1;
 }
+
+message CallGraph {
+  repeated CallGraphNode nodes = 1;
+  repeated CallGraphEdge edges = 2;
+  // The total weight of the graph, used to compute percentages.
+  uint64 total_value = 3;
+  // The total number of nodes in the source full graph.
+  uint64 nodes_total = 4;
+  // The number of nodes not present in the graph.
+  uint64 nodes_dropped = 5;
+}
+
+message CallGraphNode {
+  // Values associated to this node. Self is exclusive to this node,
+  // total includes all descendents.
+  uint64 total = 1;
+  uint64 self = 2;
+  string name = 3;
+}
+
+message CallGraphEdge {
+  // source is the index of the source node in the nodes array.
+  uint32 source = 1;
+  // destination is the index of the destination node in the nodes array.
+  uint32 destination = 2;
+  // sum of samples the edge represents.
+  uint64 total = 3;
+  // residual edges connect nodes that were connected through a
+  // separate node, which has been removed from the report.
+  bool residual = 4;
+  // An inline edge represents a call that was inlined into the caller.
+  bool inline = 5;
+}


### PR DESCRIPTION
Resolves #3219

The PR introduces a new endpoint for querying profiling data in the call graph format. The format is greatly inspired by the pprof's implementation: https://github.com/grafana/pyroscope/blob/main/pkg/frontend/dot/graph/graph.go#L50

Despite the fact that a call graph can be built from a flame graph or a profile in pprof format, the new use-case specific API will significantly help us integrate call graphs into the Pyroscope UI.

The issue lies in the fact that truncating flame graphs/pprof profiles is not suitable for call graphs: the heuristics we use to trim insignificant nodes make the call graph incorrect. A workaround could be keeping all the nodes (disabling the truncation); however, this will not work well with large profiles. Thus, it's preferable to build call graphs in the backend, trimming nodes in a way optimized for call graphs; otherwise, we will be juggling between incorrect call graph structures/numbers and very poor performance.

TODO:
 - [x] Define the call graph DTO
 - [ ] Add RPC service endopoint
 - [ ] Implement the endpoint in query-frontend