### PR TITLE
fix: clear profile buffer at flush

### DIFF
--- a/pkg/parquet/row_reader.go
+++ b/pkg/parquet/row_reader.go
@@ -45,7 +45,7 @@ func NewMergeRowReader(readers []parquet.RowReader, maxValue parquet.Row, less f
 	}
 	its := make([]iter.Iterator[parquet.Row], len(readers))
 	for i := range readers {
-		its[i] = NewBufferedRowReaderIterator(readers[i], defaultRowBufferSize)
+		its[i] = NewBufferedRowReaderIterator(readers[i], 1)
 	}
 
 	return NewIteratorRowReader(

--- a/pkg/parquet/row_reader.go
+++ b/pkg/parquet/row_reader.go
@@ -11,10 +11,6 @@ import (
 	"github.com/grafana/pyroscope/pkg/util/loser"
 )
 
-const (
-	defaultRowBufferSize = 64
-)
-
 var (
 	_ parquet.RowReader          = (*emptyRowReader)(nil)
 	_ parquet.RowReader          = (*ErrRowReader)(nil)
@@ -143,8 +139,10 @@ func (r *BufferedRowReaderIterator) Close() error {
 	return r.err
 }
 
+// TODO: refactor: the ReadAll and ReadAllWithBufferSize functions are only used in tests.
+
 func ReadAll(r parquet.RowReader) ([]parquet.Row, error) {
-	return ReadAllWithBufferSize(r, defaultRowBufferSize)
+	return ReadAllWithBufferSize(r, 1)
 }
 
 func ReadAllWithBufferSize(r parquet.RowReader, bufferSize int) ([]parquet.Row, error) {

--- a/pkg/parquet/row_writer.go
+++ b/pkg/parquet/row_writer.go
@@ -18,7 +18,7 @@ func CopyAsRowGroups(dst RowWriterFlusher, src parquet.RowReader, rowGroupNumCou
 	if rowGroupNumCount <= 0 {
 		panic("rowGroupNumCount must be positive")
 	}
-	bufferSize := defaultRowBufferSize
+	bufferSize := 1
 	// We clamp the buffer to the rowGroupNumCount to avoid allocating a buffer that is too large.
 	if rowGroupNumCount < bufferSize {
 		bufferSize = rowGroupNumCount

--- a/pkg/phlaredb/delta.go
+++ b/pkg/phlaredb/delta.go
@@ -39,7 +39,7 @@ func newSampleDict(samples schemav1.Samples) map[uint32]uint64 {
 	return dict
 }
 
-func (d *deltaProfiles) computeDelta(ps schemav1.InMemoryProfile) schemav1.Samples {
+func (d *deltaProfiles) computeDelta(ps *schemav1.InMemoryProfile) schemav1.Samples {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 

--- a/pkg/phlaredb/downsample/downsample_test.go
+++ b/pkg/phlaredb/downsample/downsample_test.go
@@ -44,7 +44,7 @@ func TestDownsampler_ProfileCounts(t *testing.T) {
 }
 
 func TestDownsampler_Aggregation(t *testing.T) {
-	profiles := make([]schemav1.InMemoryProfile, 0)
+	profiles := make([]*schemav1.InMemoryProfile, 0)
 	builder := testhelper.NewProfileBuilder(1703853310000000000).CPUProfile() // 2023-12-29T12:35:10Z
 	builder.ForStacktraceString("a", "b", "c").AddSamples(30)
 	builder.ForStacktraceString("a", "b", "c", "d").AddSamples(20)
@@ -106,7 +106,7 @@ func TestDownsampler_Aggregation(t *testing.T) {
 }
 
 func TestDownsampler_VaryingFingerprints(t *testing.T) {
-	profiles := make([]schemav1.InMemoryProfile, 0)
+	profiles := make([]*schemav1.InMemoryProfile, 0)
 	for i := 0; i < 5; i++ {
 		builder := testhelper.NewProfileBuilder(1703853310000000000).CPUProfile() // 2023-12-29T12:35:10Z
 		builder.ForStacktraceString("a", "b", "c").AddSamples(30)

--- a/pkg/phlaredb/head.go
+++ b/pkg/phlaredb/head.go
@@ -217,7 +217,7 @@ func (h *Head) Ingest(ctx context.Context, p *profilev1.Profile, id uuid.UUID, e
 			continue
 		}
 
-		if err := h.profiles.ingest(ctx, []schemav1.InMemoryProfile{profile}, lbls[idxType], metricName); err != nil {
+		if err := h.profiles.ingest(ctx, []*schemav1.InMemoryProfile{profile}, lbls[idxType], metricName); err != nil {
 			return err
 		}
 

--- a/pkg/phlaredb/profile_store.go
+++ b/pkg/phlaredb/profile_store.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/pyroscope/pkg/phlaredb/block"
 	"github.com/grafana/pyroscope/pkg/phlaredb/query"
 	schemav1 "github.com/grafana/pyroscope/pkg/phlaredb/schemas/v1"
+	"github.com/grafana/pyroscope/pkg/slices"
 	"github.com/grafana/pyroscope/pkg/util/build"
 )
 
@@ -288,7 +289,12 @@ func (s *profileStore) cutRowGroup(count int) (err error) {
 	s.rowGroups = append(s.rowGroups, rowGroup)
 	// Cutting the index is relatively quick op (no I/O).
 	err = s.index.cutRowGroup(s.flushBuffer)
-
+	// The buffer references profiles, so we should reset it in order for
+	// the GC to reclaim the memory. Note that the profile buffer holds values;
+	// therefore, zeroing is not needed, in contrast to the label buffer.
+	slices.Clear(s.flushBufferLbs)
+	s.flushBuffer = s.flushBuffer[:0]
+	s.flushBufferLbs = s.flushBufferLbs[:0]
 	s.profilesLock.Lock()
 	defer s.profilesLock.Unlock()
 	for i := range s.slice[:count] {

--- a/pkg/phlaredb/profile_store.go
+++ b/pkg/phlaredb/profile_store.go
@@ -290,10 +290,10 @@ func (s *profileStore) cutRowGroup(count int) (err error) {
 	// Cutting the index is relatively quick op (no I/O).
 	err = s.index.cutRowGroup(s.flushBuffer)
 	// The buffer references profiles, so we should reset it in order for
-	// the GC to reclaim the memory. Note that the profile buffer holds values;
-	// therefore, zeroing is not needed, in contrast to the label buffer.
-	slices.Clear(s.flushBufferLbs)
+	// the GC to reclaim the memory.
+	slices.Clear(s.flushBuffer)
 	s.flushBuffer = s.flushBuffer[:0]
+	slices.Clear(s.flushBufferLbs)
 	s.flushBufferLbs = s.flushBufferLbs[:0]
 	s.profilesLock.Lock()
 	defer s.profilesLock.Unlock()

--- a/pkg/phlaredb/profile_store_test.go
+++ b/pkg/phlaredb/profile_store_test.go
@@ -236,7 +236,7 @@ func TestProfileStore_RowGroupSplitting(t *testing.T) {
 
 			for i := 0; i < 100; i++ {
 				p := tc.values(i)
-				require.NoError(t, store.ingest(ctx, []schemav1.InMemoryProfile{p.p}, p.lbls, p.profileName))
+				require.NoError(t, store.ingest(ctx, []*schemav1.InMemoryProfile{&p.p}, p.lbls, p.profileName))
 				for store.flushing.Load() {
 					time.Sleep(time.Millisecond)
 				}
@@ -302,7 +302,7 @@ func TestProfileStore_Ingestion_SeriesIndexes(t *testing.T) {
 
 	for i := 0; i < 9; i++ {
 		p := threeProfileStreams(i)
-		require.NoError(t, store.ingest(ctx, []schemav1.InMemoryProfile{p.p}, p.lbls, p.profileName))
+		require.NoError(t, store.ingest(ctx, []*schemav1.InMemoryProfile{&p.p}, p.lbls, p.profileName))
 	}
 
 	// flush profiles and ensure the correct number of files are created
@@ -345,7 +345,7 @@ func BenchmarkFlush(b *testing.B) {
 			for i := 0; i < 10^6; i++ {
 				p := threeProfileStreams(i)
 				p.p.Samples = samples
-				require.NoError(b, store.ingest(ctx, []schemav1.InMemoryProfile{p.p}, p.lbls, p.profileName))
+				require.NoError(b, store.ingest(ctx, []*schemav1.InMemoryProfile{&p.p}, p.lbls, p.profileName))
 			}
 			require.NoError(b, store.cutRowGroup(len(store.slice)))
 		}
@@ -602,7 +602,7 @@ func TestRemoveFailedSegment(t *testing.T) {
 	require.NoError(t, store.Init(dir, defaultParquetConfig, contextHeadMetrics(context.Background())))
 	// fake a failed segment
 	_, err := os.Create(dir + "/profiles.0.parquet")
-	require.NoError(t, store.ingest(context.Background(), []schemav1.InMemoryProfile{{}}, phlaremodel.LabelsFromStrings(), "memory"))
+	require.NoError(t, store.ingest(context.Background(), []*schemav1.InMemoryProfile{{}}, phlaremodel.LabelsFromStrings(), "memory"))
 	require.NoError(t, err)
 	err = store.cutRowGroup(1)
 	require.NoError(t, err)

--- a/pkg/phlaredb/profiles.go
+++ b/pkg/phlaredb/profiles.go
@@ -493,7 +493,6 @@ func (pi *profilesIndex) cutRowGroup(rgProfiles []*schemav1.InMemoryProfile) err
 		n := copy(ps.profiles, ps.profiles[count:])
 		slices.Clear(ps.profiles[n:])
 		ps.profiles = ps.profiles[:n]
-		// attach rowGroup and rowNum information
 		ps.profilesOnDisk = append(
 			ps.profilesOnDisk,
 			rowRangePerFP[ps.fp],

--- a/pkg/phlaredb/profiles.go
+++ b/pkg/phlaredb/profiles.go
@@ -462,7 +462,7 @@ func (pi *profilesIndex) writeTo(ctx context.Context, path string) ([][]rowRange
 	return rangesPerRG, writer.Close()
 }
 
-func (pi *profilesIndex) cutRowGroup(rgProfiles []schemav1.InMemoryProfile) error {
+func (pi *profilesIndex) cutRowGroup(rgProfiles []*schemav1.InMemoryProfile) error {
 	pi.mutex.Lock()
 	defer pi.mutex.Unlock()
 

--- a/pkg/phlaredb/schemas/v1/profiles.go
+++ b/pkg/phlaredb/schemas/v1/profiles.go
@@ -490,7 +490,7 @@ const profileSize = uint64(unsafe.Sizeof(InMemoryProfile{}))
 func (p InMemoryProfile) Size() uint64 {
 	size := profileSize + uint64(cap(p.Comments)*8)
 	// 4 bytes for stacktrace id and 8 bytes for each stacktrace value
-	return size + uint64(cap(p.Samples.StacktraceIDs)*(4+8))
+	return size + uint64(cap(p.Samples.StacktraceIDs)*(4+8)+cap(p.Samples.Spans)*8)
 }
 
 func (p InMemoryProfile) Timestamp() model.Time {

--- a/pkg/phlaredb/schemas/v1/profiles.go
+++ b/pkg/phlaredb/schemas/v1/profiles.go
@@ -81,7 +81,7 @@ var (
 )
 
 func init() {
-	maxProfileRow = deconstructMemoryProfile(InMemoryProfile{
+	maxProfileRow = deconstructMemoryProfile(&InMemoryProfile{
 		SeriesIndex: math.MaxUint32,
 		TimeNanos:   math.MaxInt64,
 	}, maxProfileRow)
@@ -514,14 +514,14 @@ func copySlice[T any](in []T) []T {
 	return out
 }
 
-func NewInMemoryProfilesRowReader(slice []InMemoryProfile) *SliceRowReader[InMemoryProfile] {
-	return &SliceRowReader[InMemoryProfile]{
+func NewInMemoryProfilesRowReader(slice []*InMemoryProfile) *SliceRowReader[*InMemoryProfile] {
+	return &SliceRowReader[*InMemoryProfile]{
 		slice:     slice,
 		serialize: deconstructMemoryProfile,
 	}
 }
 
-func deconstructMemoryProfile(imp InMemoryProfile, row parquet.Row) parquet.Row {
+func deconstructMemoryProfile(imp *InMemoryProfile, row parquet.Row) parquet.Row {
 	var (
 		col    = -1
 		newCol = func() int {

--- a/pkg/phlaredb/schemas/v1/testhelper/profile.go
+++ b/pkg/phlaredb/schemas/v1/testhelper/profile.go
@@ -12,13 +12,13 @@ import (
 	"github.com/grafana/pyroscope/pkg/pprof"
 )
 
-func NewProfileSchema(p *profilev1.Profile, name string) ([]schemav1.InMemoryProfile, []phlaremodel.Labels) {
+func NewProfileSchema(p *profilev1.Profile, name string) ([]*schemav1.InMemoryProfile, []phlaremodel.Labels) {
 	var (
 		lbls, seriesRefs = labels.CreateProfileLabels(p, &typesv1.LabelPair{Name: model.MetricNameLabel, Value: name})
-		ps               = make([]schemav1.InMemoryProfile, len(lbls))
+		ps               = make([]*schemav1.InMemoryProfile, len(lbls))
 	)
 	for idxType := range lbls {
-		ps[idxType] = schemav1.InMemoryProfile{
+		ps[idxType] = &schemav1.InMemoryProfile{
 			ID:                uuid.New(),
 			TimeNanos:         p.TimeNanos,
 			Comments:          p.Comment,

--- a/pkg/phlaredb/symdb/dedup_slice.go
+++ b/pkg/phlaredb/symdb/dedup_slice.go
@@ -29,7 +29,7 @@ var (
 //   - PartitionWriter should only rewrite profile symbol indices;
 //   - InMemoryProfile should be created somewhere else on the call side.
 
-func (p *PartitionWriter) WriteProfileSymbols(profile *profilev1.Profile) []schemav1.InMemoryProfile {
+func (p *PartitionWriter) WriteProfileSymbols(profile *profilev1.Profile) []*schemav1.InMemoryProfile {
 	// create a rewriter state
 	rewrites := &rewriter{}
 
@@ -87,9 +87,9 @@ func (p *PartitionWriter) WriteProfileSymbols(profile *profilev1.Profile) []sche
 	p.locations.ingest(locs, rewrites)
 	samplesPerType := p.convertSamples(rewrites, profile.Sample, spans)
 
-	profiles := make([]schemav1.InMemoryProfile, len(samplesPerType))
+	profiles := make([]*schemav1.InMemoryProfile, len(samplesPerType))
 	for idxType := range samplesPerType {
-		profiles[idxType] = schemav1.InMemoryProfile{
+		profiles[idxType] = &schemav1.InMemoryProfile{
 			StacktracePartition: p.header.Partition,
 			Samples:             samplesPerType[idxType],
 			DropFrames:          profile.DropFrames,

--- a/pkg/phlaredb/symdb/symdb.go
+++ b/pkg/phlaredb/symdb/symdb.go
@@ -175,7 +175,7 @@ func (s *SymDB) newPartition(partition uint64) *PartitionWriter {
 	return &p
 }
 
-func (s *SymDB) WriteProfileSymbols(partition uint64, profile *profilev1.Profile) []schemav1.InMemoryProfile {
+func (s *SymDB) WriteProfileSymbols(partition uint64, profile *profilev1.Profile) []*schemav1.InMemoryProfile {
 	return s.PartitionWriter(partition).WriteProfileSymbols(profile)
 }
 

--- a/pkg/phlaredb/symdb/symdb_test.go
+++ b/pkg/phlaredb/symdb/symdb_test.go
@@ -22,7 +22,7 @@ type memSuite struct {
 	db       *SymDB
 	files    [][]string
 	profiles map[uint64]*googlev1.Profile
-	indexed  map[uint64][]v1.InMemoryProfile
+	indexed  map[uint64][]*v1.InMemoryProfile
 }
 
 type blockSuite struct {
@@ -58,7 +58,7 @@ func (s *memSuite) init() {
 		s.db = NewSymDB(s.config)
 	}
 	s.profiles = make(map[uint64]*googlev1.Profile)
-	s.indexed = make(map[uint64][]v1.InMemoryProfile)
+	s.indexed = make(map[uint64][]*v1.InMemoryProfile)
 	for p, files := range s.files {
 		for _, f := range files {
 			s.writeProfileFromFile(uint64(p), f)


### PR DESCRIPTION
When writing a chunk of profiles to disk, we allocate a buffer to hold the affected profiles, which we reuse throughout the lifetime of a mutable block in memory. Each entry in this buffer refers to a profile, including its metadata and samples.

The problem is that we do not clear this buffer after use, preventing the written profiles from being garbage collected, and thus consuming memory unnecessarily.

To compound the problem, creating a new parquet row group may require a considerable amount of memory, as evidenced by the spike in the graph. This makes the ingesters susceptible to OOM kills, even in relatively small deployments.

Notable changes proposed in the PR:
 - Parquet writer is not retained in-between chunk flushes.
 - Iterators are not buffers when row groups are read from the disk at block flush.
 - Flush buffers are cleaned out explicitly.

![image](https://github.com/grafana/pyroscope/assets/12090599/46d8fb13-18e5-46e5-b5f5-97242c0a0aeb)

No noticeable increase in CPU consumption was identified. From the OS view, the working set size of the process will likely not change substantially, because of the FS cache.

The impact of the change is expected to be larger in large-scale deployments, where the amount of erroneously retained object and buffers is larger.