### PR TITLE
Fix panic when dealing with missing mapping ID

### DIFF
--- a/pkg/phlaredb/symdb/resolver_pprof_truncate.go
+++ b/pkg/phlaredb/symdb/resolver_pprof_truncate.go
@@ -262,6 +262,10 @@ func createLocationStub(profile *googlev1.Profile) {
 		SystemName: stubNodeNameIdx,
 	}
 	profile.Function = append(profile.Function, stubFn)
+	// in the case there is no mapping, we need to create one
+	if len(profile.Mapping) == 0 {
+		profile.Mapping = append(profile.Mapping, &googlev1.Mapping{Id: 1})
+	}
 	stubLoc := &googlev1.Location{
 		Id:        uint64(len(profile.Location) + 1),
 		Line:      []*googlev1.Line{{FunctionId: stubFn.Id}},


### PR DESCRIPTION
I have not gotten to the bottom of why the mapping ID is missing when
maxNodes!=0.

This is presenting a workaround until we full understand the issue.

Fixes #3164
