### PR TITLE
Add profilecli command to dump the tsdb index

### DIFF
--- a/cmd/profilecli/main.go
+++ b/cmd/profilecli/main.go
@@ -60,6 +60,10 @@ func main() {
 	parquetInspectCmd := parquetCmd.Command("inspect", "Inspect a parquet file's structure.")
 	parquetInspectFiles := parquetInspectCmd.Arg("file", "parquet file path").Required().ExistingFiles()
 
+	tsdbCmd := adminCmd.Command("tsdb", "Operate on a TSDB index file.")
+	tsdbSeriesCmd := tsdbCmd.Command("series", "dump series in an TSDB index file.")
+	tsdbSeriesFiles := tsdbSeriesCmd.Arg("file", "tsdb file path").Required().ExistingFiles()
+
 	queryCmd := app.Command("query", "Query profile store.")
 	queryMergeCmd := queryCmd.Command("merge", "Request merged profile.")
 	queryMergeOutput := queryMergeCmd.Flag("output", "How to output the result, examples: console, raw, pprof=./my.pprof").Default("console").String()
@@ -94,6 +98,12 @@ func main() {
 	case parquetInspectCmd.FullCommand():
 		for _, file := range *parquetInspectFiles {
 			if err := parquetInspect(ctx, file); err != nil {
+				os.Exit(checkError(err))
+			}
+		}
+	case tsdbSeriesCmd.FullCommand():
+		for _, file := range *tsdbSeriesFiles {
+			if err := tsdbSeries(ctx, file); err != nil {
 				os.Exit(checkError(err))
 			}
 		}

--- a/cmd/profilecli/tsdb.go
+++ b/cmd/profilecli/tsdb.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	phlaremodel "github.com/grafana/pyroscope/pkg/model"
+	"github.com/grafana/pyroscope/pkg/phlaredb"
+	"github.com/grafana/pyroscope/pkg/phlaredb/tsdb/index"
+)
+
+func tsdbSeries(ctx context.Context, path string) error {
+	r, err := index.NewFileReader(path)
+	if err != nil {
+		return err
+	}
+
+	it, err := phlaredb.PostingsForMatchers(r, nil, labels.MustNewMatcher(labels.MatchNotEqual, "__name__", ""))
+	if err != nil {
+		return err
+	}
+
+	var (
+		lbls      phlaremodel.Labels
+		chunkMeta []index.ChunkMeta
+	)
+	line := struct {
+		SeriesRef   uint64
+		SeriesIndex *uint32
+		Labels      json.RawMessage
+	}{}
+	enc := json.NewEncoder(output(ctx))
+
+	for it.Next() {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		_, err = r.Series(it.At(), &lbls, &chunkMeta)
+		if err != nil {
+			return fmt.Errorf("error retrieving seriesRef: %w", err)
+		}
+
+		line.Labels, err = lbls.ToPrometheusLabels().MarshalJSON()
+		if err != nil {
+			return fmt.Errorf("error marshalling labels: %w", err)
+		}
+
+		if len(chunkMeta) > 0 {
+			line.SeriesIndex = &chunkMeta[0].SeriesIndex
+		} else {
+			line.SeriesIndex = nil
+		}
+		line.SeriesRef = uint64(it.At())
+		if err := enc.Encode(&line); err != nil {
+			return fmt.Errorf("error writing line: %w", err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is useful connecting SeriesIndex to the one in profiles.parquet.

```
❯ go run ./cmd/profilecli admin tsdb series ./my-block/index.tsdb
{"SeriesRef":247850,"SeriesIndex":16992,"Labels":{"__name__":"process_cpu","__period_type__":"cpu","__period_unit__":"nanoseconds","__profile_type__":"process_cpu:cpu:nanoseconds:cpu:nanoseconds", ...}}
[...]
```
