### PR TITLE
fix: discard invalid samples at read

### DIFF
--- a/pkg/phlaredb/schemas/v1/profiles.go
+++ b/pkg/phlaredb/schemas/v1/profiles.go
@@ -337,10 +337,14 @@ func NewSamplesFromMap(m map[uint32]int64) Samples {
 	}
 	var i int
 	for k, v := range m {
-		s.StacktraceIDs[i] = k
-		s.Values[i] = uint64(v)
-		i++
+		if k != 0 && v > 0 {
+			s.StacktraceIDs[i] = k
+			s.Values[i] = uint64(v)
+			i++
+		}
 	}
+	s.StacktraceIDs = s.StacktraceIDs[:i]
+	s.Values = s.Values[:i]
 	sort.Sort(s)
 	return s
 }

--- a/pkg/phlaredb/schemas/v1/profiles_test.go
+++ b/pkg/phlaredb/schemas/v1/profiles_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/parquet-go/parquet-go"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	phlareparquet "github.com/grafana/pyroscope/pkg/parquet"
@@ -439,4 +440,16 @@ func generateSamples(n int) []*Sample {
 		}
 	}
 	return samples
+}
+
+func Test_SamplesFromMap(t *testing.T) {
+	m := map[uint32]int64{
+		1: 2,
+		0: 0,
+		2: 3,
+		3: -1,
+	}
+	samples := NewSamplesFromMap(m)
+	assert.Equal(t, len(m), cap(samples.Values))
+	assert.Equal(t, 2, len(samples.Values))
 }

--- a/pkg/pprof/merge.go
+++ b/pkg/pprof/merge.go
@@ -32,8 +32,18 @@ func (m *ProfileMerge) MergeNoClone(p *profilev1.Profile) error {
 	return m.merge(p, false)
 }
 
+func isProfileValid(p *profilev1.Profile) bool {
+	return p != nil &&
+		len(p.SampleType) > 0 &&
+		len(p.StringTable) > 1 &&
+		len(p.Sample) > 0 &&
+		len(p.Location) > 0 &&
+		len(p.Mapping) > 0 &&
+		p.PeriodType != nil
+}
+
 func (m *ProfileMerge) merge(p *profilev1.Profile, clone bool) error {
-	if p == nil || len(p.StringTable) < 2 {
+	if !isProfileValid(p) {
 		return nil
 	}
 	ConvertIDsToIndices(p)

--- a/pkg/pprof/merge.go
+++ b/pkg/pprof/merge.go
@@ -32,18 +32,8 @@ func (m *ProfileMerge) MergeNoClone(p *profilev1.Profile) error {
 	return m.merge(p, false)
 }
 
-func isProfileValid(p *profilev1.Profile) bool {
-	return p != nil &&
-		len(p.SampleType) > 0 &&
-		len(p.StringTable) > 1 &&
-		len(p.Sample) > 0 &&
-		len(p.Location) > 0 &&
-		len(p.Mapping) > 0 &&
-		p.PeriodType != nil
-}
-
 func (m *ProfileMerge) merge(p *profilev1.Profile, clone bool) error {
-	if !isProfileValid(p) {
+	if p == nil || len(p.StringTable) < 2 {
 		return nil
 	}
 	ConvertIDsToIndices(p)


### PR DESCRIPTION
It's been discovered that some of the persisted profiles may contain invalid samples (stack trace ID == 0). As an immediate fix, such samples should be discarded, as further processing does not expect "empty" stack traces. This has led to numerous cryptic failures (#3164 and #2377, for example).

We should also ensure that such profiles are discarded before they gets writtien to the block (see #3194)