### PR TITLE
fix: pprof export incompatible period types

### DIFF
--- a/pkg/pprof/merge.go
+++ b/pkg/pprof/merge.go
@@ -218,8 +218,12 @@ func equalValueType(st1, st2 *profilev1.ValueType) bool {
 
 func RewriteStrings(p *profilev1.Profile, n []uint32) {
 	for _, t := range p.SampleType {
-		t.Unit = int64(n[t.Unit])
-		t.Type = int64(n[t.Type])
+		if t.Unit != 0 {
+			t.Unit = int64(n[t.Unit])
+		}
+		if t.Type != 0 {
+			t.Type = int64(n[t.Type])
+		}
 	}
 	for _, s := range p.Sample {
 		for _, l := range s.Label {
@@ -238,8 +242,12 @@ func RewriteStrings(p *profilev1.Profile, n []uint32) {
 	}
 	p.DropFrames = int64(n[p.DropFrames])
 	p.KeepFrames = int64(n[p.KeepFrames])
-	p.PeriodType.Type = int64(n[p.PeriodType.Type])
-	p.PeriodType.Unit = int64(n[p.PeriodType.Unit])
+	if p.PeriodType.Type != 0 {
+		p.PeriodType.Type = int64(n[p.PeriodType.Type])
+	}
+	if p.PeriodType.Unit != 0 {
+		p.PeriodType.Unit = int64(n[p.PeriodType.Unit])
+	}
 	for i, x := range p.Comment {
 		p.Comment[i] = int64(n[x])
 	}


### PR DESCRIPTION
Fixes #3197

The issue was that empty `ValueType` values (both period type and sample type) were used in the pprof response along the read path as they added after the profile merge. An empty `ValueType` references string with index 0, assuming that the value is `""`. However, in practice, we cannot guarantee that it's always true, which leads to period/sample type mismatches in rare cases.

This was necessary in the past because the original `profile.Merge` verified the compatibility of profiles. Now that we have our own specialized pprof merge, this is no longer needed. The fix ensures that empty `ValueType` is ignored during the merge. I believe this could be further simplified by removing the stubs entirely. Although a quick attempt revealed that this would require quite a few changes, I think it's best to implement this separately.