### PR TITLE
[DOC] Add note for Agent to Alloy to docs

### DIFF
--- a/docs/sources/configure-client/_index.md
+++ b/docs/sources/configure-client/_index.md
@@ -19,17 +19,19 @@ This document explains these two techniques and guide you when to choose each on
 
 ## About auto-instrumentation with Grafana Agent
 
+{{< docs/shared lookup="agent-deprecation.md" source="alloy" version="next" >}}
+
 The Grafana Agent is a component that runs alongside your application and periodically gathers profiling data from it.
 This method is suitable when you want to collect profiles from existing applications without modifying their source code.
 This approach is simplified with the eBPF profiling option that doesn't necessitate pull or push mechanisms.
 
 Here's how it works:
 
-1. Install and configure the Grafana Agent on the same machine or container where your application is running
+1. Install and configure Grafana Agent on the same machine or container where your application is running
 2. The Agent periodically retrieves your application's performance profiling data, regardless of the language or technology stack your application is using
 3. The captured profiles are then sent to the Pyroscope server for storage and analysis
 
-Using the Grafana Agent provides a hassle-free option, especially when dealing with multiple applications or microservices, allowing you to centralize the profiling process without changing your application's codebase.
+Using Grafana Agent provides a hassle-free option, especially when dealing with multiple applications or microservices, allowing you to centralize the profiling process without changing your application's codebase.
 
 ## About instrumentation with Pyroscope SDKs
 
@@ -52,7 +54,7 @@ The method you choose depends on your specific use case and requirements.
 
 Here are some factors to consider when making the choice:
 
-- Ease of setup: The Grafana Agent is an ideal choice for a quick and straightforward setup without modifying your application's code. Note that eBPF profiling supports some languages (for example, Golang) better than others. More robust support for Python, Java, and other languages is coming soon!
+- Ease of setup: The Grafana Agent is an ideal choice for a quick and straightforward setup without modifying your application's code. Note that eBPF profiling supports some languages (for example, Golang) better than others. More robust support for Python, Java, and other languages are in development.
 - Language support: If you want more control over the profiling process and your application is written in a language supported by the Pyroscope SDKs, consider using the SDKs.
 - Flexibility: The Pyroscope SDKs offer greater flexibility in terms of customizing the profiling process and capturing specific sections of code with labels. If you have particular profiling needs or want to fine-tune the data collection process, the SDKs would be your best bet.
 
@@ -113,8 +115,8 @@ To get started, choose one of the integrations below:
 
 You can add tags to your profiles to help correlate them with your other telemetry signals. Some common tags that are used are version, region, environment, request types, etc. You have the ability to add tags using both the SDK and the agent.
 
-Valid tag formats may contain ASCII letters and digits, as well as underscores. It must match the regex `[a-zA-Z_][a-zA-Z0-9_]`. 
-In Pyroscope, a period (`.`) is not a valid character inside of tags and labels. 
+Valid tag formats may contain ASCII letters and digits, as well as underscores. It must match the regex `[a-zA-Z_][a-zA-Z0-9_]`.
+In Pyroscope, a period (`.`) is not a valid character inside of tags and labels.
 
 ## Assistance with Pyroscope
 

--- a/docs/sources/configure-client/grafana-agent/_index.md
+++ b/docs/sources/configure-client/grafana-agent/_index.md
@@ -9,44 +9,47 @@ aliases:
 
 # Grafana Agent
 
-The Grafana Agent is a powerful tool for collecting and forwarding profiling data. Recently, with the introduction of support for eBPF and continuing support for Golang in pull mode, the Grafana Agent has become even more versatile in its capabilities. This document provides an overview of these two modes of profiling and guides users on setting them up.
+Grafana Agent is a powerful tool for collecting and forwarding profiling data.
+With the introduction of support for eBPF and continuing support for Golang in pull mode, Grafana Agent has become even more versatile in its capabilities.
+This document provides an overview of these two modes of profiling and guides users on setting them up.
 
-## eBPF Profiling with Grafana Agent
+{{< docs/shared lookup="agent-deprecation.md" source="alloy" version="next" >}}
+
+## eBPF profiling with Grafana Agent
 
 eBPF (Extended Berkeley Packet Filter) is a modern Linux kernel technology that allows for safe, efficient, and customizable tracing of system and application behaviors without modifying the source code or restarting processes.
 
-**Benefits of eBPF Profiling:**
+Benefits of eBPF profiling:
 
-- **Low Overhead**: eBPF collects data with minimal impact on performance.
-- **Versatile**: eBPF can trace system calls, network packets, and even user-space application logic.
-- **Dynamic**: No need to recompile or restart applications. eBPF allows for live tracing.
+- Low overhead: eBPF collects data with minimal impact on performance.
+- Versatile: eBPF can trace system calls, network packets, and even user-space application logic.
+- Dynamic: No need to recompile or restart applications. eBPF allows for live tracing.
 
-**How to Set Up eBPF Profiling with the Grafana Agent:**
+### Set up eBPF profiling with Grafana Agent
 
 1. Ensure your system runs a Linux kernel version 4.9 or newer.
-2. Install the Grafana Agent on the target machine or container.
-3. Configure the agent to use eBPF for profiling. Refer to the [eBPF documentation](/docs/pyroscope/latest/configure-client/grafana-agent/ebpf) for detailed steps.
-4. Once configured, the agent will start collecting eBPF profiles and send them to the Pyroscope server.
+1. Install Grafana Agent or Grafana Alloy on the target machine or container.
+1. Configure the agent to use eBPF for profiling. Refer to the [eBPF documentation](/docs/pyroscope/latest/configure-client/grafana-agent/ebpf) for detailed steps.
+1. After it's configured, the agent starts collecting eBPF profiles and sends them to the Pyroscope server.
 
-## Golang Profiling in Pull Mode with Grafana Agent
+## Golang profiling in pull mode with Grafana Agent
 
-In pull mode, the Grafana Agent periodically retrieves profiles from Golang applications, specifically targeting the pprof endpoints.
+In pull mode, Grafana Agent periodically retrieves profiles from Golang applications, specifically targeting the pprof endpoints.
 
-**Benefits of Golang Profiling in Pull Mode:**
+### Benefits of Golang profiling in pull mode
 
-- **Non-Intrusive**: No need to modify your application’s source code.
-- **Centralized Profiling**: Suitable for environments with multiple Golang applications or microservices.
-- **Automatic**: The agent handles the pulling and sending of profiles, requiring minimal configuration.
+- Non-intrusive: No need to modify your application’s source code.
+- Centralized profiling: Suitable for environments with multiple Golang applications or microservices.
+- Automatic: The agent handles the pulling and sending of profiles, requiring minimal configuration.
 
-**How to Set Up Golang Profiling in Pull Mode:**
+### Set up Golang profiling in pull mode
 
 1. Ensure your Golang application exposes pprof endpoints.
-2. Install and configure the Grafana Agent on the same machine or container where your application runs.
+2. Install and configure Grafana Agent on the same machine or container where your application runs.
 3. Ensure the agent is set to pull mode and targeting the correct pprof endpoints. For step-by-step instructions, visit the [Go (Pull Mode)](/docs/pyroscope/latest/configure-client/grafana-agent/go_pull) docs.
-4. The agent will start querying the pprof endpoints of your Golang application, collecting the profiles, and forwarding them to the Pyroscope server.
+4. The agent starta querying the pprof endpoints of your Golang application, collecting the profiles, and forwarding them to the Pyroscope server.
 
 ## Next steps
 
-Whether using eBPF for versatile system and application profiling or relying on Golang's built-in pprof endpoints in pull mode, the Grafana Agent offers a streamlined process to gather essential profiling data. Choose the method that best fits your application and infrastructure needs.
+Whether using eBPF for versatile system and application profiling or relying on Golang's built-in pprof endpoints in pull mode, Grafana Agent and Grafana Alloy offer a streamlined process to gather essential profiling data. Choose the method that best fits your application and infrastructure needs.
 
-For additional details, examples, or troubleshooting, please visit the links provided above. And as always, the Pyroscope team is available on Slack or GitHub for further assistance.

--- a/docs/sources/configure-client/grafana-agent/ebpf/_index.md
+++ b/docs/sources/configure-client/grafana-agent/ebpf/_index.md
@@ -32,6 +32,9 @@ However, eBPF has some limitations that make it unsuitable for certain use cases
 
 ## eBPF via the Grafana Agent
 
+{{< docs/shared lookup="agent-deprecation.md" source="alloy" version="next" >}}
+
 The Grafana Agent is a lightweight, all-in-one agent that can collect, transform, and ship observability data. For profiling, the Grafana Agent can be configured to collect eBPF profiles and send them to Pyroscope.
 
-This section contains instructions for installing and configuring the Grafana Agent to collect eBPF profiles. For more information about the Grafana Agent itself, see the [Grafana Agent documentation](/docs/agent/latest/flow/).
+This section contains instructions for installing and configuring the Grafana Agent to collect eBPF profiles.
+For more information about the Grafana Agent itself, see the [Grafana Agent documentation](/docs/agent/latest/flow/).

--- a/docs/sources/configure-client/grafana-agent/ebpf/setup-docker.md
+++ b/docs/sources/configure-client/grafana-agent/ebpf/setup-docker.md
@@ -10,9 +10,11 @@ weight: 20
 To set up eBPF profiling with Grafana Agent on Linux, you need to:
 
 - Verify that your system meets the requirements.
-- Create a Grafana Agent configuration file. For more information, see [Configuration reference][config-reference].
-- Run the Grafana Agent.
-- Finally, verify that profiles are received.
+- Create a Grafana Agent configuration file. For more information, refer to the [Configuration reference][config-reference].
+- Run Grafana Agent or Grafana Alloy.
+- Verify that profiles are received.
+
+{{< docs/shared lookup="agent-deprecation.md" source="alloy" version="next" >}}
 
 ## Prerequisites
 
@@ -40,9 +42,10 @@ docker info | grep Kernel
 
 Make sure you have a kernel version >= 4.9.
 
-## Configure the Grafana Agent
+## Configure Grafana Agent
 
-We'll configure the Grafana Agent eBPF profiler to profile local containers. To do so we'll use the `discovery.docker` component to discover local containers and the `pyroscope.ebpf` component to profile them.
+You can configure the Grafana Agent eBPF profiler to profile local containers.
+To do so, use the `discovery.docker` component to discover local containers and the `pyroscope.ebpf` component to profile them.
 
 Create a file named `agent.river` with the following content:
 
@@ -82,9 +85,9 @@ If you're using your own Pyroscope server, you can remove the `basic_auth` secti
 
 For more information, refer to the [Configure the Grafana Pyroscope data source documentation](/docs/grafana-cloud/connect-externally-hosted/data-sources/grafana-pyroscope#configure-the-grafana-pyroscope-data-source).
 
-## Start the Grafana Agent
+## Start Grafana Agent
 
-To start the Grafana Agent with docker, run:
+To start Grafana Agent with Docker, run:
 
 ```shell
 docker run \

--- a/docs/sources/configure-client/grafana-agent/ebpf/setup-kubernetes.md
+++ b/docs/sources/configure-client/grafana-agent/ebpf/setup-kubernetes.md
@@ -11,9 +11,11 @@ To set up eBPF profiling with Grafana Agent on Kubernetes, you need to:
 
 - Verify that your cluster meets the prerequisites.
 - Add the Grafana helm repository.
-- Create a Grafana Agent configuration file. For more information, see [Configuration reference][config-reference].
-- Install the Grafana Agent.
-- Finally, verify that profiles are received.
+- Create a Grafana Agent configuration file. For more information, refer to [Configuration reference][config-reference].
+- Install Grafana Agent.
+- Verify that profiles are received.
+
+{{< docs/shared lookup="agent-deprecation.md" source="alloy" version="next" >}}
 
 ## Prerequisites
 
@@ -23,7 +25,9 @@ Before you begin, you need:
 - A Pyroscope server where the agent will send profiling data.
 - Access to Grafana with the [Grafana Pyroscope datasource][pyroscope-ds] provisioned.
 
-> Note: If you don't have a Grafana and/or a Pyroscope server, you can use the [Grafana Cloud][gcloud] free plan to get started.
+{{< admonition type="note" >}}
+If you don't have a Grafana and/or a Pyroscope server, you can use the [Grafana Cloud][gcloud] free plan to get started.
+{{< /admonition >}}
 
 ## Verify that your cluster meets the requirements
 
@@ -41,7 +45,7 @@ Make sure all nodes have a kernel version >= 4.9.
 
 ## Add the Grafana Helm repository
 
-We recommend using [Helm][helm] to install the Grafana Agent. To add the Grafana Helm repository, run:
+We recommend using [Helm][helm] to install Grafana Agent. To add the Grafana Helm repository, run:
 
 ```shell
 helm repo add grafana https://grafana.github.io/helm-charts
@@ -54,7 +58,7 @@ You can verify that the repository was added successfully by running:
 helm search repo grafana/grafana-agent
 ```
 
-It should return a list of available versions of the Grafana Agent.
+It should return a list of available versions of Grafana Agent.
 
 ## Create a Grafana Agent configuration file
 

--- a/docs/sources/configure-client/grafana-agent/ebpf/setup-linux.md
+++ b/docs/sources/configure-client/grafana-agent/ebpf/setup-linux.md
@@ -11,9 +11,11 @@ To set up eBPF profiling with Grafana Agent on Linux, you need to:
 
 - Verify that your system meets the requirements.
 - Install the Grafana Agent Flow mode.
-- Create a Grafana Agent configuration file. For more information, see [Configuration reference][config-reference].
-- Run the Grafana Agent.
+- Create a Grafana Agent configuration file. For more information, refer to [Configuration reference][config-reference].
+- Run Grafana Agent or Grafana Alloy.
 - Finally, verify that profiles are received.
+
+{{< docs/shared lookup="agent-deprecation.md" source="alloy" version="next" >}}
 
 ## Prerequisites
 

--- a/docs/sources/configure-client/grafana-agent/java/_index.md
+++ b/docs/sources/configure-client/grafana-agent/java/_index.md
@@ -7,9 +7,12 @@ weight: 20
 
 # Profiling Java using the Grafana Agent
 
-Grafana Agent supports Java profiling in [Flow mode](/docs/agent/latest/flow/). Written in the
+Grafana Agent supports Java profiling in [Flow mode](/docs/agent/latest/flow/).
+Written in the
 [River](/docs/agent/latest/flow/config-language/) language, the configuration file is composed of components that are used to collect,
 transform, and send data.
+
+{{< docs/shared lookup="agent-deprecation.md" source="alloy" version="next" >}}
 
 ## Configure the components
 


### PR DESCRIPTION
With the release of Grafana Alloy, we're adding an admonition to the Agent-related documenation notifying people about Alloy and the deprecation of Agent.

This admonition is contained in a shared file that is in the Alloy repository. When used, the admonition looks like this:
![image](https://github.com/grafana/pyroscope/assets/104772500/ffb1b66f-cdaf-412d-9385-275666f50ae8)
