### PR TITLE
Handle zero references when merging

### DIFF
--- a/pkg/pprof/merge.go
+++ b/pkg/pprof/merge.go
@@ -257,21 +257,27 @@ func RewriteStrings(p *profilev1.Profile, n []uint32) {
 func RewriteFunctions(p *profilev1.Profile, n []uint32) {
 	for _, loc := range p.Location {
 		for _, line := range loc.Line {
-			line.FunctionId = uint64(n[line.FunctionId-1]) + 1
+			if line.FunctionId > 0 {
+				line.FunctionId = uint64(n[line.FunctionId-1]) + 1
+			}
 		}
 	}
 }
 
 func RewriteMappings(p *profilev1.Profile, n []uint32) {
 	for _, loc := range p.Location {
-		loc.MappingId = uint64(n[loc.MappingId-1]) + 1
+		if loc.MappingId > 0 {
+			loc.MappingId = uint64(n[loc.MappingId-1]) + 1
+		}
 	}
 }
 
 func RewriteLocations(p *profilev1.Profile, n []uint32) {
 	for _, s := range p.Sample {
 		for i, loc := range s.LocationId {
-			s.LocationId[i] = uint64(n[loc-1]) + 1
+			if loc > 0 {
+				s.LocationId[i] = uint64(n[loc-1]) + 1
+			}
 		}
 	}
 }

--- a/pkg/pprof/merge_test.go
+++ b/pkg/pprof/merge_test.go
@@ -33,6 +33,51 @@ func Test_Merge_Self(t *testing.T) {
 	testhelper.EqualProto(t, p.Profile, m.Profile())
 }
 
+func Test_Merge_ZeroReferences(t *testing.T) {
+	p, err := OpenFile("testdata/go.cpu.labels.pprof")
+	require.NoError(t, err)
+
+	t.Run("mappingID=0", func(t *testing.T) {
+		before := p.Location[10]
+		p.Location[10].MappingId = 0
+		defer func() {
+			p.Location[10] = before
+		}()
+
+		var m ProfileMerge
+		require.NoError(t, m.Merge(p.Profile))
+
+		testhelper.EqualProto(t, p.Profile, m.Profile())
+	})
+
+	t.Run("locationID=0", func(t *testing.T) {
+		before := p.Sample[10].LocationId[0]
+		p.Sample[10].LocationId[0] = 0
+		defer func() {
+			p.Sample[10].LocationId[0] = before
+		}()
+
+		var m ProfileMerge
+		require.NoError(t, m.Merge(p.Profile))
+
+		testhelper.EqualProto(t, p.Profile, m.Profile())
+	})
+
+	t.Run("functionID=0", func(t *testing.T) {
+		before := p.Location[10].Line[0].FunctionId
+		p.Location[10].Line[0].FunctionId = 0
+		defer func() {
+			p.Location[10].Line[0].FunctionId = before
+		}()
+
+		var m ProfileMerge
+		require.NoError(t, m.Merge(p.Profile))
+
+		testhelper.EqualProto(t, p.Profile, m.Profile())
+	})
+
+}
+
 func Test_Merge_Halves(t *testing.T) {
 	p, err := OpenFile("testdata/go.cpu.labels.pprof")
 	require.NoError(t, err)


### PR DESCRIPTION
This fixes a bug in handling 0 references to mappings, locations and functions.

See also #3203 