### PR TITLE
Remove tenant-settings from Ingress

### DIFF
--- a/operations/pyroscope/helm/pyroscope/templates/ingress.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/ingress.yaml
@@ -89,16 +89,5 @@ spec:
               number: {{ $.Values.pyroscope.service.port }}
         path: /ingest
         pathType: Prefix
-      - backend:
-          service:
-            {{- if gt (len $.Values.pyroscope.components) 1}}
-            name: {{ include "pyroscope.fullname" $ }}-tenant-settings
-            {{- else }}
-            name: {{ include "pyroscope.fullname" $ }}
-            {{- end }}
-            port:
-              number: {{ $.Values.pyroscope.service.port }}
-        path: /settings.v1.SettingsService/
-        pathType: ImplementationSpecific
   {{- end }}
 {{- end }}


### PR DESCRIPTION
The backend Service is no longer available as it was removed in #2922.
Honestly, I don't know what it was in detail but the PR said the service is not relevant when running outside of Grafana Cloud so I believe this ingress path setting can be removed as well.