### PR TITLE
[release/v1.5] docs: Fix invalid references to  in discovery.relabel

### DIFF
--- a/docs/sources/configure-client/grafana-agent/ebpf/setup-linux.md
+++ b/docs/sources/configure-client/grafana-agent/ebpf/setup-linux.md
@@ -80,7 +80,7 @@ discovery.relabel "agent" {
 
 pyroscope.ebpf "instance" {
  forward_to     = [pyroscope.write.endpoint.receiver]
- targets = discovery.relabel.agent.targets
+ targets = discovery.relabel.agent.output
 }
 
 pyroscope.scrape "local" {

--- a/docs/sources/configure-client/grafana-agent/go_pull.md
+++ b/docs/sources/configure-client/grafana-agent/go_pull.md
@@ -195,7 +195,7 @@ pyroscope.write "write_job_name" {
     }
     ```
 
-3. Use `discovery.relabel.specific_pods.targets` as a target for `pyroscope.scrape` block.
+3. Use `discovery.relabel.specific_pods.output` as a target for `pyroscope.scrape` block.
 
     ```river
         pyroscope.scrape "scrape_job_name" {

--- a/examples/grafana-agent-auto-instrumentation/ebpf/k8s/config.river
+++ b/examples/grafana-agent-auto-instrumentation/ebpf/k8s/config.river
@@ -55,7 +55,7 @@ discovery.relabel "specific_pods" {
 
 pyroscope.ebpf "instance" {
     forward_to = [pyroscope.write.endpoint.receiver]
-    targets = discovery.relabel.specific_pods.targets
+    targets = discovery.relabel.specific_pods.output
 }
 
 pyroscope.write "endpoint" {


### PR DESCRIPTION
Backport 65be0e07d548a7f6e048fb419f9a0c8f58bb9465 from #3153

---

The component [`discovery.relabel`](https://grafana.com/docs/agent/latest/flow/reference/components/discovery.relabel/) exports a label [`output`](https://grafana.com/docs/agent/latest/flow/reference/components/discovery.relabel/#exported-fields), but some code examples are trying to get `targets` field instead and failing.

This PR fixes such invalid references.
