### PR TITLE
[release/v1.5] Example and docs for Python span profiles

### DIFF
--- a/docs/sources/configure-client/trace-span-profiles/_index.md
+++ b/docs/sources/configure-client/trace-span-profiles/_index.md
@@ -21,11 +21,12 @@ Key benefits and features:
 Get started:
 
 - Configure Pyroscope: Begin sending profiling data to unlock the full potential of Span Profiles
-- Client-Side Packages: Easily link traces and profiles using available packages for Go, Java, Ruby and .NET
+- Client-side packages: Easily link traces and profiles using available packages for Go, Java, Ruby, .NET, and Python
   - Go: [Span profiles with Traces to profiles (Go)]({{< relref "./go-span-profiles" >}})
   - Java: [Span profiles with Traces to profiles (Java)]({{< relref "./java-span-profiles" >}})
   - Ruby: [Span profiles with Traces to profiles (Ruby)]({{< relref "./ruby-span-profiles" >}})
   - .NET: [Span profiles with Traces to profiles (.NET)]({{< relref "./dotnet-span-profiles" >}})
+  - Python: [Span profiles with Traces to profiles (Python)]({{< relref "./python-span-profiles" >}})
 - Grafana Tempo: Visualize and analyze Span Profiles within the Grafana using a Tempo data source.
 
 To learn more, check out our product announcement blog: [Introducing Span Profiles](/blog/2024/02/06/combining-tracing-and-profiling-for-enhanced-observability-introducing-span-profiles/).

--- a/docs/sources/configure-client/trace-span-profiles/python-span-profiles.md
+++ b/docs/sources/configure-client/trace-span-profiles/python-span-profiles.md
@@ -1,11 +1,11 @@
 ---
-title: Span profiles with Traces to profiles for .NET
-menuTitle: Span profiles with Traces to profiles (.NET)
-description: Learn about and configure Span profiles with Traces to profiles in Grafana for .NET applications.
-weight: 103
+title: Span profiles with Traces to profiles for Python
+menuTitle: Span profiles with Traces to profiles (Python)
+description: Learn about and configure Span profiles with Traces to profiles in Grafana for Python applications.
+weight: 104
 ---
 
-# Span profiles with Traces to profiles for .NET
+# Span profiles with Traces to profiles for Python
 
 Span Profiles represents a major shift in profiling methodology, enabling deeper analysis of both tracing and profiling data.
 Traditional continuous profiling provides an application-wide view over fixed intervals.
@@ -17,7 +17,7 @@ To learn more about Span Profiles, refer to [Combining tracing and profiling for
 
 ![span-profiles screenshot](https://grafana.com/static/img/docs/tempo/profiles/tempo-profiles-Span-link-profile-data-source.png)
 
-Pyroscope integrates with distributed tracing systems supporting the [**OpenTelemetry**](https://opentelemetry.io/docs/languages/net/getting-started/) standard.
+Pyroscope integrates with distributed tracing systems supporting the [**OpenTelemetry**](https://opentelemetry.io/docs/languages/python/getting-started/) standard.
 This integration lets you link traces with the profiling data and find resource usage for specific lines of code for your trace spans.
 
 {{< admonition type="note" >}}
@@ -28,45 +28,44 @@ This integration lets you link traces with the profiling data and find resource 
 To use Span Profiles, you need to:
 
 * [Configure Pyroscope to send profiling data]({{< relref "../../configure-client" >}})
-* Configure a client-side package to link traces and profiles: [.NET](https://github.com/grafana/pyroscope-dotnet/tree/main/Pyroscope/Pyroscope.OpenTelemetry)
+* Configure a client-side package to link traces and profiles: [Python](https://github.com/grafana/otel-profiling-python)
 * [Configure the Tempo data source in Grafana or Grafana Cloud to discover linked traces and profiles](/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/)
 
 ## Before you begin
 
 Your applications must be instrumented for profiling and tracing before you can use span profiles.
 
-* Profiling: Your application must be instrumented with Pyroscope's .NET instrumentation library. Refer to the [.NET]({{< relref "../language-sdks/dotnet" >}}) guide for instructions.
-* Tracing: Your application must be instrumented with OpenTelemetry traces. Refer to the [OpenTelemetry](https://opentelemetry.io/docs/languages/net/getting-started/) guide for isntructions.
+* Profiling: Your application must be instrumented with Pyroscope's Python instrumentation library. Refer to the [Python]({{< relref "../language-sdks/python" >}}) guide for instructions.
+* Tracing: Your application must be instrumented with OpenTelemetry traces. Refer to the [OpenTelemetry](https://opentelemetry.io/docs/languages/python/getting-started/) guide for isntructions.
 
-{{< admonition type="note" >}}
-Span profiles in .NET are only supported using [OpenTelemetry manual instrumentation](https://opentelemetry.io/docs/languages/net/instrumentation/)
-because Pyroscope's .NET profiler and OpenTelemetry's auto instrumentation are based on separate .NET CLR profilers.
-{{< /admonition >}}
+## Configure the `pyroscope-otel` package
 
-## Configure the `Pyroscope.OpenTelemetry` package
+To start collecting Span Profiles for your Python application, you need to include [pyroscope-otel](https://github.com/grafana/otel-profiling-python) in your code.
 
-To start collecting Span Profiles for your .NET application, you need to include [Pyroscope.OpenTelemetry](https://github.com/grafana/pyroscope-dotnet/tree/main/Pyroscope/Pyroscope.OpenTelemetry) in your code.
-
-This package provides a [`SpanProcessor`](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/BaseProcessor.cs) implementation, which connects the two telemetry signals (traces and profiles) together.
+This package provides a [`SpanProcessor`](https://github.com/open-telemetry/opentelemetry-python/blob/d213e02941039d4383abc3608b75404ce84725b1/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py#L85) implementation, which connects the two telemetry signals (traces and profiles) together.
 
 ```shell
-dotnet add package Pyroscope.OpenTelemetry
+pip install pyroscope-otel
 ```
 
 Next, create and register the `PyroscopeSpanProcessor`:
-```csharp
-builder.Services.AddOpenTelemetry()
-    .WithTracing(b =>
-    {
-        b
-        .AddAspNetCoreInstrumentation()
-        .AddConsoleExporter()
-        .AddOtlpExporter()
-        .AddProcessor(new Pyroscope.OpenTelemetry.PyroscopeSpanProcessor());
-    });
+```python
+# import span processor
+from pyroscope-otel import PyroscopeSpanProcessor
+
+# obtain a OpenTelemetry tracer provider
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+provider = TracerProvider()
+
+# register the span processor
+provider.add_span_processor(PyroscopeSpanProcessor())
+
+# register the tracer provider
+trace.set_tracer_provider(provider)
 ```
 
-With the span processor registered, spans created automatically (for example, HTTP handlers) and manually (`ActivitySource.StartActivity()`) have profiling data associated with them.
+With the span processor registered, spans created automatically (for example, HTTP handlers) and manually will have profiling data associated with them.
 
 ## View the span profiles in Grafana Tempo
 

--- a/examples/language-sdk-instrumentation/python/rideshare/flask/Dockerfile
+++ b/examples/language-sdk-instrumentation/python/rideshare/flask/Dockerfile
@@ -1,10 +1,10 @@
 FROM python:3.9
 
-RUN pip3 install flask pyroscope-io==0.8.5
+RUN pip3 install flask pyroscope-io==0.8.7 pyroscope-otel==0.1.0
+RUN pip3 install opentelemetry-api opentelemetry-sdk opentelemetry-instrumentation-flask opentelemetry-exporter-otlp-proto-grpc
 
 ENV FLASK_ENV=development
 ENV PYTHONUNBUFFERED=1
 
 COPY lib ./lib
 CMD [ "python", "lib/server.py" ]
-

--- a/examples/tracing/tempo/docker-compose.yml
+++ b/examples/tracing/tempo/docker-compose.yml
@@ -62,6 +62,24 @@ services:
       context: ../../language-sdk-instrumentation/dotnet/rideshare
       dockerfile: Dockerfile
 
+  rideshare-python-eu-east:
+    ports:
+      - 5000
+    hostname: rideshare-python-eu-east
+    environment:
+      <<: *env
+      OTEL_TRACES_EXPORTER: otlp
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
+      OTEL_SERVICE_NAME: rideshare.python.push.app
+      OTEL_METRICS_EXPORTER: none
+      OTEL_TRACES_SAMPLER: always_on
+      OTEL_PROPAGATORS: tracecontext
+      PYROSCOPE_LABELS: hostname=rideshare-python-us-east
+      REGION: us-east
+    build:
+      context: ../../language-sdk-instrumentation/python/rideshare/flask
+      dockerfile: Dockerfile
+
   load-generator:
     environment: *env
     build:
@@ -73,6 +91,7 @@ services:
       - http://rideshare-go-eu-north:5000
       - http://rideshare-java-us-east:5000
       - http://rideshare-dotnet-eu-west:5000
+      - http://rideshare-python-eu-east:5000
 
   grafana:
     image: grafana/grafana-dev:10.3.0-151740


### PR DESCRIPTION
Backport 960fc3221b738f4cf374ffa29ae3528588435313 from #3252

---

- enables OpenTelemetry based tracing in the Python ride share Flask example
- adds the Python ride share Flask app to examples/tracing/tempo, to demonstrate span profiles in Python
- adds docs for Python span profiles
