### PR TITLE
Fix debug info attribute

### DIFF
--- a/ebpf/sd/target.go
+++ b/ebpf/sd/target.go
@@ -146,7 +146,7 @@ type containerID string
 type TargetFinder interface {
 	FindTarget(pid uint32) *Target
 	RemoveDeadPID(pid uint32)
-	DebugInfo() []string
+	DebugInfo() []map[string]string
 	Update(args TargetsOptions)
 }
 type TargetsOptions struct {
@@ -252,14 +252,15 @@ func (tf *targetFinder) resizeContainerIDCache(size int) {
 	tf.containerIDCache.Resize(size)
 }
 
-func (tf *targetFinder) DebugInfo() []string {
+func (tf *targetFinder) DebugInfo() []map[string]string {
 	tf.sync.Lock()
 	defer tf.sync.Unlock()
 
-	debugTargets := make([]string, 0, len(tf.cid2target))
+	debugTargets := make([]map[string]string, 0, len(tf.cid2target))
 	for _, target := range tf.cid2target {
+
 		_, ls := target.Labels()
-		debugTargets = append(debugTargets, ls.String())
+		debugTargets = append(debugTargets, ls.Map())
 	}
 	return debugTargets
 }

--- a/ebpf/session.go
+++ b/ebpf/session.go
@@ -68,7 +68,7 @@ type Session interface {
 type SessionDebugInfo struct {
 	ElfCache symtab.ElfCacheDebugInfo                          `alloy:"elf_cache,attr,optional" river:"elf_cache,attr,optional"`
 	PidCache symtab.GCacheDebugInfo[symtab.ProcTableDebugInfo] `alloy:"pid_cache,attr,optional" river:"pid_cache,attr,optional"`
-	Arch     string                                            `alloy:"arch,atttr" river:"arch,attr"`
+	Arch     string                                            `alloy:"arch,attr" river:"arch,attr"`
 	Kernel   string                                            `alloy:"kernel,attr" river:"kernel,attr"`
 }
 


### PR DESCRIPTION
This is something that would be nice to test, but I guess we don't want to get into circular dependecies with alloy :cry:

I also migrated the targets to be fully structured, so they display better than:

![image](https://github.com/grafana/pyroscope/assets/223048/25c6e38d-27d6-42f4-a039-f4adaa564921)

