### PR TITLE
doc(): fix typo and broken link

### DIFF
--- a/docs/sources/view-and-analyze-profile-data/flamegraphs.md
+++ b/docs/sources/view-and-analyze-profile-data/flamegraphs.md
@@ -39,6 +39,6 @@ This is a CPU profile, but profiles can represent many other types of resource s
 
 ## Flame graph visualization panel UI
 
-To learn more about the flame graph in the Pyroscope UI, refer to [Pyrosceop UI]({{< relref "./pyroscope-ui" >}}.
+To learn more about the flame graph in the Pyroscope UI, refer to [Pyroscope UI]({{< relref "./pyroscope-ui" >}}).
 
 To learn more about the flame graph user interface in Grafana, refer to [Flame graph visualization panel](https://grafana.com/docs/grafana-cloud/visualizations/panels-visualizations/visualizations/flame-graph).


### PR DESCRIPTION
## Description
* Fix typo and broken link

## Context
* Navigate to https://grafana.com/docs/pyroscope/latest/view-and-analyze-profile-data/flamegraphs/ and check
  <img width="762" alt="image" src="https://github.com/grafana/pyroscope/assets/39351487/d78a3679-3119-4022-b113-beb838172c28">

## How to review?
* Check link refer to an existing document and it's properly closed