### PR TITLE
Pyroscope: Provide an example for ebpf sidecar collection

### DIFF
--- a/examples/grafana-agent-auto-instrumentation/ebpf/sidecar/Dockerfile
+++ b/examples/grafana-agent-auto-instrumentation/ebpf/sidecar/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.21.10 AS build
+
+WORKDIR /app
+COPY main.go .
+RUN CGO_ENABLED=0 GOOS=linux go build -o collect-ebpf-sidecar ./main.go
+
+FROM alpine:3.19.1
+
+# Copy the binary from the build stage
+COPY --from=build /app/collect-ebpf-sidecar /usr/local/bin/
+
+# Set the timezone and install CA certificates
+RUN apk --no-cache add ca-certificates tzdata
+
+# Set the entrypoint command
+ENTRYPOINT ["/usr/local/bin/collect-ebpf-sidecar"]

--- a/examples/grafana-agent-auto-instrumentation/ebpf/sidecar/deploy.yaml
+++ b/examples/grafana-agent-auto-instrumentation/ebpf/sidecar/deploy.yaml
@@ -1,0 +1,118 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: collect-sidecar
+  labels:
+    app: example-ebpf-sidecar
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: example-ebpf-sidecar
+  template:
+    metadata:
+      labels:
+        app: example-ebpf-sidecar
+    spec:
+      shareProcessNamespace: true
+      containers:
+      - name: collect
+        image: docker.io/simonswine/collect-ebpf-sidecar:latest@sha256:40b10016e90324dadabf5141e10b164bdbd05cd35de0e277609a1b29f44e3fda
+      - name: alloy
+        image: grafana/alloy
+        securityContext:
+          runAsUser: 0
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+              - BPF
+              - SYS_ADMIN
+        command:
+          - /bin/bash
+          - -c
+          - |
+            set -euo pipefail
+            set -x
+
+            cat > /tmp/config.alloy <<"EOF"
+            discovery.process "all" {
+              refresh_interval = "200ms"
+              discover_config {
+                cwd = true
+                exe = true
+                commandline = true
+                username = true
+                uid = true
+                container_id = true
+              }
+            }
+            discovery.relabel "process" {
+              targets = discovery.process.all.targets
+              rule {
+                action = "replace"
+                regex = ".*/(.*)$"
+                replacement = "${1}"
+                source_labels = ["__meta_process_exe"]
+                target_label = "service_name"
+              }
+              rule {
+                action = "replace"
+                source_labels = ["__meta_process_commandline"]
+                target_label = "commandline"
+              }
+            }
+            pyroscope.write "pyroscope" {
+              endpoint {
+                url = "http://pyroscope"
+              }
+            }
+            pyroscope.ebpf "default" {
+              forward_to = [ pyroscope.write.pyroscope.receiver ]
+              targets    = discovery.relabel.process.output
+            }
+            EOF
+
+            exec alloy run --stability.level public-preview /tmp/config.alloy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pyroscope
+  labels:
+    app: pyroscope
+spec:
+  ports:
+  - port: 80
+    targetPort: http
+  selector:
+    app: pyroscope
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: pyroscope
+spec:
+  selector:
+    matchLabels:
+      app: pyroscope
+  serviceName: "pyroscope"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: pyroscope
+    spec:
+      containers:
+      - name: pyroscope
+        image: grafana/pyroscope
+        ports:
+        - containerPort: 4040
+          name: http
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1G

--- a/examples/grafana-agent-auto-instrumentation/ebpf/sidecar/main.go
+++ b/examples/grafana-agent-auto-instrumentation/ebpf/sidecar/main.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"sync"
+	"time"
+)
+
+//go:noinline
+func work(n int) {
+	// revive:disable:empty-block this is fine because this is a example app, not real production code
+	for i := 0; i < n; i++ {
+	}
+	// revive:enable:empty-block
+}
+
+func workUntil(c context.Context) {
+	for {
+		if c.Err() != nil {
+			break
+		}
+		work(100_000)
+	}
+}
+
+func orchestrate(ctx context.Context) error {
+	tasks := []*struct {
+		lck       sync.Mutex
+		frequency time.Duration
+		length    time.Duration
+		due       time.Time
+		cmd       *exec.Cmd
+	}{
+		{frequency: 5 * time.Second, length: 100 * time.Millisecond},
+		{frequency: 5 * time.Second, length: 500 * time.Millisecond},
+		{frequency: 10 * time.Second, length: 1 * time.Second},
+		{frequency: 15 * time.Second, length: 3 * time.Second},
+		{frequency: 15 * time.Second, length: 5 * time.Second},
+	}
+
+	waitCh := make(chan struct {
+		idx int
+		err error
+	}, len(tasks))
+
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case w := <-waitCh:
+			// handle finished tasks
+			if w.err != nil {
+				return fmt.Errorf("error waiting for command %v: %w", tasks[w.idx].cmd.Args, w.err)
+			}
+			log.Printf("finished with %v", tasks[w.idx].cmd.Args)
+			tasks[w.idx].cmd = nil
+			tasks[w.idx].due = time.Now().Add(tasks[w.idx].frequency)
+		case <-ctx.Done():
+			// handle context cancellation
+			for _, t := range tasks {
+				if t.cmd != nil && t.cmd.Process != nil {
+					t.cmd.Process.Signal(os.Interrupt)
+				}
+			}
+
+		case <-ticker.C:
+			// check if we need to start any tasks
+			for idx, t := range tasks {
+				// already running
+				if t.cmd != nil {
+					continue
+				}
+
+				// is due
+				if time.Now().After(t.due) {
+					t.cmd = exec.Command(os.Args[0], t.length.String())
+					log.Printf("starting with %v", t.cmd.Args)
+					err := t.cmd.Start()
+					if err != nil {
+						return fmt.Errorf("error starting command: %v", err)
+					}
+					go func(idx int) {
+						err := tasks[idx].cmd.Wait()
+						waitCh <- struct {
+							idx int
+							err error
+						}{idx: idx, err: err}
+					}(idx)
+
+				}
+
+			}
+		}
+	}
+
+	return nil
+}
+
+func run() error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	// when argument is provided, sleep for that amount
+	if len(os.Args) == 2 {
+		d, err := time.ParseDuration(os.Args[1])
+		if err != nil {
+			return fmt.Errorf("error parsing duration: %v", err)
+		}
+
+		ctx, cancel := context.WithTimeout(ctx, d)
+		defer cancel()
+		log.Printf("starting work for %s\n", d)
+		workUntil(ctx)
+		return nil
+	}
+	if len(os.Args) > 2 {
+		return errors.New("too many arguments")
+	}
+
+	return orchestrate(ctx)
+}
+
+func main() {
+	err := run()
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
+}


### PR DESCRIPTION
This shows how Alloy can be used to collect profiles as a sidecar. I am not too sure if this is something we should advertise too heavily, but valuable if you would only like to collect a very specific workloads, that is supported by eBPF.

Maybe we also want to have something like `pyroscope exec` was for this usecase.

The test workload launches some short-lived sub processes of varying length, the problem is that collection requires to have a quite low `discovery.process.refresh_interval` 
