### PR TITLE
Update dotnet examples to SDK version 8

### DIFF
--- a/examples/language-sdk-instrumentation/dotnet/rideshare/Dockerfile
+++ b/examples/language-sdk-instrumentation/dotnet/rideshare/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 WORKDIR /dotnet
 

--- a/examples/language-sdk-instrumentation/dotnet/rideshare/example/Example.csproj
+++ b/examples/language-sdk-instrumentation/dotnet/rideshare/example/Example.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>example</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>example</PackageId>

--- a/examples/language-sdk-instrumentation/dotnet/rideshare/musl.Dockerfile
+++ b/examples/language-sdk-instrumentation/dotnet/rideshare/musl.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine
 
 WORKDIR /dotnet
 


### PR DESCRIPTION
Unfortunately, this doesn't work for me on Apple M2, with rosetta I get build errors, works on my linux/amd64 machine though:

```
# For musl
$ docker buildx build --load --platform linux/amd64 examples/language-sdk-instrumentation/dotnet/rideshare/  -f examples/language-sdk-instrumentation/dotnet/rideshare/musl.Dockerfile
[...]
 => ERROR [stage-0 6/6] RUN dotnet publish -o . -r $(dotnet --info | grep RID | cut -b 6- | tr -d ' ')                                                                                                                                          1.7s
------
 > [stage-0 6/6] RUN dotnet publish -o . -r $(dotnet --info | grep RID | cut -b 6- | tr -d ' '):
1.564 The expression "[MSBuild]::GetTargetPlatformIdentifier('')" cannot be evaluated. Exception has been thrown by the target of an invocation.  /usr/share/dotnet/sdk/8.0.204/Sdks/Microsoft.NET.Sdk.Web/Sdk/Sdk.props
1.581 MSBuild version 17.9.8+b34f75857 for .NET
------

# For glibc
$ docker buildx build --load --platform linux/amd64 examples/language-sdk-instrumentation/dotnet/rideshare/
  => ERROR [stage-0 6/6] RUN dotnet publish -o . -r $(dotnet --info | grep RID | cut -b 6- | tr -d ' ')                                                                                                                                          1.7s
------
 > [stage-0 6/6] RUN dotnet publish -o . -r $(dotnet --info | grep RID | cut -b 6- | tr -d ' '):
1.634 terminate called after throwing an instance of 'PAL_SEHException'
1.639 Aborted

```

Not really too sure if that is something broken locally, wonder if some of you could give it a try before merging. @grafana/pyroscope-dotnet 

