### PR TITLE
docs: Fix some broken links

### DIFF
--- a/docs/sources/configure-client/grafana-agent/ebpf/setup-docker.md
+++ b/docs/sources/configure-client/grafana-agent/ebpf/setup-docker.md
@@ -83,7 +83,7 @@ If you need to send data to Grafana Cloud, you'll have to configure HTTP Basic a
 If you're using your own Pyroscope server, you can remove the `basic_auth` section altogether.
 {{% /admonition %}}
 
-For more information, refer to the [Configure the Grafana Pyroscope data source documentation](/docs/grafana-cloud/connect-externally-hosted/data-sources/grafana-pyroscope#configure-the-grafana-pyroscope-data-source).
+For more information, refer to the [Configure the Grafana Pyroscope data source documentation](/docs/grafana-cloud/connect-externally-hosted/data-sources/pyroscope/configure-pyroscope-data-source/).
 
 ## Start Grafana Agent
 

--- a/docs/sources/configure-client/grafana-agent/ebpf/setup-kubernetes.md
+++ b/docs/sources/configure-client/grafana-agent/ebpf/setup-kubernetes.md
@@ -108,7 +108,7 @@ If you need to send data to Grafana Cloud, you'll have to configure HTTP Basic a
 If you're using your own Pyroscope server, you can remove the `basic_auth` section altogether.
 {{% /admonition %}}
 
-For more information, refer to the [Configure the Grafana Pyroscope data source documentation](/docs/grafana-cloud/connect-externally-hosted/data-sources/grafana-pyroscope#configure-the-grafana-pyroscope-data-source).
+For more information, refer to the [Configure the Grafana Pyroscope data source documentation](/docs/grafana-cloud/connect-externally-hosted/data-sources/pyroscope/configure-pyroscope-data-source/).
 
 ## Install the Grafana Agent
 

--- a/docs/sources/configure-client/grafana-agent/ebpf/setup-linux.md
+++ b/docs/sources/configure-client/grafana-agent/ebpf/setup-linux.md
@@ -113,7 +113,7 @@ If you need to send data to Grafana Cloud, you'll have to configure HTTP Basic a
 If you're using your own Pyroscope server, you can remove the `basic_auth` section altogether.
 {{% /admonition %}}
 
-For more information, refer to the [Configure the Grafana Pyroscope data source documentation](/docs/grafana-cloud/connect-externally-hosted/data-sources/grafana-pyroscope#configure-the-grafana-pyroscope-data-source).
+For more information, refer to the [Configure the Grafana Pyroscope data source documentation](/docs/grafana-cloud/connect-externally-hosted/data-sources/pyroscope/configure-pyroscope-data-source/).
 
 ## Start the Grafana Agent
 

--- a/docs/sources/configure-client/trace-span-profiles/dotnet-span-profiles.md
+++ b/docs/sources/configure-client/trace-span-profiles/dotnet-span-profiles.md
@@ -29,7 +29,7 @@ To use Span Profiles, you need to:
 
 * [Configure Pyroscope to send profiling data]({{< relref "../../configure-client" >}})
 * Configure a client-side package to link traces and profiles: [.NET](https://github.com/grafana/pyroscope-dotnet/tree/main/Pyroscope/Pyroscope.OpenTelemetry)
-* [Configure the Tempo data source in Grafana or Grafana Cloud to discover linked traces and profiles](/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/)
+* [Configure the Tempo data source in Grafana or Grafana Cloud to discover linked traces and profiles](/docs/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/)
 
 ## Before you begin
 

--- a/docs/sources/configure-client/trace-span-profiles/go-span-profiles.md
+++ b/docs/sources/configure-client/trace-span-profiles/go-span-profiles.md
@@ -32,7 +32,7 @@ To use Span Profiles, you need to:
 
 * [Configure Pyroscope to send profiling data]({{< relref "../../configure-client" >}})
 * Configure a client-side package to link traces and profiles: [Go](https://github.com/grafana/otel-profiling-go)
-* [Configure the Tempo data source in Grafana or Grafana Cloud to discover linked traces and profiles](/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/)
+* [Configure the Tempo data source in Grafana or Grafana Cloud to discover linked traces and profiles](/docs/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/)
 
 ## Before you begin
 

--- a/docs/sources/configure-client/trace-span-profiles/java-span-profiles.md
+++ b/docs/sources/configure-client/trace-span-profiles/java-span-profiles.md
@@ -29,7 +29,7 @@ To use Span Profiles, you need to:
 
 * [Configure Pyroscope to send profiling data]({{< relref "../../configure-client" >}})
 * Configure a client-side package to link traces and profiles: [Java](https://github.com/grafana/otel-profiling-java)
-* [Configure the Tempo data source in Grafana or Grafana Cloud to discover linked traces and profiles](/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/)
+* [Configure the Tempo data source in Grafana or Grafana Cloud to discover linked traces and profiles](/docs/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/)
 
 ## Before you begin
 

--- a/docs/sources/configure-client/trace-span-profiles/python-span-profiles.md
+++ b/docs/sources/configure-client/trace-span-profiles/python-span-profiles.md
@@ -29,7 +29,7 @@ To use Span Profiles, you need to:
 
 * [Configure Pyroscope to send profiling data]({{< relref "../../configure-client" >}})
 * Configure a client-side package to link traces and profiles: [Python](https://github.com/grafana/otel-profiling-python)
-* [Configure the Tempo data source in Grafana or Grafana Cloud to discover linked traces and profiles](/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/)
+* [Configure the Tempo data source in Grafana or Grafana Cloud to discover linked traces and profiles](/docs/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/)
 
 ## Before you begin
 

--- a/docs/sources/configure-client/trace-span-profiles/ruby-span-profiles.md
+++ b/docs/sources/configure-client/trace-span-profiles/ruby-span-profiles.md
@@ -29,7 +29,7 @@ To use Span Profiles, you need to:
 
 * [Configure Pyroscope to send profiling data]({{< relref "../../configure-client" >}})
 * Configure a client-side package to link traces and profiles: [Ruby](https://github.com/grafana/otel-profiling-ruby)
-* [Configure the Tempo data source in Grafana or Grafana Cloud to discover linked traces and profiles](/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/)
+* [Configure the Tempo data source in Grafana or Grafana Cloud to discover linked traces and profiles](/docs/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/)
 
 ## Before you begin
 

--- a/docs/sources/view-and-analyze-profile-data/_index.md
+++ b/docs/sources/view-and-analyze-profile-data/_index.md
@@ -40,4 +40,4 @@ For more information on using profiles in Grafana, refer to [Pyroscope and profi
 
 The Pyroscope app plugin works for Grafana Cloud.
 
-For more information on configuring these data sources, refer to the Pyroscope data source documentation in [Grafana Cloud](/docs/grafana-cloud/connect-externally-hosted/data-sources/grafana-pyroscope/) and [Grafana](/docs/grafana/latest/datasources/grafana-pyroscope/).
+For more information on configuring these data sources, refer to the Pyroscope data source documentation in [Grafana Cloud](/docs/grafana-cloud/connect-externally-hosted/data-sources/pyroscope/) and [Grafana](/docs/grafana/latest/datasources/grafana-pyroscope/).


### PR DESCRIPTION
Something seems to have changed to the place where pyroscope grafana-cloud docs are.