### PR TITLE
docs: Add note about environment variable `DOTNET_EnableDiagnostics`

### DIFF
--- a/docs/sources/configure-client/language-sdks/dotnet.md
+++ b/docs/sources/configure-client/language-sdks/dotnet.md
@@ -64,7 +64,16 @@ CORECLR_PROFILER_PATH=Pyroscope.Profiler.Native.so
 LD_PRELOAD=Pyroscope.Linux.ApiWrapper.x64.so
 ```
 
-&nbsp;
+{{< admonition type="note" >}}
+Since .NET version 8 the environment variable `DOTNET_EnableDiagnostics=0` (or its legacy equivalent `COMPlus_EnableDiagnostics=0`) will also disable the profiler. In order to get the previous behaviour (allowing profiling, but switch off IPC and Debugging) the following environment variables should be set instead:
+
+```shell
+DOTNET_EnableDiagnostics=1
+DOTNET_EnableDiagnostics_IPC=0
+DOTNET_EnableDiagnostics_Debugger=0
+DOTNET_EnableDiagnostics_Profiler=1
+```
+{{< /admonition >}}
 
 ### .NET Profiler API
 


### PR DESCRIPTION
This adds some instructions how to make sure profiling is working in dotnet 8.

![image](https://github.com/grafana/pyroscope/assets/223048/dde6caf0-1705-48a5-8045-74f813243789)


See https://github.com/dotnet/runtime/issues/96227
