### PR TITLE
vcs: Derive per tenant key

### DIFF
--- a/pkg/querier/vcs/service.go
+++ b/pkg/querier/vcs/service.go
@@ -44,13 +44,19 @@ func (q *Service) GithubLogin(ctx context.Context, req *connect.Request[vcsv1.Gi
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to authorize with GitHub"))
 	}
 
+	encryptionKey, err := deriveEncryptionKeyForContext(ctx)
+	if err != nil {
+		q.logger.Log("err", err, "msg", "failed to derive encryption key")
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to authorize with GitHub"))
+	}
+
 	token, err := cfg.Exchange(ctx, req.Msg.AuthorizationCode)
 	if err != nil {
 		q.logger.Log("err", err, "msg", "failed to exchange authorization code with GitHub")
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("failed to authorize with GitHub"))
 	}
 
-	cookie, err := encodeToken(token)
+	cookie, err := encodeToken(token, encryptionKey)
 	if err != nil {
 		q.logger.Log("err", err, "msg", "failed to encode GitHub OAuth token")
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to authorize with GitHub"))
@@ -63,7 +69,7 @@ func (q *Service) GithubLogin(ctx context.Context, req *connect.Request[vcsv1.Gi
 }
 
 func (q *Service) GithubRefresh(ctx context.Context, req *connect.Request[vcsv1.GithubRefreshRequest]) (*connect.Response[vcsv1.GithubRefreshResponse], error) {
-	token, err := tokenFromRequest(req)
+	token, err := tokenFromRequest(ctx, req)
 	if err != nil {
 		q.logger.Log("err", err, "msg", "failed to extract token from request")
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("invalid token"))
@@ -83,7 +89,13 @@ func (q *Service) GithubRefresh(ctx context.Context, req *connect.Request[vcsv1.
 
 	newToken := githubToken.toOAuthToken()
 
-	cookie, err := encodeToken(newToken)
+	derivedKey, err := deriveEncryptionKeyForContext(ctx)
+	if err != nil {
+		q.logger.Log("err", err, "msg", "failed to derive encryption key")
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to process token"))
+	}
+
+	cookie, err := encodeToken(newToken, derivedKey)
 	if err != nil {
 		q.logger.Log("err", err, "msg", "failed to encode GitHub OAuth token")
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to refresh token"))
@@ -96,7 +108,7 @@ func (q *Service) GithubRefresh(ctx context.Context, req *connect.Request[vcsv1.
 }
 
 func (q *Service) GetFile(ctx context.Context, req *connect.Request[vcsv1.GetFileRequest]) (*connect.Response[vcsv1.GetFileResponse], error) {
-	token, err := tokenFromRequest(req)
+	token, err := tokenFromRequest(ctx, req)
 	if err != nil {
 		q.logger.Log("err", err, "msg", "failed to extract token from request")
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("invalid token"))
@@ -141,7 +153,7 @@ func (q *Service) GetFile(ctx context.Context, req *connect.Request[vcsv1.GetFil
 }
 
 func (q *Service) GetCommit(ctx context.Context, req *connect.Request[vcsv1.GetCommitRequest]) (*connect.Response[vcsv1.GetCommitResponse], error) {
-	token, err := tokenFromRequest(req)
+	token, err := tokenFromRequest(ctx, req)
 	if err != nil {
 		q.logger.Log("err", err, "msg", "failed to extract token from request")
 		return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("invalid token"))


### PR DESCRIPTION
Currently we use the same global session encryption secret, for each tenant. In order to ensure tenant isolation, this change will derive a custom secret per tenant.

By using sha256 we also increase the secret used for encryption from 128bit to 256bit, while allowing to get an arbitrary secret specified. 

Note: This change will require all users to re-authenticate, as the the previous GitSession won't be decrypted by this. It is possible to implement this without this breaking change, but given session length is 8 hours, I rather would re-authenticate instead. 
