### PR TITLE
Fix link to spanprofiler

### DIFF
--- a/examples/tracing/tempo/README.md
+++ b/examples/tracing/tempo/README.md
@@ -33,7 +33,7 @@ less than the sample interval (10ms).
  - `rideshare` demo application instrumented with OpenTelemetry:
    - Go [OTel integration](https://github.com/grafana/otel-profiling-go)
    - Java [OTel integration](https://github.com/grafana/otel-profiling-java) 
- - `pyroscope` itself is instrumented with `opentracing-go` SDK and [`spanprofiler`](../../../pkg/util/spanprofiler) for profiling integration.
+ - `pyroscope` itself is instrumented with `opentracing-go` SDK and [`spanprofiler`](https://github.com/grafana/dskit/tree/main/spanprofiler) for profiling integration.
 
 ### Grafana Tempo configuration
 


### PR DESCRIPTION
Just fix the link for the `spanprofiler` application in the examples.