### PR TITLE
connect: Use klauspost/compress/gzip decompression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ docker-image/pyroscope/build: frontend/build go/bin
 docker-image/pyroscope/push: GOOS=linux
 docker-image/pyroscope/push: GOARCH=amd64
 docker-image/pyroscope/push: frontend/build go/bin
-	$(call docker_buildx,--push)
+	$(call docker_buildx,--push,)
 
 define UPDATER_CONFIG_JSON
 {

--- a/pkg/api/connect/compression.go
+++ b/pkg/api/connect/compression.go
@@ -1,0 +1,33 @@
+package connectapi
+
+import (
+	"io"
+
+	"connectrpc.com/connect"
+	"github.com/klauspost/compress/gzip"
+)
+
+const (
+	compressionGzip = "gzip"
+)
+
+var (
+	gzipPoolHandler = connect.WithCompression(
+		compressionGzip,
+		func() connect.Decompressor { return &gzip.Reader{} },
+		func() connect.Compressor { return gzip.NewWriter(io.Discard) },
+	)
+	gzipPoolClient = connect.WithAcceptCompression(
+		compressionGzip,
+		func() connect.Decompressor { return &gzip.Reader{} },
+		func() connect.Compressor { return gzip.NewWriter(io.Discard) },
+	)
+)
+
+func WithGzipHandler() connect.HandlerOption {
+	return gzipPoolHandler
+}
+
+func WithGzipClient() connect.ClientOption {
+	return gzipPoolClient
+}

--- a/pkg/api/connect/connect.go
+++ b/pkg/api/connect/connect.go
@@ -7,11 +7,13 @@ import (
 func DefaultClientOptions() []connect.ClientOption {
 	return []connect.ClientOption{
 		connect.WithCodec(ProtoCodec),
+		WithGzipClient(),
 	}
 }
 
 func DefaultHandlerOptions() []connect.HandlerOption {
 	return []connect.HandlerOption{
 		connect.WithCodec(ProtoCodec),
+		WithGzipHandler(),
 	}
 }


### PR DESCRIPTION
Now that we have shared options between all connect Handlers/Clients it is easy to swap out compress/gzip with klauspost/compress/gzip.

At the same time this makes sure that all handlers and clients use the same compressor pool. Otherwise every new handler and client maintains its own pool (And we create a lot of clients dynamically).

Relies on the work of #3310 