### PR TITLE
Improve block plan creation for standalone binary mode

### DIFF
--- a/pkg/querier/analyze_query.go
+++ b/pkg/querier/analyze_query.go
@@ -34,11 +34,13 @@ func (q *Querier) AnalyzeQuery(ctx context.Context, req *connect.Request[querier
 	}
 	addBlockStatsToQueryScope(blockStatsFromReplicas, ingesterQueryScope)
 
-	blockStatsFromReplicas, err = q.getBlockStatsFromStoreGateways(ctx, plan, storeGatewayQueryScope.blockIds)
-	if err != nil {
-		return nil, err
+	if q.storeGatewayQuerier != nil {
+		blockStatsFromReplicas, err = q.getBlockStatsFromStoreGateways(ctx, plan, storeGatewayQueryScope.blockIds)
+		if err != nil {
+			return nil, err
+		}
+		addBlockStatsToQueryScope(blockStatsFromReplicas, storeGatewayQueryScope)
 	}
-	addBlockStatsToQueryScope(blockStatsFromReplicas, storeGatewayQueryScope)
 
 	queriedSeries, err := q.getQueriedSeriesCount(ctx, req.Msg)
 	if err != nil {

--- a/pkg/querier/analyze_query.go
+++ b/pkg/querier/analyze_query.go
@@ -66,14 +66,16 @@ func getDataFromPlan(plan blockPlan) (ingesterQueryScope *queryScope, storeGatew
 	deduplicationNeeded = false
 	for _, planEntry := range plan {
 		deduplicationNeeded = deduplicationNeeded || planEntry.Deduplication
-		if planEntry.InstanceType == ingesterInstance {
-			ingesterQueryScope.ComponentCount += 1
-			ingesterQueryScope.BlockCount += uint64(len(planEntry.Ulids))
-			ingesterQueryScope.blockIds = append(ingesterQueryScope.blockIds, planEntry.Ulids...)
-		} else {
-			storeGatewayQueryScope.ComponentCount += 1
-			storeGatewayQueryScope.BlockCount += uint64(len(planEntry.Ulids))
-			storeGatewayQueryScope.blockIds = append(storeGatewayQueryScope.blockIds, planEntry.Ulids...)
+		for _, t := range planEntry.InstanceTypes {
+			if t == ingesterInstance {
+				ingesterQueryScope.ComponentCount += 1
+				ingesterQueryScope.BlockCount += uint64(len(planEntry.Ulids))
+				ingesterQueryScope.blockIds = append(ingesterQueryScope.blockIds, planEntry.Ulids...)
+			} else {
+				storeGatewayQueryScope.ComponentCount += 1
+				storeGatewayQueryScope.BlockCount += uint64(len(planEntry.Ulids))
+				storeGatewayQueryScope.blockIds = append(storeGatewayQueryScope.blockIds, planEntry.Ulids...)
+			}
 		}
 	}
 	return ingesterQueryScope, storeGatewayQueryScope, deduplicationNeeded

--- a/pkg/querier/querier_test.go
+++ b/pkg/querier/querier_test.go
@@ -1350,7 +1350,7 @@ func Test_splitQueryToStores(t *testing.T) {
 			start:           model.TimeFromUnixNano(int64(30 * time.Minute)),
 			end:             model.TimeFromUnixNano(int64(45*time.Minute) + int64(3*time.Hour)),
 			queryStoreAfter: 30 * time.Minute,
-			plan:            blockPlan{"replica-a": &blockPlanEntry{InstanceType: ingesterInstance, BlockHints: &ingestv1.BlockHints{Ulids: []string{"block-a", "block-b"}}}},
+			plan:            blockPlan{"replica-a": &blockPlanEntry{InstanceTypes: []instanceType{ingesterInstance}, BlockHints: &ingestv1.BlockHints{Ulids: []string{"block-a", "block-b"}}}},
 
 			expected: storeQueries{
 				queryStoreAfter: 0,


### PR DESCRIPTION
In standalone mode the ingester and store-gateway are represented with the same replica address. This doesn't cause real issues in the query path (the same physical block plan is re-used for both query paths), however it does impact query analysis because we end up including one of the paths only.

Not sure if this would break something else, but seems fairly safe to me. 