### PR TITLE
Align default step for /render with Grafana

### DIFF
--- a/pkg/querier/timeline/calculator.go
+++ b/pkg/querier/timeline/calculator.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	DefaultRes         int64 = 1500
-	DefaultMinInterval       = time.Second * 10
+	DefaultMinInterval       = time.Second * 15
 )
 
 // CalcPointInterval calculates the appropriate interval between each point (aka step)

--- a/pkg/querier/timeline/calculator_test.go
+++ b/pkg/querier/timeline/calculator_test.go
@@ -18,8 +18,8 @@ func Test_CalcPointInterval(t *testing.T) {
 		end   time.Time
 		want  int64
 	}{
-		{name: "1 second", start: TestDate, end: TestDate.Add(1 * time.Second), want: 10},
-		{name: "1 hour", start: TestDate, end: TestDate.Add(1 * time.Hour), want: 10},
+		{name: "1 second", start: TestDate, end: TestDate.Add(1 * time.Second), want: 15},
+		{name: "1 hour", start: TestDate, end: TestDate.Add(1 * time.Hour), want: 15},
 		{name: "7 days", start: TestDate, end: TestDate.Add(7 * 24 * time.Hour), want: 300},
 		{name: "30 days", start: TestDate, end: TestDate.Add(30 * 24 * time.Hour), want: 1800},
 		{name: "90 days", start: TestDate, end: TestDate.Add(30 * 24 * time.Hour), want: 1800},


### PR DESCRIPTION
In Grafana's native Explore Profiles view, the default step is 15 seconds. This is only used when the data source doesn't supply a configured min step:

https://github.com/grafana/grafana/blob/24d65fa32f6ba7af3dc2e0ffa115c64aa7c97184/pkg/tsdb/grafana-pyroscope-datasource/query.go#L71-L87
