### PR TITLE
Return error when GH configuration is missing

### DIFF
--- a/pkg/querier/vcs/github.go
+++ b/pkg/querier/vcs/github.go
@@ -2,6 +2,7 @@ package vcs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -147,4 +148,22 @@ func githubAuthTokenFromFormURLEncoded(values url.Values) (*githubAuthToken, err
 	}
 
 	return token, nil
+}
+
+func isGitHubIntegrationConfigured() error {
+	var errs []error
+
+	if githubAppClientID == "" {
+		errs = append(errs, fmt.Errorf("missing GITHUB_CLIENT_ID environment variable"))
+	}
+
+	if githubAppClientSecret == "" {
+		errs = append(errs, fmt.Errorf("missing GITHUB_CLIENT_SECRET environment variable"))
+	}
+
+	if len(githubSessionSecret) == 0 {
+		errs = append(errs, fmt.Errorf("missing GITHUB_SESSION_SECRET environment variable"))
+	}
+
+	return errors.Join(errs...)
 }

--- a/pkg/querier/vcs/service.go
+++ b/pkg/querier/vcs/service.go
@@ -37,6 +37,12 @@ func New(logger log.Logger, reg prometheus.Registerer) *Service {
 }
 
 func (q *Service) GithubApp(ctx context.Context, req *connect.Request[vcsv1.GithubAppRequest]) (*connect.Response[vcsv1.GithubAppResponse], error) {
+	err := isGitHubIntegrationConfigured()
+	if err != nil {
+		q.logger.Log("err", err, "msg", "GitHub integration is not configured")
+		return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("GitHub integration is not configured"))
+	}
+
 	return connect.NewResponse(&vcsv1.GithubAppResponse{
 		ClientID: githubAppClientID,
 	}), nil


### PR DESCRIPTION
The first request the UI makes when interacting with the GH integration is to call `/GithubApp`. This change has that endpoint verify the server is configured correctly to support the GH integration feature. If it isn't it will return an "unimplemented" error.