### PR TITLE
Use default sample rate of 100 per second for CPU

### DIFF
--- a/pkg/model/flamegraph.go
+++ b/pkg/model/flamegraph.go
@@ -132,8 +132,6 @@ func ExportToFlamebearer(fg *querierv1.FlameGraph, profileType *typesv1.ProfileT
 		unit = metadata.ObjectsUnits
 	case "cpu":
 		unit = metadata.SamplesUnits
-		sampleRate = uint32(1_000_000_000)
-
 	}
 	levels := make([][]int, len(fg.Levels))
 	for i := range levels {

--- a/pkg/og/structs/flamebearer/flamebearer.go
+++ b/pkg/og/structs/flamebearer/flamebearer.go
@@ -82,7 +82,7 @@ type FlamebearerMetadataV1 struct {
 	Format string `json:"format"`
 	// Name of the spy / profiler used to generate the profile, if any.
 	SpyName string `json:"spyName"`
-	// Sample rate at which the profiler was operating.
+	// Sample rate at which the profiler was operating. Note: This unit is not related to the Units field and is measured in samples per second.
 	SampleRate uint32 `json:"sampleRate"`
 	// The unit of measurement for the profiled data.
 	Units metadata.Units `json:"units"`


### PR DESCRIPTION
This fixes the default sample rate for profiling and clarfies the field value. Relates to #3340.
