### PR TITLE
feat: optimize series order

### DIFF
--- a/cmd/profilecli/tsdb.go
+++ b/cmd/profilecli/tsdb.go
@@ -44,7 +44,7 @@ func tsdbSeries(ctx context.Context, path string) error {
 			return fmt.Errorf("error retrieving seriesRef: %w", err)
 		}
 
-		line.Labels, err = lbls.ToPrometheusLabels().MarshalJSON()
+		line.Labels, err = json.Marshal(lbls)
 		if err != nil {
 			return fmt.Errorf("error marshalling labels: %w", err)
 		}

--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -1047,6 +1047,8 @@ Usage of ./pyroscope:
     	[experimental] Set to true to enable profiling integration.
   -usage-stats.enabled
     	Enable anonymous usage reporting. (default true)
+  -validation.enforce-labels-order
+    	Enforce labels order optimization.
   -validation.max-label-names-per-series int
     	Maximum number of label names per series. (default 30)
   -validation.max-length-label-name int

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -381,6 +381,8 @@ Usage of ./pyroscope:
     	Set to false to disable tracing. (default true)
   -usage-stats.enabled
     	Enable anonymous usage reporting. (default true)
+  -validation.enforce-labels-order
+    	Enforce labels order optimization.
   -validation.max-label-names-per-series int
     	Maximum number of label names per series. (default 30)
   -validation.max-length-label-name int

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -1815,6 +1815,10 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -validation.max-sessions-per-series
 [max_sessions_per_series: <int> | default = 0]
 
+# Enforce labels order optimization.
+# CLI flag: -validation.enforce-labels-order
+[enforce_labels_order: <boolean> | default = false]
+
 # Maximum size of a profile in bytes. This is based off the uncompressed size. 0
 # to disable.
 # CLI flag: -validation.max-profile-size-bytes

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -415,7 +415,8 @@ func Test_Sessions_Limit(t *testing.T) {
 				}), nil, log.NewLogfmtLogger(os.Stdout))
 
 			require.NoError(t, err)
-			assert.Equal(t, tc.expectedLabels, d.limitMaxSessionsPerSeries("user-1", tc.seriesLabels))
+			limit := d.limits.MaxSessionsPerSeries("user-1")
+			assert.Equal(t, tc.expectedLabels, d.limitMaxSessionsPerSeries(limit, tc.seriesLabels))
 		})
 	}
 }

--- a/pkg/model/labels_test.go
+++ b/pkg/model/labels_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 )
 
 func TestLabelsUnique(t *testing.T) {
@@ -67,21 +69,20 @@ func TestLabelsUnique(t *testing.T) {
 }
 
 func TestLabels_SessionID_Order(t *testing.T) {
-	const serviceNameLabel = "__service_name__"
 	input := []Labels{
 		{
 			{Name: LabelNameSessionID, Value: "session-a"},
 			{Name: LabelNameProfileType, Value: "cpu"},
-			{Name: serviceNameLabel, Value: "service-name"},
+			{Name: LabelNameServiceNamePrivate, Value: "service-name"},
 		}, {
 			{Name: LabelNameSessionID, Value: "session-b"},
 			{Name: LabelNameProfileType, Value: "cpu"},
-			{Name: serviceNameLabel, Value: "service-name"},
+			{Name: LabelNameServiceNamePrivate, Value: "service-name"},
 		},
 	}
 
 	for _, x := range input {
-		sort.Sort(x)
+		sort.Sort(LabelsEnforcedOrder(x))
 	}
 	sort.Slice(input, func(i, j int) bool {
 		return CompareLabelPairs(input[i], input[j]) < 0
@@ -90,11 +91,11 @@ func TestLabels_SessionID_Order(t *testing.T) {
 	expectedOrder := []Labels{
 		{
 			{Name: LabelNameProfileType, Value: "cpu"},
-			{Name: serviceNameLabel, Value: "service-name"},
+			{Name: LabelNameServiceNamePrivate, Value: "service-name"},
 			{Name: LabelNameSessionID, Value: "session-a"},
 		}, {
 			{Name: LabelNameProfileType, Value: "cpu"},
-			{Name: serviceNameLabel, Value: "service-name"},
+			{Name: LabelNameServiceNamePrivate, Value: "service-name"},
 			{Name: LabelNameSessionID, Value: "session-b"},
 		},
 	}
@@ -132,4 +133,131 @@ func Test_SessionID_Parse(t *testing.T) {
 
 	_, err = ParseSessionID("not-a-session-id-either")
 	assert.NotNil(t, err)
+}
+
+func TestLabels_LabelsEnforcedOrder(t *testing.T) {
+	labels := []*typesv1.LabelPair{
+		{Name: "foo", Value: "bar"},
+		{Name: LabelNameProfileType, Value: "cpu"},
+		{Name: "__request_id__", Value: "mess"},
+		{Name: LabelNameServiceNamePrivate, Value: "service"},
+		{Name: "Alarm", Value: "Order"},
+	}
+
+	expected := Labels{
+		{Name: LabelNameProfileType, Value: "cpu"},
+		{Name: LabelNameServiceNamePrivate, Value: "service"},
+		{Name: "Alarm", Value: "Order"},
+		{Name: "__request_id__", Value: "mess"},
+		{Name: "foo", Value: "bar"},
+	}
+
+	permute(labels, func(x []*typesv1.LabelPair) {
+		sort.Sort(LabelsEnforcedOrder(x))
+		assert.Equal(t, LabelPairsString(expected), LabelPairsString(labels))
+	})
+}
+
+func permute[T any](s []T, f func([]T)) {
+	n := len(s)
+	stack := make([]int, n)
+	f(s)
+	i := 0
+	for i < n {
+		if stack[i] < i {
+			if i%2 == 0 {
+				s[0], s[i] = s[i], s[0]
+			} else {
+				s[stack[i]], s[i] = s[i], s[stack[i]]
+			}
+			f(s)
+			stack[i]++
+			i = 0
+		} else {
+			stack[i] = 0
+			i++
+		}
+	}
+}
+
+func TestInsert(t *testing.T) {
+	tests := []struct {
+		name        string
+		labels      Labels
+		insertName  string
+		insertValue string
+		expected    Labels
+	}{
+		{
+			name:        "Insert into empty slice",
+			labels:      Labels{},
+			insertName:  "foo",
+			insertValue: "bar",
+			expected: Labels{
+				{Name: "foo", Value: "bar"},
+			},
+		},
+		{
+			name: "Insert at the beginning",
+			labels: Labels{
+				{Name: "baz", Value: "qux"},
+				{Name: "quux", Value: "corge"},
+			},
+			insertName:  "alice",
+			insertValue: "bob",
+			expected: Labels{
+				{Name: "alice", Value: "bob"},
+				{Name: "baz", Value: "qux"},
+				{Name: "quux", Value: "corge"},
+			},
+		},
+		{
+			name: "Insert in the middle",
+			labels: Labels{
+				{Name: "baz", Value: "qux"},
+				{Name: "quux", Value: "corge"},
+			},
+			insertName:  "foo",
+			insertValue: "bar",
+			expected: Labels{
+				{Name: "baz", Value: "qux"},
+				{Name: "foo", Value: "bar"},
+				{Name: "quux", Value: "corge"},
+			},
+		},
+		{
+			name: "Insert at the end",
+			labels: Labels{
+				{Name: "baz", Value: "qux"},
+				{Name: "quux", Value: "corge"},
+			},
+			insertName:  "xyz",
+			insertValue: "123",
+			expected: Labels{
+				{Name: "baz", Value: "qux"},
+				{Name: "quux", Value: "corge"},
+				{Name: "xyz", Value: "123"},
+			},
+		},
+		{
+			name: "Update existing label",
+			labels: Labels{
+				{Name: "baz", Value: "qux"},
+				{Name: "quux", Value: "corge"},
+			},
+			insertName:  "baz",
+			insertValue: "updated_value",
+			expected: Labels{
+				{Name: "baz", Value: "updated_value"},
+				{Name: "quux", Value: "corge"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.labels.Insert(test.insertName, test.insertValue)
+			assert.Equal(t, test.expected, test.labels)
+		})
+	}
 }

--- a/pkg/phlaredb/head.go
+++ b/pkg/phlaredb/head.go
@@ -187,7 +187,10 @@ func (h *Head) Ingest(ctx context.Context, p *profilev1.Profile, id uuid.UUID, e
 	delta := phlaremodel.Labels(externalLabels).Get(phlaremodel.LabelNameDelta) != "false"
 	externalLabels = phlaremodel.Labels(externalLabels).Delete(phlaremodel.LabelNameDelta)
 
-	lbls, seriesFingerprints := phlarelabels.CreateProfileLabels(p, externalLabels...)
+	enforceLabelOrder := phlaremodel.Labels(externalLabels).Get(phlaremodel.LabelNameOrder) == phlaremodel.LabelOrderEnforced
+	externalLabels = phlaremodel.Labels(externalLabels).Delete(phlaremodel.LabelNameOrder)
+
+	lbls, seriesFingerprints := phlarelabels.CreateProfileLabels(enforceLabelOrder, p, externalLabels...)
 
 	for i, fp := range seriesFingerprints {
 		if err := h.limiter.AllowProfile(fp, lbls[i], p.TimeNanos); err != nil {

--- a/pkg/phlaredb/labels/labels.go
+++ b/pkg/phlaredb/labels/labels.go
@@ -1,7 +1,7 @@
 package labels
 
 import (
-	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/prometheus/common/model"
@@ -11,9 +11,7 @@ import (
 	phlaremodel "github.com/grafana/pyroscope/pkg/model"
 )
 
-var labelNameServiceName = fmt.Sprintf("__%s__", phlaremodel.LabelNameServiceName)
-
-func CreateProfileLabels(p *profilev1.Profile, externalLabels ...*typesv1.LabelPair) ([]phlaremodel.Labels, []model.Fingerprint) {
+func CreateProfileLabels(enforceOrder bool, p *profilev1.Profile, externalLabels ...*typesv1.LabelPair) ([]phlaremodel.Labels, []model.Fingerprint) {
 	// build label set per sample type before references are rewritten
 	var (
 		sb                                             strings.Builder
@@ -24,8 +22,8 @@ func CreateProfileLabels(p *profilev1.Profile, externalLabels ...*typesv1.LabelP
 
 	// Inject into labels the __service_name__ label if it exists
 	// This allows better locality of the data in parquet files (row group are sorted by).
-	if serviceName := lbls.Labels().Get(phlaremodel.LabelNameServiceName); serviceName != "" {
-		lbls.Set(labelNameServiceName, serviceName)
+	if serviceName := phlaremodel.Labels(externalLabels).Get(phlaremodel.LabelNameServiceName); serviceName != "" {
+		lbls.Set(phlaremodel.LabelNameServiceNamePrivate, serviceName)
 	}
 
 	// set common labels
@@ -56,7 +54,12 @@ func CreateProfileLabels(p *profilev1.Profile, externalLabels ...*typesv1.LabelP
 		_, _ = sb.WriteString(periodUnit)
 		t := sb.String()
 		lbls.Set(phlaremodel.LabelNameProfileType, t)
-		lbs := lbls.Labels().Clone()
+		lbs := lbls.LabelsUnsorted().Clone()
+		if enforceOrder {
+			sort.Sort(phlaremodel.LabelsEnforcedOrder(lbs))
+		} else {
+			sort.Sort(lbs)
+		}
 		profilesLabels[pos] = lbs
 		seriesRefs[pos] = model.Fingerprint(lbs.Hash())
 

--- a/pkg/phlaredb/labels/labels_test.go
+++ b/pkg/phlaredb/labels/labels_test.go
@@ -1,7 +1,6 @@
 package labels
 
 import (
-	"sort"
 	"testing"
 
 	"github.com/prometheus/common/model"
@@ -21,12 +20,12 @@ func TestLabelsForProfiles(t *testing.T) {
 			"default",
 			phlaremodel.Labels{{Name: model.MetricNameLabel, Value: "cpu"}},
 			phlaremodel.Labels{
-				{Name: model.MetricNameLabel, Value: "cpu"},
-				{Name: phlaremodel.LabelNameUnit, Value: "unit"},
 				{Name: phlaremodel.LabelNameProfileType, Value: "cpu:type:unit:type:unit"},
-				{Name: phlaremodel.LabelNameType, Value: "type"},
+				{Name: model.MetricNameLabel, Value: "cpu"},
 				{Name: phlaremodel.LabelNamePeriodType, Value: "type"},
 				{Name: phlaremodel.LabelNamePeriodUnit, Value: "unit"},
+				{Name: phlaremodel.LabelNameType, Value: "type"},
+				{Name: phlaremodel.LabelNameUnit, Value: "unit"},
 			},
 		},
 		{
@@ -36,21 +35,20 @@ func TestLabelsForProfiles(t *testing.T) {
 				{Name: phlaremodel.LabelNameServiceName, Value: "service_name"},
 			},
 			phlaremodel.Labels{
-				{Name: model.MetricNameLabel, Value: "cpu"},
-				{Name: phlaremodel.LabelNameUnit, Value: "unit"},
 				{Name: phlaremodel.LabelNameProfileType, Value: "cpu:type:unit:type:unit"},
-				{Name: phlaremodel.LabelNameType, Value: "type"},
+				{Name: phlaremodel.LabelNameServiceNamePrivate, Value: "service_name"},
+				{Name: model.MetricNameLabel, Value: "cpu"},
 				{Name: phlaremodel.LabelNamePeriodType, Value: "type"},
 				{Name: phlaremodel.LabelNamePeriodUnit, Value: "unit"},
-				{Name: labelNameServiceName, Value: "service_name"},
+				{Name: phlaremodel.LabelNameType, Value: "type"},
+				{Name: phlaremodel.LabelNameUnit, Value: "unit"},
 				{Name: phlaremodel.LabelNameServiceName, Value: "service_name"},
 			},
 		},
 	} {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			sort.Sort(tt.expected)
-			result, fps := CreateProfileLabels(newProfileFoo(), tt.in...)
+			result, fps := CreateProfileLabels(true, newProfileFoo(), tt.in...)
 			require.Equal(t, tt.expected, result[0])
 			require.Equal(t, model.Fingerprint(tt.expected.Hash()), fps[0])
 		})

--- a/pkg/phlaredb/schemas/v1/testhelper/profile.go
+++ b/pkg/phlaredb/schemas/v1/testhelper/profile.go
@@ -14,7 +14,7 @@ import (
 
 func NewProfileSchema(p *profilev1.Profile, name string) ([]schemav1.InMemoryProfile, []phlaremodel.Labels) {
 	var (
-		lbls, seriesRefs = labels.CreateProfileLabels(p, &typesv1.LabelPair{Name: model.MetricNameLabel, Value: name})
+		lbls, seriesRefs = labels.CreateProfileLabels(true, p, &typesv1.LabelPair{Name: model.MetricNameLabel, Value: name})
 		ps               = make([]schemav1.InMemoryProfile, len(lbls))
 	)
 	for idxType := range lbls {

--- a/pkg/phlaredb/tsdb/index.go
+++ b/pkg/phlaredb/tsdb/index.go
@@ -298,7 +298,6 @@ func (shard *indexShard) add(metric []*typesv1.LabelPair, fp model.Fingerprint) 
 		values.fps[fingerprints.value] = fingerprints
 		internedLabels[i] = &typesv1.LabelPair{Name: values.name, Value: fingerprints.value}
 	}
-	sort.Sort(internedLabels)
 	return internedLabels
 }
 

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -33,6 +33,7 @@ type Limits struct {
 	MaxLabelValueLength    int     `yaml:"max_label_value_length" json:"max_label_value_length"`
 	MaxLabelNamesPerSeries int     `yaml:"max_label_names_per_series" json:"max_label_names_per_series"`
 	MaxSessionsPerSeries   int     `yaml:"max_sessions_per_series" json:"max_sessions_per_series"`
+	EnforceLabelsOrder     bool    `yaml:"enforce_labels_order" json:"enforce_labels_order"`
 
 	MaxProfileSizeBytes              int `yaml:"max_profile_size_bytes" json:"max_profile_size_bytes"`
 	MaxProfileStacktraceSamples      int `yaml:"max_profile_stacktrace_samples" json:"max_profile_stacktrace_samples"`
@@ -109,6 +110,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxLabelValueLength, "validation.max-length-label-value", 2048, "Maximum length accepted for label value. This setting also applies to the metric name.")
 	f.IntVar(&l.MaxLabelNamesPerSeries, "validation.max-label-names-per-series", 30, "Maximum number of label names per series.")
 	f.IntVar(&l.MaxSessionsPerSeries, "validation.max-sessions-per-series", 0, "Maximum number of sessions per series. 0 to disable.")
+	f.BoolVar(&l.EnforceLabelsOrder, "validation.enforce-labels-order", false, "Enforce labels order optimization.")
 
 	f.IntVar(&l.MaxLocalSeriesPerTenant, "ingester.max-local-series-per-tenant", 0, "Maximum number of active series of profiles per tenant, per ingester. 0 to disable.")
 	f.IntVar(&l.MaxGlobalSeriesPerTenant, "ingester.max-global-series-per-tenant", 5000, "Maximum number of active series of profiles per tenant, across the cluster. 0 to disable. When the global limit is enabled, each ingester is configured with a dynamic local limit based on the replication factor and the current number of healthy ingesters, and is kept updated whenever the number of ingesters change.")
@@ -284,6 +286,10 @@ func (o *Overrides) MaxProfileSymbolValueLength(tenantID string) int {
 // MaxSessionsPerSeries returns the maximum number of sessions per single series.
 func (o *Overrides) MaxSessionsPerSeries(tenantID string) int {
 	return o.getOverridesForTenant(tenantID).MaxSessionsPerSeries
+}
+
+func (o *Overrides) EnforceLabelsOrder(tenantID string) bool {
+	return o.getOverridesForTenant(tenantID).EnforceLabelsOrder
 }
 
 func (o *Overrides) DistributorAggregationWindow(tenantID string) model.Duration {


### PR DESCRIPTION
Series order determines the physical placement of profiling data in blocks. It has been observed that the standard prometheus label and series order is not aligned with our access patterns, leading to an increase in the read amplification factor and query latency.

The PR proposes an option to enforce the optimized order. The main access pattern is a query that targets a specific profile/sample type of a specific service, therefore we want all the profiles matching such query to be stored sequentially. To achieve this, we ensure that the first labels of any series are `__profile_type__` and `__service_name__`.

The change should be applied with great caution. Since we can only enforce the order in ingesters (`__profile_type__` is not available in distributors), we need to ensure that all ingester instances either apply the optimization for a given profile, or not. Otherwise, there's possibility that the profile replicas will be handled differently, and the same series will have two representations: one with the standard order, and another one optimized; this will make it challenging or impossible to resolve the conflicts at query time and compaction. This is solved by "marking" profiles with the new private label `__order__` in distributors, which indicates whether we need to enforce the new order, and is removed before ingestion. This will result in doubling the active series temporarily but will allow for the normal deduplication process.

N.B.: No changes are required in the query path, because the order does not affect "user" labels. For the `Series` call that lists profile types and services, the order does not change.

Thus, the change should be applied in two steps:
 1. Rollout the new version: all ingester instances _must_ run the new version.
 2. Enable the `enforce_labels_order` limit.

Eventually, this optimization should become the default behaviour.

The optimization is only recommended if you are using user-defined labels (static or dynamic) that begin with `_` or with a capital letter and are experiencing very poor query performance.