### PR TITLE
Omit replicas for components with HPA enabled

### DIFF
--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services-hpa.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services-hpa.yaml
@@ -2058,7 +2058,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
-  replicas: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: pyroscope
@@ -2152,7 +2151,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
-  replicas: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: pyroscope
@@ -2246,7 +2244,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
-  replicas: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: pyroscope
@@ -2340,7 +2337,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
-  replicas: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: pyroscope

--- a/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
@@ -17,7 +17,7 @@ spec:
   serviceName: {{ $values.name }}-headless
   podManagementPolicy: Parallel
 {{- end }}
-{{- if hasKey $values "replicaCount" }}
+{{- if and (hasKey $values "replicaCount") (not ($values.autoscaling).enabled) }}
   replicas: {{ $values.replicaCount }}
 {{- end }}
   selector:


### PR DESCRIPTION
ArgoCD cannot handle a disagreement in replica count between a Deployment/Statefulset definition and HorizontalPodAutoscaler definition. When an HPA is enabled, it is better to omit the replicas field on the Deployment/StatefulSet and let the HPA manage it instead