### PR TITLE
fix: goreleaser compatibility issue

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -54,7 +54,7 @@ jobs:
           # either 'goreleaser' (default) or 'goreleaser-pro':
           distribution: goreleaser
           version: latest
-          args: release --clean --skip-publish --timeout 60m
+          args: release --clean --skip=publish --timeout 60m
         env:
           GITHUB_TOKEN: ${{ steps.app-releaser.outputs.token }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,5 @@
 project_name: pyroscope
+version: 2
 before:
   hooks:
     # This hook ensures that goreleaser uses the correct go version for a Pyroscope release

--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,7 @@ $(BIN)/updater: Makefile
 
 $(BIN)/goreleaser: Makefile go.mod
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/goreleaser/goreleaser@v1.20.0
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/goreleaser/goreleaser/v2@v2.0.0
 
 $(BIN)/gotestsum: Makefile go.mod
 	@mkdir -p $(@D)


### PR DESCRIPTION
goreleaser 2.0 has been released and brought some nice but incompatible changes: https://github.com/grafana/pyroscope/actions/runs/9441815396/job/26003085405

The change is already in weekly/f70: https://github.com/grafana/pyroscope/actions/runs/9443073885