### PR TITLE
perf: optimize tree resolve

### DIFF
--- a/pkg/model/stacktraces.go
+++ b/pkg/model/stacktraces.go
@@ -213,6 +213,7 @@ func (t *StacktraceTree) LookupLocations(dst []uint64, idx int32) []uint64 {
 
 // MinValue returns the minimum "total" value a node in a tree has to have.
 func (t *StacktraceTree) MinValue(maxNodes int64) int64 {
+	// TODO(kolesnikovae): Consider quickselect.
 	if maxNodes < 1 || maxNodes >= int64(len(t.Nodes)) {
 		return 0
 	}
@@ -286,8 +287,6 @@ func (t *StacktraceTree) Traverse(maxNodes int64, fn StacktraceTreeTraverseFn) e
 	return nil
 }
 
-var lostDuringSerializationNameBytes = []byte(truncatedNodeName)
-
 func (t *StacktraceTree) Bytes(dst io.Writer, maxNodes int64, funcs []string) {
 	if len(t.Nodes) == 0 || len(funcs) == 0 {
 		return
@@ -302,9 +301,8 @@ func (t *StacktraceTree) Bytes(dst io.Writer, maxNodes int64, funcs []string) {
 			// and the byte slice backing capacity is managed by GC.
 			name = unsafeStringBytes(funcs[n.Location])
 		case sentinel:
-			name = lostDuringSerializationNameBytes
+			name = truncatedNodeNameBytes
 		}
-
 		_, _ = vw.Write(dst, uint64(len(name)))
 		_, _ = dst.Write(name)
 		_, _ = vw.Write(dst, uint64(n.Value))
@@ -315,4 +313,42 @@ func (t *StacktraceTree) Bytes(dst io.Writer, maxNodes int64, funcs []string) {
 
 func unsafeStringBytes(s string) []byte {
 	return unsafe.Slice(unsafe.StringData(s), len(s))
+}
+
+func (t *StacktraceTree) Tree(maxNodes int64, names []string) *Tree {
+	if len(t.Nodes) < 2 || len(names) == 0 {
+		// stack trace tree has root at 0: trees with less
+		// than 2 nodes are considered empty.
+		return new(Tree)
+	}
+
+	nodesSize := maxNodes
+	if nodesSize < 1 || nodesSize > 10<<10 {
+		nodesSize = 1 << 10 // Sane default.
+	}
+	root := new(node) // Virtual root node.
+	nodes := make([]*node, 1, nodesSize)
+	nodes[0] = root
+	var current *node
+
+	_ = t.Traverse(maxNodes, func(index int32, children []int32) error {
+		current, nodes = nodes[len(nodes)-1], nodes[:len(nodes)-1]
+		sn := &t.Nodes[index]
+		var name string
+		if sn.Location < 0 {
+			name = truncatedNodeName
+		} else {
+			name = names[sn.Location]
+		}
+		n := current.insert(name)
+		n.self = sn.Value
+		n.total = sn.Total
+		n.children = make([]*node, 0, len(children))
+		for i := 0; i < len(children); i++ {
+			nodes = append(nodes, n)
+		}
+		return nil
+	})
+
+	return &Tree{root: root.children[0].children}
 }

--- a/pkg/model/tree.go
+++ b/pkg/model/tree.go
@@ -129,6 +129,14 @@ func (t *Tree) IterateStacks(cb func(name string, self int64, stack []string)) {
 const defaultDFSSize = 128
 
 func (t *Tree) Merge(src *Tree) {
+	if t.Total() == 0 && src.Total() > 0 {
+		*t = *src
+		return
+	}
+	if src.Total() == 0 {
+		return
+	}
+
 	srcNodes := make([]*node, 0, defaultDFSSize)
 	srcRoot := &node{children: src.root}
 	srcNodes = append(srcNodes, srcRoot)
@@ -325,6 +333,8 @@ func (h *minHeap) Pop() interface{} {
 }
 
 const truncatedNodeName = "other"
+
+var truncatedNodeNameBytes = []byte(truncatedNodeName)
 
 // MarshalTruncate writes tree byte representation to the writer provider,
 // the number of nodes is limited to maxNodes. The function modifies

--- a/pkg/phlaredb/block_querier.go
+++ b/pkg/phlaredb/block_querier.go
@@ -566,14 +566,14 @@ type Querier interface {
 	Open(ctx context.Context) error
 	Sort([]Profile) []Profile
 
-	MergeByStacktraces(ctx context.Context, rows iter.Iterator[Profile]) (*phlaremodel.Tree, error)
+	MergeByStacktraces(ctx context.Context, rows iter.Iterator[Profile], maxNodes int64) (*phlaremodel.Tree, error)
 	MergeBySpans(ctx context.Context, rows iter.Iterator[Profile], spans phlaremodel.SpanSelector) (*phlaremodel.Tree, error)
 	MergeByLabels(ctx context.Context, rows iter.Iterator[Profile], s *typesv1.StackTraceSelector, by ...string) ([]*typesv1.Series, error)
 	MergePprof(ctx context.Context, rows iter.Iterator[Profile], maxNodes int64, s *typesv1.StackTraceSelector) (*profilev1.Profile, error)
 	Series(ctx context.Context, params *ingestv1.SeriesRequest) ([]*typesv1.Labels, error)
 
 	SelectMatchingProfiles(ctx context.Context, params *ingestv1.SelectProfilesRequest) (iter.Iterator[Profile], error)
-	SelectMergeByStacktraces(ctx context.Context, params *ingestv1.SelectProfilesRequest) (*phlaremodel.Tree, error)
+	SelectMergeByStacktraces(ctx context.Context, params *ingestv1.SelectProfilesRequest, maxNodes int64) (*phlaremodel.Tree, error)
 	SelectMergeByLabels(ctx context.Context, params *ingestv1.SelectProfilesRequest, s *typesv1.StackTraceSelector, by ...string) ([]*typesv1.Series, error)
 	SelectMergeBySpans(ctx context.Context, params *ingestv1.SelectSpanProfileRequest) (*phlaremodel.Tree, error)
 	SelectMergePprof(ctx context.Context, params *ingestv1.SelectProfilesRequest, maxNodes int64, s *typesv1.StackTraceSelector) (*profilev1.Profile, error)
@@ -835,7 +835,7 @@ func MergeProfilesStacktraces(ctx context.Context, stream *connect.BidiStream[in
 			querier := querier
 			g.Go(util.RecoverPanic(func() error {
 				// TODO(simonswine): Split profiles per row group and run the MergeByStacktraces in parallel.
-				merge, err := querier.SelectMergeByStacktraces(ctx, request)
+				merge, err := querier.SelectMergeByStacktraces(ctx, request, r.GetMaxNodes())
 				if err != nil {
 					return err
 				}
@@ -871,7 +871,7 @@ func MergeProfilesStacktraces(ctx context.Context, stream *connect.BidiStream[in
 			// Sort profiles for better read locality.
 			// Merge async the result so we can continue streaming profiles.
 			g.Go(util.RecoverPanic(func() error {
-				merge, err := querier.MergeByStacktraces(ctx, iter.NewSliceIterator(querier.Sort(selectedProfiles[i])))
+				merge, err := querier.MergeByStacktraces(ctx, iter.NewSliceIterator(querier.Sort(selectedProfiles[i])), r.GetMaxNodes())
 				if err != nil {
 					return err
 				}
@@ -1709,7 +1709,7 @@ func (b *singleBlockQuerier) SelectMergeByLabels(
 	return mergeByLabelsWithStackTraceSelector[Profile](ctx, profiles.file, rows, r, by...)
 }
 
-func (b *singleBlockQuerier) SelectMergeByStacktraces(ctx context.Context, params *ingestv1.SelectProfilesRequest) (tree *phlaremodel.Tree, err error) {
+func (b *singleBlockQuerier) SelectMergeByStacktraces(ctx context.Context, params *ingestv1.SelectProfilesRequest, maxNodes int64) (tree *phlaremodel.Tree, err error) {
 	sp, ctx := opentracing.StartSpanFromContext(ctx, "SelectMergeByStacktraces - Block")
 	defer sp.Finish()
 	sp.SetTag("block ULID", b.meta.ULID.String())
@@ -1748,7 +1748,7 @@ func (b *singleBlockQuerier) SelectMergeByStacktraces(ctx context.Context, param
 		}
 		lblsPerRef[int64(chks[0].SeriesIndex)] = struct{}{}
 	}
-	r := symdb.NewResolver(ctx, b.symbols)
+	r := symdb.NewResolver(ctx, b.symbols, symdb.WithResolverMaxNodes(maxNodes))
 	defer r.Release()
 
 	g, ctx := errgroup.WithContext(ctx)

--- a/pkg/phlaredb/compact_test.go
+++ b/pkg/phlaredb/compact_test.go
@@ -81,7 +81,7 @@ func TestCompact(t *testing.T) {
 
 	it, err = querier.SelectMatchingProfiles(ctx, matchAll)
 	require.NoError(t, err)
-	res, err := querier.MergeByStacktraces(ctx, it)
+	res, err := querier.MergeByStacktraces(ctx, it, 0)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
@@ -148,7 +148,7 @@ func TestCompactWithDownsampling(t *testing.T) {
 
 	it, err = querier.SelectMatchingProfiles(ctx, matchAll)
 	require.NoError(t, err)
-	res, err := querier.MergeByStacktraces(ctx, it)
+	res, err := querier.MergeByStacktraces(ctx, it, 0)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
@@ -156,7 +156,7 @@ func TestCompactWithDownsampling(t *testing.T) {
 	expected.InsertStack(3, "baz", "bar", "foo")
 	require.Equal(t, expected.String(), res.String())
 
-	res, err = querier.SelectMergeByStacktraces(ctx, matchAll)
+	res, err = querier.SelectMergeByStacktraces(ctx, matchAll, 0)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	require.Equal(t, expected.String(), res.String())
@@ -281,7 +281,7 @@ func TestCompactWithSplitting(t *testing.T) {
 	// Finally test some stacktraces resolution.
 	it, err = queriers[1].SelectMatchingProfiles(ctx, matchAll)
 	require.NoError(t, err)
-	res, err := queriers[1].MergeByStacktraces(ctx, it)
+	res, err := queriers[1].MergeByStacktraces(ctx, it, 0)
 	require.NoError(t, err)
 
 	expected := new(phlaremodel.Tree)

--- a/pkg/phlaredb/sample_merge.go
+++ b/pkg/phlaredb/sample_merge.go
@@ -20,7 +20,7 @@ import (
 	"github.com/grafana/pyroscope/pkg/phlaredb/symdb"
 )
 
-func (b *singleBlockQuerier) MergeByStacktraces(ctx context.Context, rows iter.Iterator[Profile]) (*phlaremodel.Tree, error) {
+func (b *singleBlockQuerier) MergeByStacktraces(ctx context.Context, rows iter.Iterator[Profile], maxNodes int64) (*phlaremodel.Tree, error) {
 	sp, ctx := opentracing.StartSpanFromContext(ctx, "MergeByStacktraces - Block")
 	defer sp.Finish()
 	sp.SetTag("block ULID", b.meta.ULID.String())
@@ -32,7 +32,7 @@ func (b *singleBlockQuerier) MergeByStacktraces(ctx context.Context, rows iter.I
 	defer b.queries.Done()
 
 	ctx = query.AddMetricsToContext(ctx, b.metrics.query)
-	r := symdb.NewResolver(ctx, b.symbols)
+	r := symdb.NewResolver(ctx, b.symbols, symdb.WithResolverMaxNodes(maxNodes))
 	defer r.Release()
 	if err := mergeByStacktraces(ctx, b.profileSourceTable().file, rows, r); err != nil {
 		return nil, err

--- a/pkg/phlaredb/sample_merge_test.go
+++ b/pkg/phlaredb/sample_merge_test.go
@@ -125,7 +125,7 @@ func TestMergeSampleByStacktraces(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			r, err := q.queriers[0].MergeByStacktraces(ctx, profiles)
+			r, err := q.queriers[0].MergeByStacktraces(ctx, profiles, 0)
 			require.NoError(t, err)
 			require.Equal(t, expected.String(), r.String())
 		})
@@ -220,7 +220,7 @@ func TestHeadMergeSampleByStacktraces(t *testing.T) {
 				End:   int64(model.TimeFromUnixNano(int64(1 * time.Minute))),
 			})
 			require.NoError(t, err)
-			r, err := db.queriers()[0].MergeByStacktraces(ctx, profiles)
+			r, err := db.queriers()[0].MergeByStacktraces(ctx, profiles, 0)
 			require.NoError(t, err)
 			require.Equal(t, expected.String(), r.String())
 		})

--- a/pkg/phlaredb/symdb/resolver.go
+++ b/pkg/phlaredb/symdb/resolver.go
@@ -223,7 +223,7 @@ func (r *Resolver) Tree() (*model.Tree, error) {
 	var lock sync.Mutex
 	tree := new(model.Tree)
 	err := r.withSymbols(ctx, func(symbols *Symbols, samples schemav1.Samples) error {
-		resolved, err := symbols.Tree(ctx, samples)
+		resolved, err := symbols.Tree(ctx, samples, r.maxNodes)
 		if err != nil {
 			return err
 		}
@@ -309,14 +309,19 @@ func (r *Symbols) Pprof(
 	return b.buildPprof(), nil
 }
 
-func (r *Symbols) Tree(ctx context.Context, samples schemav1.Samples) (*model.Tree, error) {
+func (r *Symbols) Tree(
+	ctx context.Context,
+	samples schemav1.Samples,
+	maxNodes int64,
+) (*model.Tree, error) {
 	t := treeSymbolsFromPool()
+	t.maxNodes = maxNodes
 	defer t.reset()
 	t.init(r, samples)
 	if err := r.Stacktraces.ResolveStacktraceLocations(ctx, t, samples.StacktraceIDs); err != nil {
 		return nil, err
 	}
-	return t.tree, nil
+	return t.buildTree(), nil
 }
 
 // findCallSite returns the stack trace of the call site

--- a/pkg/phlaredb/symdb/resolver.go
+++ b/pkg/phlaredb/symdb/resolver.go
@@ -315,13 +315,12 @@ func (r *Symbols) Tree(
 	maxNodes int64,
 ) (*model.Tree, error) {
 	t := treeSymbolsFromPool()
-	t.maxNodes = maxNodes
 	defer t.reset()
 	t.init(r, samples)
 	if err := r.Stacktraces.ResolveStacktraceLocations(ctx, t, samples.StacktraceIDs); err != nil {
 		return nil, err
 	}
-	return t.buildTree(), nil
+	return t.tree.Tree(maxNodes, t.symbols.Strings), nil
 }
 
 // findCallSite returns the stack trace of the call site

--- a/pkg/phlaredb/symdb/resolver_tree.go
+++ b/pkg/phlaredb/symdb/resolver_tree.go
@@ -1,7 +1,6 @@
 package symdb
 
 import (
-	"bytes"
 	"sync"
 
 	"github.com/grafana/pyroscope/pkg/model"
@@ -9,12 +8,11 @@ import (
 )
 
 type treeSymbols struct {
-	symbols  *Symbols
-	samples  *schemav1.Samples
-	tree     *model.StacktraceTree
-	maxNodes int64
-	lines    []int32
-	cur      int
+	symbols *Symbols
+	samples *schemav1.Samples
+	tree    *model.StacktraceTree
+	lines   []int32
+	cur     int
 }
 
 var treeSymbolsPool = sync.Pool{
@@ -54,15 +52,4 @@ func (r *treeSymbols) InsertStacktrace(_ uint32, locations []int32) {
 	}
 	r.tree.Insert(r.lines, int64(r.samples.Values[r.cur]))
 	r.cur++
-}
-
-func (r *treeSymbols) buildTree() *model.Tree {
-	// TODO(kolesnikovae): Eliminate intermediate serialization.
-	var buf bytes.Buffer
-	r.tree.Bytes(&buf, r.maxNodes, r.symbols.Strings)
-	t, err := model.UnmarshalTree(buf.Bytes())
-	if err != nil {
-		panic(err)
-	}
-	return t
 }

--- a/pkg/phlaredb/symdb/resolver_tree.go
+++ b/pkg/phlaredb/symdb/resolver_tree.go
@@ -1,6 +1,7 @@
 package symdb
 
 import (
+	"bytes"
 	"sync"
 
 	"github.com/grafana/pyroscope/pkg/model"
@@ -8,11 +9,12 @@ import (
 )
 
 type treeSymbols struct {
-	symbols *Symbols
-	samples *schemav1.Samples
-	tree    *model.Tree
-	lines   []string
-	cur     int
+	symbols  *Symbols
+	samples  *schemav1.Samples
+	tree     *model.StacktraceTree
+	maxNodes int64
+	lines    []int32
+	cur      int
 }
 
 var treeSymbolsPool = sync.Pool{
@@ -26,7 +28,7 @@ func treeSymbolsFromPool() *treeSymbols {
 func (r *treeSymbols) reset() {
 	r.symbols = nil
 	r.samples = nil
-	r.tree = nil
+	r.tree.Reset()
 	r.lines = r.lines[:0]
 	r.cur = 0
 	treeSymbolsPool.Put(r)
@@ -35,18 +37,32 @@ func (r *treeSymbols) reset() {
 func (r *treeSymbols) init(symbols *Symbols, samples schemav1.Samples) {
 	r.symbols = symbols
 	r.samples = &samples
-	r.tree = new(model.Tree)
+	if r.tree == nil {
+		// Branching factor.
+		r.tree = model.NewStacktraceTree(samples.Len() * 2)
+	}
 }
 
 func (r *treeSymbols) InsertStacktrace(_ uint32, locations []int32) {
 	r.lines = r.lines[:0]
-	for i := len(locations) - 1; i >= 0; i-- {
+	for i := 0; i < len(locations); i++ {
 		lines := r.symbols.Locations[locations[i]].Line
-		for j := len(lines) - 1; j >= 0; j-- {
+		for j := 0; j < len(lines); j++ {
 			f := r.symbols.Functions[lines[j].FunctionId]
-			r.lines = append(r.lines, r.symbols.Strings[f.Name])
+			r.lines = append(r.lines, int32(f.Name))
 		}
 	}
-	r.tree.InsertStack(int64(r.samples.Values[r.cur]), r.lines...)
+	r.tree.Insert(r.lines, int64(r.samples.Values[r.cur]))
 	r.cur++
+}
+
+func (r *treeSymbols) buildTree() *model.Tree {
+	// TODO(kolesnikovae): Eliminate intermediate serialization.
+	var buf bytes.Buffer
+	r.tree.Bytes(&buf, r.maxNodes, r.symbols.Strings)
+	t, err := model.UnmarshalTree(buf.Bytes())
+	if err != nil {
+		panic(err)
+	}
+	return t
 }

--- a/pkg/storegateway/bucket_stores_test.go
+++ b/pkg/storegateway/bucket_stores_test.go
@@ -66,7 +66,7 @@ func TestBucketStores_BlockMetricsRegistration(t *testing.T) {
 		},
 		Start: 0,
 		End:   time.Now().UnixMilli(),
-	})
+	}, 0)
 	require.NoError(t, err)
 	require.NotNil(t, r)
 


### PR DESCRIPTION
The PR is aimed at optimizing the way we resolve a tree from stack traces at read.

Specifically, I replaced the `model.Tree` with `model.StacktaceTree` that we've optimized for pprof symbolication.

---

Here is a comparison of queries that build a flame graph that includes 3M unique stack traces, and 10M nodes (real-case dataset) in a singe thread: 
```
Before    	       9615096375 ns/op	4244433576 B/op	26203002 allocs/op
After    	       3626939417 ns/op	1399753624 B/op	  497736 allocs/op
```
The improvement is appx. 60% (9.6s -> 3.8s). In the test, I used the default 16k max nodes limit. However, even without the limit (tested on ~1-10M node trees), the performance is sustainable:

```
goos: darwin
goarch: arm64
pkg: github.com/grafana/pyroscope/pkg/phlaredb/symdb
Benchmark_Resolver_ResolveTree_Big/0-10     3	 364309236 ns/op	93448242 B/op	    6059 allocs/op
Benchmark_Resolver_ResolveTree_Big/8K-10    3	 383892556 ns/op	94366349 B/op	  106298 allocs/op
Benchmark_Resolver_ResolveTree_Big/16K-10   3	 382851180 ns/op	94969890 B/op	  184351 allocs/op
Benchmark_Resolver_ResolveTree_Big/32K-10   3	 389259681 ns/op	96135072 B/op	  313091 allocs/op
Benchmark_Resolver_ResolveTree_Big/64K-10   3	 413904764 ns/op	98080141 B/op	  523357 allocs/op
```

---

Further optimization of tree symbolication seems to be complicated (although, there is an opportunity to decrease cache misses and improve branch prediction). I'd rather consider optimizing stack trace selection: instead of resolving each stack trace, it makes sense to trim insignificant ones based on their weight (various heuristics could be employed), if the stack trace set exceeds a threshold (e.g., cardinality > 1-2M). This will introduce some inaccuracy in the flame graphs, but I believe this is acceptable:

<img width="761" alt="image" src="https://github.com/grafana/pyroscope/assets/12090599/7c76b8da-c29a-46eb-815f-11a4d81baff1">
