### PR TITLE
fix: group by with enforced labels order

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -419,9 +419,7 @@ func (d *Distributor) sendRequests(ctx context.Context, req *distributormodel.Pu
 	enforceLabelsOrder := d.limits.EnforceLabelsOrder(tenantID)
 	for i, series := range profileSeries {
 		if enforceLabelsOrder {
-			labels := phlaremodel.Labels(series.Labels)
-			labels.Insert(phlaremodel.LabelNameOrder, phlaremodel.LabelOrderEnforced)
-			series.Labels = labels
+			series.Labels = phlaremodel.Labels(series.Labels).InsertSorted(phlaremodel.LabelNameOrder, phlaremodel.LabelOrderEnforced)
 		}
 		if err = validation.ValidateLabels(d.limits, tenantID, series.Labels); err != nil {
 			validation.DiscardedProfiles.WithLabelValues(string(validation.ReasonOf(err)), tenantID).Add(float64(req.TotalProfiles))

--- a/pkg/model/labels_test.go
+++ b/pkg/model/labels_test.go
@@ -158,6 +158,27 @@ func TestLabels_LabelsEnforcedOrder(t *testing.T) {
 	})
 }
 
+func TestLabels_LabelsEnforcedOrder_BytesWithLabels(t *testing.T) {
+	labels := Labels{
+		{Name: LabelNameProfileType, Value: "cpu"},
+		{Name: LabelNameServiceNamePrivate, Value: "service"},
+		{Name: "__request_id__", Value: "mess"},
+		{Name: "A_label", Value: "bad"},
+		{Name: "foo", Value: "bar"},
+	}
+	sort.Sort(LabelsEnforcedOrder(labels))
+
+	assert.NotEqual(t,
+		labels.BytesWithLabels(nil, "A_label"),
+		labels.BytesWithLabels(nil, "not_a_label"),
+	)
+
+	assert.Equal(t,
+		labels.BytesWithLabels(nil, "A_label"),
+		Labels{{Name: "A_label", Value: "bad"}}.BytesWithLabels(nil, "A_label"),
+	)
+}
+
 func permute[T any](s []T, f func([]T)) {
 	n := len(s)
 	stack := make([]int, n)
@@ -256,8 +277,7 @@ func TestInsert(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			test.labels.Insert(test.insertName, test.insertValue)
-			assert.Equal(t, test.expected, test.labels)
+			assert.Equal(t, test.expected, test.labels.InsertSorted(test.insertName, test.insertValue))
 		})
 	}
 }


### PR DESCRIPTION
The recently added series order optimization (#3345) has a bug, leading to invalid `group by` results. The cause is that `BytesWithLabels` assumed the standard order. The requirement has been relaxed: this makes the function less efficient, but not to the extent that it is a concern.

Also cleaned up the package a bit.