### PR TITLE
feat(profilecli): Add a label values cardinality subcommand

### DIFF
--- a/cmd/profilecli/main.go
+++ b/cmd/profilecli/main.go
@@ -73,6 +73,8 @@ func main() {
 	queryGoPGOParams := addQueryGoPGOParams(queryGoPGOCmd)
 	querySeriesCmd := queryCmd.Command("series", "Request series labels.")
 	querySeriesParams := addQuerySeriesParams(querySeriesCmd)
+	queryLabelValuesCardinalityCmd := queryCmd.Command("label-values-cardinality", "Request label values cardinality.")
+	queryLabelValuesCardinalityParams := addQueryLabelValuesCardinalityParams(queryLabelValuesCardinalityCmd)
 
 	queryTracerCmd := app.Command("query-tracer", "Analyze query traces.")
 	queryTracerParams := addQueryTracerParams(queryTracerCmd)
@@ -120,6 +122,11 @@ func main() {
 		}
 	case querySeriesCmd.FullCommand():
 		if err := querySeries(ctx, querySeriesParams); err != nil {
+			os.Exit(checkError(err))
+		}
+
+	case queryLabelValuesCardinalityCmd.FullCommand():
+		if err := queryLabelValuesCardinality(ctx, queryLabelValuesCardinalityParams); err != nil {
 			os.Exit(checkError(err))
 		}
 


### PR DESCRIPTION
This allows to find the source of cardinality increases easier.

```
❯ profilecli query label-values-cardinality
level=info msg="query label names" url=http://localhost:8080 from=2024-06-19T13:09:11.417419+01:00 to=2024-06-19T14:09:11.417419+01:00
level=info msg="received 87 label names"
+------------------------------------+-------------+
|             LABELNAME              | VALUE COUNT |
+------------------------------------+-------------+
| pod                                |      67,397 |
| instance                           |      48,438 |
| pod_template_hash                  |      12,000 |
| resource_version                   |       9,007 |
| tenant                             |       7,795 |
| node                               |       6,986 |
| org                                |       6,930 |
| instanceId                         |       6,930 |
| slug                               |       6,930 |
| stackId                            |       6,929 |
| statefulset_kubernetes_io_pod_name |       3,105 |
| __service_name__                   |       2,434 |
| service_name                       |       2,434 |
| job                                |       2,155 |
| controller_revision_hash           |         812 |
| name                               |         670 |
| container                          |         402 |
| apps_kubernetes_io_pod_index       |         350 |
| batch_kubernetes_io_controller_uid |         270 |
| namespace                          |         268 |
+------------------------------------+-------------+
```


 
