### PR TITLE
perf: tune async batch iterator

### DIFF
--- a/pkg/iter/batch_async.go
+++ b/pkg/iter/batch_async.go
@@ -19,7 +19,7 @@ type batch[T any] struct {
 	done     chan struct{}
 }
 
-const minBatchSize = 64
+const minBatchSize = 2
 
 func NewAsyncBatchIterator[T, N any](
 	iterator Iterator[T],

--- a/pkg/phlaredb/query/repeated.go
+++ b/pkg/phlaredb/query/repeated.go
@@ -28,12 +28,6 @@ type repeatedRowIterator[T any] struct {
 }
 
 const (
-	// Batch size specifies how many rows to be read
-	// from a column at once. Note that the batched rows
-	// are buffered in-memory, but not reference pages
-	// they were read from.
-	defaultRepeatedRowIteratorBatchSize = 32
-
 	// The value specifies how many individual values to be
 	// read (decoded) from the page.
 	//
@@ -57,8 +51,14 @@ func NewRepeatedRowIterator[T any](
 		rows: rows,
 		columns: NewMultiColumnIterator(ctx,
 			WrapWithRowNumber(rowNumbers),
-			defaultRepeatedRowIteratorBatchSize,
-			rowGroups, columns...),
+			// Batch size specifies how many rows to be read
+			// from a column at once. Note that the batched rows
+			// are buffered in-memory, but not reference pages
+			// they were read from.
+			4,
+			rowGroups,
+			columns...,
+		),
 	}
 }
 

--- a/pkg/phlaredb/query/util.go
+++ b/pkg/phlaredb/query/util.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/colega/zeropool"
@@ -86,9 +87,7 @@ var parquetValuesPool = zeropool.New(func() []parquet.Value { return nil })
 
 func CloneParquetValues(values []parquet.Value) []parquet.Value {
 	p := parquetValuesPool.Get()
-	if l := len(values); cap(p) < l {
-		p = make([]parquet.Value, 0, 2*l)
-	}
+	p = slices.Grow(p, len(values))
 	p = p[:len(values)]
 	for i, v := range values {
 		p[i] = v.Clone()


### PR DESCRIPTION
It's been observed that the async batch iterator we're using for fetching Parquet rows might be using too much memory. Note the `query.CloneParquetValues` call under `iter.(*AsyncBatchIterator[...]).fillBuffer` in the flame graph:

<img width="1693" alt="image" src="https://github.com/grafana/pyroscope/assets/12090599/559055b7-c24a-4cbe-ae0c-828afa73ea08">

The problem manifests when the query hits downsampled (aggregated) profiles: a row may contain thousands of values. Another factor is the misalignment of the query split interval and the block duration: each sub-range is processed independently, with its own iterator, thus multiplying the memory requirement.

In practice, a large buffer is not required here, as it is only needed to avoid waiting for fetches from individual columns by reading the data from them ahead of time. In turn, each of the columns has it's own "read ahead" buffer, which should minimaize blocking of the top-level iterator.

One way to solve the problem is to make the iterator work with size in bytes and have a predictable memory footprint. In the PR, I reduce the default buffer size and change the allocation strategy to use the new `slices.Grow` function.