### PR TITLE
feat(distributor): Relabel profiles at ingest

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"sync"
 	"time"
+	"unsafe"
 
 	"connectrpc.com/connect"
 	"github.com/dustin/go-humanize"
@@ -31,7 +32,7 @@ import (
 	"github.com/prometheus/common/model"
 	"go.uber.org/atomic"
 
-	googlev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 	pushv1 "github.com/grafana/pyroscope/api/gen/proto/go/push/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	connectapi "github.com/grafana/pyroscope/pkg/api/connect"
@@ -496,8 +497,20 @@ func (d *Distributor) sendRequests(ctx context.Context, req *distributormodel.Pu
 	}
 }
 
+// sampleSize returns the size of a samples in bytes.
+func sampleSize(stringTable []string, samplesSlice []*profilev1.Sample) int64 {
+	var size int64
+	for _, s := range samplesSlice {
+		size += int64(s.SizeVT())
+		for _, l := range s.Label {
+			size += int64(len(stringTable[l.Key]) + len(stringTable[l.Str]) + len(stringTable[l.NumUnit]))
+		}
+	}
+	return size
+}
+
 // profileSizeBytes returns the size of symbols and samples in bytes.
-func profileSizeBytes(p *googlev1.Profile) (symbols, samples int64) {
+func profileSizeBytes(p *profilev1.Profile) (symbols, samples int64) {
 	fullSize := p.SizeVT()
 	// remove samples
 	samplesSlice := p.Sample
@@ -521,7 +534,7 @@ func profileSizeBytes(p *googlev1.Profile) (symbols, samples int64) {
 	return
 }
 
-func (d *Distributor) maybeAggregate(tenantID string, labels phlaremodel.Labels, profile *googlev1.Profile) (func() (*pprof.ProfileMerge, error), bool, error) {
+func (d *Distributor) maybeAggregate(tenantID string, labels phlaremodel.Labels, profile *profilev1.Profile) (func() (*pprof.ProfileMerge, error), bool, error) {
 	a, ok := d.aggregator.AggregatorForTenant(tenantID)
 	if !ok {
 		return nil, false, nil
@@ -539,7 +552,7 @@ func (d *Distributor) maybeAggregate(tenantID string, labels phlaremodel.Labels,
 	return r.Handler(), true, nil
 }
 
-func mergeProfile(profile *googlev1.Profile) aggregator.AggregateFn[*pprof.ProfileMerge] {
+func mergeProfile(profile *profilev1.Profile) aggregator.AggregateFn[*pprof.ProfileMerge] {
 	return func(m *pprof.ProfileMerge) (*pprof.ProfileMerge, error) {
 		if m == nil {
 			m = new(pprof.ProfileMerge)
@@ -638,39 +651,99 @@ func (d *Distributor) HealthyInstancesCount() int {
 	return int(d.healthyInstancesCount.Load())
 }
 
-type groupsWithFingerprints struct {
-	labelSets    []phlaremodel.Labels
-	groups       []pprof.SampleGroup
-	fingerprints map[uint64][]int
+type sampleKey struct {
+	stacktrace string
+	// note this is an index into the string table, rather than span ID
+	spanIDIdx int64
 }
 
-func newGroupsWithFingerprints(n int) *groupsWithFingerprints {
-	return &groupsWithFingerprints{
-		labelSets:    make([]phlaremodel.Labels, 0, n),
-		groups:       make([]pprof.SampleGroup, 0, n),
-		fingerprints: make(map[uint64][]int),
+func sampleKeyFromSample(stringTable []string, s *profilev1.Sample) sampleKey {
+	var k sampleKey
+
+	// populate spanID if present
+	for _, l := range s.Label {
+		if stringTable[int(l.Key)] == pprof.SpanIDLabelName {
+			k.spanIDIdx = l.Str
+		}
 	}
+	if len(s.LocationId) > 0 {
+		k.stacktrace = unsafe.String(
+			(*byte)(unsafe.Pointer(&s.LocationId[0])),
+			len(s.LocationId)*8,
+		)
+	}
+	return k
 }
 
-func (g *groupsWithFingerprints) add(lbls phlaremodel.Labels, group pprof.SampleGroup) {
-	fp := lbls.Hash()
-	idxs, ok := g.fingerprints[fp]
-	if ok {
-		// fingerprint matches, check if the labels arethe same
-		for _, idx := range idxs {
-			if phlaremodel.CompareLabelPairs(g.labelSets[idx], lbls) == 0 {
-				// append samples to the group
-				g.groups[idx].Samples = append(g.groups[idx].Samples, group.Samples...)
-				return
-			}
+type lazyGroup struct {
+	sampleGroup pprof.SampleGroup
+	// The map is only initialized when the group is being modified. Key is the
+	// string representation (unsafe) of the sample stack trace and its potential
+	// span ID.
+	sampleMap map[sampleKey]*profilev1.Sample
+	labels    phlaremodel.Labels
+}
+
+func (g *lazyGroup) addSampleGroup(stringTable []string, sg pprof.SampleGroup) {
+	if len(g.sampleGroup.Samples) == 0 {
+		g.sampleGroup = sg
+		return
+	}
+
+	// If the group is already initialized, we need to merge the samples.
+	if g.sampleMap == nil {
+		g.sampleMap = make(map[sampleKey]*profilev1.Sample)
+		for _, s := range g.sampleGroup.Samples {
+			g.sampleMap[sampleKeyFromSample(stringTable, s)] = s
 		}
 	}
 
-	// add the labels to the list
-	g.fingerprints[fp] = append(g.fingerprints[fp], len(g.labelSets))
-	g.labelSets = append(g.labelSets, lbls)
-	g.groups = append(g.groups, group)
+	for _, s := range sg.Samples {
+		k := sampleKeyFromSample(stringTable, s)
+		if _, ok := g.sampleMap[k]; !ok {
+			g.sampleGroup.Samples = append(g.sampleGroup.Samples, s)
+			g.sampleMap[k] = s
+		} else {
+			// merge the samples
+			for idx := range s.Value {
+				g.sampleMap[k].Value[idx] += s.Value[idx]
+			}
+		}
+	}
+}
 
+type groupsWithFingerprints struct {
+	m     map[uint64][]lazyGroup
+	order []uint64
+}
+
+func newGroupsWithFingerprints() *groupsWithFingerprints {
+	return &groupsWithFingerprints{
+		m: make(map[uint64][]lazyGroup),
+	}
+}
+
+func (g *groupsWithFingerprints) add(stringTable []string, lbls phlaremodel.Labels, group pprof.SampleGroup) {
+	fp := lbls.Hash()
+	idxs, ok := g.m[fp]
+	if ok {
+		// fingerprint matches, check if the labels are the same
+		for _, idx := range idxs {
+			if phlaremodel.CompareLabelPairs(idx.labels, lbls) == 0 {
+				// append samples to the group
+				idx.addSampleGroup(stringTable, group)
+				return
+			}
+		}
+	} else {
+		g.order = append(g.order, fp)
+	}
+
+	// add the labels to the list
+	g.m[fp] = append(g.m[fp], lazyGroup{
+		sampleGroup: group,
+		labels:      lbls,
+	})
 }
 
 func extractSampleSeries(req *distributormodel.PushRequest, relabelRules []*relabel.Config) (result []*distributormodel.ProfileSeries, bytesRelabelDropped, profilesRelabelDropped float64) {
@@ -711,42 +784,43 @@ func extractSampleSeries(req *distributormodel.PushRequest, relabelRules []*rela
 				continue
 			}
 
-			e := pprof.NewSampleExporter(raw.Profile.Profile)
-
 			// iterate through groups relabel them and find relevant overlapping labelsets
-			groupsKept := newGroupsWithFingerprints(len(groups))
+			groupsKept := newGroupsWithFingerprints()
 			for _, group := range groups {
 				lblbuilder.Reset(series.Labels)
 				addSampleLabelsToLabelsBuilder(lblbuilder, raw.Profile.Profile, group.Labels)
 				if len(relabelRules) > 0 {
 					keep := relabel.ProcessBuilder(lblbuilder, relabelRules...)
 					if !keep {
-						// not too sure if this is worth doing, as it might be quite expensive
-						bytesRelabelDropped += float64(exportSamples(e, group.Samples).SizeVT())
+						bytesRelabelDropped += float64(sampleSize(raw.Profile.Profile.StringTable, group.Samples))
 						continue
 					}
 				}
 
 				// add the group to the list
-				groupsKept.add(lblbuilder.Labels(), group)
+				groupsKept.add(raw.Profile.StringTable, lblbuilder.Labels(), group)
 			}
 
-			if len(groupsKept.groups) == 0 {
+			if len(groupsKept.m) == 0 {
 				// no groups kept, count the whole profile as dropped
 				profilesRelabelDropped++
+				continue
 			}
 
-			for idx, group := range groupsKept.groups {
-				// exportSamples creates a new profile with the samples provided.
-				// The samples are obtained via GroupSamples call, which means
-				// the underlying capacity is referenced by the source profile.
-				// Therefore, the slice has to be copied and samples zeroed to
-				// avoid ownership issues.
-				profile := exportSamples(e, group.Samples)
-				profileSeries = append(profileSeries, &distributormodel.ProfileSeries{
-					Labels:  groupsKept.labelSets[idx],
-					Samples: []*distributormodel.ProfileSample{{Profile: profile}},
-				})
+			e := pprof.NewSampleExporter(raw.Profile.Profile)
+			for _, idx := range groupsKept.order {
+				for _, group := range groupsKept.m[idx] {
+					// exportSamples creates a new profile with the samples provided.
+					// The samples are obtained via GroupSamples call, which means
+					// the underlying capacity is referenced by the source profile.
+					// Therefore, the slice has to be copied and samples zeroed to
+					// avoid ownership issues.
+					profile := exportSamples(e, group.sampleGroup.Samples)
+					profileSeries = append(profileSeries, &distributormodel.ProfileSeries{
+						Labels:  group.labels,
+						Samples: []*distributormodel.ProfileSample{{Profile: profile}},
+					})
+				}
 			}
 		}
 		if len(s.Samples) > 0 {
@@ -797,7 +871,7 @@ func (d *Distributor) rateLimit(tenantID string, req *distributormodel.PushReque
 }
 
 // addSampleLabelsToLabelsBuilder: adds sample label that don't exists yet on the profile builder. So the existing labels take precedence.
-func addSampleLabelsToLabelsBuilder(b *phlaremodel.LabelsBuilder, p *googlev1.Profile, pl []*googlev1.Label) {
+func addSampleLabelsToLabelsBuilder(b *phlaremodel.LabelsBuilder, p *profilev1.Profile, pl []*profilev1.Label) {
 	var name string
 	for _, l := range pl {
 		name = p.StringTable[l.Key]
@@ -813,8 +887,8 @@ func addSampleLabelsToLabelsBuilder(b *phlaremodel.LabelsBuilder, p *googlev1.Pr
 	}
 }
 
-func exportSamples(e *pprof.SampleExporter, samples []*googlev1.Sample) *pprof.Profile {
-	samplesCopy := make([]*googlev1.Sample, len(samples))
+func exportSamples(e *pprof.SampleExporter, samples []*profilev1.Sample) *pprof.Profile {
+	samplesCopy := make([]*profilev1.Sample, len(samples))
 	copy(samplesCopy, samples)
 	slices.Clear(samples)
 	n := pprof.NewProfile()

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -24,10 +24,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/pyroscope/pkg/model/relabel"
 	testhelper2 "github.com/grafana/pyroscope/pkg/pprof/testhelper"
 
 	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
@@ -423,6 +423,9 @@ func Test_Sessions_Limit(t *testing.T) {
 }
 
 func Test_SampleLabels(t *testing.T) {
+	o := validation.MockDefaultOverrides()
+	defaultRelabelConfigs := o.IngestionRelabelingRules("")
+
 	type testCase struct {
 		description           string
 		pushReq               *distributormodel.PushRequest
@@ -586,6 +589,56 @@ func Test_SampleLabels(t *testing.T) {
 			},
 		},
 		{
+			description: "has series labels, and the only sample label name overlaps with series label, creating overlapping groups",
+			pushReq: &distributormodel.PushRequest{
+				Series: []*distributormodel.ProfileSeries{
+					{
+						Labels: []*typesv1.LabelPair{
+							{Name: "foo", Value: "bar"},
+						},
+						Samples: []*distributormodel.ProfileSample{
+							{
+								Profile: pprof2.RawFromProto(&profilev1.Profile{
+									StringTable: []string{"", "foo", "bar"},
+									Sample: []*profilev1.Sample{
+										{
+											Value: []int64{1},
+											Label: []*profilev1.Label{
+												{Key: 1, Str: 2},
+											},
+										},
+										{
+											Value: []int64{2},
+										},
+									},
+								}),
+							},
+						},
+					},
+				},
+			},
+			series: []*distributormodel.ProfileSeries{
+				{
+					Labels: []*typesv1.LabelPair{
+						{Name: "foo", Value: "bar"},
+					},
+					Samples: []*distributormodel.ProfileSample{
+						{
+							Profile: pprof2.RawFromProto(&profilev1.Profile{
+								StringTable: []string{"", "foo", "bar"},
+								Sample: []*profilev1.Sample{
+									{
+										Value: []int64{3},
+										Label: nil,
+									},
+								},
+							}),
+						},
+					},
+				},
+			},
+		},
+		{
 			description: "has series labels, samples have distinct label sets",
 			pushReq: &distributormodel.PushRequest{
 				Series: []*distributormodel.ProfileSeries{
@@ -646,6 +699,291 @@ func Test_SampleLabels(t *testing.T) {
 								StringTable: []string{""},
 								Sample: []*profilev1.Sample{{
 									Value: []int64{2},
+									Label: []*profilev1.Label{},
+								}},
+							}),
+						},
+					},
+				},
+			},
+		},
+		{
+			description:  "has series labels that should be renamed to no longer include godeltaprof",
+			relabelRules: defaultRelabelConfigs,
+			pushReq: &distributormodel.PushRequest{
+				Series: []*distributormodel.ProfileSeries{
+					{
+						Labels: []*typesv1.LabelPair{
+							{Name: "__name__", Value: "godeltaprof_memory"},
+						},
+						Samples: []*distributormodel.ProfileSample{
+							{
+								Profile: pprof2.RawFromProto(&profilev1.Profile{
+									StringTable: []string{""},
+									Sample: []*profilev1.Sample{{
+										Value: []int64{2},
+										Label: []*profilev1.Label{},
+									}},
+								}),
+							},
+						},
+					},
+				},
+			},
+			series: []*distributormodel.ProfileSeries{
+				{
+					Labels: []*typesv1.LabelPair{
+						{Name: "__name__", Value: "memory"},
+						{Name: "__name_replaced__", Value: "godeltaprof_memory"},
+					},
+					Samples: []*distributormodel.ProfileSample{
+						{
+							Profile: pprof2.RawFromProto(&profilev1.Profile{
+								StringTable: []string{""},
+								Sample: []*profilev1.Sample{{
+									Value: []int64{2},
+									Label: []*profilev1.Label{},
+								}},
+							}),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "has series labels and sample label, which relabel rules drop",
+			relabelRules: []*relabel.Config{
+				{Action: relabel.Drop, SourceLabels: []model.LabelName{"__name__", "span_name"}, Separator: "/", Regex: relabel.MustNewRegexp("unwanted/randomness")},
+			},
+			pushReq: &distributormodel.PushRequest{
+				Series: []*distributormodel.ProfileSeries{
+					{
+						Labels: []*typesv1.LabelPair{
+							{Name: "__name__", Value: "unwanted"},
+						},
+						Samples: []*distributormodel.ProfileSample{
+							{
+								Profile: pprof2.RawFromProto(&profilev1.Profile{
+									StringTable: []string{"", "span_name", "randomness"},
+									Sample: []*profilev1.Sample{
+										{
+											Value: []int64{2},
+											Label: []*profilev1.Label{
+												{Key: 1, Str: 2},
+											},
+										},
+										{
+											Value: []int64{1},
+										},
+									},
+								}),
+							},
+						},
+					},
+				},
+			},
+			expectProfilesDropped: 0,
+			expectBytesDropped:    3,
+			series: []*distributormodel.ProfileSeries{
+				{
+					Labels: []*typesv1.LabelPair{
+						{Name: "__name__", Value: "unwanted"},
+					},
+					Samples: []*distributormodel.ProfileSample{
+						{
+							Profile: pprof2.RawFromProto(&profilev1.Profile{
+								StringTable: []string{""},
+								Sample: []*profilev1.Sample{{
+									Value: []int64{1},
+								}},
+							}),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "has series/sample labels, drops everything",
+			relabelRules: []*relabel.Config{
+				{Action: relabel.Drop, Regex: relabel.MustNewRegexp(".*")},
+			},
+			pushReq: &distributormodel.PushRequest{
+				Series: []*distributormodel.ProfileSeries{
+					{
+						Labels: []*typesv1.LabelPair{
+							{Name: "__name__", Value: "unwanted"},
+						},
+						Samples: []*distributormodel.ProfileSample{
+							{
+								Profile: pprof2.RawFromProto(&profilev1.Profile{
+									StringTable: []string{"", "span_name", "randomness"},
+									Sample: []*profilev1.Sample{
+										{
+											Value: []int64{2},
+											Label: []*profilev1.Label{
+												{Key: 1, Str: 2},
+											},
+										},
+										{
+											Value: []int64{1},
+										},
+									},
+								}),
+							},
+						},
+					},
+				},
+			},
+			expectProfilesDropped: 1,
+			expectBytesDropped:    6,
+		},
+		{
+			description: "has series labels / sample rules, drops samples label",
+			relabelRules: []*relabel.Config{
+				{Action: relabel.Replace, Regex: relabel.MustNewRegexp(".*"), Replacement: "", TargetLabel: "span_name"},
+			},
+			pushReq: &distributormodel.PushRequest{
+				Series: []*distributormodel.ProfileSeries{
+					{
+						Labels: []*typesv1.LabelPair{
+							{Name: "__name__", Value: "unwanted"},
+						},
+						Samples: []*distributormodel.ProfileSample{
+							{
+								Profile: pprof2.RawFromProto(&profilev1.Profile{
+									StringTable: []string{"", "span_name", "randomness"},
+									Sample: []*profilev1.Sample{
+										{
+											Value: []int64{2},
+											Label: []*profilev1.Label{
+												{Key: 1, Str: 2},
+											},
+										},
+										{
+											Value: []int64{1},
+										},
+									},
+								}),
+							},
+						},
+					},
+				},
+			},
+			series: []*distributormodel.ProfileSeries{
+				{
+					Labels: []*typesv1.LabelPair{
+						{Name: "__name__", Value: "unwanted"},
+					},
+					Samples: []*distributormodel.ProfileSample{
+						{
+							Profile: pprof2.RawFromProto(&profilev1.Profile{
+								StringTable: []string{""},
+								Sample: []*profilev1.Sample{{
+									Value: []int64{3},
+								}},
+							}),
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "ensure only samples of same stacktraces get grouped",
+			pushReq: &distributormodel.PushRequest{
+				Series: []*distributormodel.ProfileSeries{
+					{
+						Labels: []*typesv1.LabelPair{
+							{Name: "__name__", Value: "profile"},
+						},
+						Samples: []*distributormodel.ProfileSample{
+							{
+								Profile: pprof2.RawFromProto(&profilev1.Profile{
+									StringTable: []string{"", "foo", "bar", "binary", "span_id", "aaaabbbbccccdddd", "__name__"},
+									Location: []*profilev1.Location{
+										{Id: 1, MappingId: 1, Line: []*profilev1.Line{{FunctionId: 1}}},
+										{Id: 2, MappingId: 1, Line: []*profilev1.Line{{FunctionId: 2}}},
+									},
+									Mapping: []*profilev1.Mapping{{}, {Id: 1, Filename: 3}},
+									Function: []*profilev1.Function{
+										{Id: 1, Name: 1},
+										{Id: 2, Name: 2},
+									},
+									Sample: []*profilev1.Sample{
+										{
+											LocationId: []uint64{1, 2},
+											Value:      []int64{2},
+											Label: []*profilev1.Label{
+												{Key: 6, Str: 1}, // This __name__ label is expected to be removed as it overlaps with the series label name
+
+											},
+										},
+										{
+											LocationId: []uint64{1, 2},
+											Value:      []int64{1},
+										},
+										{
+											LocationId: []uint64{1, 2},
+											Value:      []int64{4},
+											Label: []*profilev1.Label{
+												{Key: 4, Str: 5},
+											},
+										},
+										{
+											Value: []int64{8},
+										},
+										{
+											Value: []int64{16},
+											Label: []*profilev1.Label{
+												{Key: 1, Str: 2},
+											},
+										},
+									},
+								}),
+							},
+						},
+					},
+				},
+			},
+			series: []*distributormodel.ProfileSeries{
+				{
+					Labels: []*typesv1.LabelPair{
+						{Name: "__name__", Value: "profile"},
+					},
+					Samples: []*distributormodel.ProfileSample{
+						{
+							Profile: pprof2.RawFromProto(&profilev1.Profile{
+								StringTable: []string{""},
+								Sample: []*profilev1.Sample{
+									{
+										LocationId: []uint64{1, 2},
+										Value:      []int64{3},
+									},
+									{
+										LocationId: []uint64{1, 2},
+										Value:      []int64{4},
+										Label: []*profilev1.Label{
+											{Key: 1, Str: 2},
+										},
+									},
+									{
+										Value: []int64{8},
+									},
+								},
+							}),
+						},
+					},
+				},
+				{
+					Labels: []*typesv1.LabelPair{
+						{Name: "__name__", Value: "profile"},
+						{Name: "foo", Value: "bar"},
+					},
+					Samples: []*distributormodel.ProfileSample{
+						{
+							Profile: pprof2.RawFromProto(&profilev1.Profile{
+								StringTable: []string{""},
+								Sample: []*profilev1.Sample{{
+									Value: []int64{16},
 									Label: []*profilev1.Label{},
 								}},
 							}),

--- a/pkg/model/relabel/relabel.go
+++ b/pkg/model/relabel/relabel.go
@@ -1,0 +1,126 @@
+// Provenance-includes-location: https://github.com/prometheus/prometheus/blob/v2.51.2/model/relabel/relabel.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: Prometheus Authors
+
+package relabel
+
+import (
+	"crypto/md5"
+	"encoding/binary"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/relabel"
+
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	phlaremodel "github.com/grafana/pyroscope/pkg/model"
+)
+
+type Config = relabel.Config
+
+// Process returns a relabeled version of the given label set. The relabel configurations
+// are applied in order of input.
+// There are circumstances where Process will modify the input label.
+// If you want to avoid issues with the input label set being modified, at the cost of
+// higher memory usage, you can use lbls.Copy().
+// If a label set is dropped, EmptyLabels and false is returned.
+func Process(lbls phlaremodel.Labels, cfgs ...*relabel.Config) (ret phlaremodel.Labels, keep bool) {
+	lb := phlaremodel.NewLabelsBuilder(lbls)
+	if !ProcessBuilder(lb, cfgs...) {
+		return phlaremodel.EmptyLabels(), false
+	}
+	return lb.Labels(), true
+}
+
+// ProcessBuilder is like Process, but the caller passes a labels.Builder
+// containing the initial set of labels, which is mutated by the rules.
+func ProcessBuilder(lb *phlaremodel.LabelsBuilder, cfgs ...*Config) (keep bool) {
+	for _, cfg := range cfgs {
+		keep = relabelBuilder(cfg, lb)
+		if !keep {
+			return false
+		}
+	}
+	return true
+}
+
+func relabelBuilder(cfg *Config, lb *phlaremodel.LabelsBuilder) (keep bool) {
+	var va [16]string
+	values := va[:0]
+	if len(cfg.SourceLabels) > cap(values) {
+		values = make([]string, 0, len(cfg.SourceLabels))
+	}
+	for _, ln := range cfg.SourceLabels {
+		values = append(values, lb.Get(string(ln)))
+	}
+	val := strings.Join(values, cfg.Separator)
+
+	switch cfg.Action {
+	case relabel.Drop:
+		if cfg.Regex.MatchString(val) {
+			return false
+		}
+	case relabel.Keep:
+		if !cfg.Regex.MatchString(val) {
+			return false
+		}
+	case relabel.DropEqual:
+		if lb.Get(cfg.TargetLabel) == val {
+			return false
+		}
+	case relabel.KeepEqual:
+		if lb.Get(cfg.TargetLabel) != val {
+			return false
+		}
+	case relabel.Replace:
+		indexes := cfg.Regex.FindStringSubmatchIndex(val)
+		// If there is no match no replacement must take place.
+		if indexes == nil {
+			break
+		}
+		target := model.LabelName(cfg.Regex.ExpandString([]byte{}, cfg.TargetLabel, val, indexes))
+		if !target.IsValid() {
+			break
+		}
+		res := cfg.Regex.ExpandString([]byte{}, cfg.Replacement, val, indexes)
+		if len(res) == 0 {
+			lb.Del(string(target))
+			break
+		}
+		lb.Set(string(target), string(res))
+	case relabel.Lowercase:
+		lb.Set(cfg.TargetLabel, strings.ToLower(val))
+	case relabel.Uppercase:
+		lb.Set(cfg.TargetLabel, strings.ToUpper(val))
+	case relabel.HashMod:
+		hash := md5.Sum([]byte(val))
+		// Use only the last 8 bytes of the hash to give the same result as earlier versions of this code.
+		mod := binary.BigEndian.Uint64(hash[8:]) % cfg.Modulus
+		lb.Set(cfg.TargetLabel, strconv.FormatUint(mod, 10))
+	case relabel.LabelMap:
+		lb.Range(func(l *typesv1.LabelPair) {
+			if cfg.Regex.MatchString(l.Name) {
+				res := cfg.Regex.ReplaceAllString(l.Name, cfg.Replacement)
+				lb.Set(res, l.Value)
+			}
+		})
+	case relabel.LabelDrop:
+		lb.Range(func(l *typesv1.LabelPair) {
+			if cfg.Regex.MatchString(l.Name) {
+				lb.Del(l.Name)
+			}
+		})
+	case relabel.LabelKeep:
+		lb.Range(func(l *typesv1.LabelPair) {
+			if !cfg.Regex.MatchString(l.Name) {
+				lb.Del(l.Name)
+			}
+		})
+	default:
+		panic(fmt.Errorf("relabel: unknown relabel action type %q", cfg.Action))
+	}
+
+	return true
+}

--- a/pkg/model/relabel/relabel_test.go
+++ b/pkg/model/relabel/relabel_test.go
@@ -1,0 +1,591 @@
+// Provenance-includes-location: https://github.com/prometheus/prometheus/blob/v2.51.2/model/relabel/relabel_test.go
+// Provenance-includes-license: Apache-2.0
+// Provenance-includes-copyright: Prometheus Authors
+
+package relabel
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/prometheus/prometheus/util/testutil"
+	"github.com/stretchr/testify/require"
+
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	phlaremodel "github.com/grafana/pyroscope/pkg/model"
+)
+
+func TestRelabel(t *testing.T) {
+	tests := []struct {
+		input   phlaremodel.Labels
+		relabel []*relabel.Config
+		output  phlaremodel.Labels
+		drop    bool
+	}{
+		{
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "foo",
+				"b": "bar",
+				"c": "baz",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					Regex:        relabel.MustNewRegexp("f(.*)"),
+					TargetLabel:  "d",
+					Separator:    ";",
+					Replacement:  "ch${1}-ch${1}",
+					Action:       relabel.Replace,
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "foo",
+				"b": "bar",
+				"c": "baz",
+				"d": "choo-choo",
+			}),
+		},
+		{
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "foo",
+				"b": "bar",
+				"c": "baz",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"a", "b"},
+					Regex:        relabel.MustNewRegexp("f(.*);(.*)r"),
+					TargetLabel:  "a",
+					Separator:    ";",
+					Replacement:  "b${1}${2}m", // boobam
+					Action:       relabel.Replace,
+				},
+				{
+					SourceLabels: model.LabelNames{"c", "a"},
+					Regex:        relabel.MustNewRegexp("(b).*b(.*)ba(.*)"),
+					TargetLabel:  "d",
+					Separator:    ";",
+					Replacement:  "$1$2$2$3",
+					Action:       relabel.Replace,
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "boobam",
+				"b": "bar",
+				"c": "baz",
+				"d": "boooom",
+			}),
+		},
+		{
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "foo",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					Regex:        relabel.MustNewRegexp(".*o.*"),
+					Action:       relabel.Drop,
+				}, {
+					SourceLabels: model.LabelNames{"a"},
+					Regex:        relabel.MustNewRegexp("f(.*)"),
+					TargetLabel:  "d",
+					Separator:    ";",
+					Replacement:  "ch$1-ch$1",
+					Action:       relabel.Replace,
+				},
+			},
+			drop: true,
+		},
+		{
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "foo",
+				"b": "bar",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					Regex:        relabel.MustNewRegexp(".*o.*"),
+					Action:       relabel.Drop,
+				},
+			},
+			drop: true,
+		},
+		{
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "abc",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					Regex:        relabel.MustNewRegexp(".*(b).*"),
+					TargetLabel:  "d",
+					Separator:    ";",
+					Replacement:  "$1",
+					Action:       relabel.Replace,
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "abc",
+				"d": "b",
+			}),
+		},
+		{
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "foo",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					Regex:        relabel.MustNewRegexp("no-match"),
+					Action:       relabel.Drop,
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "foo",
+			}),
+		},
+		{
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "foo",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					Regex:        relabel.MustNewRegexp("f|o"),
+					Action:       relabel.Drop,
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "foo",
+			}),
+		},
+		{
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "foo",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					Regex:        relabel.MustNewRegexp("no-match"),
+					Action:       relabel.Keep,
+				},
+			},
+			drop: true,
+		},
+		{
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "foo",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					Regex:        relabel.MustNewRegexp("f.*"),
+					Action:       relabel.Keep,
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "foo",
+			}),
+		},
+		{
+			// No replacement must be applied if there is no match.
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "boo",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					Regex:        relabel.MustNewRegexp("f"),
+					TargetLabel:  "b",
+					Replacement:  "bar",
+					Action:       relabel.Replace,
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "boo",
+			}),
+		},
+		{
+			// Blank replacement should delete the label.
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "foo",
+				"f": "baz",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					Regex:        relabel.MustNewRegexp("(f).*"),
+					TargetLabel:  "$1",
+					Replacement:  "$2",
+					Action:       relabel.Replace,
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "foo",
+			}),
+		},
+		{
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "foo",
+				"b": "bar",
+				"c": "baz",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"c"},
+					TargetLabel:  "d",
+					Separator:    ";",
+					Action:       relabel.HashMod,
+					Modulus:      1000,
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "foo",
+				"b": "bar",
+				"c": "baz",
+				"d": "976",
+			}),
+		},
+		{
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "foo\nbar",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					TargetLabel:  "b",
+					Separator:    ";",
+					Action:       relabel.HashMod,
+					Modulus:      1000,
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "foo\nbar",
+				"b": "734",
+			}),
+		},
+		{
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"a":  "foo",
+				"b1": "bar",
+				"b2": "baz",
+			}),
+			relabel: []*relabel.Config{
+				{
+					Regex:       relabel.MustNewRegexp("(b.*)"),
+					Replacement: "bar_${1}",
+					Action:      relabel.LabelMap,
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"a":      "foo",
+				"b1":     "bar",
+				"b2":     "baz",
+				"bar_b1": "bar",
+				"bar_b2": "baz",
+			}),
+		},
+		{
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"a":             "foo",
+				"__meta_my_bar": "aaa",
+				"__meta_my_baz": "bbb",
+				"__meta_other":  "ccc",
+			}),
+			relabel: []*relabel.Config{
+				{
+					Regex:       relabel.MustNewRegexp("__meta_(my.*)"),
+					Replacement: "${1}",
+					Action:      relabel.LabelMap,
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"a":             "foo",
+				"__meta_my_bar": "aaa",
+				"__meta_my_baz": "bbb",
+				"__meta_other":  "ccc",
+				"my_bar":        "aaa",
+				"my_baz":        "bbb",
+			}),
+		},
+		{ // valid case
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "some-name-value",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					Regex:        relabel.MustNewRegexp("some-([^-]+)-([^,]+)"),
+					Action:       relabel.Replace,
+					Replacement:  "${2}",
+					TargetLabel:  "${1}",
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"a":    "some-name-value",
+				"name": "value",
+			}),
+		},
+		{ // invalid replacement ""
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "some-name-value",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					Regex:        relabel.MustNewRegexp("some-([^-]+)-([^,]+)"),
+					Action:       relabel.Replace,
+					Replacement:  "${3}",
+					TargetLabel:  "${1}",
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "some-name-value",
+			}),
+		},
+		{ // invalid target_labels
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "some-name-0",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"a"},
+					Regex:        relabel.MustNewRegexp("some-([^-]+)-([^,]+)"),
+					Action:       relabel.Replace,
+					Replacement:  "${1}",
+					TargetLabel:  "${3}",
+				},
+				{
+					SourceLabels: model.LabelNames{"a"},
+					Regex:        relabel.MustNewRegexp("some-([^-]+)-([^,]+)"),
+					Action:       relabel.Replace,
+					Replacement:  "${1}",
+					TargetLabel:  "${3}",
+				},
+				{
+					SourceLabels: model.LabelNames{"a"},
+					Regex:        relabel.MustNewRegexp("some-([^-]+)(-[^,]+)"),
+					Action:       relabel.Replace,
+					Replacement:  "${1}",
+					TargetLabel:  "${3}",
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "some-name-0",
+			}),
+		},
+		{ // more complex real-life like usecase
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"__meta_sd_tags": "path:/secret,job:some-job,label:foo=bar",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"__meta_sd_tags"},
+					Regex:        relabel.MustNewRegexp("(?:.+,|^)path:(/[^,]+).*"),
+					Action:       relabel.Replace,
+					Replacement:  "${1}",
+					TargetLabel:  "__metrics_path__",
+				},
+				{
+					SourceLabels: model.LabelNames{"__meta_sd_tags"},
+					Regex:        relabel.MustNewRegexp("(?:.+,|^)job:([^,]+).*"),
+					Action:       relabel.Replace,
+					Replacement:  "${1}",
+					TargetLabel:  "job",
+				},
+				{
+					SourceLabels: model.LabelNames{"__meta_sd_tags"},
+					Regex:        relabel.MustNewRegexp("(?:.+,|^)label:([^=]+)=([^,]+).*"),
+					Action:       relabel.Replace,
+					Replacement:  "${2}",
+					TargetLabel:  "${1}",
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"__meta_sd_tags":   "path:/secret,job:some-job,label:foo=bar",
+				"__metrics_path__": "/secret",
+				"job":              "some-job",
+				"foo":              "bar",
+			}),
+		},
+		{ // From https://github.com/prometheus/prometheus/issues/12283
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"__meta_kubernetes_pod_container_port_name":         "foo",
+				"__meta_kubernetes_pod_annotation_XXX_metrics_port": "9091",
+			}),
+			relabel: []*relabel.Config{
+				{
+					Regex:  relabel.MustNewRegexp("^__meta_kubernetes_pod_container_port_name$"),
+					Action: relabel.LabelDrop,
+				},
+				{
+					SourceLabels: model.LabelNames{"__meta_kubernetes_pod_annotation_XXX_metrics_port"},
+					Regex:        relabel.MustNewRegexp("(.+)"),
+					Action:       relabel.Replace,
+					Replacement:  "metrics",
+					TargetLabel:  "__meta_kubernetes_pod_container_port_name",
+				},
+				{
+					SourceLabels: model.LabelNames{"__meta_kubernetes_pod_container_port_name"},
+					Regex:        relabel.MustNewRegexp("^metrics$"),
+					Action:       relabel.Keep,
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"__meta_kubernetes_pod_annotation_XXX_metrics_port": "9091",
+				"__meta_kubernetes_pod_container_port_name":         "metrics",
+			}),
+		},
+		{
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"a":  "foo",
+				"b1": "bar",
+				"b2": "baz",
+			}),
+			relabel: []*relabel.Config{
+				{
+					Regex:  relabel.MustNewRegexp("(b.*)"),
+					Action: relabel.LabelKeep,
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"b1": "bar",
+				"b2": "baz",
+			}),
+		},
+		{
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"a":  "foo",
+				"b1": "bar",
+				"b2": "baz",
+			}),
+			relabel: []*relabel.Config{
+				{
+					Regex:  relabel.MustNewRegexp("(b.*)"),
+					Action: relabel.LabelDrop,
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"a": "foo",
+			}),
+		},
+		{
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"foo": "bAr123Foo",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"foo"},
+					Action:       relabel.Uppercase,
+					TargetLabel:  "foo_uppercase",
+				},
+				{
+					SourceLabels: model.LabelNames{"foo"},
+					Action:       relabel.Lowercase,
+					TargetLabel:  "foo_lowercase",
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"foo":           "bAr123Foo",
+				"foo_lowercase": "bar123foo",
+				"foo_uppercase": "BAR123FOO",
+			}),
+		},
+		{
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"__tmp_port": "1234",
+				"__port1":    "1234",
+				"__port2":    "5678",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"__tmp_port"},
+					Action:       relabel.KeepEqual,
+					TargetLabel:  "__port1",
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"__tmp_port": "1234",
+				"__port1":    "1234",
+				"__port2":    "5678",
+			}),
+		},
+		{
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"__tmp_port": "1234",
+				"__port1":    "1234",
+				"__port2":    "5678",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"__tmp_port"},
+					Action:       relabel.DropEqual,
+					TargetLabel:  "__port1",
+				},
+			},
+			drop: true,
+		},
+		{
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"__tmp_port": "1234",
+				"__port1":    "1234",
+				"__port2":    "5678",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"__tmp_port"},
+					Action:       relabel.DropEqual,
+					TargetLabel:  "__port2",
+				},
+			},
+			output: phlaremodel.LabelsFromMap(map[string]string{
+				"__tmp_port": "1234",
+				"__port1":    "1234",
+				"__port2":    "5678",
+			}),
+		},
+		{
+			input: phlaremodel.LabelsFromMap(map[string]string{
+				"__tmp_port": "1234",
+				"__port1":    "1234",
+				"__port2":    "5678",
+			}),
+			relabel: []*relabel.Config{
+				{
+					SourceLabels: model.LabelNames{"__tmp_port"},
+					Action:       relabel.KeepEqual,
+					TargetLabel:  "__port2",
+				},
+			},
+			drop: true,
+		},
+	}
+
+	for _, test := range tests {
+		// Setting default fields, mimicking the behaviour in Prometheus.
+		for _, cfg := range test.relabel {
+			if cfg.Action == "" {
+				cfg.Action = relabel.DefaultRelabelConfig.Action
+			}
+			if cfg.Separator == "" {
+				cfg.Separator = relabel.DefaultRelabelConfig.Separator
+			}
+			if cfg.Regex.Regexp == nil || cfg.Regex.String() == "" {
+				cfg.Regex = relabel.DefaultRelabelConfig.Regex
+			}
+			if cfg.Replacement == "" {
+				cfg.Replacement = relabel.DefaultRelabelConfig.Replacement
+			}
+			require.NoError(t, cfg.Validate())
+		}
+
+		res, keep := Process(test.input, test.relabel...)
+		require.Equal(t, !test.drop, keep)
+		if keep {
+			testutil.RequireEqualWithOptions(t, test.output, res, []cmp.Option{cmpopts.IgnoreUnexported(typesv1.LabelPair{})})
+		}
+	}
+}

--- a/pkg/phlare/modules.go
+++ b/pkg/phlare/modules.go
@@ -3,6 +3,7 @@ package phlare
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"time"
@@ -118,7 +119,9 @@ func (f *Phlare) initRuntimeConfig() (services.Service, error) {
 		return nil, nil
 	}
 
-	f.Cfg.RuntimeConfig.Loader = loadRuntimeConfig
+	f.Cfg.RuntimeConfig.Loader = func(r io.Reader) (interface{}, error) {
+		return validation.LoadRuntimeConfig(r)
+	}
 
 	// make sure to set default limits before we start loading configuration into memory
 	validation.SetDefaultLimitsForYAMLUnmarshalling(f.Cfg.LimitsConfig)

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/relabel"
 	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/pyroscope/pkg/phlaredb/block"
@@ -19,6 +20,14 @@ const (
 	// MinCompactorPartialBlockDeletionDelay is the minimum partial blocks deletion delay that can be configured in Mimir.
 	// Partial blocks are blocks that are not having meta file uploaded yet.
 	MinCompactorPartialBlockDeletionDelay = 4 * time.Hour
+)
+
+type RulesPosition string
+
+const (
+	RulePositionFirst    RulesPosition = "first"
+	RulePositionDisabled RulesPosition = "disabled"
+	RulePositionLast     RulesPosition = "last"
 )
 
 // Limits describe all the limits for tenants; can be used to describe global default
@@ -44,6 +53,10 @@ type Limits struct {
 	// Distributor aggregation.
 	DistributorAggregationWindow model.Duration `yaml:"distributor_aggregation_window" json:"distributor_aggregation_window"`
 	DistributorAggregationPeriod model.Duration `yaml:"distributor_aggregation_period" json:"distributor_aggregation_period"`
+
+	// IngestionRelabelingRules allow to specify additional relabeling rules that get applied before a profile gets ingested. There are some default relabeling rules, which ensure consistency of profiling series. The position of the default rules can be contolled by IngestionRelabelingDefaultRulesPosition
+	IngestionRelabelingRules                []*relabel.Config `yaml:"ingestion_relabeling_rules" json:"ingestion_relabeling_rules"`
+	IngestionRelabelingDefaultRulesPosition RulesPosition     `yaml:"ingestion_relabeling_default_rules_position" json:"ingestion_relabeling_default_rules_position"`
 
 	// The tenant shard size determines the how many ingesters a particular
 	// tenant will be sharded to. Needs to be specified on distributors for
@@ -181,6 +194,14 @@ func (l *Limits) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // Validate validates that this limits config is valid.
 func (l *Limits) Validate() error {
+
+	switch l.IngestionRelabelingDefaultRulesPosition {
+	case "", RulePositionFirst, RulePositionLast, RulePositionDisabled:
+		break
+	default:
+		return fmt.Errorf("invalid ingestion_relabeling_default_rules_position: %s", l.IngestionRelabelingDefaultRulesPosition)
+	}
+
 	return nil
 }
 

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -162,3 +162,7 @@ func TestOverwriteMarshalingStringMapYAML(t *testing.T) {
 	require.Nil(t, yaml.Unmarshal(out, &back))
 	require.Equal(t, m, back)
 }
+
+func TestIngestionRelabelingOverwrites(t *testing.T) {
+
+}

--- a/pkg/validation/relabeling.go
+++ b/pkg/validation/relabeling.go
@@ -1,0 +1,68 @@
+package validation
+
+import (
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/relabel"
+)
+
+var (
+	godeltaprof         = relabel.MustNewRegexp("godeltaprof_(.*)")
+	defaultRelabelRules = []*relabel.Config{
+		// replace godeltaprof_ prefix from name
+		{
+			SourceLabels: []model.LabelName{"__name__"},
+			Action:       relabel.Replace,
+			Regex:        godeltaprof,
+			TargetLabel:  "__name_replaced__",
+			Replacement:  "$0",
+		},
+		{
+			SourceLabels: []model.LabelName{"__name__"},
+			Regex:        godeltaprof,
+			Action:       relabel.Replace,
+			TargetLabel:  "__name__",
+			Replacement:  "$1",
+		},
+		// replace wall with process_cpu when __type__ is cpu
+		{
+			SourceLabels: []model.LabelName{"__name__", "__type__"},
+			Separator:    "/",
+			Regex:        relabel.MustNewRegexp("wall/cpu"),
+			Action:       relabel.Replace,
+			Replacement:  "wall",
+			TargetLabel:  "__name_replaced__",
+		},
+		{
+			SourceLabels: []model.LabelName{"__name__", "__type__"},
+			Separator:    "/",
+			Regex:        relabel.MustNewRegexp("wall/cpu"),
+			Action:       relabel.Replace,
+			Replacement:  "process_cpu",
+			TargetLabel:  "__name__",
+		},
+	}
+)
+
+func (o *Overrides) IngestionRelabelingRules(tenantID string) []*relabel.Config {
+	l := o.getOverridesForTenant(tenantID)
+
+	// return only custom rules when default rules are disabled
+	if l.IngestionRelabelingDefaultRulesPosition == RulePositionDisabled {
+		return l.IngestionRelabelingRules
+	}
+
+	// quick return if no rules are defined
+	if len(l.IngestionRelabelingRules) == 0 {
+		return defaultRelabelRules
+	}
+
+	rules := make([]*relabel.Config, 0, len(l.IngestionRelabelingRules)+len(defaultRelabelRules))
+
+	if l.IngestionRelabelingDefaultRulesPosition == "" || l.IngestionRelabelingDefaultRulesPosition == RulePositionFirst {
+		rules = append(rules, defaultRelabelRules...)
+		return append(rules, l.IngestionRelabelingRules...)
+	}
+
+	rules = append(rules, l.IngestionRelabelingRules...)
+	return append(rules, defaultRelabelRules...)
+}

--- a/pkg/validation/relabeling_test.go
+++ b/pkg/validation/relabeling_test.go
@@ -1,0 +1,147 @@
+package validation
+
+import (
+	"bytes"
+	"flag"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/stretchr/testify/require"
+
+	phlaremodel "github.com/grafana/pyroscope/pkg/model"
+)
+
+type wrappedRuntimeConfig struct {
+	rc *RuntimeConfigValues
+}
+
+func (w *wrappedRuntimeConfig) TenantLimits(tenantID string) *Limits {
+	return w.rc.TenantLimits[tenantID]
+}
+
+func (w *wrappedRuntimeConfig) AllByTenantID() map[string]*Limits {
+	return w.rc.TenantLimits
+}
+
+func newOverrides(rc *RuntimeConfigValues) (*Overrides, error) {
+	var defaultCfg Limits
+	fs := flag.NewFlagSet("test", flag.PanicOnError)
+	defaultCfg.RegisterFlags(fs)
+	return NewOverrides(defaultCfg, &wrappedRuntimeConfig{rc})
+}
+
+const tenantOverrideConfig = `
+overrides:
+  nothing: {}
+  disabled:
+    ingestion_relabeling_default_rules_position: disabled
+  custom-rule-end:
+    ingestion_relabeling_rules:
+      - action: drop
+  custom-rule-start:
+    ingestion_relabeling_default_rules_position: last
+    ingestion_relabeling_rules:
+      - action: drop
+  custom-rule-only:
+    ingestion_relabeling_default_rules_position: disabled
+    ingestion_relabeling_rules:
+      - action: drop
+  
+`
+
+func Test_IngestionRelabelingRules(t *testing.T) {
+	rc, err := LoadRuntimeConfig(bytes.NewReader([]byte(tenantOverrideConfig)))
+	require.NoError(t, err)
+
+	o, err := newOverrides(rc)
+	require.NoError(t, err)
+
+	rules := o.IngestionRelabelingRules("xxxx")
+	require.Equal(t, len(defaultRelabelRules), len(rules))
+
+	rules = o.IngestionRelabelingRules("nothing")
+	require.Equal(t, len(defaultRelabelRules), len(rules))
+
+	rules = o.IngestionRelabelingRules("disabled")
+	require.Equal(t, 0, len(rules))
+
+	rules = o.IngestionRelabelingRules("custom-rule-end")
+	require.Equal(t, len(defaultRelabelRules)+1, len(rules))
+	require.Equal(t, relabel.Drop, rules[len(defaultRelabelRules)].Action)
+
+	rules = o.IngestionRelabelingRules("custom-rule-start")
+	require.Equal(t, len(defaultRelabelRules)+1, len(rules))
+	require.Equal(t, relabel.Drop, rules[0].Action)
+
+	rules = o.IngestionRelabelingRules("custom-rule-only")
+	require.Equal(t, 1, len(rules))
+	require.Equal(t, relabel.Drop, rules[0].Action)
+
+	_, err = LoadRuntimeConfig(bytes.NewReader([]byte(`
+overrides:
+  wrong-mode:
+    ingestion_relabeling_default_rules_position: end
+  `)))
+	require.ErrorContains(t, err, "invalid ingestion_relabeling_default_rules_position: end")
+
+	_, err = LoadRuntimeConfig(bytes.NewReader([]byte(`
+overrides:
+  wrong-rule-action:
+    ingestion_relabeling_rules: [{action: refund}]
+  `)))
+	require.ErrorContains(t, err, "unknown relabel action \"refund\"")
+
+	_, err = LoadRuntimeConfig(bytes.NewReader([]byte(`
+overrides:
+  empty-rule:
+    ingestion_relabeling_rules: [{}]
+  `)))
+	require.ErrorContains(t, err, "relabel configuration for replace action requires 'target_label'")
+
+}
+
+func Test_defaultRelabelRules(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    labels.Labels
+		expected labels.Labels
+		kept     bool
+	}{
+		{
+			name:     "let empty through",
+			input:    labels.Labels{},
+			expected: labels.Labels{},
+			kept:     true,
+		},
+		{
+			name: "godelta prof remove prefix",
+			input: labels.FromStrings(
+				phlaremodel.LabelNameProfileName, "godeltaprof_memory", // TODO: Verify is this is really the prefix used
+			),
+			expected: labels.FromStrings(
+				phlaremodel.LabelNameProfileName, "memory",
+				"__name_replaced__", "godeltaprof_memory",
+			),
+			kept: true,
+		},
+		{
+			name: "replace wall name with cpu type",
+			input: labels.FromStrings(
+				phlaremodel.LabelNameProfileName, "wall",
+				phlaremodel.LabelNameType, "cpu",
+			),
+			expected: labels.FromStrings(
+				phlaremodel.LabelNameProfileName, "process_cpu",
+				"__name_replaced__", "wall",
+				phlaremodel.LabelNameType, "cpu",
+			),
+			kept: true,
+		},
+	} {
+		result, kept := relabel.Process(tc.input, defaultRelabelRules...)
+		require.Equal(t, tc.expected, result)
+		require.Equal(t, tc.kept, kept)
+	}
+
+}

--- a/pkg/validation/runtime_config.go
+++ b/pkg/validation/runtime_config.go
@@ -1,0 +1,44 @@
+package validation
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/go-kit/log/level"
+	"gopkg.in/yaml.v3"
+
+	"github.com/grafana/pyroscope/pkg/util"
+)
+
+type RuntimeConfigValues struct {
+	TenantLimits map[string]*Limits `yaml:"overrides"`
+}
+
+func (r RuntimeConfigValues) validate() error {
+	for t, c := range r.TenantLimits {
+		if c == nil {
+			level.Warn(util.Logger).Log("msg", "skipping empty tenant limit definition", "tenant", t)
+			continue
+		}
+
+		if err := c.Validate(); err != nil {
+			return fmt.Errorf("invalid override for tenant %s: %w", t, err)
+		}
+	}
+
+	return nil
+}
+
+func LoadRuntimeConfig(r io.Reader) (*RuntimeConfigValues, error) {
+	overrides := &RuntimeConfigValues{}
+
+	decoder := yaml.NewDecoder(r)
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&overrides); err != nil {
+		return nil, err
+	}
+	if err := overrides.validate(); err != nil {
+		return nil, err
+	}
+	return overrides, nil
+}

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -55,6 +55,9 @@ const (
 	MalformedProfile  Reason = "malformed_profile"
 	FlameGraphLimit   Reason = "flamegraph_limit"
 
+	// Those profiles were dropped because of relabeling rules
+	RelabelRules Reason = "dropped_by_relabel_rules"
+
 	SeriesLimitErrorMsg                 = "Maximum active series limit exceeded (%d/%d), reduce the number of active streams (reduce labels or reduce label values), or contact your administrator to see if the limit can be increased"
 	MissingLabelsErrorMsg               = "error at least one label pair is required per profile"
 	InvalidLabelsErrorMsg               = "invalid labels '%s' with error: %s"


### PR DESCRIPTION
This is an important operational tool: It allows us to deal with problems in the ingested profile labels.

The relabeling rules cover both series label and also sample labes.

By default we supply relabeling rules, which do remove the `godeltaprof_` prefix from profiles generated by pyroscope-go.
