### PR TITLE
Change protocol default for profilecli

### DIFF
--- a/cmd/profilecli/client.go
+++ b/cmd/profilecli/client.go
@@ -12,9 +12,9 @@ import (
 const (
 	envPrefix = "PROFILECLI_"
 
+	protocolTypeConnect = "connect"
 	protocolTypeGRPC    = "grpc"
 	protocolTypeGRPCWeb = "grpc-web"
-	protocolTypeJSON    = "json"
 )
 
 var userAgentHeader = fmt.Sprintf("pyroscope/%s", version.Version)
@@ -69,10 +69,10 @@ func (c *phlareClient) protocolOption() connect.ClientOption {
 		return connect.WithGRPC()
 	case protocolTypeGRPCWeb:
 		return connect.WithGRPCWeb()
-	case protocolTypeJSON:
-		return connect.WithProtoJSON()
+	case protocolTypeConnect:
+		return connect.WithClientOptions()
 	default:
-		return connect.WithProtoJSON()
+		return connect.WithClientOptions()
 	}
 }
 
@@ -88,6 +88,7 @@ func addPhlareClient(cmd commander) *phlareClient {
 	cmd.Flag("tenant-id", "The tenant ID to be used for the X-Scope-OrgID header.").Default("").Envar(envPrefix + "TENANT_ID").StringVar(&client.TenantID)
 	cmd.Flag("username", "The username to be used for basic auth.").Default("").Envar(envPrefix + "USERNAME").StringVar(&client.BasicAuth.Username)
 	cmd.Flag("password", "The password to be used for basic auth.").Default("").Envar(envPrefix + "PASSWORD").StringVar(&client.BasicAuth.Password)
-	cmd.Flag("protocol", "The protocol to be used for communicating with the server.").Default(protocolTypeJSON).EnumVar(&client.protocol, protocolTypeGRPC, protocolTypeGRPCWeb, protocolTypeJSON)
+	cmd.Flag("protocol", "The protocol to be used for communicating with the server.").Default(protocolTypeConnect).EnumVar(&client.protocol,
+		protocolTypeConnect, protocolTypeGRPC, protocolTypeGRPCWeb)
 	return client
 }

--- a/cmd/profilecli/query.go
+++ b/cmd/profilecli/query.go
@@ -14,6 +14,11 @@ import (
 	"github.com/go-kit/log/level"
 	gprofile "github.com/google/pprof/profile"
 	"github.com/grafana/dskit/runutil"
+	"github.com/k0kubun/pp/v3"
+	"github.com/klauspost/compress/gzip"
+	"github.com/mattn/go-isatty"
+	"github.com/pkg/errors"
+
 	ingestv1 "github.com/grafana/pyroscope/api/gen/proto/go/ingester/v1"
 	"github.com/grafana/pyroscope/api/gen/proto/go/ingester/v1/ingesterv1connect"
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
@@ -22,36 +27,13 @@ import (
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	connectapi "github.com/grafana/pyroscope/pkg/api/connect"
 	"github.com/grafana/pyroscope/pkg/operations"
-	"github.com/k0kubun/pp/v3"
-	"github.com/klauspost/compress/gzip"
-	"github.com/mattn/go-isatty"
-	"github.com/pkg/errors"
 )
-
-type protocolType string
 
 const (
 	outputConsole = "console"
 	outputRaw     = "raw"
 	outputPprof   = "pprof="
-
-	protocolTypeGRPC    = "grpc"
-	protocolTypeGRPCWeb = "grpc-web"
-	protocolTypeJSON    = "json"
 )
-
-func (c *phlareClient) protocolOption() connect.ClientOption {
-	switch c.protocol {
-	case protocolTypeGRPC:
-		return connect.WithGRPC()
-	case protocolTypeGRPCWeb:
-		return connect.WithGRPCWeb()
-	case protocolTypeJSON:
-		return connect.WithProtoJSON()
-	default:
-		return connect.WithGRPC()
-	}
-}
 
 func (c *phlareClient) queryClient() querierv1connect.QuerierServiceClient {
 	return querierv1connect.NewQuerierServiceClient(


### PR DESCRIPTION
Follow up to #3368, it looks like the default protocol value (`grpc`) breaks many commands (the canary exporter, upload, ...). 

cc @simonswine 