### PR TITLE
Update release workflow to be v2 compatible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           # either 'goreleaser' (default) or 'goreleaser-pro':
           distribution: goreleaser
           version: latest
-          args: release --rm-dist --timeout 60m
+          args: release --clean --timeout 60m
         env:
           GITHUB_TOKEN: ${{ steps.app-goreleaser.outputs.token }}
           # Your GoReleaser Pro key, if you are using the 'goreleaser-pro'


### PR DESCRIPTION
I am currently trying to cut a v1.6.1 to address #3355 and this was missed as part of #3347
