### PR TITLE
chore: Fix template issue with older Helm versions

### DIFF
--- a/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
@@ -97,7 +97,7 @@ spec:
               path: /ready
               port: {{ $values.service.port_name }}
               scheme: {{ $values.service.scheme }}
-          {{- if and (hasKey $values "readinessProbe") (hasKey $values.readinessProbe "initialDelaySeconds") }}
+          {{- if ($values.readinessProbe).initialDelaySeconds }}
             initialDelaySeconds: {{ $values.readinessProbe.initialDelaySeconds }}
           {{- end }}
           volumeMounts:


### PR DESCRIPTION
Fixes #3004 by changing the template in question. Verified with Helm 3.8.1 and 3.15.2.