### PR TITLE
feat: implement parent pointer tree recovery

### DIFF
--- a/pkg/phlaredb/symdb/stacktrace_tree_test.go
+++ b/pkg/phlaredb/symdb/stacktrace_tree_test.go
@@ -164,6 +164,31 @@ func Test_stacktrace_tree_pprof_locations(t *testing.T) {
 	}
 }
 
+func Test_parentPointerTree_toStacktraceTree(t *testing.T) {
+	x := newStacktraceTree(10)
+	for _, stack := range [][]uint64{
+		{5, 4, 3, 2, 1},
+		{6, 4, 3, 2, 1},
+		{4, 3, 2, 1},
+		{3, 2, 1},
+		{4, 2, 1},
+		{7, 2, 1},
+		{2, 1},
+		{1},
+	} {
+		x.insert(stack)
+	}
+
+	var b bytes.Buffer
+	_, _ = x.WriteTo(&b)
+	ppt := newParentPointerTree(x.len())
+	_, err := ppt.ReadFrom(bytes.NewBuffer(b.Bytes()))
+	require.NoError(t, err)
+
+	restored := ppt.toStacktraceTree()
+	assert.Equal(t, x.nodes, restored.nodes)
+}
+
 func Benchmark_stacktrace_tree_insert(b *testing.B) {
 	p, err := pprof.OpenFile("testdata/profile.pb.gz")
 	require.NoError(b, err)


### PR DESCRIPTION
The PR adds a way to convert a parent pointer tree to a full tree, which allows for tree traversal and quick reverse lookups (call site -> stack trace identifiers). This lightweight operation is instrumental for implementing #3219, #3384, #3220, and #2729. As of now, it is not used anywhere, but I'm afraid of forgetting the algorithm, so I'm adding it to the codebase.