### PR TITLE
Reject queries without a time range

### DIFF
--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -1853,6 +1853,10 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -distributor.aggregation-period
 [distributor_aggregation_period: <duration> | default = 0s]
 
+[ingestion_relabeling_rules: <relabel_config...> | default = ]
+
+[ingestion_relabeling_default_rules_position: <string> | default = ""]
+
 # The tenant's shard size used by shuffle-sharding. Must be set both on
 # ingesters and distributors. 0 disables shuffle sharding.
 # CLI flag: -distributor.ingestion-tenant-shard-size

--- a/pkg/frontend/frontend_diff_test.go
+++ b/pkg/frontend/frontend_diff_test.go
@@ -76,7 +76,7 @@ func Test_Frontend_Diff(t *testing.T) {
 				Left: &querierv1.SelectMergeStacktracesRequest{
 					ProfileTypeID: profileType,
 					LabelSelector: "{}",
-					Start:         0000,
+					Start:         1,
 					End:           1000,
 				},
 				Right: &querierv1.SelectMergeStacktracesRequest{

--- a/pkg/test/integration/helper.go
+++ b/pkg/test/integration/helper.go
@@ -416,7 +416,7 @@ func (b *RequestBuilder) SelectMergeProfile(metric string, query map[string]stri
 	qc := b.QueryClient()
 	resp, err := qc.SelectMergeProfile(context.Background(), connect.NewRequest(&querierv1.SelectMergeProfileRequest{
 		ProfileTypeID: metric,
-		Start:         time.Unix(0, 0).UnixMilli(),
+		Start:         time.Unix(1, 0).UnixMilli(),
 		End:           time.Now().UnixMilli(),
 		LabelSelector: selector.String(),
 	}))

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -329,7 +329,7 @@ type ValidatedRangeRequest struct {
 }
 
 func ValidateRangeRequest(limits RangeRequestLimits, tenantIDs []string, req model.Interval, now model.Time) (ValidatedRangeRequest, error) {
-	if req.Start == 0 && req.End == 0 {
+	if req.Start == 0 || req.End == 0 {
 		return ValidatedRangeRequest{}, NewErrorf(QueryMissingTimeRange, QueryMissingTimeRangeErrorMsg)
 	}
 

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -47,13 +47,14 @@ const (
 	DuplicateLabelNames Reason = "duplicate_label_names"
 	// SeriesLimit is a reason for discarding lines when we can't create a new stream
 	// because the limit of active streams has been reached.
-	SeriesLimit       Reason = "series_limit"
-	QueryLimit        Reason = "query_limit"
-	SamplesLimit      Reason = "samples_limit"
-	ProfileSizeLimit  Reason = "profile_size_limit"
-	SampleLabelsLimit Reason = "sample_labels_limit"
-	MalformedProfile  Reason = "malformed_profile"
-	FlameGraphLimit   Reason = "flamegraph_limit"
+	SeriesLimit           Reason = "series_limit"
+	QueryLimit            Reason = "query_limit"
+	SamplesLimit          Reason = "samples_limit"
+	ProfileSizeLimit      Reason = "profile_size_limit"
+	SampleLabelsLimit     Reason = "sample_labels_limit"
+	MalformedProfile      Reason = "malformed_profile"
+	FlameGraphLimit       Reason = "flamegraph_limit"
+	QueryMissingTimeRange Reason = "missing_time_range"
 
 	// Those profiles were dropped because of relabeling rules
 	RelabelRules Reason = "dropped_by_relabel_rules"
@@ -72,6 +73,7 @@ const (
 	NotInIngestionWindowErrorMsg        = "profile with labels '%s' is outside of ingestion window (profile timestamp: %s, %s)"
 	MaxFlameGraphNodesErrorMsg          = "max flamegraph nodes limit %d is greater than allowed %d"
 	MaxFlameGraphNodesUnlimitedErrorMsg = "max flamegraph nodes limit must be set (max allowed %d)"
+	QueryMissingTimeRangeErrorMsg       = "missing time range in the query"
 )
 
 var (
@@ -327,6 +329,10 @@ type ValidatedRangeRequest struct {
 }
 
 func ValidateRangeRequest(limits RangeRequestLimits, tenantIDs []string, req model.Interval, now model.Time) (ValidatedRangeRequest, error) {
+	if req.Start == 0 && req.End == 0 {
+		return ValidatedRangeRequest{}, NewErrorf(QueryMissingTimeRange, QueryMissingTimeRangeErrorMsg)
+	}
+
 	if maxQueryLookback := validation.SmallestPositiveNonZeroDurationPerTenant(tenantIDs, limits.MaxQueryLookback); maxQueryLookback > 0 {
 		minStartTime := now.Add(-maxQueryLookback)
 

--- a/pkg/validation/validate_test.go
+++ b/pkg/validation/validate_test.go
@@ -200,6 +200,14 @@ func Test_ValidateRangeRequest(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "empty start and end",
+			in: model.Interval{
+				Start: 0,
+				End:   0,
+			},
+			expectedErr: NewErrorf(QueryMissingTimeRange, QueryMissingTimeRangeErrorMsg),
+		},
 	} {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/validation/validate_test.go
+++ b/pkg/validation/validate_test.go
@@ -201,6 +201,22 @@ func Test_ValidateRangeRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "empty start",
+			in: model.Interval{
+				Start: 0,
+				End:   now,
+			},
+			expectedErr: NewErrorf(QueryMissingTimeRange, QueryMissingTimeRangeErrorMsg),
+		},
+		{
+			name: "empty end",
+			in: model.Interval{
+				Start: now,
+				End:   0,
+			},
+			expectedErr: NewErrorf(QueryMissingTimeRange, QueryMissingTimeRangeErrorMsg),
+		},
+		{
 			name: "empty start and end",
 			in: model.Interval{
 				Start: 0,


### PR DESCRIPTION
In https://github.com/grafana/explore-profiles/pull/15, I ran across a bug where the UI was sending queries without a time range. It was a little tricky to track down because Pyroscope would respond with a success status code, but an empty payload. This made me wonder if there was a bug in Pyroscope's query logic.

I think we should classify queries with no time range an error. I don't know of any use cases in which we want to have a time range, but allow it to be optionally provided.