### PR TITLE
chore: Update kubeVersion and branch to main

### DIFF
--- a/operations/pyroscope/helm/ct.yaml
+++ b/operations/pyroscope/helm/ct.yaml
@@ -1,7 +1,7 @@
 # See https://github.com/helm/chart-testing#configuration
 remote: origin
-target-branch: next
-kubeVersion: "1.22"
+target-branch: main
+kubeVersion: "1.23"
 chart-dirs:
   - operations/pyroscope/helm/
 chart-repos:


### PR DESCRIPTION
Small follow-up to #3332 

This fixes the kubeVersion to match the one from the makefile and compares to the correct branch.
