### PR TITLE
fix: honor stacktrace partitions at downsampling

### DIFF
--- a/pkg/phlaredb/schemas/v1/profiles.go
+++ b/pkg/phlaredb/schemas/v1/profiles.go
@@ -672,6 +672,10 @@ func (p ProfileRow) SetSeriesIndex(v uint32) {
 	p[seriesIndexColIndex] = parquet.Int32Value(int32(v)).Level(0, 0, seriesIndexColIndex)
 }
 
+func (p ProfileRow) SetStacktracePartitionID(v uint64) {
+	p[stacktracePartitionColIndex] = parquet.Int64Value(int64(v)).Level(0, 0, stacktracePartitionColIndex)
+}
+
 func (p ProfileRow) ForStacktraceIDsValues(fn func([]parquet.Value)) {
 	start := -1
 	var i int

--- a/pkg/phlaredb/symdb/rewriter.go
+++ b/pkg/phlaredb/symdb/rewriter.go
@@ -40,7 +40,7 @@ func (r *Rewriter) Rewrite(partition uint64, stacktraces []uint32) error {
 
 func (r *Rewriter) init(partition uint64) (p *partitionRewriter, err error) {
 	if r.partitions == nil {
-		r.partitions, _ = lru.NewWithEvict(2, func(_ uint64, p *partitionRewriter) {
+		r.partitions, _ = lru.NewWithEvict(8, func(_ uint64, p *partitionRewriter) {
 			p.reader.Release()
 		})
 	}

--- a/pkg/phlaredb/symdb/stacktrace_tree.go
+++ b/pkg/phlaredb/symdb/stacktrace_tree.go
@@ -153,10 +153,10 @@ func newParentPointerTree(size uint32) *parentPointerTree {
 }
 
 func (t *parentPointerTree) resolve(dst []int32, id uint32) []int32 {
+	dst = dst[:0]
 	if id >= uint32(len(t.nodes)) {
 		return dst
 	}
-	dst = dst[:0]
 	n := t.nodes[id]
 	for n.p >= 0 {
 		dst = append(dst, n.r)
@@ -166,10 +166,10 @@ func (t *parentPointerTree) resolve(dst []int32, id uint32) []int32 {
 }
 
 func (t *parentPointerTree) resolveUint64(dst []uint64, id uint32) []uint64 {
+	dst = dst[:0]
 	if id >= uint32(len(t.nodes)) {
 		return dst
 	}
-	dst = dst[:0]
 	n := t.nodes[id]
 	for n.p >= 0 {
 		dst = append(dst, uint64(n.r))

--- a/pkg/phlaredb/symdb/stacktrace_tree_test.go
+++ b/pkg/phlaredb/symdb/stacktrace_tree_test.go
@@ -115,6 +115,16 @@ func Test_stacktrace_tree_encoding_rand(t *testing.T) {
 	}
 }
 
+func Test_stacktrace_tree_pprof_locations_(t *testing.T) {
+	x := newStacktraceTree(0)
+	assert.Len(t, x.resolve([]int32{0, 1, 2, 3}, 42), 0)
+	assert.Len(t, x.resolveUint64([]uint64{0, 1, 2, 3}, 42), 0)
+
+	p := newParentPointerTree(0)
+	assert.Len(t, p.resolve([]int32{0, 1, 2, 3}, 42), 0)
+	assert.Len(t, p.resolveUint64([]uint64{0, 1, 2, 3}, 42), 0)
+}
+
 func Test_stacktrace_tree_pprof_locations(t *testing.T) {
 	p, err := pprof.OpenFile("testdata/profile.pb.gz")
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes https://github.com/grafana/pyroscope/issues/3406.

Currently, during compaction, when the downsampler aggregates profiles, the stack trace partition is ignored. The initial assumption was that profiles of the same series (label set) would always have the same stack trace partition. This is almost always the case; however, this is not guaranteed as the partitioning heuristic also depends on the main mapping name (see [#3262](https://github.com/grafana/pyroscope/issues/3262)).

We've recently discovered a few cases where this led to data inconsistencies. Specifically, profiles that refer to the wrong partition, and therefore can't be read: their samples refer to stack traces that can't be found in the partition. Another issue is that such occurrences are not handled properly: a wrong stack trace may be resolved to wrong locations (the stack trace buffer is not cleared if the stack trace is not found), which will likely cause a panic when attempting to resolve it.

I also increased the symbol rewriter LRU cache size from 2 to 8, as I've seen that the interlacing of partitions might be quite heavy.