### PR TITLE
fix: revert rewriter LRU cache size

### DIFF
--- a/pkg/phlaredb/symdb/rewriter.go
+++ b/pkg/phlaredb/symdb/rewriter.go
@@ -40,7 +40,7 @@ func (r *Rewriter) Rewrite(partition uint64, stacktraces []uint32) error {
 
 func (r *Rewriter) init(partition uint64) (p *partitionRewriter, err error) {
 	if r.partitions == nil {
-		r.partitions, _ = lru.NewWithEvict(8, func(_ uint64, p *partitionRewriter) {
+		r.partitions, _ = lru.NewWithEvict(2, func(_ uint64, p *partitionRewriter) {
 			p.reader.Release()
 		})
 	}


### PR DESCRIPTION
Increasing the LRU cache size from 2 to 8 turned out to be quite a problem for large deployments and might be causing OOMs, so I'm reverting it

See #3408 