### PR TITLE
fix: stack trace selector ignores conflicting functions

### DIFF
--- a/pkg/phlaredb/symdb/resolver_pprof.go
+++ b/pkg/phlaredb/symdb/resolver_pprof.go
@@ -39,7 +39,7 @@ func buildPprof(
 	// limit on the number of the nodes in the profile, or
 	// if stack traces should be filtered by the call site.
 	case maxNodes > 0 || len(selection.callSite) > 0:
-		b = &pprofTree{maxNodes: maxNodes, callSite: selection.callSite}
+		b = &pprofTree{maxNodes: maxNodes, selection: selection}
 	}
 	b.init(symbols, samples)
 	if err := symbols.Stacktraces.ResolveStacktraceLocations(ctx, b, samples.StacktraceIDs); err != nil {


### PR DESCRIPTION
Fixes #3411

Instead of resolving the selected stack trace to function identifiers to optimize the search (which is not trivial if there are functions with identical names, which is totally possible), frames will be compared by their string values