### PR TITLE
chore: Build weeklies with debug information

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -15,6 +15,8 @@ jobs:
         run: echo "GORELEASER_CURRENT_TAG=v0.0.0-$(./tools/image-tag)" >> $GITHUB_ENV
       - name: Set WEEKLY_IMAGE_TAG
         run: echo "WEEKLY_IMAGE_TAG=$(./tools/image-tag)" >> $GITHUB_ENV
+      - name: Set GORELEASER_STRIP_DEBUG_INFO=false, so binaries are not stripped of debug info
+        run: echo "GORELEASER_STRIP_DEBUG_INFO=false" >> $GITHUB_ENV
       # Forces goreleaser to use the correct previous tag for the changelog
       - name: Set GORELEASER_PREVIOUS_TAG
         run: echo "GORELEASER_PREVIOUS_TAG=$(git tag -l --sort=-version:refname | grep -E '^weekly-.*' | head -n 2 | tail -1)" >> $GITHUB_ENV

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,7 +3,10 @@ version: 2
 before:
   hooks:
     # This hook ensures that goreleaser uses the correct go version for a Pyroscope release
-    - sh -euc "go version | grep "go version go1.21.11 " || { echo "Unexpected go version"; exit 1; }"
+    - sh -euc 'go version | grep "go version go1.21.11 " || { echo "Unexpected go version"; exit 1; }'
+env:
+  # Strip debug information from the binary by default, weekly builds will have debug information
+  - GORELEASER_DEBUG_INFO_FLAGS={{ if and (index .Env "GORELEASER_STRIP_DEBUG_INFO") (eq .Env.GORELEASER_STRIP_DEBUG_INFO "false")  }}{{ else }}-s -w{{ end }}
 builds:
   - env:
       - CGO_ENABLED=0
@@ -26,7 +29,7 @@ builds:
       - embedassets
     ldflags:
       - >
-        -extldflags "-static" -s -w
+        -extldflags "-static" {{ .Env.GORELEASER_DEBUG_INFO_FLAGS }}
         -X "github.com/grafana/pyroscope/pkg/util/build.Branch={{ .Branch }}"
         -X "github.com/grafana/pyroscope/pkg/util/build.Version={{ .Version }}"
         -X "github.com/grafana/pyroscope/pkg/util/build.Revision={{ .ShortCommit }}"
@@ -38,7 +41,7 @@ builds:
       - netgo
     ldflags:
       - >
-        -extldflags "-static" -s -w
+        -extldflags "-static" {{ .Env.GORELEASER_DEBUG_INFO_FLAGS }}
         -X "github.com/grafana/pyroscope/pkg/util/build.Branch={{ .Branch }}"
         -X "github.com/grafana/pyroscope/pkg/util/build.Version={{ .Version }}"
         -X "github.com/grafana/pyroscope/pkg/util/build.Revision={{ .ShortCommit }}"


### PR DESCRIPTION
This will allow to have more meaningful ways of debugging core dump and live processes in all environments.

I tested this quickly:

```
# Without any env we still strip the debug info
❯ goreleaser build --clean --snapshot --single-target
[...]
❯ dlv exec dist/profilecli_darwin_arm64/profilecli
could not launch process: decoding dwarf section info at offset 0x0: too short - debuggee must not be built with 'go run' or -ldflags='-s -w', which strip debug info

# With environment set
❯ GORELEASER_STRIP_DEBUG_INFO=false goreleaser build --clean --snapshot --single-target
[...]
❯ dlv exec dist/profilecli_darwin_arm64/profilecli
Type 'help' for list of commands.
(dlv)
```