### PR TITLE
profiles parquet encoding: fix profile column count

### DIFF
--- a/pkg/phlaredb/schemas/v1/profiles.go
+++ b/pkg/phlaredb/schemas/v1/profiles.go
@@ -503,8 +503,9 @@ func deconstructMemoryProfile(imp InMemoryProfile, row parquet.Row) parquet.Row 
 			col++
 			return col
 		}
-		totalCols = 8 + (7 * len(imp.Samples.StacktraceIDs)) + len(imp.Comments)
+		totalCols = profileColumnCount(imp)
 	)
+
 	if cap(row) < totalCols {
 		row = make(parquet.Row, 0, totalCols)
 	}
@@ -612,6 +613,17 @@ func deconstructMemoryProfile(imp InMemoryProfile, row parquet.Row) parquet.Row 
 		row = append(row, parquet.Int64Value(imp.DefaultSampleType).Level(0, 1, newCol()))
 	}
 	return row
+}
+
+func profileColumnCount(imp InMemoryProfile) int {
+	var totalCols = 10 + (7 * len(imp.Samples.StacktraceIDs)) + len(imp.Comments)
+	if len(imp.Comments) == 0 {
+		totalCols++
+	}
+	if len(imp.Samples.StacktraceIDs) == 0 {
+		totalCols += 7
+	}
+	return totalCols
 }
 
 func NewMergeProfilesRowReader(rowGroups []parquet.RowReader) parquet.RowReader {

--- a/pkg/phlaredb/schemas/v1/profiles_test.go
+++ b/pkg/phlaredb/schemas/v1/profiles_test.go
@@ -542,3 +542,41 @@ func Test_SamplesRange(t *testing.T) {
 		})
 	}
 }
+
+func TestColumnCount(t *testing.T) {
+	profiles := []InMemoryProfile{{
+		SeriesIndex: 1,
+		TimeNanos:   2,
+		Samples: Samples{
+			StacktraceIDs: []uint32{1, 2, 3},
+			Values:        []uint64{1, 2, 3},
+		},
+	},
+		{
+			SeriesIndex: 1,
+			TimeNanos:   2,
+			Samples: Samples{
+				StacktraceIDs: []uint32{1, 2, 3},
+				Values:        []uint64{1, 2, 3},
+				Spans:         []uint64{1, 2, 3},
+			},
+		},
+		{
+			SeriesIndex: 1,
+			TimeNanos:   2,
+			Samples: Samples{
+				StacktraceIDs: []uint32{1, 2, 3},
+				Values:        []uint64{1, 2, 3},
+				Spans:         []uint64{1, 2, 3},
+			},
+			Comments: []int64{1, 2, 3},
+		}}
+	for _, profile := range profiles {
+		count := profileColumnCount(profile)
+
+		row := deconstructMemoryProfile(profile, nil)
+		assert.Equal(t, len(row), count)
+		assert.Equal(t, cap(row), count)
+	}
+
+}


### PR DESCRIPTION
noticed last columns appends are allocating

![image](https://github.com/user-attachments/assets/7916dd43-af14-4f16-b0f0-da67b78350ac)
