### PR TITLE
fix: readiness check for ingesters and frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,13 +77,10 @@ build: frontend/build go/bin ## Do a production build (requiring the frontend bu
 build-dev: ## Do a dev build (without requiring the frontend)
 	$(MAKE) EMBEDASSETS="" go/bin
 
-.PHONY: frontend/build
-frontend/build: frontend/deps ## Do a production build for the frontend
-	yarn build
 
-.PHONY: frontend/deps
-frontend/deps:
-	yarn --frozen-lockfile
+.PHONY: frontend/build
+frontend/build:
+	docker build  -f cmd/pyroscope/frontend.Dockerfile --output=public/build .
 
 .PHONY: release
 release/prereq: $(BIN)/goreleaser ## Ensure release pre requesites are met

--- a/cmd/pyroscope/frontend.Dockerfile
+++ b/cmd/pyroscope/frontend.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18 as builder
+FROM node:18 AS builder
 RUN apt-get update && apt-get install -y libpango1.0-dev libcairo2-dev
 WORKDIR /pyroscope
 COPY yarn.lock package.json tsconfig.json ./

--- a/pkg/phlare/modules.go
+++ b/pkg/phlare/modules.go
@@ -109,6 +109,7 @@ func (f *Phlare) initQueryFrontend() (services.Service, error) {
 	f.API.RegisterPyroscopeHandlers(frontendSvc)
 	f.API.RegisterQueryFrontend(frontendSvc)
 	f.API.RegisterQuerier(frontendSvc)
+	f.frontend = frontendSvc
 
 	return frontendSvc, nil
 }
@@ -408,6 +409,7 @@ func (f *Phlare) initIngester() (_ services.Service, err error) {
 	}
 
 	f.API.RegisterIngester(svc)
+	f.ingester = svc
 
 	return svc, nil
 }


### PR DESCRIPTION
This will likely slowdown (already slow) ingesters rollouts due to `  [min_ready_duration: <duration> | default = 15s]`

As a side quest I made `make frontend/build` use docker.