### PR TITLE
docs: Add parameters from otel-profiling-java

### DIFF
--- a/docs/sources/configure-client/trace-span-profiles/java-span-profiles.md
+++ b/docs/sources/configure-client/trace-span-profiles/java-span-profiles.md
@@ -88,6 +88,14 @@ ENV PYROSCOPE_SERVER_ADDRESS=http://localhost:4040
 CMD ["java", "-Dserver.port=5000", "-javaagent:./opentelemetry-javaagent.jar", "-javaagent:pyroscope.jar", "-jar", "./my-app.jar" ]
 ```
 
+### Available configuration options
+
+| Flag                             | Description                                                                                                                                                                                                                                                                                                             | Default |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `otel.pyroscope.start.profiling` | Boolean flag to start PyroscopeAgent. Set to false if you want to start the PyroscopeAgent manually.                                                                                                                                                                                                                    | `true`  |
+| `otel.pyroscope.root.span.only`  | Boolean flag. When enabled, the tracer will annotate only the first span created locally (the root span), but the profile will include samples of all the nested spans. This may be helpful in case if the trace consists of multiple spans shorter than 10ms and profiler can't collect and annotate samples properly. | `true`  |
+| `otel.pyroscope.add.span.name`   | Boolean flag. Controls whether the span name added to profile labels.                                                                                                                                                                                                                                                   | `true`  |
+
 ## View the span profiles in Grafana Tempo
 
 To view the span profiles in Grafana Tempo, you need to have a Grafana instance running and a data source configured to link trace spans and profiles.


### PR DESCRIPTION
I would like to get rid of the rich READMEs and link everything into docs. This is something that our docs don't have.
