### PR TITLE
chore: Drop linux/arm/v6 architecture

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,7 +18,6 @@ builds:
       - arm64
       - arm
     goarm:
-      - "6"
       - "7"
     main: ./cmd/pyroscope
     mod_timestamp: "{{ .CommitTimestamp }}"
@@ -55,7 +54,6 @@ builds:
       - arm64
       - arm
     goarm:
-      - "6"
       - "7"
     ignore:
       - goos: windows
@@ -103,22 +101,6 @@ dockers:
   - use: buildx
     goos: linux
     goarch: arm
-    goarm: "6"
-    extra_files:
-      - cmd/pyroscope/pyroscope.yaml
-    dockerfile: ./cmd/pyroscope/Dockerfile
-    image_templates:
-      - "grafana/{{ .ProjectName }}:{{ .Version }}-armv6"
-      - "grafana/{{ .ProjectName }}:latest-armv6"
-    build_flag_templates:
-      - "--platform=linux/arm/v6"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-  - use: buildx
-    goos: linux
-    goarch: arm
     goarm: "7"
     dockerfile: ./cmd/pyroscope/Dockerfile
     extra_files:
@@ -138,13 +120,11 @@ docker_manifests:
     image_templates:
       - grafana/{{ .ProjectName }}:{{ .Version }}-amd64
       - grafana/{{ .ProjectName }}:{{ .Version }}-arm64v8
-      - grafana/{{ .ProjectName }}:{{ .Version }}-armv6
       - grafana/{{ .ProjectName }}:{{ .Version }}-armv7
   - name_template: grafana/{{ .ProjectName }}:latest
     image_templates:
       - grafana/{{ .ProjectName }}:latest-amd64
       - grafana/{{ .ProjectName }}:latest-arm64v8
-      - grafana/{{ .ProjectName }}:latest-armv6
       - grafana/{{ .ProjectName }}:latest-armv7
 nfpms:
   - id: pyroscope


### PR DESCRIPTION
This is a follow up to #3437 as there are no distroless images provided by upstream.
