### PR TITLE
bug: Docker image ensure data folder for compactor exists

### DIFF
--- a/cmd/pyroscope/Dockerfile
+++ b/cmd/pyroscope/Dockerfile
@@ -14,6 +14,8 @@ COPY --from=debug /etc/group /etc/group
 # in order for the container to run as non-root.
 VOLUME /data
 COPY --chown=pyroscope:pyroscope --from=debug /data /data
+VOLUME /data-compactor
+COPY --chown=pyroscope:pyroscope --from=debug /data /data-compactor
 
 COPY cmd/pyroscope/pyroscope.yaml /etc/pyroscope/config.yaml
 COPY profilecli /usr/bin/profilecli

--- a/cmd/pyroscope/debug.Dockerfile
+++ b/cmd/pyroscope/debug.Dockerfile
@@ -5,9 +5,12 @@ SHELL [ "/busybox/sh", "-c" ]
 RUN addgroup -g 10001 -S pyroscope && \
     adduser -u 10001 -S pyroscope -G pyroscope -h /data
 
-# Copy folder from debug container, this folder needs to have the correct UID
-# in order for the container to run as non-root.
+# This folder is created by adduser command with right owner/group
 VOLUME /data
+
+# This folder needs to be created and set to the right owner/group
+VOLUME /data-compactor
+RUN mkdir -p /data-compactor && chown pyroscope:pyroscope /data /data-compactor
 
 COPY .tmp/bin/linux_amd64/dlv /usr/bin/dlv
 COPY cmd/pyroscope/pyroscope.yaml /etc/pyroscope/config.yaml


### PR DESCRIPTION
This apparently was missed in #2875

```
ts=2024-07-31T14:22:52.491454333Z caller=compactor.go:646 level=error component=compactor component=compactor msg="failed to compact user blocks" tenant=anonymous err="mkdir data-compactor: permission denied"
```
