### PR TITLE
chore: Move paths from docs/phlare to docs/pyroscope

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -15,7 +15,7 @@ jobs:
       uses: "actions/checkout@v3"
     - name: "Build website"
       run: |
-        docker run -v ${PWD}/docs/sources:/hugo/content/docs/phlare/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
+        docker run -v ${PWD}/docs/sources:/hugo/content/docs/pyroscope/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
 
   sync:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -17,7 +17,7 @@ jobs:
       uses: "actions/checkout@v3"
     - name: "Build website"
       run: |
-        docker run -v ${PWD}/docs/sources:/hugo/content/docs/phlare/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
+        docker run -v ${PWD}/docs/sources:/hugo/content/docs/pyroscope/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
 
   sync:
     runs-on: "ubuntu-latest"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,4 +10,4 @@ include docs.mk
 
 .PHONY: test
 test:
-	docker run -v $(CURDIR)/sources:/hugo/content/docs/phlare/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'exec make hugo'
+	docker run -v $(CURDIR)/sources:/hugo/content/docs/pyroscope/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'exec make hugo'

--- a/operations/pyroscope/helm/pyroscope/values.yaml
+++ b/operations/pyroscope/helm/pyroscope/values.yaml
@@ -47,7 +47,7 @@ pyroscope:
     name: ""
 
   podAnnotations:
-    # Scrapes itself see https://grafana.com/docs/phlare/latest/operators-guide/deploy-kubernetes/#optional-scrape-your-own-workloads-profiles
+    # Scrapes itself see https://grafana.com/docs/pyroscope/latest/deploy-kubernetes/helm/#optional-scrape-your-own-workloads-profiles
     profiles.grafana.com/memory.scrape: "true"
     profiles.grafana.com/memory.port_name: http2
     profiles.grafana.com/cpu.scrape: "true"


### PR DESCRIPTION
I had noticed a couple of paths, which still point to the old path /docs/phlare instead of /docs/pyroscope