### PR TITLE
chore: Apparently github broke docker compose:

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -60,7 +60,7 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: make build
       - name: run nginx with /foobar/
-        run: docker-compose -f scripts/base-url/docker-compose.yaml up -d
+        run: docker compose -f scripts/base-url/docker-compose.yaml up -d
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:


### PR DESCRIPTION
Related: https://github.com/actions/runner-images/issues/9692
