### PR TITLE
feat: Add pyrobench github action

### DIFF
--- a/.github/workflows/pyrobench.yaml
+++ b/.github/workflows/pyrobench.yaml
@@ -1,0 +1,16 @@
+on: issue_comment
+
+jobs:
+  pyrobench:
+    name: Run Pyrobench on demand by PR comment
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Pyrobench
+        uses: grafana/pyrobench@main
+        with:
+          github_context: ${{ toJson(github) }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pyrobench is a hackathon 2024-08 project, which provides a github action that can run go microbenchmarks on demand. It will:


- Double check the code for the package with the Benchmarks in has  changed (comparing base..head of PR)
- Will run the benchmarks multiple times for base and head and then compare it using benstat (WIP).
- Each benchmark run will also collect profiles and upload them to flamegraph.com


https://github.com/grafana/hackathon-2024-08-pyrobench (README is WIP)

Example project

https://github.com/grafana/hackathon-2024-08-pyrobench-dskit/pull/1#issuecomment-2275953511
![image](https://github.com/user-attachments/assets/de4ee8e8-f6cc-4e62-a544-9d305f376c67)



