### PR TITLE
fix(ci): remove reviewdog hack

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,30 +67,6 @@ jobs:
     steps:
       - name: "Checkout code"
         uses: "actions/checkout@v4"
-      # reviewdog is having issues with large diffs.
-      # The issue https://github.com/reviewdog/reviewdog/issues/1696 is not
-      # yet fully solved (as of reviewdog 0.17.4).
-      # The workaround is to fetch PR head and merge base commits explicitly:
-      # Credits to https://github.com/grafana/deployment_tools/pull/162200.
-      # NB: fetch-depth=0 does not help (and is not recommended per se).
-      # TODO(kolesnikovae): Remove this workaround when the issue is fixed.
-      - name: Get merge commit between head SHA and base SHA
-        id: merge-commit
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          script: |
-            const { data: { merge_base_commit } } = await github.rest.repos.compareCommitsWithBasehead({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              basehead: `${context.payload.pull_request.base.sha}...${context.payload.pull_request.head.sha}`,
-            });
-            console.log(`Merge base commit: ${merge_base_commit.sha}`);
-            core.setOutput('merge-commit', merge_base_commit.sha);
-      - name: Fetch merge base and PR head
-        run: |
-          git config --system --add safe.directory '*'
-          git fetch --depth=1 origin "${{ steps.merge-commit.outputs.merge-commit }}"
-          git fetch --depth=1 origin "${{ github.event.pull_request.head.sha }}"
       - name: "Run doc-validator tool"
         run: >
           doc-validator
@@ -105,7 +81,6 @@ jobs:
           --reporter=github-pr-review
         env:
           REVIEWDOG_GITHUB_API_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          REVIEWDOG_SKIP_GIT_FETCH: true
 
   build-image:
     if: github.event_name != 'push'


### PR DESCRIPTION
In #3388, I added a workaround to bypass some bugs in reviewdog that were breaking CI on large diffs. The workaround relies on the PR head commit SHA, which is not available when merging to main and causes CI to fail. I could have added a separate doc-validation action or modified the script to work in both cases. Instead, I'm removing the workaround to fix the CI pipeline for now. Large diffs (20K+ lines, 300+ files) will break CI.

/cc @jdbaldry