### PR TITLE
chore: pass HeadMetrics explicitly, instead of context

### DIFF
--- a/pkg/ingester/instance.go
+++ b/pkg/ingester/instance.go
@@ -29,7 +29,7 @@ type instance struct {
 	tenantID string
 }
 
-func newInstance(phlarectx context.Context, cfg phlaredb.Config, tenantID string, localBucket, storageBucket phlareobj.Bucket, limiter Limiter) (*instance, error) {
+func newInstance(phlarectx context.Context, cfg phlaredb.Config, hm *phlaredb.HeadMetrics, tenantID string, localBucket, storageBucket phlareobj.Bucket, limiter Limiter) (*instance, error) {
 	cfg.DataPath = path.Join(cfg.DataPath, tenantID)
 
 	// TODO(kolesnikovae): Get rid of phlarectx and pass logger and registry directly.
@@ -37,7 +37,7 @@ func newInstance(phlarectx context.Context, cfg phlaredb.Config, tenantID string
 	reg := prometheus.WrapRegistererWith(prometheus.Labels{"component": "ingester"}, phlarecontext.Registry(phlarectx))
 	phlarectx = phlarecontext.WithRegistry(phlarectx, reg)
 
-	db, err := phlaredb.New(phlarectx, cfg, limiter, phlareobj.NewPrefixedBucket(localBucket, tenantID))
+	db, err := phlaredb.New(phlarectx, cfg, hm, limiter, phlareobj.NewPrefixedBucket(localBucket, tenantID))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/phlaredb/block/testutil/create_block.go
+++ b/pkg/phlaredb/block/testutil/create_block.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
@@ -35,7 +37,7 @@ func CreateBlock(t testing.TB, generator func() []*testhelper.ProfileBuilder) (b
 		Parquet: &phlaredb.ParquetConfig{
 			MaxBufferRowCount: 10,
 		},
-	}, noLimit{})
+	}, phlaredb.NewHeadMetrics(prometheus.NewRegistry()), noLimit{})
 	require.NoError(t, err)
 
 	// ingest.

--- a/pkg/phlaredb/compact_test.go
+++ b/pkg/phlaredb/compact_test.go
@@ -649,7 +649,7 @@ func newBlock(t testing.TB, generator func() []*testhelper.ProfileBuilder) *sing
 		Parquet: &ParquetConfig{
 			MaxBufferRowCount: 10,
 		},
-	}, NoLimit)
+	}, testHeadMetrics, NoLimit)
 	require.NoError(t, err)
 
 	// ingest.

--- a/pkg/phlaredb/head_test.go
+++ b/pkg/phlaredb/head_test.go
@@ -42,9 +42,10 @@ var NoLimit = noLimit{}
 func newTestHead(t testing.TB) *testHead {
 	dataPath := t.TempDir()
 	ctx := testContext(t)
-	head, err := NewHead(ctx, Config{DataPath: dataPath}, NoLimit)
+	reg := phlarecontext.Registry(ctx).(*prometheus.Registry)
+	head, err := NewHead(ctx, Config{DataPath: dataPath}, NewHeadMetrics(reg), NoLimit)
 	require.NoError(t, err)
-	return &testHead{Head: head, t: t, reg: phlarecontext.Registry(ctx).(*prometheus.Registry)}
+	return &testHead{Head: head, t: t, reg: reg}
 }
 
 type testHead struct {
@@ -267,7 +268,7 @@ func TestHead_SelectMatchingProfiles_Order(t *testing.T) {
 		Parquet: &ParquetConfig{
 			MaxBufferRowCount: n - 1,
 		},
-	}, NoLimit)
+	}, testHeadMetrics, NoLimit)
 	require.NoError(t, err)
 
 	c := make(chan struct{})
@@ -437,7 +438,7 @@ func TestHead_Concurrent_Ingest_Querying(t *testing.T) {
 		cfg = Config{
 			DataPath: t.TempDir(),
 		}
-		head, err = NewHead(ctx, cfg, NoLimit)
+		head, err = NewHead(ctx, cfg, testHeadMetrics, NoLimit)
 	)
 	require.NoError(t, err)
 

--- a/pkg/phlaredb/metrics.go
+++ b/pkg/phlaredb/metrics.go
@@ -13,11 +13,10 @@ import (
 type contextKey uint8
 
 const (
-	headMetricsContextKey contextKey = iota
-	blockMetricsContextKey
+	blockMetricsContextKey contextKey = iota
 )
 
-type headMetrics struct {
+type HeadMetrics struct {
 	series        prometheus.Gauge
 	seriesCreated *prometheus.CounterVec
 
@@ -44,8 +43,8 @@ type headMetrics struct {
 	writtenProfileSegmentsBytes prometheus.Histogram
 }
 
-func newHeadMetrics(reg prometheus.Registerer) *headMetrics {
-	m := &headMetrics{
+func NewHeadMetrics(reg prometheus.Registerer) *HeadMetrics {
+	m := &HeadMetrics{
 		seriesCreated: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "pyroscope_tsdb_head_series_created_total",
 			Help: "Total number of series created in the head",
@@ -156,41 +155,29 @@ func newHeadMetrics(reg prometheus.Registerer) *headMetrics {
 	return m
 }
 
-func (m *headMetrics) register(reg prometheus.Registerer) {
+func (m *HeadMetrics) register(reg prometheus.Registerer) {
 	if reg == nil {
 		return
 	}
-	m.series = util.RegisterOrGet(reg, m.series)
-	m.seriesCreated = util.RegisterOrGet(reg, m.seriesCreated)
-	m.profiles = util.RegisterOrGet(reg, m.profiles)
-	m.profilesCreated = util.RegisterOrGet(reg, m.profilesCreated)
-	m.sizeBytes = util.RegisterOrGet(reg, m.sizeBytes)
-	m.rowsWritten = util.RegisterOrGet(reg, m.rowsWritten)
-	m.sampleValuesIngested = util.RegisterOrGet(reg, m.sampleValuesIngested)
-	m.sampleValuesReceived = util.RegisterOrGet(reg, m.sampleValuesReceived)
-	m.flushedFileSizeBytes = util.RegisterOrGet(reg, m.flushedFileSizeBytes)
-	m.flushedBlockSizeBytes = util.RegisterOrGet(reg, m.flushedBlockSizeBytes)
-	m.flushedBlockDurationSeconds = util.RegisterOrGet(reg, m.flushedBlockDurationSeconds)
-	m.flushedBlockSeries = util.RegisterOrGet(reg, m.flushedBlockSeries)
-	m.flushedBlockSamples = util.RegisterOrGet(reg, m.flushedBlockSamples)
-	m.flusehdBlockProfiles = util.RegisterOrGet(reg, m.flusehdBlockProfiles)
-	m.blockDurationSeconds = util.RegisterOrGet(reg, m.blockDurationSeconds)
-	m.flushedBlocks = util.RegisterOrGet(reg, m.flushedBlocks)
-	m.flushedBlocksReasons = util.RegisterOrGet(reg, m.flushedBlocksReasons)
-	m.writtenProfileSegments = util.RegisterOrGet(reg, m.writtenProfileSegments)
-	m.writtenProfileSegmentsBytes = util.RegisterOrGet(reg, m.writtenProfileSegmentsBytes)
-}
-
-func contextWithHeadMetrics(ctx context.Context, m *headMetrics) context.Context {
-	return context.WithValue(ctx, headMetricsContextKey, m)
-}
-
-func contextHeadMetrics(ctx context.Context) *headMetrics {
-	m, ok := ctx.Value(headMetricsContextKey).(*headMetrics)
-	if !ok {
-		return newHeadMetrics(phlarecontext.Registry(ctx))
-	}
-	return m
+	reg.MustRegister(m.series)
+	reg.MustRegister(m.seriesCreated)
+	reg.MustRegister(m.profiles)
+	reg.MustRegister(m.profilesCreated)
+	reg.MustRegister(m.sizeBytes)
+	reg.MustRegister(m.rowsWritten)
+	reg.MustRegister(m.sampleValuesIngested)
+	reg.MustRegister(m.sampleValuesReceived)
+	reg.MustRegister(m.flushedFileSizeBytes)
+	reg.MustRegister(m.flushedBlockSizeBytes)
+	reg.MustRegister(m.flushedBlockDurationSeconds)
+	reg.MustRegister(m.flushedBlockSeries)
+	reg.MustRegister(m.flushedBlockSamples)
+	reg.MustRegister(m.flusehdBlockProfiles)
+	reg.MustRegister(m.blockDurationSeconds)
+	reg.MustRegister(m.flushedBlocks)
+	reg.MustRegister(m.flushedBlocksReasons)
+	reg.MustRegister(m.writtenProfileSegments)
+	reg.MustRegister(m.writtenProfileSegmentsBytes)
 }
 
 type BlocksMetrics struct {

--- a/pkg/phlaredb/metrics_test.go
+++ b/pkg/phlaredb/metrics_test.go
@@ -15,19 +15,14 @@ import (
 )
 
 func TestMultipleRegistrationMetrics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		}
+	}()
 	reg := prometheus.NewRegistry()
-	m1 := newHeadMetrics(reg)
-	m2 := newHeadMetrics(reg)
-
-	m1.profilesCreated.WithLabelValues("test").Inc()
-	m2.profilesCreated.WithLabelValues("test").Inc()
-
-	// collect metrics and compare them
-	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
-# HELP pyroscope_head_profiles_created_total Total number of profiles created in the head
-# TYPE pyroscope_head_profiles_created_total counter
-pyroscope_head_profiles_created_total{profile_name="test"} 2
-`), "pyroscope_head_profiles_created_total"))
+	_ = NewHeadMetrics(reg)
+	_ = NewHeadMetrics(reg)
 }
 
 func TestHeadMetrics(t *testing.T) {

--- a/pkg/phlaredb/phlaredb_test.go
+++ b/pkg/phlaredb/phlaredb_test.go
@@ -35,13 +35,13 @@ func TestCreateLocalDir(t *testing.T) {
 	_, err := New(testContext(t), Config{
 		DataPath:         dataPath,
 		MaxBlockDuration: 30 * time.Minute,
-	}, NoLimit, ctx.localBucketClient)
+	}, testHeadMetrics, NoLimit, ctx.localBucketClient)
 	require.Error(t, err)
 	require.NoError(t, os.Remove(localFile))
 	_, err = New(ctx, Config{
 		DataPath:         dataPath,
 		MaxBlockDuration: 30 * time.Minute,
-	}, NoLimit, ctx.localBucketClient)
+	}, testHeadMetrics, NoLimit, ctx.localBucketClient)
 	require.NoError(t, err)
 }
 
@@ -161,11 +161,10 @@ func TestMergeProfilesStacktraces(t *testing.T) {
 		start   = end.Add(-time.Minute)
 		step    = 15 * time.Second
 	)
-
 	db, err := New(ctx, Config{
 		DataPath:         testDir,
 		MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
-	}, NoLimit, ctx.localBucketClient)
+	}, testHeadMetrics, NoLimit, ctx.localBucketClient)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, db.Close())
@@ -293,11 +292,10 @@ func Test_HeadFlush_DuplicateLabels(t *testing.T) {
 		start   = end.Add(-time.Minute)
 		step    = 15 * time.Second
 	)
-
 	db, err := New(ctx, Config{
 		DataPath:         testDir,
 		MaxBlockDuration: time.Duration(100000) * time.Minute,
-	}, NoLimit, ctx.localBucketClient)
+	}, testHeadMetrics, NoLimit, ctx.localBucketClient)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, db.Close())
@@ -321,11 +319,10 @@ func TestMergeProfilesPprof(t *testing.T) {
 		start   = end.Add(-time.Minute)
 		step    = 15 * time.Second
 	)
-
 	db, err := New(ctx, Config{
 		DataPath:         testDir,
 		MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
-	}, NoLimit, ctx.localBucketClient)
+	}, testHeadMetrics, NoLimit, ctx.localBucketClient)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, db.Close())
@@ -466,7 +463,7 @@ func Test_QueryNotInitializedHead(t *testing.T) {
 	db, err := New(ctx, Config{
 		DataPath:         contextDataDir(ctx),
 		MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
-	}, NoLimit, ctx.localBucketClient)
+	}, testHeadMetrics, NoLimit, ctx.localBucketClient)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, db.Close())
@@ -539,7 +536,7 @@ func Test_FlushNotInitializedHead(t *testing.T) {
 	db, err := New(ctx, Config{
 		DataPath:         contextDataDir(ctx),
 		MaxBlockDuration: 1 * time.Hour,
-	}, NoLimit, ctx.localBucketClient)
+	}, testHeadMetrics, NoLimit, ctx.localBucketClient)
 
 	var (
 		end   = time.Unix(0, int64(time.Hour))

--- a/pkg/phlaredb/profile_store.go
+++ b/pkg/phlaredb/profile_store.go
@@ -36,7 +36,7 @@ type profileStore struct {
 
 	logger  log.Logger
 	cfg     *ParquetConfig
-	metrics *headMetrics
+	metrics *HeadMetrics
 
 	path      string
 	persister schemav1.Persister[*schemav1.Profile]
@@ -76,10 +76,10 @@ func newParquetProfileWriter(writer io.Writer, options ...parquet.WriterOption) 
 	)
 }
 
-func newProfileStore(phlarectx context.Context) *profileStore {
+func newProfileStore(phlarectx context.Context, hm *HeadMetrics) *profileStore {
 	s := &profileStore{
 		logger:     phlarecontext.Logger(phlarectx),
-		metrics:    contextHeadMetrics(phlarectx),
+		metrics:    hm,
 		persister:  &schemav1.ProfilePersister{},
 		flushing:   atomic.NewBool(false),
 		flushQueue: make(chan int),
@@ -106,7 +106,7 @@ func (s *profileStore) MemorySize() uint64 {
 }
 
 // resets the store
-func (s *profileStore) Init(path string, cfg *ParquetConfig, metrics *headMetrics) (err error) {
+func (s *profileStore) Init(path string, cfg *ParquetConfig, metrics *HeadMetrics) (err error) {
 	// close previous iteration
 	if err := s.Close(); err != nil {
 		return err

--- a/pkg/phlaredb/profile_test.go
+++ b/pkg/phlaredb/profile_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestIndex(t *testing.T) {
-	a, err := newProfileIndex(16, newHeadMetrics(prometheus.NewRegistry()))
+	a, err := newProfileIndex(16, testHeadMetrics)
 	require.NoError(t, err)
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
@@ -85,7 +85,7 @@ func TestIndex(t *testing.T) {
 }
 
 func TestWriteRead(t *testing.T) {
-	a, err := newProfileIndex(32, newHeadMetrics(prometheus.NewRegistry()))
+	a, err := newProfileIndex(32, NewHeadMetrics(prometheus.NewRegistry()))
 	require.NoError(t, err)
 
 	for j := 0; j < 10; j++ {

--- a/pkg/phlaredb/profiles.go
+++ b/pkg/phlaredb/profiles.go
@@ -144,10 +144,10 @@ type profilesIndex struct {
 	totalSeries     *atomic.Int64
 	rowGroupsOnDisk int
 
-	metrics *headMetrics
+	metrics *HeadMetrics
 }
 
-func newProfileIndex(totalShards uint32, metrics *headMetrics) (*profilesIndex, error) {
+func newProfileIndex(totalShards uint32, metrics *HeadMetrics) (*profilesIndex, error) {
 	ix, err := tsdb.NewBitPrefixWithShards(totalShards)
 	if err != nil {
 		return nil, err

--- a/pkg/phlaredb/querier_test.go
+++ b/pkg/phlaredb/querier_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
@@ -19,7 +18,7 @@ import (
 )
 
 func TestQueryIndex(t *testing.T) {
-	a, err := newProfileIndex(32, newHeadMetrics(prometheus.NewRegistry()))
+	a, err := newProfileIndex(32, testHeadMetrics)
 	require.NoError(t, err)
 
 	for j := 0; j < 10; j++ {

--- a/pkg/phlaredb/sample_merge_test.go
+++ b/pkg/phlaredb/sample_merge_test.go
@@ -94,7 +94,7 @@ func TestMergeSampleByStacktraces(t *testing.T) {
 			db, err := New(ctx, Config{
 				DataPath:         contextDataDir(ctx),
 				MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
-			}, NoLimit, ctx.localBucketClient)
+			}, testHeadMetrics, NoLimit, ctx.localBucketClient)
 			require.NoError(t, err)
 
 			input, expected := tc.in()
@@ -200,7 +200,7 @@ func TestHeadMergeSampleByStacktraces(t *testing.T) {
 			db, err := New(ctx, Config{
 				DataPath:         contextDataDir(ctx),
 				MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
-			}, NoLimit, ctx.localBucketClient)
+			}, testHeadMetrics, NoLimit, ctx.localBucketClient)
 			require.NoError(t, err)
 
 			input, expected := tc.in()
@@ -310,7 +310,7 @@ func TestMergeSampleByLabels(t *testing.T) {
 			db, err := New(ctx, Config{
 				DataPath:         contextDataDir(ctx),
 				MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
-			}, NoLimit, ctx.localBucketClient)
+			}, testHeadMetrics, NoLimit, ctx.localBucketClient)
 			require.NoError(t, err)
 
 			for _, p := range tc.in() {
@@ -434,7 +434,7 @@ func TestHeadMergeSampleByLabels(t *testing.T) {
 			db, err := New(ctx, Config{
 				DataPath:         contextDataDir(ctx),
 				MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
-			}, NoLimit, ctx.localBucketClient)
+			}, testHeadMetrics, NoLimit, ctx.localBucketClient)
 			require.NoError(t, err)
 
 			for _, p := range tc.in() {
@@ -471,7 +471,7 @@ func TestMergePprof(t *testing.T) {
 	db, err := New(ctx, Config{
 		DataPath:         contextDataDir(ctx),
 		MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
-	}, NoLimit, ctx.localBucketClient)
+	}, testHeadMetrics, NoLimit, ctx.localBucketClient)
 	require.NoError(t, err)
 
 	for i := 0; i < 3; i++ {
@@ -529,7 +529,7 @@ func TestHeadMergePprof(t *testing.T) {
 	db, err := New(ctx, Config{
 		DataPath:         contextDataDir(ctx),
 		MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
-	}, NoLimit, ctx.localBucketClient)
+	}, testHeadMetrics, NoLimit, ctx.localBucketClient)
 	require.NoError(t, err)
 
 	for i := 0; i < 3; i++ {
@@ -578,7 +578,7 @@ func TestMergeSpans(t *testing.T) {
 	db, err := New(ctx, Config{
 		DataPath:         contextDataDir(ctx),
 		MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
-	}, NoLimit, ctx.localBucketClient)
+	}, testHeadMetrics, NoLimit, ctx.localBucketClient)
 	require.NoError(t, err)
 
 	require.NoError(t, db.Ingest(ctx, generateProfileWithSpans(t, 1000), uuid.New(), &typesv1.LabelPair{
@@ -629,7 +629,7 @@ func TestHeadMergeSpans(t *testing.T) {
 	db, err := New(ctx, Config{
 		DataPath:         contextDataDir(ctx),
 		MaxBlockDuration: time.Duration(100000) * time.Minute, // we will manually flush
-	}, NoLimit, ctx.localBucketClient)
+	}, testHeadMetrics, NoLimit, ctx.localBucketClient)
 	require.NoError(t, err)
 
 	require.NoError(t, db.Ingest(ctx, generateProfileWithSpans(t, 1000), uuid.New(), &typesv1.LabelPair{


### PR DESCRIPTION
Remove  `contextHeadMetrics` , `contextWithHeadMetrics`.