### PR TITLE
chore: Add dotnet SDKv8 support for examples

### DIFF
--- a/examples/language-sdk-instrumentation/dotnet/rideshare/Dockerfile
+++ b/examples/language-sdk-instrumentation/dotnet/rideshare/Dockerfile
@@ -1,14 +1,33 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+ARG SDK_VERSION=8.0
+# The build images takes an SDK image of the buildplatform, so the platform the build is running on.
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:$SDK_VERSION AS build
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG SDK_VERSION
 
 WORKDIR /dotnet
 
-COPY --from=pyroscope/pyroscope-dotnet:0.8.19-glibc /Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
-COPY --from=pyroscope/pyroscope-dotnet:0.8.19-glibc /Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
-
-
 ADD example .
 
-RUN dotnet publish -o . -r $(dotnet --info | grep RID | cut -b 6- | tr -d ' ')
+# Set the target framework to SDK_VERSION
+RUN sed -i -E 's|<TargetFramework>.*</TargetFramework>|<TargetFramework>net'$SDK_VERSION'</TargetFramework>|' Example.csproj
+
+# We hardcode linux-x64 here, as the profiler doesn't support any other platform
+RUN dotnet publish -o . --framework net$SDK_VERSION --runtime linux-x64 --no-self-contained
+
+# This fetches the SDK
+FROM --platform=linux/amd64 pyroscope/pyroscope-dotnet:0.8.20-glibc AS sdk
+
+# Runtime only image of the targetplatfrom, so the platform the image will be running on.
+FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:$SDK_VERSION
+
+WORKDIR /dotnet
+
+COPY --from=sdk /Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
+COPY --from=sdk /Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
+COPY --from=build /dotnet/ ./
+
 
 ENV CORECLR_ENABLE_PROFILING=1
 ENV CORECLR_PROFILER={BD1A650D-AC5D-4896-B64F-D6FA25D6B26A}
@@ -22,6 +41,7 @@ ENV PYROSCOPE_PROFILING_ENABLED=1
 ENV PYROSCOPE_PROFILING_ALLOCATION_ENABLED=true
 ENV PYROSCOPE_PROFILING_CONTENTION_ENABLED=true
 ENV PYROSCOPE_PROFILING_EXCEPTION_ENABLED=true
+ENV PYROSCOPE_PROFILING_HEAP_ENABLED=true
 ENV RIDESHARE_LISTEN_PORT=5000
 
 

--- a/examples/language-sdk-instrumentation/dotnet/rideshare/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/dotnet/rideshare/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     ports:
     - 4040:4040
   us-east:
-    platform: linux/amd64
     ports:
     - 5000
     environment:
@@ -16,7 +15,6 @@ services:
     build:
       context: .
   eu-north:
-    platform: linux/amd64
     ports:
     - 5000
     environment:
@@ -26,8 +24,9 @@ services:
     - RIDESHARE_LISTEN_PORT=5000
     build:
       context: .
+      args:
+        SDK_VERSION: "6.0"
   ap-south:
-    platform: linux/amd64
     ports:
     - 5000
     environment:
@@ -38,7 +37,6 @@ services:
     build:
       context: .
   ap-south-alpine:
-    platform: linux/amd64
     ports:
     - 5000
     environment:

--- a/examples/language-sdk-instrumentation/dotnet/rideshare/example/Example.csproj
+++ b/examples/language-sdk-instrumentation/dotnet/rideshare/example/Example.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>example</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>example</PackageId>

--- a/examples/language-sdk-instrumentation/dotnet/rideshare/musl.Dockerfile
+++ b/examples/language-sdk-instrumentation/dotnet/rideshare/musl.Dockerfile
@@ -1,14 +1,33 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine
+ARG SDK_VERSION=8.0
+# The build images takes an SDK image of the buildplatform, so the platform the build is running on.
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:$SDK_VERSION-alpine AS build
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG SDK_VERSION
 
 WORKDIR /dotnet
 
-COPY --from=pyroscope/pyroscope-dotnet:0.8.19-musl /Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
-COPY --from=pyroscope/pyroscope-dotnet:0.8.19-musl /Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
-
-
 ADD example .
 
-RUN dotnet publish -o . -r $(dotnet --info | grep RID | cut -b 6- | tr -d ' ')
+# Set the target framework to SDK_VERSION
+RUN sed -i -E 's|<TargetFramework>.*</TargetFramework>|<TargetFramework>net'$SDK_VERSION'</TargetFramework>|' Example.csproj
+
+# We hardcode linux-x64 here, as the profiler doesn't support any other platform
+RUN dotnet publish -o . --framework net$SDK_VERSION --runtime linux-musl-x64 --no-self-contained
+
+# This fetches the SDK
+FROM --platform=linux/amd64 pyroscope/pyroscope-dotnet:0.8.20-musl AS sdk
+
+# Runtime only image of the targetplatfrom, so the platform the image will be running on.
+FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:$SDK_VERSION-alpine
+
+WORKDIR /dotnet
+
+COPY --from=sdk /Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
+COPY --from=sdk /Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
+COPY --from=build /dotnet/ ./
+
 
 ENV CORECLR_ENABLE_PROFILING=1
 ENV CORECLR_PROFILER={BD1A650D-AC5D-4896-B64F-D6FA25D6B26A}
@@ -22,6 +41,8 @@ ENV PYROSCOPE_PROFILING_ENABLED=1
 ENV PYROSCOPE_PROFILING_ALLOCATION_ENABLED=true
 ENV PYROSCOPE_PROFILING_CONTENTION_ENABLED=true
 ENV PYROSCOPE_PROFILING_EXCEPTION_ENABLED=true
+ENV PYROSCOPE_PROFILING_HEAP_ENABLED=true
 ENV RIDESHARE_LISTEN_PORT=5000
+
 
 CMD sh -c "ASPNETCORE_URLS=http://*:${RIDESHARE_LISTEN_PORT} exec dotnet /dotnet/example.dll"

--- a/examples/tracing/tempo/docker-compose.yml
+++ b/examples/tracing/tempo/docker-compose.yml
@@ -43,7 +43,6 @@ services:
       dockerfile: Dockerfile.otel-instrumentation
 
   rideshare-dotnet-eu-west:
-    platform: linux/amd64
     ports:
       - 5000
     hostname: rideshare-dotnet-eu-west


### PR DESCRIPTION
Unfortunately this problem #3288 has come back to me. 🙂 

I think I have a solution now based on (https://github.com/dotnet/dotnet-docker/issues/3832): It uses a multi-stage build in order to overcome build problems on dotnet sdk7+ on Rosetta based macs, when emulating amd64.

It will cross compile using the linux/arm64 dotnet sdk for the linux/amd64 target. (which is the only arch we support)
