### PR TITLE
[profilecli] Add ready command

### DIFF
--- a/cmd/profilecli/main.go
+++ b/cmd/profilecli/main.go
@@ -164,11 +164,16 @@ func main() {
 }
 
 func checkError(err error) int {
-	if err != nil {
+	switch err {
+	case nil:
+		return 0
+	case notReadyErr:
+		// The reason for the failed ready is already logged, so just exit with
+		// an error code.
+	default:
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		return 1
 	}
-	return 0
+	return 1
 }
 
 type contextKey uint8

--- a/cmd/profilecli/main.go
+++ b/cmd/profilecli/main.go
@@ -89,6 +89,9 @@ func main() {
 	bucketWebCmd := bucketCmd.Command("web", "Run the web tool for visualizing blocks in object-store buckets.")
 	bucketWebParams := addBucketWebToolParams(bucketWebCmd)
 
+	readyCmd := app.Command("ready", "Check Pyroscope health.")
+	readyParams := addReadyParams(readyCmd)
+
 	// parse command line arguments
 	parsedCmd := kingpin.MustParse(app.Parse(os.Args[1:]))
 
@@ -149,6 +152,10 @@ func main() {
 		}
 	case blocksCompactCmd.FullCommand():
 		if err := blocksCompact(ctx, cfg.blocks.compact.src, cfg.blocks.compact.dst, cfg.blocks.compact.shards); err != nil {
+			os.Exit(checkError(err))
+		}
+	case readyCmd.FullCommand():
+		if err := ready(ctx, readyParams); err != nil {
 			os.Exit(checkError(err))
 		}
 	default:

--- a/cmd/profilecli/ready.go
+++ b/cmd/profilecli/ready.go
@@ -7,6 +7,12 @@ import (
 	"net/http"
 
 	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
+)
+
+var (
+	// Occurs when Pyroscope is not
+	notReadyErr = errors.New("not ready")
 )
 
 type readyParams struct {
@@ -41,7 +47,7 @@ func ready(ctx context.Context, params *readyParams) error {
 
 	if res.StatusCode != http.StatusOK {
 		level.Error(logger).Log("msg", "not ready", "status", res.Status, "body", string(bytes))
-		return nil
+		return notReadyErr
 	}
 
 	level.Info(logger).Log("msg", "ready")

--- a/cmd/profilecli/ready.go
+++ b/cmd/profilecli/ready.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/go-kit/log/level"
+)
+
+type readyParams struct {
+	*phlareClient
+}
+
+func addReadyParams(cmd commander) *readyParams {
+	params := &readyParams{}
+	params.phlareClient = addPhlareClient(cmd)
+
+	return params
+}
+
+func ready(ctx context.Context, params *readyParams) error {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/ready", params.URL), nil)
+	if err != nil {
+		return err
+	}
+	req = req.WithContext(ctx)
+
+	client := params.phlareClient.httpClient()
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	bytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		level.Error(logger).Log("msg", "not ready", "status", res.Status, "body", string(bytes))
+		return nil
+	}
+
+	level.Info(logger).Log("msg", "ready")
+	return nil
+}

--- a/cmd/profilecli/ready.go
+++ b/cmd/profilecli/ready.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	// Occurs when Pyroscope is not
+	// Occurs when Pyroscope is not ready.
 	notReadyErr = errors.New("not ready")
 )
 


### PR DESCRIPTION
When doing some local testing, I came across the problem where I wanted to quickly check if pyroscope was up. A similar problem was described here https://github.com/grafana/pyroscope/pull/3468 and @korniltsev commented a similar solution https://github.com/grafana/pyroscope/pull/3468#issuecomment-2272830497.

```
$ profilecli ready --help
usage: profilecli ready [<flags>]

Check Pyroscope health.

Flags:
  -h, --help              Show context-sensitive help (also try --help-long and --help-man).
      --version           Show application version.
  -v, --verbose           Enable verbose logging.
      --url="http://localhost:4040"  
                          URL of the profile store.
      --tenant-id=""      The tenant ID to be used for the X-Scope-OrgID header.
      --username=""       The username to be used for basic auth.
      --password=""       The password to be used for basic auth.
      --protocol=connect  The protocol to be used for communicating with the server.
```

Using `profilecli ready` will hit the `/ready` health check endpoint. Examples:

```
# Local server not accepting traffic
$ profilecli ready
error: Get "http://localhost:4040/ready": dial tcp [::1]:4040: connect: connection refused

# Local server accepting traffic but not ready
$ profilecli ready
level=error msg="not ready" status="503 Service Unavailable" body="Ingester not ready: waiting for 15s after being ready\n"

# Local server accepting traffic and ready
$ profilecli ready
level=info msg=ready

# Remote server accepting traffic but not ready
$ profilecli ready --url "https://firedev001.grafana-dev.net" --username 1218 --password "<redacted>"
level=error msg="not ready" status="503 Service Unavailable" body="{\"code\":\"Loading\",\"message\":\"Your instance is loading, and will be ready shortly.\"}\n"

# Remote server accepting traffic and ready
$ profilecli ready --url "https://firedev001.grafana-dev.net" --username 1218 --password "<redacted>"
level=info msg=ready
```