### PR TITLE
fix: int overflow on arm7

### DIFF
--- a/pkg/experiment/metastore/metastore_boltdb.go
+++ b/pkg/experiment/metastore/metastore_boltdb.go
@@ -19,7 +19,7 @@ import (
 const (
 	boltDBFileName        = "metastore.boltdb"
 	boltDBSnapshotName    = "metastore_snapshot.boltdb"
-	boltDBInitialMmapSize = 2 << 30
+	boltDBInitialMmapSize = 1 << 30
 )
 
 type boltdb struct {


### PR DESCRIPTION
This blocks weekly build: https://github.com/grafana/pyroscope/actions/runs/10445827891/job/28922337156

I doubt we want to support arm7. Either way, I think 2GiB of the initial mmap size might be a little too much. However, the size determines how many writes can be handled without being blocked by the ongoing snapshot capturing, so we want to be very generous here. This clearly should be a configurable parameter.
