### PR TITLE
fix: use ubuntu-24.04 in goreleaser-weekly

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -6,7 +6,7 @@ on:
       - 'weekly/f*'
 jobs:
   goreleaser-weekly:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
We've been experiencing issues with the ubuntu-latest image recently, which [has affected our weekly build](https://github.com/grafana/pyroscope/actions/runs/10447953800/job/28929135845#step:1:108) pipeline:

```
You are running out of disk space. The runner will stop working when the machine runs out of disk space. Free space left: 80 MB
```
My understanding is that the image was updated recently, and our build no longer fits within the available space. There are numerous reports of similar issues in various projects using this image. One workaround has been to use the new ubuntu-22.04 image. While this has helped, we should consider using dedicated Grafana runners.
