### PR TITLE
Fix: Handle context correctly in the querier

### DIFF
--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -178,11 +178,11 @@ func (q *QueryHandlers) Render(w http.ResponseWriter, req *http.Request) {
 	}
 
 	var resFlame *connect.Response[querierv1.SelectMergeStacktracesResponse]
-	g, ctx := errgroup.WithContext(req.Context())
+	g, gCtx := errgroup.WithContext(req.Context())
 	selectParamsClone := selectParams.CloneVT()
 	g.Go(func() error {
 		var err error
-		resFlame, err = q.client.SelectMergeStacktraces(ctx, connect.NewRequest(selectParamsClone))
+		resFlame, err = q.client.SelectMergeStacktraces(gCtx, connect.NewRequest(selectParamsClone))
 		return err
 	})
 

--- a/pkg/querier/ingester_querier.go
+++ b/pkg/querier/ingester_querier.go
@@ -111,7 +111,7 @@ func (q *Querier) selectTreeFromIngesters(ctx context.Context, req *querierv1.Se
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	// send the first initial request to all ingesters.
-	g, gCtx := errgroup.WithContext(ctx)
+	g, _ := errgroup.WithContext(ctx)
 	for idx := range responses {
 		r := responses[idx]
 		blockHints, err := BlockHints(plan, r.addr)
@@ -137,7 +137,7 @@ func (q *Querier) selectTreeFromIngesters(ctx context.Context, req *querierv1.Se
 	}
 
 	// merge all profiles
-	return selectMergeTree(gCtx, responses)
+	return selectMergeTree(ctx, responses)
 }
 
 func (q *Querier) selectProfileFromIngesters(ctx context.Context, req *querierv1.SelectMergeProfileRequest, plan blockPlan) (*googlev1.Profile, error) {
@@ -168,7 +168,7 @@ func (q *Querier) selectProfileFromIngesters(ctx context.Context, req *querierv1
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	// send the first initial request to all ingesters.
-	g, gCtx := errgroup.WithContext(ctx)
+	g, _ := errgroup.WithContext(ctx)
 	for idx := range responses {
 		r := responses[idx]
 		blockHints, err := BlockHints(plan, r.addr)
@@ -196,7 +196,7 @@ func (q *Querier) selectProfileFromIngesters(ctx context.Context, req *querierv1
 
 	// merge all profiles
 	span.LogFields(otlog.String("msg", "selectMergePprofProfile"))
-	return selectMergePprofProfile(gCtx, profileType, responses)
+	return selectMergePprofProfile(ctx, profileType, responses)
 }
 
 func (q *Querier) selectSeriesFromIngesters(ctx context.Context, req *ingesterv1.MergeProfilesLabelsRequest, plan map[string]*blockPlanEntry) ([]ResponseFromReplica[clientpool.BidiClientMergeProfilesLabels], error) {
@@ -321,7 +321,7 @@ func (q *Querier) selectSpanProfileFromIngesters(ctx context.Context, req *queri
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	// send the first initial request to all ingesters.
-	g, gCtx := errgroup.WithContext(ctx)
+	g, _ := errgroup.WithContext(ctx)
 	for idx := range responses {
 		r := responses[idx]
 		blockHints, err := BlockHints(plan, r.addr)
@@ -348,7 +348,7 @@ func (q *Querier) selectSpanProfileFromIngesters(ctx context.Context, req *queri
 	}
 
 	// merge all profiles
-	return selectMergeSpanProfile(gCtx, responses)
+	return selectMergeSpanProfile(ctx, responses)
 }
 
 func (q *Querier) blockSelectFromIngesters(ctx context.Context, req *ingestv1.BlockMetadataRequest) ([]ResponseFromReplica[[]*typesv1.BlockInfo], error) {

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -237,11 +237,11 @@ func (q *Querier) LabelValues(ctx context.Context, req *connect.Request[typesv1.
 
 	var responses []ResponseFromReplica[[]string]
 	var lock sync.Mutex
-	group, ctx := errgroup.WithContext(ctx)
+	group, gCtx := errgroup.WithContext(ctx)
 
 	if storeQueries.ingester.shouldQuery {
 		group.Go(func() error {
-			ir, err := q.labelValuesFromIngesters(ctx, storeQueries.ingester.LabelValuesRequest(req.Msg))
+			ir, err := q.labelValuesFromIngesters(gCtx, storeQueries.ingester.LabelValuesRequest(req.Msg))
 			if err != nil {
 				return err
 			}
@@ -255,7 +255,7 @@ func (q *Querier) LabelValues(ctx context.Context, req *connect.Request[typesv1.
 
 	if storeQueries.storeGateway.shouldQuery {
 		group.Go(func() error {
-			ir, err := q.labelValuesFromStoreGateway(ctx, storeQueries.storeGateway.LabelValuesRequest(req.Msg))
+			ir, err := q.labelValuesFromStoreGateway(gCtx, storeQueries.storeGateway.LabelValuesRequest(req.Msg))
 			if err != nil {
 				return err
 			}
@@ -307,11 +307,11 @@ func (q *Querier) LabelNames(ctx context.Context, req *connect.Request[typesv1.L
 
 	var responses []ResponseFromReplica[[]string]
 	var lock sync.Mutex
-	group, ctx := errgroup.WithContext(ctx)
+	group, gCtx := errgroup.WithContext(ctx)
 
 	if storeQueries.ingester.shouldQuery {
 		group.Go(func() error {
-			ir, err := q.labelNamesFromIngesters(ctx, storeQueries.ingester.LabelNamesRequest(req.Msg))
+			ir, err := q.labelNamesFromIngesters(gCtx, storeQueries.ingester.LabelNamesRequest(req.Msg))
 			if err != nil {
 				return err
 			}
@@ -325,7 +325,7 @@ func (q *Querier) LabelNames(ctx context.Context, req *connect.Request[typesv1.L
 
 	if storeQueries.storeGateway.shouldQuery {
 		group.Go(func() error {
-			ir, err := q.labelNamesFromStoreGateway(ctx, storeQueries.storeGateway.LabelNamesRequest(req.Msg))
+			ir, err := q.labelNamesFromStoreGateway(gCtx, storeQueries.storeGateway.LabelNamesRequest(req.Msg))
 			if err != nil {
 				return err
 			}
@@ -427,11 +427,11 @@ func (q *Querier) Series(ctx context.Context, req *connect.Request[querierv1.Ser
 
 	var responses []ResponseFromReplica[[]*typesv1.Labels]
 	var lock sync.Mutex
-	group, ctx := errgroup.WithContext(ctx)
+	group, gCtx := errgroup.WithContext(ctx)
 
 	if storeQueries.ingester.shouldQuery {
 		group.Go(func() error {
-			ir, err := q.seriesFromIngesters(ctx, storeQueries.ingester.SeriesRequest(req.Msg))
+			ir, err := q.seriesFromIngesters(gCtx, storeQueries.ingester.SeriesRequest(req.Msg))
 			if err != nil {
 				return err
 			}
@@ -445,7 +445,7 @@ func (q *Querier) Series(ctx context.Context, req *connect.Request[querierv1.Ser
 
 	if storeQueries.storeGateway.shouldQuery {
 		group.Go(func() error {
-			ir, err := q.seriesFromStoreGateway(ctx, storeQueries.storeGateway.SeriesRequest(req.Msg))
+			ir, err := q.seriesFromStoreGateway(gCtx, storeQueries.storeGateway.SeriesRequest(req.Msg))
 			if err != nil {
 				return err
 			}
@@ -690,11 +690,11 @@ func (q *Querier) selectTree(ctx context.Context, req *querierv1.SelectMergeStac
 		return q.selectTreeFromIngesters(ctx, storeQueries.ingester.MergeStacktracesRequest(req), plan)
 	}
 
-	g, ctx := errgroup.WithContext(ctx)
+	g, gCtx := errgroup.WithContext(ctx)
 	var ingesterTree, storegatewayTree *phlaremodel.Tree
 	g.Go(func() error {
 		var err error
-		ingesterTree, err = q.selectTreeFromIngesters(ctx, storeQueries.ingester.MergeStacktracesRequest(req), plan)
+		ingesterTree, err = q.selectTreeFromIngesters(gCtx, storeQueries.ingester.MergeStacktracesRequest(req), plan)
 		if err != nil {
 			return err
 		}
@@ -893,11 +893,11 @@ func (q *Querier) selectProfile(ctx context.Context, req *querierv1.SelectMergeP
 		return q.selectProfileFromIngesters(ctx, storeQueries.ingester.MergeProfileRequest(req), plan)
 	}
 
-	g, ctx := errgroup.WithContext(ctx)
+	g, gCtx := errgroup.WithContext(ctx)
 	var lock sync.Mutex
 	var merge pprof.ProfileMerge
 	g.Go(func() error {
-		ingesterProfile, err := q.selectProfileFromIngesters(ctx, storeQueries.ingester.MergeProfileRequest(req), plan)
+		ingesterProfile, err := q.selectProfileFromIngesters(gCtx, storeQueries.ingester.MergeProfileRequest(req), plan)
 		if err != nil {
 			return err
 		}
@@ -906,7 +906,7 @@ func (q *Querier) selectProfile(ctx context.Context, req *querierv1.SelectMergeP
 		return merge.Merge(ingesterProfile)
 	})
 	g.Go(func() error {
-		storegatewayProfile, err := q.selectProfileFromStoreGateway(ctx, storeQueries.storeGateway.MergeProfileRequest(req), plan)
+		storegatewayProfile, err := q.selectProfileFromStoreGateway(gCtx, storeQueries.storeGateway.MergeProfileRequest(req), plan)
 		if err != nil {
 			return err
 		}
@@ -1090,11 +1090,11 @@ func (q *Querier) selectSpanProfile(ctx context.Context, req *querierv1.SelectMe
 		return q.selectSpanProfileFromIngesters(ctx, storeQueries.ingester.MergeSpanProfileRequest(req), plan)
 	}
 
-	g, ctx := errgroup.WithContext(ctx)
+	g, gCtx := errgroup.WithContext(ctx)
 	var ingesterTree, storegatewayTree *phlaremodel.Tree
 	g.Go(func() error {
 		var err error
-		ingesterTree, err = q.selectSpanProfileFromIngesters(ctx, storeQueries.ingester.MergeSpanProfileRequest(req), plan)
+		ingesterTree, err = q.selectSpanProfileFromIngesters(gCtx, storeQueries.ingester.MergeSpanProfileRequest(req), plan)
 		if err != nil {
 			return err
 		}
@@ -1102,7 +1102,7 @@ func (q *Querier) selectSpanProfile(ctx context.Context, req *querierv1.SelectMe
 	})
 	g.Go(func() error {
 		var err error
-		storegatewayTree, err = q.selectSpanProfileFromStoreGateway(ctx, storeQueries.storeGateway.MergeSpanProfileRequest(req), plan)
+		storegatewayTree, err = q.selectSpanProfileFromStoreGateway(gCtx, storeQueries.storeGateway.MergeSpanProfileRequest(req), plan)
 		if err != nil {
 			return err
 		}

--- a/pkg/querier/store_gateway_querier.go
+++ b/pkg/querier/store_gateway_querier.go
@@ -206,7 +206,7 @@ func (q *Querier) selectTreeFromStoreGateway(ctx context.Context, req *querierv1
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	// send the first initial request to all ingesters.
-	g, gCtx := errgroup.WithContext(ctx)
+	g, _ := errgroup.WithContext(ctx)
 	for _, r := range responses {
 		r := r
 		blockHints, err := BlockHints(plan, r.addr)
@@ -231,7 +231,7 @@ func (q *Querier) selectTreeFromStoreGateway(ctx context.Context, req *querierv1
 	}
 
 	// merge all profiles
-	return selectMergeTree(gCtx, responses)
+	return selectMergeTree(ctx, responses)
 }
 
 func (q *Querier) selectProfileFromStoreGateway(ctx context.Context, req *querierv1.SelectMergeProfileRequest, plan map[string]*blockPlanEntry) (*googlev1.Profile, error) {
@@ -266,7 +266,7 @@ func (q *Querier) selectProfileFromStoreGateway(ctx context.Context, req *querie
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	// send the first initial request to all ingesters.
-	g, gCtx := errgroup.WithContext(ctx)
+	g, _ := errgroup.WithContext(ctx)
 	for _, r := range responses {
 		r := r
 		blockHints, err := BlockHints(plan, r.addr)
@@ -292,7 +292,7 @@ func (q *Querier) selectProfileFromStoreGateway(ctx context.Context, req *querie
 	}
 
 	// merge all profiles
-	return selectMergePprofProfile(gCtx, profileType, responses)
+	return selectMergePprofProfile(ctx, profileType, responses)
 }
 
 func (q *Querier) selectSeriesFromStoreGateway(ctx context.Context, req *ingesterv1.MergeProfilesLabelsRequest, plan map[string]*blockPlanEntry) ([]ResponseFromReplica[clientpool.BidiClientMergeProfilesLabels], error) {
@@ -434,7 +434,7 @@ func (q *Querier) selectSpanProfileFromStoreGateway(ctx context.Context, req *qu
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	// send the first initial request to all ingesters.
-	g, gCtx := errgroup.WithContext(ctx)
+	g, _ := errgroup.WithContext(ctx)
 	for _, r := range responses {
 		r := r
 		blockHints, err := BlockHints(plan, r.addr)
@@ -460,7 +460,7 @@ func (q *Querier) selectSpanProfileFromStoreGateway(ctx context.Context, req *qu
 	}
 
 	// merge all profiles
-	return selectMergeSpanProfile(gCtx, responses)
+	return selectMergeSpanProfile(ctx, responses)
 }
 
 func (q *Querier) blockSelectFromStoreGateway(ctx context.Context, req *ingestv1.BlockMetadataRequest) ([]ResponseFromReplica[[]*typesv1.BlockInfo], error) {


### PR DESCRIPTION
selectTree was using the a errgroup context past calling `Wait()`. This caused some errors when store-gateways were used for queries, that required deduplication.

 https://ops.grafana-ops.net/explore?schemaVersion=1&panes=%7B%22yce%22%3A%7B%22datasource%22%3A%22Em2icyuMk%22%2C%22queries%22%3A%5B%7B%22query%22%3A%2277764ad0d6f03fb3bab49a2c0176dad%22%2C%22queryType%22%3A%22traceql%22%2C%22refId%22%3A%22A%22%2C%22datasource%22%3A%7B%22type%22%3A%22tempo%22%2C%22uid%22%3A%22Em2icyuMk%22%7D%2C%22limit%22%3A20%2C%22tableType%22%3A%22traces%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%221724071628719%22%2C%22to%22%3A%221724072528719%22%7D%7D%7D&orgId=1

This fix also updated all errgroups returned contexts to use `gCtx`, as an additional measure we could consider using a block to limit the use `gCtx` after `Wait()`.
