### PR TITLE
Update credentials: Use git directly

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -2,7 +2,7 @@ name: Update Contributors in README
 
 on:
   push:
-    branches: [main]
+    branches: [main, maintest]
 
 jobs:
   update-contributors:
@@ -10,22 +10,23 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22'
       - name: Update contributors
         run: make update-contributors
 
-      - name: Update git credentials
-        run: git remote set-url origin https://x-access-token:${{ secrets.BOT_GITHUB_TOKEN }}@github.com/${{ github.repository }}
-
-      - uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_user_name: Pyroscope Bot
-          commit_user_email: dmitry+bot@pyroscope.io
-          commit_author: 'Pyroscope Bot <dmitry+bot@pyroscope.io>'
-          commit_message: 'docs: updates the list of contributors in README [skip ci]'
-          file_pattern: README.md
-          push_options: '--force-with-lease'
+      - name: Commit and push changes
+        run: |
+          git config --local user.name 'Pyroscope Bot'
+          git config --local user.email 'dmitry+bot@pyroscope.io'
+          if ! git diff --exit-code README.md; then
+              git add README.md
+              git commit -m 'docs: updates the list of contributors in README [skip ci]'
+              gh auth status
+              git push --force https://x-access-token:${{ secrets.BOT_GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:maintest
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -2,7 +2,7 @@ name: Update Contributors in README
 
 on:
   push:
-    branches: [main, maintest]
+    branches: [main]
 
 jobs:
   update-contributors:
@@ -26,7 +26,7 @@ jobs:
               git add README.md
               git commit -m 'docs: updates the list of contributors in README [skip ci]'
               gh auth status
-              git push --force https://x-access-token:${{ secrets.BOT_GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:maintest
+              git push --force https://x-access-token:${{ secrets.BOT_GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:main
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Apart from using a shell script to determine when to update this also debugs problems with the token better (using `gh auth status`). Also disabling the persisting of credentials, avoids using wrong credentials.

