### PR TITLE
fix(metastore): local raft server id

### DIFF
--- a/pkg/experiment/metastore/metastore.go
+++ b/pkg/experiment/metastore/metastore.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/dns"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/services"
@@ -130,6 +131,8 @@ type Metastore struct {
 	metrics    *metastoreMetrics
 	client     *metastoreclient.Client
 	readySince time.Time
+
+	dnsProvider *dns.Provider
 }
 
 type Limits interface{}
@@ -226,6 +229,8 @@ func (m *Metastore) initRaft() (err error) {
 		if err = m.bootstrap(); err != nil {
 			return fmt.Errorf("failed to bootstrap cluster: %w", err)
 		}
+	} else {
+		_ = level.Info(m.logger).Log("msg", "restoring existing state, not bootstraping")
 	}
 
 	m.leaderhealth.Register(m.raft, metastoreRaftLeaderHealthServiceName)

--- a/tools/dev/experiment/values-micro-services-experiment.yaml
+++ b/tools/dev/experiment/values-micro-services-experiment.yaml
@@ -5,7 +5,7 @@ pyroscope:
     query-backend.address: "dns:///_grpc._tcp.pyroscope-query-worker-headless.$(NAMESPACE_FQDN):9095"
     metastore.address: "dns:///_grpc._tcp.pyroscope-metastore-headless.$(NAMESPACE_FQDN):9095"
     metastore.raft.bind-address: ":9099"
-    metastore.raft.server-id: "$(POD_NAME).pyroscope-metastore-headless.$(NAMESPACE_FQDN)"
+    metastore.raft.server-id: "$(POD_NAME).pyroscope-metastore-headless.$(NAMESPACE_FQDN):9099"
     metastore.raft.advertise-address: "$(POD_NAME).pyroscope-metastore-headless.$(NAMESPACE_FQDN):9099"
     metastore.raft.bootstrap-peers: "dnssrvnoa+_raft._tcp.pyroscope-metastore-headless.$(NAMESPACE_FQDN):9099"
     metastore.raft.bootstrap-expect-peers: "3"


### PR DESCRIPTION
Wrong server id resulted to deduplication failure
```
Failed to resolve bootstrap peers" err="expected number of bootstrap peers not reached: got 4, expected 3\n[
...
{Suffrage:Voter ID:pyroscope-metastore-2.pyroscope-metastore-headless.pyroscope-test.svc.cluster.local. Address:pyroscope-metastore-2.pyroscope-metastore-headless.pyroscope-test.svc.cluster.local.:9099}

{Suffrage:Voter ID:pyroscope-metastore-2.pyroscope-metastore-headless.pyroscope-test.svc.cluster.local.:9099 Address:pyroscope-metastore-2.pyroscope-metastore-headless.pyroscope-test.svc.cluster.local.:9099}]"
```
- fix bootstrap of metastore with correct server id
- add bootstrap retries