### PR TITLE
feat: do not recover from panics with fatal errors

### DIFF
--- a/pkg/experiment/metastore/metastore_fsm_test.go
+++ b/pkg/experiment/metastore/metastore_fsm_test.go
@@ -1,0 +1,80 @@
+package metastore
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+)
+
+var testError = errors.New("test error")
+var typedNil *metastorev1.AddBlockResponse = nil
+
+func Test_handleCommandErrorHandling(t *testing.T) {
+	type args[Req proto.Message, Resp proto.Message] struct {
+		raw  []byte
+		cmd  *raft.Log
+		call commandCall[Req, Resp]
+	}
+	type testCase[Req proto.Message, Resp proto.Message] struct {
+		name      string
+		args      args[Req, Resp]
+		want      fsmResponse
+		wantPanic bool
+	}
+	tests := []testCase[*metastorev1.AddBlockRequest, *metastorev1.AddBlockResponse]{
+		{
+			name: "no error",
+			args: args[*metastorev1.AddBlockRequest, *metastorev1.AddBlockResponse]{
+				raw: make([]byte, 0),
+				cmd: &raft.Log{},
+				call: func(log *raft.Log, request *metastorev1.AddBlockRequest) (*metastorev1.AddBlockResponse, error) {
+					return &metastorev1.AddBlockResponse{}, nil
+				},
+			},
+			want: fsmResponse{
+				msg: &metastorev1.AddBlockResponse{},
+				err: nil,
+			},
+		},
+		{
+			name: "a simple error is returned",
+			args: args[*metastorev1.AddBlockRequest, *metastorev1.AddBlockResponse]{
+				raw: make([]byte, 0),
+				cmd: &raft.Log{},
+				call: func(log *raft.Log, request *metastorev1.AddBlockRequest) (*metastorev1.AddBlockResponse, error) {
+					return nil, testError
+				},
+			},
+			want: fsmResponse{
+				msg: typedNil,
+				err: testError,
+			},
+		},
+		{
+			name: "a panic with a fatal error results in a real panic",
+			args: args[*metastorev1.AddBlockRequest, *metastorev1.AddBlockResponse]{
+				raw: make([]byte, 0),
+				cmd: &raft.Log{},
+				call: func(log *raft.Log, request *metastorev1.AddBlockRequest) (*metastorev1.AddBlockResponse, error) {
+					panic(fatalCommandError{testError})
+				},
+			},
+			wantPanic: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					assert.True(t, tt.wantPanic)
+				}
+			}()
+			assert.Equal(t, tt.want, handleCommand(tt.args.raw, tt.args.cmd, tt.args.call))
+		})
+	}
+}

--- a/pkg/experiment/metastore/metastore_state_poll_compaction_jobs_test.go
+++ b/pkg/experiment/metastore/metastore_state_poll_compaction_jobs_test.go
@@ -271,6 +271,20 @@ func Test_FailedCompaction(t *testing.T) {
 	verifyCompactionState(t, m)
 }
 
+func Test_PanicWithDbErrors(t *testing.T) {
+	m := initState(t)
+	addLevel0Blocks(m, 20)
+
+	// set up panic recovery
+	defer func() {
+		r := recover()
+		require.NotNilf(t, r, "we should panic when a DB error is returned")
+	}()
+	// close the db, this should cause errors when persisting the state
+	_ = m.db.boltdb.Close()
+	_, _ = m.pollCompactionJobs(&compactorv1.PollCompactionJobsRequest{JobCapacity: 2}, 20, 20)
+}
+
 func addLevel0Blocks(m *metastoreState, count int) {
 	for i := 0; i < count; i++ {
 		b := createBlock(i, 0, "", 0)


### PR DESCRIPTION
The metastore FSM recovers from any panics in Raft command handlers. This change adds a custom error type which when used in a panic will result in a real panic. It also downgrades a few existing error cases, when the underlying issue is a logical one (a bug) as opposed to a technical problem.

The intention is to terminate replicas when they encounter a real error, e.g., failing to persist the state to the DB. 