### PR TITLE
fix (v2): remove outdated compaction jobs from storage

### DIFF
--- a/pkg/experiment/metastore/metastore_state.go
+++ b/pkg/experiment/metastore/metastore_state.go
@@ -214,7 +214,7 @@ func (m *metastoreState) loadCompactionPlan(b *bbolt.Bucket, blockQueue *compact
 				"shard", storedBlockQueue.Shard,
 				"compaction_level", storedBlockQueue.CompactionLevel,
 				"block_count", len(storedBlockQueue.Blocks),
-				"blocks", storedBlockQueue.Blocks)
+				"blocks", strings.Join(storedBlockQueue.Blocks, ","))
 		} else {
 			var job compactionpb.CompactionJob
 			if err := job.UnmarshalVT(v); err != nil {
@@ -223,6 +223,7 @@ func (m *metastoreState) loadCompactionPlan(b *bbolt.Bucket, blockQueue *compact
 			m.compactionJobQueue.enqueue(&job)
 			level.Debug(m.logger).Log(
 				"msg", "restored job into queue",
+				"job", job.Name,
 				"shard", job.Shard,
 				"tenant", job.TenantId,
 				"compaction_level", job.CompactionLevel,
@@ -230,7 +231,7 @@ func (m *metastoreState) loadCompactionPlan(b *bbolt.Bucket, blockQueue *compact
 				"raft_log_index", job.RaftLogIndex,
 				"lease_expires_at", job.LeaseExpiresAt,
 				"block_count", len(job.Blocks),
-				"blocks", job.Blocks)
+				"blocks", strings.Join(job.Blocks, ","))
 		}
 	}
 	return nil

--- a/pkg/experiment/metastore/metastore_state_poll_compaction_jobs_test.go
+++ b/pkg/experiment/metastore/metastore_state_poll_compaction_jobs_test.go
@@ -285,6 +285,26 @@ func Test_PanicWithDbErrors(t *testing.T) {
 	_, _ = m.pollCompactionJobs(&compactorv1.PollCompactionJobsRequest{JobCapacity: 2}, 20, 20)
 }
 
+func Test_RemoveInvalidJobsFromStorage(t *testing.T) {
+	m := initState(t)
+	addLevel0Blocks(m, 20)
+	require.Equal(t, 1, len(m.compactionJobQueue.jobs), "there should be one job in the queue")
+
+	// delete all blocks, making the existing job invalid
+	for _, shard := range m.shards {
+		for _, segment := range shard.segments {
+			shard.deleteSegment(segment.Id)
+		}
+	}
+
+	// try to assign the job
+	resp, err := m.pollCompactionJobs(&compactorv1.PollCompactionJobsRequest{JobCapacity: 1}, 20, 20)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(resp.CompactionJobs), "the one job in the queue became invalid")
+	require.Equal(t, 0, len(m.compactionJobQueue.jobs), "there should be no jobs in the queue")
+	verifyCompactionState(t, m)
+}
+
 func addLevel0Blocks(m *metastoreState, count int) {
 	for i := 0; i < count; i++ {
 		b := createBlock(i, 0, "", 0)


### PR DESCRIPTION
When we encounter a job that has no valid blocks (e.g., because they were deleted by the truncation logic) we currently remove it from the in-memory store but not from bolt DB. This causes a burst of new (invalid) jobs every time we restore from a snapshot.

This change ensures that such jobs are removed. There are a few other (mostly cosmetic) changes as well.