### PR TITLE
Test backport workflow with branch that doesn't make a GraphQL call

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           repository: grafana/grafana-github-actions
           path: ./actions
-          ref: main
+          ref: jdb/2024-09-replace-graphql-with-rest
       - name: Install Actions
         run: npm install --production --prefix ./actions
       - name: Run backport


### PR DESCRIPTION
For more information, refer to https://github.com/grafana/grafana-github-actions/pull/224.

I'd like to try backporting this to at least one release branch to check if it behaves correctly.