### PR TITLE
Revert "chore(update-contributors): do not skip ci (#3556)"

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -24,7 +24,7 @@ jobs:
           git config --local user.email 'dmitry+bot@pyroscope.io'
           if ! git diff --exit-code README.md; then
               git add README.md
-              git commit -m 'docs: updates the list of contributors in README'
+              git commit -m 'docs: updates the list of contributors in README [skip ci]'
               gh auth status
               git push --force https://x-access-token:${{ secrets.BOT_GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:main
           fi


### PR DESCRIPTION
Closes https://github.com/grafana/pyroscope/issues/3574

This reverts commit e56265f5faeef13ae1eae370419419cc11ec7871.