### PR TITLE
Fix issues when porting alloy/pyroscope to android

### DIFF
--- a/ebpf/session.go
+++ b/ebpf/session.go
@@ -167,16 +167,19 @@ func (s *session) Start() error {
 	}
 
 	_, nsIno, err := getPIDNamespace()
-	if err != nil {
-		return fmt.Errorf("unable to get pid namespace %w", err)
-	}
-	err = spec.RewriteConstants(map[string]interface{}{
-		"global_config": pyrobpf.ProfileGlobalConfigT{
-			NsPidIno: nsIno,
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("pyrobpf rewrite constants %w", err)
+	// if the file does not exist, CONFIG_PID_NS is not supported, so we just ignore the error
+	if !os.IsNotExist(err) {
+		if err != nil {
+			return fmt.Errorf("unable to get pid namespace %w", err)
+		}
+		err = spec.RewriteConstants(map[string]interface{}{
+			"global_config": pyrobpf.ProfileGlobalConfigT{
+				NsPidIno: nsIno,
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("pyrobpf rewrite constants %w", err)
+		}
 	}
 	err = spec.LoadAndAssign(&s.bpf, opts)
 	if err != nil {

--- a/ebpf/symtab/kallsyms.go
+++ b/ebpf/symtab/kallsyms.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"sort"
 	"strconv"
 )
 
@@ -94,5 +95,9 @@ func NewKallsymsFromData(kallsyms []byte) (*SymbolTab, error) {
 	if allZeros {
 		return NewSymbolTab(nil), nil
 	}
+	// kallsyms maybe unsorted when bpf/modules are loaded from userspace after kernel boot.
+	sort.Slice(syms, func(i, j int) bool {
+		return syms[i].Start < syms[j].Start
+	})
 	return NewSymbolTab(syms), nil
 }

--- a/ebpf/symtab/kallsyms_test.go
+++ b/ebpf/symtab/kallsyms_test.go
@@ -25,7 +25,9 @@ ffffffff81001750 T memblock_find
 ffffffff81001780 T __memblock_alloc_base
 ffffffff810017d0 T memblock_alloc
 ffffffff81001820 T early_memtest
-ffffffff810018a0 T early_memtest_report`
+ffffffff810018a0 T early_memtest_report
+ffffffff81000800 T unordered_symbol_0
+ffffffff81000100 T unordered_symbol_1`
 
 func TestKallsyms(t *testing.T) {
 	kallsyms, err := NewKallsymsFromData([]byte(testdata))


### PR DESCRIPTION
I'm porting alloy/pyroscope to the mobile phone running Android 14. And I found some issues:

1. The config `CONFIG_PID_NS` is not set in standard Android kernel, which means /proc/self/ns/pid is not exist and alloy will exit with failure. The first commit fixed this issue by ignoring error when /proc/self/ns/pid doesn't exist.

2. When kernel modules or bpf programs are dynamic loaded from userspace after kernel boot, the address in /proc/kallsyms may be unordered, which causes the origin code find wrong symbol. The second commit fixed this issue by sorting the symbol by address.
Here's an example for such /proc/kallsyms:
```
# cat /proc/kallsyms
...
ffffffd6b60e2140 t cleanup_module       [bootprof]
ffffffd6b60e53c0 d __this_module        [bootprof]  
ffffffc0145a52cc t bpf_prog_98e4c662c49a1bca_xdp_drop_ipv4_u    [bpf]
ffffffc0145ad4a8 t bpf_prog_a06399a1ec0a769e_schedcls_tether    [bpf]
ffffffc012b4b218 t bpf_prog_e814348da2c722a4_schedcls_tether    [bpf]
...
```
