### PR TITLE
chore: disable stack trace range chunking

### DIFF
--- a/pkg/experiment/ingester/memdb/head.go
+++ b/pkg/experiment/ingester/memdb/head.go
@@ -49,9 +49,6 @@ func NewHead(metrics *HeadMetrics) *Head {
 		metrics: metrics,
 		symbols: symdb.NewPartitionWriter(0, &symdb.Config{
 			Version: symdb.FormatV3,
-			Stacktraces: symdb.StacktracesConfig{
-				MaxNodesPerChunk: 4 << 20,
-			},
 		}),
 		totalSamples: atomic.NewUint64(0),
 		minTimeNanos: math.MaxInt64,

--- a/pkg/phlaredb/compact.go
+++ b/pkg/phlaredb/compact.go
@@ -750,10 +750,7 @@ func newSymbolsCompactor(path string, version symdb.FormatVersion) *symbolsCompa
 		version: symdb.FormatV2,
 		w: symdb.NewSymDB(symdb.DefaultConfig().
 			WithVersion(symdb.FormatV2).
-			WithDirectory(dst).
-			WithParquetConfig(symdb.ParquetConfig{
-				MaxBufferRowCount: defaultParquetConfig.MaxBufferRowCount,
-			})),
+			WithDirectory(dst)),
 		dst:       dst,
 		rewriters: make(map[BlockReader]*symdb.Rewriter),
 	}

--- a/pkg/phlaredb/symdb/partition_memory_test.go
+++ b/pkg/phlaredb/symdb/partition_memory_test.go
@@ -13,75 +13,19 @@ import (
 	"github.com/grafana/pyroscope/pkg/pprof"
 )
 
-func Test_StacktraceAppender_shards(t *testing.T) {
-	t.Run("WithMaxStacktraceTreeNodesPerChunk", func(t *testing.T) {
-		db := NewSymDB(&Config{
-			Stacktraces: StacktracesConfig{
-				MaxNodesPerChunk: 7,
-			},
-		})
+func Test_Stacktrace_append_empty(t *testing.T) {
+	db := NewSymDB(new(Config))
+	w := db.PartitionWriter(0)
 
-		w := db.PartitionWriter(0)
-		sids := make([]uint32, 4)
-		w.AppendStacktraces(sids, []*schemav1.Stacktrace{
-			{LocationIDs: []uint64{3, 2, 1}},
-			{LocationIDs: []uint64{2, 1}},
-			{LocationIDs: []uint64{4, 3, 2, 1}},
-			{LocationIDs: []uint64{3, 1}},
-		})
-		assert.Equal(t, []uint32{3, 2, 11, 16}, sids)
+	sids := make([]uint32, 2)
+	w.AppendStacktraces(sids, nil)
+	assert.Equal(t, []uint32{0, 0}, sids)
 
-		w.AppendStacktraces(sids[:3], []*schemav1.Stacktrace{
-			{LocationIDs: []uint64{3, 2, 1}},
-			{LocationIDs: []uint64{2, 1}},
-			{LocationIDs: []uint64{4, 3, 2, 1}},
-		})
-		// Same input. Note that len(sids) > len(schemav1.Stacktrace)
-		assert.Equal(t, []uint32{3, 2, 11}, sids[:3])
+	w.AppendStacktraces(sids, []*schemav1.Stacktrace{})
+	assert.Equal(t, []uint32{0, 0}, sids)
 
-		w.AppendStacktraces(sids[:1], []*schemav1.Stacktrace{
-			{LocationIDs: []uint64{5, 2, 1}},
-		})
-		assert.Equal(t, []uint32{18}, sids[:1])
-
-		require.Len(t, db.partitions, 1)
-		m := db.partitions[0]
-		require.Len(t, m.stacktraces.chunks, 3)
-
-		c1 := m.stacktraces.chunks[0]
-		assert.Equal(t, uint32(0), c1.stid)
-		assert.Equal(t, uint32(4), c1.tree.len())
-
-		c2 := m.stacktraces.chunks[1]
-		assert.Equal(t, uint32(7), c2.stid)
-		assert.Equal(t, uint32(5), c2.tree.len())
-
-		c3 := m.stacktraces.chunks[2]
-		assert.Equal(t, uint32(14), c3.stid)
-		assert.Equal(t, uint32(5), c3.tree.len())
-	})
-
-	t.Run("WithoutMaxStacktraceTreeNodesPerChunk", func(t *testing.T) {
-		db := NewSymDB(new(Config))
-		w := db.PartitionWriter(0)
-		sids := make([]uint32, 5)
-		w.AppendStacktraces(sids, []*schemav1.Stacktrace{
-			{LocationIDs: []uint64{3, 2, 1}},
-			{LocationIDs: []uint64{2, 1}},
-			{LocationIDs: []uint64{4, 3, 2, 1}},
-			{LocationIDs: []uint64{3, 1}},
-			{LocationIDs: []uint64{5, 3, 2, 1}},
-		})
-		assert.Equal(t, []uint32{3, 2, 4, 5, 6}, sids)
-
-		require.Len(t, db.partitions, 1)
-		m := db.partitions[0]
-		require.Len(t, m.stacktraces.chunks, 1)
-
-		c1 := m.stacktraces.chunks[0]
-		assert.Equal(t, uint32(0), c1.stid)
-		assert.Equal(t, uint32(7), c1.tree.len())
-	})
+	w.AppendStacktraces(sids, []*schemav1.Stacktrace{{}})
+	assert.Equal(t, []uint32{0, 0}, sids)
 }
 
 func Test_Stacktrace_append_existing(t *testing.T) {
@@ -99,144 +43,6 @@ func Test_Stacktrace_append_existing(t *testing.T) {
 		{LocationIDs: []uint64{6, 5, 4, 3, 2, 1}},
 	})
 	assert.Equal(t, []uint32{5, 6}, sids)
-}
-
-func Test_Stacktrace_append_empty(t *testing.T) {
-	db := NewSymDB(new(Config))
-	w := db.PartitionWriter(0)
-
-	sids := make([]uint32, 2)
-	w.AppendStacktraces(sids, nil)
-	assert.Equal(t, []uint32{0, 0}, sids)
-
-	w.AppendStacktraces(sids, []*schemav1.Stacktrace{})
-	assert.Equal(t, []uint32{0, 0}, sids)
-
-	w.AppendStacktraces(sids, []*schemav1.Stacktrace{{}})
-	assert.Equal(t, []uint32{0, 0}, sids)
-}
-
-func Test_Stacktraces_append_resolve(t *testing.T) {
-	ctx := context.Background()
-
-	t.Run("single chunk", func(t *testing.T) {
-		db := NewSymDB(new(Config))
-		w := db.PartitionWriter(0)
-
-		sids := make([]uint32, 5)
-		w.AppendStacktraces(sids, []*schemav1.Stacktrace{
-			{LocationIDs: []uint64{3, 2, 1}},
-			{LocationIDs: []uint64{2, 1}},
-			{LocationIDs: []uint64{4, 3, 2, 1}},
-			{LocationIDs: []uint64{3, 1}},
-			{LocationIDs: []uint64{5, 2, 1}},
-		})
-
-		r, ok := db.lookupPartition(0)
-		require.True(t, ok)
-		dst := new(mockStacktraceInserter)
-		dst.On("InsertStacktrace", uint32(2), []int32{2, 1})
-		dst.On("InsertStacktrace", uint32(3), []int32{3, 2, 1})
-		dst.On("InsertStacktrace", uint32(4), []int32{4, 3, 2, 1})
-		dst.On("InsertStacktrace", uint32(5), []int32{3, 1})
-		dst.On("InsertStacktrace", uint32(6), []int32{5, 2, 1})
-		require.NoError(t, r.ResolveStacktraceLocations(ctx, dst, []uint32{2, 3, 4, 5, 6}))
-	})
-
-	t.Run("multiple chunks", func(t *testing.T) {
-		db := NewSymDB(&Config{
-			Stacktraces: StacktracesConfig{
-				MaxNodesPerChunk: 7,
-			},
-		})
-
-		w := db.PartitionWriter(0)
-		stacktraces := []*schemav1.Stacktrace{ // ID, Chunk ID:
-			{LocationIDs: []uint64{3, 2, 1}},        // 3  0
-			{LocationIDs: []uint64{2, 1}},           // 2  0
-			{LocationIDs: []uint64{4, 3, 2, 1}},     // 11 1
-			{LocationIDs: []uint64{3, 1}},           // 16 2
-			{LocationIDs: []uint64{5, 2, 1}},        // 18 2
-			{LocationIDs: []uint64{13, 12, 11}},     // 24 3
-			{LocationIDs: []uint64{12, 11}},         // 23 3
-			{LocationIDs: []uint64{14, 13, 12, 11}}, // 32 4
-			{LocationIDs: []uint64{13, 11}},         // 37 5
-			{LocationIDs: []uint64{15, 12, 11}},     // 39 5
-		}
-		/*
-			// TODO(kolesnikovae): Add test cases:
-			// Invariants:
-			//        0
-			//      1
-			//      1 0
-			//    2
-			//    2   0
-			//    2 1
-			//    2 1 0
-			//  3
-			//  3     0
-			//  3   1
-			//  3   1 0
-			//  3 2
-			//  3 2   0
-			//  3 2 1
-			//  3 2 1 0
-		*/
-		sids := make([]uint32, len(stacktraces))
-		w.AppendStacktraces(sids, stacktraces)
-		require.Len(t, db.partitions[0].stacktraces.chunks, 6)
-
-		t.Run("adjacent shards at beginning", func(t *testing.T) {
-			r, _ := db.lookupPartition(0)
-			dst := new(mockStacktraceInserter)
-			dst.On("InsertStacktrace", uint32(2), []int32{2, 1})
-			dst.On("InsertStacktrace", uint32(3), []int32{3, 2, 1})
-			dst.On("InsertStacktrace", uint32(11), []int32{4, 3, 2, 1})
-			dst.On("InsertStacktrace", uint32(16), []int32{3, 1})
-			dst.On("InsertStacktrace", uint32(18), []int32{5, 2, 1})
-			require.NoError(t, r.ResolveStacktraceLocations(ctx, dst, []uint32{2, 3, 11, 16, 18}))
-		})
-
-		t.Run("adjacent shards at end", func(t *testing.T) {
-			r, _ := db.lookupPartition(0)
-			dst := new(mockStacktraceInserter)
-			dst.On("InsertStacktrace", uint32(23), []int32{12, 11})
-			dst.On("InsertStacktrace", uint32(24), []int32{13, 12, 11})
-			dst.On("InsertStacktrace", uint32(32), []int32{14, 13, 12, 11})
-			dst.On("InsertStacktrace", uint32(37), []int32{13, 11})
-			dst.On("InsertStacktrace", uint32(39), []int32{15, 12, 11})
-			require.NoError(t, r.ResolveStacktraceLocations(ctx, dst, []uint32{23, 24, 32, 37, 39}))
-		})
-
-		t.Run("non-adjacent shards", func(t *testing.T) {
-			r, _ := db.lookupPartition(0)
-			dst := new(mockStacktraceInserter)
-			dst.On("InsertStacktrace", uint32(11), []int32{4, 3, 2, 1})
-			dst.On("InsertStacktrace", uint32(32), []int32{14, 13, 12, 11})
-			require.NoError(t, r.ResolveStacktraceLocations(ctx, dst, []uint32{11, 32}))
-		})
-	})
-}
-
-func Test_hashLocations(t *testing.T) {
-	t.Run("hashLocations is thread safe", func(t *testing.T) {
-		b := []uint64{123, 234, 345, 456, 567}
-		h := hashLocations(b)
-		const N, M = 10, 10 << 10
-		var wg sync.WaitGroup
-		wg.Add(N)
-		for i := 0; i < N; i++ {
-			go func() {
-				defer wg.Done()
-				for j := 0; j < M; j++ {
-					if hashLocations(b) != h {
-						panic("hash mismatch")
-					}
-				}
-			}()
-		}
-		wg.Wait()
-	})
 }
 
 func Test_Stacktraces_memory_resolve_pprof(t *testing.T) {
@@ -265,12 +71,7 @@ func Test_Stacktraces_memory_resolve_chunked(t *testing.T) {
 	stacktraces := pprofSampleToStacktrace(p.Sample)
 	sids := make([]uint32, len(stacktraces))
 
-	cfg := &Config{
-		Stacktraces: StacktracesConfig{
-			MaxNodesPerChunk: 256,
-		},
-	}
-	db := NewSymDB(cfg)
+	db := NewSymDB(new(Config))
 	w := db.PartitionWriter(0)
 	w.AppendStacktraces(sids, stacktraces)
 
@@ -296,15 +97,9 @@ func Test_Stacktraces_memory_resolve_concurrency(t *testing.T) {
 	require.NoError(t, err)
 	stacktraces := pprofSampleToStacktrace(p.Sample)
 
-	cfg := &Config{
-		Stacktraces: StacktracesConfig{
-			MaxNodesPerChunk: 256,
-		},
-	}
-
 	// Allocate stacktrace IDs.
 	sids := make([]uint32, len(stacktraces))
-	db := NewSymDB(cfg)
+	db := NewSymDB(new(Config))
 	w := db.PartitionWriter(0)
 	w.AppendStacktraces(sids, stacktraces)
 
@@ -317,7 +112,7 @@ func Test_Stacktraces_memory_resolve_concurrency(t *testing.T) {
 
 	runTest := func(t *testing.T) {
 		t.Helper()
-		db := NewSymDB(cfg)
+		db := NewSymDB(new(Config))
 
 		var wg sync.WaitGroup
 		wg.Add(appenders)

--- a/pkg/phlaredb/symdb/resolver_tree_test.go
+++ b/pkg/phlaredb/symdb/resolver_tree_test.go
@@ -87,8 +87,8 @@ func Test_memory_Resolver_ResolveTree_copied_nodes(t *testing.T) {
 	// The only reason we perform this assertion is to make sure that
 	// truncation did take place, and the number of nodes is close to
 	// the target (we actually keep all nodes with top 16K values).
-	assert.Equal(t, nodesFull, int64(1585462))
-	assert.Equal(t, nodesTrunc, int64(22407))
+	assert.Equal(t, int64(1585462), nodesFull)
+	assert.Equal(t, int64(22461), nodesTrunc)
 	require.Equal(t, totalFull, totalTrunc)
 }
 
@@ -151,8 +151,11 @@ func Test_buildTreeFromParentPointerTrees(t *testing.T) {
 	const partition = 0
 	indexed := s.db.WriteProfileSymbols(partition, p)
 	assert.Equal(t, expectedSamples, indexed[partition].Samples)
-
-	symbols := s.db.partitions[partition].Symbols()
+	b := blockSuite{memSuite: s}
+	b.flush()
+	pr, err := b.reader.Partition(context.Background(), partition)
+	require.NoError(t, err)
+	symbols := pr.Symbols()
 	iterator, ok := symbols.Stacktraces.(StacktraceIDRangeIterator)
 	require.True(t, ok)
 

--- a/pkg/phlaredb/symdb/symdb.go
+++ b/pkg/phlaredb/symdb/symdb.go
@@ -2,6 +2,7 @@ package symdb
 
 import (
 	"context"
+	"math"
 	"sort"
 	"sync"
 	"time"
@@ -102,10 +103,14 @@ type Config struct {
 }
 
 type StacktracesConfig struct {
+	// DEPRECATED: the parameter is not used and
+	// will be removed in the future versions.
 	MaxNodesPerChunk uint32
 }
 
 type ParquetConfig struct {
+	// DEPRECATED: the parameter is not used and
+	// will be removed in the future versions.
 	MaxBufferRowCount int
 }
 
@@ -130,25 +135,11 @@ const statsUpdateInterval = 5 * time.Second
 func DefaultConfig() *Config {
 	return &Config{
 		Version: FormatV2,
-		Stacktraces: StacktracesConfig{
-			// At the moment chunks are loaded in memory at once.
-			// Due to the fact that chunking causes some duplication,
-			// it's better to keep them large.
-			MaxNodesPerChunk: 4 << 20,
-		},
-		Parquet: ParquetConfig{
-			MaxBufferRowCount: 100 << 10,
-		},
 	}
 }
 
 func (c *Config) WithDirectory(dir string) *Config {
 	c.Dir = dir
-	return c
-}
-
-func (c *Config) WithParquetConfig(pc ParquetConfig) *Config {
-	c.Parquet = pc
 	return c
 }
 
@@ -161,6 +152,8 @@ func NewSymDB(c *Config) *SymDB {
 	if c == nil {
 		c = DefaultConfig()
 	}
+	c.Parquet.MaxBufferRowCount = math.MaxInt
+	c.Stacktraces.MaxNodesPerChunk = math.MaxUint32
 	db := &SymDB{
 		config:     *c,
 		partitions: make(map[uint64]*PartitionWriter),
@@ -197,7 +190,7 @@ func (s *SymDB) PartitionWriter(partition uint64) *PartitionWriter {
 func NewPartitionWriter(partition uint64, config *Config) *PartitionWriter {
 	p := PartitionWriter{
 		header:      PartitionHeader{Partition: partition},
-		stacktraces: newStacktracesPartition(config.Stacktraces.MaxNodesPerChunk),
+		stacktraces: newStacktraces(),
 	}
 	switch config.Version {
 	case FormatV2:


### PR DESCRIPTION
The PR disables stack trace range chunking because it results in higher CPU and memory consumption and complicates the implementation.

Our aim was to limit the memory consumption of the symbolication process. However, loading chunks synchronously drastically increases latency while still consuming a significant amount of memory. Currently, all the chunks are loaded into memory concurrently, so we are not seeing any benefits.

<details>
  <summary>Spoiler warning</summary>
  
```
               Stacks per chunk:  10M(∞)  2M      1M     512k    256k    
------------------------------------------------------------------------------------
       Total size on disk (MiB):  27.6    30.5    33     36.8    41.8
     Total in-memory size (MiB):  44.6    51.5    58     67.7    79.5
 Max chunk in-memory size (MiB):  44.6    30.9    19.4   12.1    7.4
------------------------------------------------------------------------------------
 // In-memory size estimations are for reading; twice as much is consumed on write
 // On-disk size might be improved by better order of nodes (delta encoding)

------------------------------------------------------------------------------------

Block 01H2NAN6E6NTS013J0HE5XMN34: 3226104 rows (unique stack traces), 203269526 bytes
Output data set: 27646023 bytes written total (1 chunks, max stack traces per chunk: 10485760)
Estimated total in-memory size: 44612728 bytes
Chunk 0 is full
  Stack traces: 3226104
  Nodes: 5576591
  Ratio: 1.7285837654334764
  Built for 17.506652541s:
     Written bytes: 27646023
     Bytes per stack (on disk): 8
     Bytes per stack (in memory): 13
     In memory size: 44612728
     
------------------------------------------------------------------------------------

Block 01H2NAN6E6NTS013J0HE5XMN34: 3226104 rows (unique stack traces), 203269526 bytes
Output data set: 30505528 bytes written total (2 chunks, max stack traces per chunk: 2097152)
Estimated total in-memory size: 51554040 bytes
Chunk 0 is full
  Stack traces: 2097272
  Nodes: 3862877
  Ratio: 1.841857899213836
  Built for 9.483350875s:
     Written bytes: 18501081
     Bytes per stack (on disk): 8
     Bytes per stack (in memory): 14
     In memory size: 30903016
Chunk 1 is full
  Stack traces: 1128832
  Nodes: 2581378
  Ratio: 2.286768978909173
  Built for 2.76897675s:
     Written bytes: 12004447
     Bytes per stack (on disk): 10
     Bytes per stack (in memory): 18
     In memory size: 20651024
     
------------------------------------------------------------------------------------

Block 01H2NAN6E6NTS013J0HE5XMN34: 3226104 rows (unique stack traces), 203269526 bytes
Output data set: 33045258 bytes written total (4 chunks, max stack traces per chunk: 1048576)
Estimated total in-memory size: 58021856 bytes
Chunk 0 is full
  Stack traces: 1048636
  Nodes: 2222475
  Ratio: 2.119396053540027
  Built for 4.493750125s:
     Written bytes: 10024465
     Bytes per stack (on disk): 9
     Bytes per stack (in memory): 16
     In memory size: 17779800
Chunk 1 is full
  Stack traces: 1048636
  Nodes: 2198712
  Ratio: 2.0967351874244256
  Built for 2.383121625s:
     Written bytes: 10209418
     Bytes per stack (on disk): 9
     Bytes per stack (in memory): 16
     In memory size: 17589696
Chunk 2 is full
  Stack traces: 1048970
  Nodes: 2434981
  Ratio: 2.3213066150604877
  Built for 2.459848041s:
     Written bytes: 11258903
     Bytes per stack (on disk): 10
     Bytes per stack (in memory): 18
     In memory size: 19479848
Chunk 3 is full
  Stack traces: 79862
  Nodes: 396564
  Ratio: 4.965615687060179
  Built for 161.160334ms:
     Written bytes: 1552472
     Bytes per stack (on disk): 19
     Bytes per stack (in memory): 39
     In memory size: 3172512
     
------------------------------------------------------------------------------------

Block 01H2NAN6E6NTS013J0HE5XMN34: 3226104 rows (unique stack traces), 203269526 bytes
Output data set: 36842998 bytes written total (7 chunks, max stack traces per chunk: 524288)
Estimated total in-memory size: 67723448 bytes
Chunk 0 is full
  Stack traces: 524528
  Nodes: 1368112
  Ratio: 2.6082725803007656
  Built for 2.394663625s:
     Written bytes: 5837797
     Bytes per stack (on disk): 11
     Bytes per stack (in memory): 20
     In memory size: 10944896
Chunk 1 is full
  Stack traces: 525116
  Nodes: 1120434
  Ratio: 2.133688556433245
  Built for 1.057257s:
     Written bytes: 5005143
     Bytes per stack (on disk): 9
     Bytes per stack (in memory): 17
     In memory size: 8963472
Chunk 2 is full
  Stack traces: 524528
  Nodes: 1263265
  Ratio: 2.408384299789525
  Built for 1.057030333s:
     Written bytes: 5581112
     Bytes per stack (on disk): 10
     Bytes per stack (in memory): 19
     In memory size: 10106120
Chunk 3 is full
  Stack traces: 524738
  Nodes: 1375277
  Ratio: 2.6208831836078197
  Built for 1.068505917s:
     Written bytes: 6018478
     Bytes per stack (on disk): 11
     Bytes per stack (in memory): 20
     In memory size: 11002216
Chunk 4 is full
  Stack traces: 524652
  Nodes: 1433739
  Ratio: 2.732742846686947
  Built for 1.167284291s:
     Written bytes: 6271720
     Bytes per stack (on disk): 11
     Bytes per stack (in memory): 21
     In memory size: 11469912
Chunk 5 is full
  Stack traces: 524318
  Nodes: 1514972
  Ratio: 2.8894144393288044
  Built for 1.11052725s:
     Written bytes: 6605028
     Bytes per stack (on disk): 12
     Bytes per stack (in memory): 23
     In memory size: 12119776
Chunk 6 is full
  Stack traces: 78224
  Nodes: 389632
  Ratio: 4.980977705052158
  Built for 143.469125ms:
     Written bytes: 1523720
     Bytes per stack (on disk): 19
     Bytes per stack (in memory): 39
     In memory size: 3117056
     
------------------------------------------------------------------------------------

Block 01H2NAN6E6NTS013J0HE5XMN34: 3226104 rows (unique stack traces), 203269526 bytes
Output data set: 41776977 bytes written total (13 chunks, max stack traces per chunk: 262144)
Estimated total in-memory size: 79525928 bytes
Chunk 0 is full
  Stack traces: 262622
  Nodes: 887362
  Ratio: 3.378856302975379
  Built for 1.482846417s:
     Written bytes: 3615568
     Bytes per stack (on disk): 13
     Bytes per stack (in memory): 27
     In memory size: 7098896
Chunk 1 is full
  Stack traces: 262746
  Nodes: 586649
  Ratio: 2.2327609173878957
  Built for 655.994584ms:
     Written bytes: 2543225
     Bytes per stack (on disk): 9
     Bytes per stack (in memory): 17
     In memory size: 4693192
Chunk 2 is full
  Stack traces: 262832
  Nodes: 640279
  Ratio: 2.436077037803616
  Built for 484.878416ms:
     Written bytes: 2782450
     Bytes per stack (on disk): 10
     Bytes per stack (in memory): 19
     In memory size: 5122232
Chunk 3 is full
  Stack traces: 262578
  Nodes: 697386
  Ratio: 2.655919383954482
  Built for 491.707625ms:
     Written bytes: 2989352
     Bytes per stack (on disk): 11
     Bytes per stack (in memory): 21
     In memory size: 5579088
Chunk 4 is full
  Stack traces: 262200
  Nodes: 742836
  Ratio: 2.8330892448512586
  Built for 502.760334ms:
     Written bytes: 3172510
     Bytes per stack (on disk): 12
     Bytes per stack (in memory): 22
     In memory size: 5942688
Chunk 5 is full
  Stack traces: 262832
  Nodes: 776060
  Ratio: 2.9526846046143542
  Built for 518.939459ms:
     Written bytes: 3284356
     Bytes per stack (on disk): 12
     Bytes per stack (in memory): 23
     In memory size: 6208480
Chunk 6 is full
  Stack traces: 263124
  Nodes: 813045
  Ratio: 3.0899689880056553
  Built for 493.477208ms:
     Written bytes: 3429428
     Bytes per stack (on disk): 13
     Bytes per stack (in memory): 24
     In memory size: 6504360
Chunk 7 is full
  Stack traces: 262788
  Nodes: 851289
  Ratio: 3.239451573131193
  Built for 513.548916ms:
     Written bytes: 3563395
     Bytes per stack (on disk): 13
     Bytes per stack (in memory): 25
     In memory size: 6810312
Chunk 8 is full
  Stack traces: 262160
  Nodes: 849390
  Ratio: 3.2399679584986267
  Built for 551.642917ms:
     Written bytes: 3561803
     Bytes per stack (on disk): 13
     Bytes per stack (in memory): 25
     In memory size: 6795120
Chunk 9 is full
  Stack traces: 262284
  Nodes: 884597
  Ratio: 3.372668557746565
  Built for 503.683958ms:
     Written bytes: 3706102
     Bytes per stack (on disk): 14
     Bytes per stack (in memory): 26
     In memory size: 7076776
Chunk 10 is full
  Stack traces: 263000
  Nodes: 909931
  Ratio: 3.4598136882129276
  Built for 519.360542ms:
     Written bytes: 3808142
     Bytes per stack (on disk): 14
     Bytes per stack (in memory): 27
     In memory size: 7279448
Chunk 11 is full
  Stack traces: 262956
  Nodes: 928372
  Ratio: 3.5305222166446097
  Built for 510.007792ms:
     Written bytes: 3864171
     Bytes per stack (on disk): 14
     Bytes per stack (in memory): 28
     In memory size: 7426976
Chunk 12 is full
  Stack traces: 73982
  Nodes: 373545
  Ratio: 5.049133573031278
  Built for 141.845667ms:
     Written bytes: 1456475
     Bytes per stack (on disk): 19
     Bytes per stack (in memory): 40
     In memory size: 2988360
```

</details>
