### PR TITLE
Ignore default reviewers

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,7 +15,6 @@ jobs:
         with:
           repository: grafana/grafana-github-actions
           path: ./actions
-          ref: jdb/2024-09-replace-graphql-with-rest
       - name: Install Actions
         run: npm install --production --prefix ./actions
       - name: Run backport
@@ -23,4 +22,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           labelsToAdd: backport
+          # The provided token needs read permissions for organization members if you want to remove the default reviewers.
+          removeDefaultReviewers: false
           title: "[{{base}}] {{originalTitle}}"


### PR DESCRIPTION
Used for unassigning default reviewers. If you don't have it, you get cryptic comments posted back on the PR after the backport PRs are opened with the message `Validation Failed: "Could not resolve to a node with the global id of '<NODE ID>."`

Like in https://github.com/grafana/pyroscope/pull/3557#issuecomment-2348613956

Behavior was documented in https://github.com/grafana/grafana-github-actions/pull/226 and made configurable in 
https://github.com/grafana/grafana-github-actions/pull/227