### PR TITLE
feat: make service_name configurable through environment variable

### DIFF
--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -326,7 +326,11 @@ func New(cfg Config) (*Phlare, error) {
 
 	if cfg.Tracing.Enabled {
 		// Setting the environment variable JAEGER_AGENT_HOST enables tracing
-		trace, err := wwtracing.NewFromEnv(fmt.Sprintf("pyroscope-%s", cfg.Target))
+		name := os.Getenv("JAEGER_SERVICE_NAME")
+		if name == "" {
+			name = fmt.Sprintf("pyroscope-%s", cfg.Target)
+		}
+		trace, err := wwtracing.NewFromEnv(name)
 		if err != nil {
 			level.Error(logger).Log("msg", "error in initializing tracing. tracing will not be enabled", "err", err)
 		}


### PR DESCRIPTION
As it is [done on Mimir](https://github.com/grafana/mimir/commit/b4028c9a2b01df2ead2020c75780ee667af880fb), this would allow administrators to override the default `service_name` using the `JAEGER_SERVICE_NAME` environment variable.