### PR TITLE
fix: fix slice init length

### DIFF
--- a/pkg/frontend/dot/graph/graph.go
+++ b/pkg/frontend/dot/graph/graph.go
@@ -438,7 +438,7 @@ func newTree(prof *profile.Profile, o *Options) (g *Graph) {
 		}
 	}
 
-	nodes := make(Nodes, len(prof.Location))
+	nodes := make(Nodes, 0, len(prof.Location))
 	for _, nm := range parentNodeMap {
 		nodes = append(nodes, nm.nodes()...)
 	}


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of len(prof.Location)  rather than initializing the length of this slice.

