### PR TITLE
feat: profilecli query-blocks series

### DIFF
--- a/cmd/profilecli/main.go
+++ b/cmd/profilecli/main.go
@@ -79,6 +79,10 @@ func main() {
 	queryTracerCmd := app.Command("query-tracer", "Analyze query traces.")
 	queryTracerParams := addQueryTracerParams(queryTracerCmd)
 
+	queryBlocksCmd := app.Command("query-blocks", "Query on local/remote blocks")
+	queryBlocksSeriesCmd := queryBlocksCmd.Command("series", "Request series labels on local/remote blocks")
+	queryBlocksSeriesParams := addQueryBlocksSeriesParams(queryBlocksSeriesCmd)
+
 	uploadCmd := app.Command("upload", "Upload profile(s).")
 	uploadParams := addUploadParams(uploadCmd)
 
@@ -129,6 +133,11 @@ func main() {
 		}
 	case querySeriesCmd.FullCommand():
 		if err := querySeries(ctx, querySeriesParams); err != nil {
+			os.Exit(checkError(err))
+		}
+
+	case queryBlocksSeriesCmd.FullCommand():
+		if err := queryBlocksSeries(ctx, queryBlocksSeriesParams); err != nil {
 			os.Exit(checkError(err))
 		}
 

--- a/cmd/profilecli/output.go
+++ b/cmd/profilecli/output.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+)
+
+func outputSeries(result []*typesv1.Labels) error {
+	enc := json.NewEncoder(os.Stdout)
+	m := make(map[string]interface{})
+	for _, s := range result {
+		for k := range m {
+			delete(m, k)
+		}
+		for _, l := range s.Labels {
+			m[l.Name] = l.Value
+		}
+		if err := enc.Encode(m); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/profilecli/output.go
+++ b/cmd/profilecli/output.go
@@ -4,16 +4,14 @@ import (
 	"encoding/json"
 	"os"
 
-	"github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 )
 
 func outputSeries(result []*typesv1.Labels) error {
 	enc := json.NewEncoder(os.Stdout)
 	m := make(map[string]interface{})
 	for _, s := range result {
-		for k := range m {
-			delete(m, k)
-		}
+		clear(m)
 		for _, l := range s.Labels {
 			m[l.Name] = l.Value
 		}

--- a/cmd/profilecli/query-blocks.go
+++ b/cmd/profilecli/query-blocks.go
@@ -21,7 +21,7 @@ type queryBlocksParams struct {
 	LocalPath       string
 	BucketName      string
 	BlockIds        []string
-	TenanId         string
+	TenantID        string
 	ObjectStoreType string
 	Query           string
 }
@@ -37,7 +37,7 @@ func addQueryBlocksParams(queryCmd commander) *queryBlocksParams {
 	queryCmd.Flag("bucket-name", "The name of the object storage bucket.").StringVar(&params.BucketName)
 	queryCmd.Flag("object-store-type", "The type of the object storage (e.g., gcs).").Default("gcs").StringVar(&params.ObjectStoreType)
 	queryCmd.Flag("block-ids", "List of blocks ids to query on").StringsVar(&params.BlockIds)
-	queryCmd.Flag("tenant-id", "Tenant id of the queried block for remote bucket").StringVar(&params.TenanId)
+	queryCmd.Flag("tenant-id", "Tenant id of the queried block for remote bucket").StringVar(&params.TenantID)
 	queryCmd.Flag("query", "Label selector to query.").Default("{}").StringVar(&params.Query)
 	return params
 }
@@ -51,7 +51,7 @@ func addQueryBlocksSeriesParams(queryCmd commander) *queryBlocksSeriesParams {
 
 func queryBlocksSeries(ctx context.Context, params *queryBlocksSeriesParams) error {
 	level.Info(logger).Log("msg", "query-block series", "labelNames", fmt.Sprintf("%v", params.LabelNames),
-		"blockIds", fmt.Sprintf("%v", params.BlockIds), "localPath", params.LocalPath, "bucketName", params.BucketName, "tenantId", params.TenanId)
+		"blockIds", fmt.Sprintf("%v", params.BlockIds), "localPath", params.LocalPath, "bucketName", params.BucketName, "tenantId", params.TenantID)
 
 	bucket, err := getBucket(ctx, params)
 	if err != nil {
@@ -97,7 +97,7 @@ func getBucket(ctx context.Context, params *queryBlocksSeriesParams) (objstore.B
 }
 
 func getRemoteBucket(ctx context.Context, params *queryBlocksSeriesParams) (objstore.Bucket, error) {
-	if params.TenanId == "" {
+	if params.TenantID == "" {
 		return nil, errors.New("specify tenant id for remote bucket")
 	}
 	return objstoreclient.NewBucket(ctx, objstoreclient.Config{
@@ -107,6 +107,6 @@ func getRemoteBucket(ctx context.Context, params *queryBlocksSeriesParams) (objs
 				BucketName: params.BucketName,
 			},
 		},
-		StoragePrefix: fmt.Sprintf("%s/phlaredb", params.TenanId),
+		StoragePrefix: fmt.Sprintf("%s/phlaredb", params.TenantID),
 	}, params.BucketName)
 }

--- a/cmd/profilecli/query-blocks.go
+++ b/cmd/profilecli/query-blocks.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"connectrpc.com/connect"
+	"github.com/go-kit/log/level"
+	"github.com/pkg/errors"
+
+	ingestv1 "github.com/grafana/pyroscope/api/gen/proto/go/ingester/v1"
+	"github.com/grafana/pyroscope/pkg/objstore"
+	objstoreclient "github.com/grafana/pyroscope/pkg/objstore/client"
+	"github.com/grafana/pyroscope/pkg/objstore/providers/filesystem"
+	"github.com/grafana/pyroscope/pkg/objstore/providers/gcs"
+	"github.com/grafana/pyroscope/pkg/phlaredb"
+)
+
+type queryBlocksParams struct {
+	LocalPath       string
+	BucketName      string
+	BlockIds        []string
+	TenanId         string
+	ObjectStoreType string
+	Query           string
+}
+
+type queryBlocksSeriesParams struct {
+	*queryBlocksParams
+	LabelNames []string
+}
+
+func addQueryBlocksParams(queryCmd commander) *queryBlocksParams {
+	params := new(queryBlocksParams)
+	queryCmd.Flag("local-path", "Path to blocks directory.").Default("./data/anonymous/local").StringVar(&params.LocalPath)
+	queryCmd.Flag("bucket-name", "The name of the object storage bucket.").StringVar(&params.BucketName)
+	queryCmd.Flag("object-store-type", "The type of the object storage (e.g., gcs).").Default("gcs").StringVar(&params.ObjectStoreType)
+	queryCmd.Flag("block-ids", "List of blocks ids to query on").StringsVar(&params.BlockIds)
+	queryCmd.Flag("tenant-id", "Tenant id of the queried block for remote bucket").StringVar(&params.TenanId)
+	queryCmd.Flag("query", "Label selector to query.").Default("{}").StringVar(&params.Query)
+	return params
+}
+
+func addQueryBlocksSeriesParams(queryCmd commander) *queryBlocksSeriesParams {
+	params := new(queryBlocksSeriesParams)
+	params.queryBlocksParams = addQueryBlocksParams(queryCmd)
+	queryCmd.Flag("label-names", "Filter returned labels to the supplied label names. Without any filter all labels are returned.").StringsVar(&params.LabelNames)
+	return params
+}
+
+func queryBlocksSeries(ctx context.Context, params *queryBlocksSeriesParams) error {
+	level.Info(logger).Log("msg", "query-block series", "labelNames", fmt.Sprintf("%v", params.LabelNames),
+		"blockIds", fmt.Sprintf("%v", params.BlockIds), "localPath", params.LocalPath, "bucketName", params.BucketName, "tenantId", params.TenanId)
+
+	bucket, err := getBucket(ctx, params)
+	if err != nil {
+		return err
+	}
+
+	blockQuerier := phlaredb.NewBlockQuerier(ctx, bucket)
+
+	var from, to int64
+	from, to = math.MaxInt64, math.MinInt64
+	var targetBlockQueriers phlaredb.Queriers
+	for _, blockId := range params.queryBlocksParams.BlockIds {
+		meta, err := blockQuerier.BlockMeta(ctx, blockId)
+		if err != nil {
+			return err
+		}
+		from = min(from, meta.MinTime.Time().UnixMilli())
+		to = max(to, meta.MaxTime.Time().UnixMilli())
+		targetBlockQueriers = append(targetBlockQueriers, phlaredb.NewSingleBlockQuerierFromMeta(ctx, bucket, meta))
+	}
+
+	response, err := targetBlockQueriers.Series(ctx, connect.NewRequest(
+		&ingestv1.SeriesRequest{
+			Start:      from,
+			End:        to,
+			Matchers:   []string{params.Query},
+			LabelNames: params.LabelNames,
+		},
+	))
+	if err != nil {
+		return err
+	}
+
+	return outputSeries(response.Msg.LabelsSet)
+}
+
+func getBucket(ctx context.Context, params *queryBlocksSeriesParams) (objstore.Bucket, error) {
+	if params.BucketName != "" {
+		return getRemoteBucket(ctx, params)
+	} else {
+		return filesystem.NewBucket(params.LocalPath)
+	}
+}
+
+func getRemoteBucket(ctx context.Context, params *queryBlocksSeriesParams) (objstore.Bucket, error) {
+	if params.TenanId == "" {
+		return nil, errors.New("specify tenant id for remote bucket")
+	}
+	return objstoreclient.NewBucket(ctx, objstoreclient.Config{
+		StorageBackendConfig: objstoreclient.StorageBackendConfig{
+			Backend: params.ObjectStoreType,
+			GCS: gcs.Config{
+				BucketName: params.BucketName,
+			},
+		},
+		StoragePrefix: fmt.Sprintf("%s/phlaredb", params.TenanId),
+	}, params.BucketName)
+}

--- a/cmd/profilecli/query.go
+++ b/cmd/profilecli/query.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -320,22 +319,8 @@ func querySeries(ctx context.Context, params *querySeriesParams) (err error) {
 		return errors.Errorf("unknown api type %s", params.APIType)
 	}
 
-	enc := json.NewEncoder(os.Stdout)
-	m := make(map[string]interface{})
-	for _, s := range result {
-		for k := range m {
-			delete(m, k)
-		}
-		for _, l := range s.Labels {
-			m[l.Name] = l.Value
-		}
-		if err := enc.Encode(m); err != nil {
-			return err
-		}
-	}
-
-	return nil
-
+	err = outputSeries(result)
+	return err
 }
 
 type queryLabelValuesCardinalityParams struct {

--- a/pkg/phlaredb/block_querier.go
+++ b/pkg/phlaredb/block_querier.go
@@ -159,6 +159,23 @@ func (b *BlockQuerier) BlockMetas(ctx context.Context) (metas []*block.Meta, _ e
 	return metas[0 : pos+1], nil
 }
 
+func (b *BlockQuerier) BlockMeta(ctx context.Context, name string) (meta *block.Meta, _ error) {
+	path := filepath.Join(name, block.MetaFilename)
+	metaReader, err := b.bkt.Get(ctx, path)
+	if err != nil {
+		level.Error(b.logger).Log("msg", "error reading block meta", "block", path, "err", err)
+		return nil, err
+	}
+
+	meta, err = block.Read(metaReader)
+	if err != nil {
+		level.Error(b.logger).Log("msg", "error parsing block meta", "block", path, "err", err)
+		return nil, err
+	}
+
+	return meta, nil
+}
+
 // Sync gradually scans the available blocks. If there are any changes to the
 // last run it will Open/Close new/no longer existing ones.
 func (b *BlockQuerier) Sync(ctx context.Context) error {

--- a/pkg/phlaredb/block_querier_test.go
+++ b/pkg/phlaredb/block_querier_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/grafana/pyroscope/pkg/pprof/testhelper"
 )
 
+const testDataPath = "./block/testdata/"
+
 func TestQuerierBlockEviction(t *testing.T) {
 	type testCase struct {
 		blocks     []string
@@ -105,7 +107,7 @@ func (p *profileCounter) Next() bool {
 }
 
 func TestBlockCompatability(t *testing.T) {
-	path := "./block/testdata/"
+	path := testDataPath
 	bucket, err := filesystem.NewBucket(path)
 	require.NoError(t, err)
 
@@ -156,7 +158,7 @@ func TestBlockCompatability(t *testing.T) {
 }
 
 func TestBlockCompatability_SelectMergeSpans(t *testing.T) {
-	path := "./block/testdata/"
+	path := testDataPath
 	bucket, err := filesystem.NewBucket(path)
 	require.NoError(t, err)
 
@@ -1385,4 +1387,22 @@ func testSelectMergeByStacktracesRace(t testing.TB, times int) {
 
 	require.NoError(t, g.Wait())
 	require.NoError(t, querier.Close())
+}
+
+func TestBlockMeta_loadsMetasIndividually(t *testing.T) {
+	path := testDataPath
+	bucket, err := filesystem.NewBucket(path)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	blockQuerier := NewBlockQuerier(ctx, bucket)
+	metas, err := blockQuerier.BlockMetas(ctx)
+	require.NoError(t, err)
+
+	for _, meta := range metas {
+		singleMeta, err := blockQuerier.BlockMeta(ctx, meta.ULID.String())
+		require.NoError(t, err)
+
+		require.Equal(t, meta, singleMeta)
+	}
 }

--- a/pkg/phlaredb/block_querier_test.go
+++ b/pkg/phlaredb/block_querier_test.go
@@ -1398,6 +1398,7 @@ func TestBlockMeta_loadsMetasIndividually(t *testing.T) {
 	blockQuerier := NewBlockQuerier(ctx, bucket)
 	metas, err := blockQuerier.BlockMetas(ctx)
 	require.NoError(t, err)
+	require.NotEmpty(t, metas)
 
 	for _, meta := range metas {
 		singleMeta, err := blockQuerier.BlockMeta(ctx, meta.ULID.String())


### PR DESCRIPTION
In this PR we introduce a new profilecli command: `query-blocks`. With this command, you can execute queries directly to single or multiple blocks hosted in your localhost or a remote bucket.

Partially solves https://github.com/grafana/pyroscope/issues/3559, `profile query-blocks merge` will come in a later PR.


### Capabilities
This feature gives similar capabilities as `profilecli query series`but for a specified local/remote blocks:
* It has support for checking label values with `--label-names` or specify the query with `--query`.
* You may choose to use it locally (`--local-path`) or remotely (`--bucket-name`, `--tenant-id` and `--object-store-type` - only gcs supported right now).
* You specify queried blocks with the `--block-ids` flag.
* Time ranges (`to` and `from`) are not needed: it will query the whole blocks instead. 


### doc
```
profilecl query-blocks series --help
usage: profilecli query-blocks series [<flags>]

Request series labels on a local/remote block

Flags:
  -h, --help                     Show context-sensitive help (also try --help-long and --help-man).
      --version                  Show application version.
  -v, --verbose                  Enable verbose logging.
      --local-path="./data/anonymous/local"
                                 Path to blocks directory.
      --bucket-name=BUCKET-NAME  The name of the object storage bucket.
      --object-store-type="gcs"  The type of the object storage (e.g., gcs).
      --block-ids=BLOCK-IDS ...  List of blocks ids to query on
      --tenant-id=TENANT-ID      Tenant id of the queried block for remote bucket
      --query="{}"               Label selector to query.
      --label-names=LABEL-NAMES ...
                                 Filter returned labels to the supplied label names. Without any filter all labels are returned.
```

### Usage example:
Querying series on a local block, and filter on service_name
```
profilecli query-blocks series --local-path=./data/anonymous/local --block-ids=01J9K65Z1RP3YJG66GSR9FVDQ0 --query='{service_name="ride-sharing-app"}'
level=info msg="query-block series" labelNames=[] blockIds=[01J9K65Z1RP3YJG66GSR9FVDQ0] localPath=./data/anonymous/local bucketName= tenantId=
{"__name__":"memory","__period_type__":"space","__period_unit__":"bytes","__profile_type__":"memory:alloc_objects:count:space:bytes","__service_name__":"ride-sharing-app","__type__":"alloc_objects","__unit__":"count","hostname":"6faf2cfcb5e8","pyroscope_spy":"gospy","region":"us-east","service_git_ref":"HEAD","service_name":"ride-sharing-app","service_repository":"https://github.com/grafana/pyroscope","service_root_path":"examples/language-sdk-instrumentation/golang-push/rideshare"}
{"__name__":"memory","__period_type__":"space","__period_unit__":"bytes","__profile_type__":"memory:alloc_objects:count:space:bytes","__service_name__":"ride-sharing-app","__type__":"alloc_objects","__unit__":"count","hostname":"bf91795602f5","pyroscope_spy":"gospy","region":"eu-north","service_git_ref":"HEAD","service_name":"ride-sharing-app","service_repository":"https://github.com/grafana/pyroscope","service_root_path":"examples/language-sdk-instrumentation/golang-push/rideshare"}
...
```

Querying series on two remote blocks, just checking at `__profile_type__` label:
```
profilecli query-blocks series --bucket-name='dev-us-central-0-profiles-dev-001-data' --tenant-id=1218 --block-ids=01J9NBD1V2BJQWCMDQGMNGC4W5 --block-ids=01J9NBD1THECVDYVWFJVYWWX7M --label-names=__profile_type__
level=info msg="query-block series" labelNames=[__profile_type__] blockIds="[01J9NBD1V2BJQWCMDQGMNGC4W5 01J9NBD1THECVDYVWFJVYWWX7M]" localPath=./data/anonymous/local bucketName=dev-us-central-0-profiles-dev-001-data tenantId=1218
{"__profile_type__":"block:contentions:count:contentions:count"}
{"__profile_type__":"block:delay:nanoseconds:contentions:count"}
{"__profile_type__":"goroutine:goroutine:count:goroutine:count"}
{"__profile_type__":"goroutines:goroutine:count:goroutine:count"}
{"__profile_type__":"memory:alloc_objects:count:space:bytes"}
{"__profile_type__":"memory:alloc_space:bytes:space:bytes"}
{"__profile_type__":"memory:inuse_objects:count:space:bytes"}
{"__profile_type__":"memory:inuse_space:bytes:space:bytes"}
{"__profile_type__":"mutex:contentions:count:contentions:count"}
{"__profile_type__":"mutex:delay:nanoseconds:contentions:count"}
{"__profile_type__":"process_cpu:cpu:nanoseconds:cpu:nanoseconds"}
{"__profile_type__":"process_cpu:samples:count::milliseconds"}
{"__profile_type__":"process_cpu:samples:count:cpu:nanoseconds"}
```