### PR TITLE
[DOC] Fix broken links from doc report

### DIFF
--- a/docs/sources/configure-client/grafana-agent/_index.md
+++ b/docs/sources/configure-client/grafana-agent/_index.md
@@ -9,7 +9,7 @@ aliases:
 
 # Grafana Alloy and Grafana Agent
 
-You can send data from your application using Grafana Alloy or Grafana Agent collectors.
+You can send data from your application using Grafana Alloy (preferred) or Grafana Agent (legacy) collectors.
 Both collectors support profiling with eBPF, Java, and Golang in pull mode.
 
 [Grafana Alloy](https://grafana.com/docs/alloy/latest/) is a vendor-neutral distribution of the OpenTelemetry (OTel) Collector.
@@ -23,7 +23,6 @@ New installations should use Alloy.
 
 Grafana Agent is a powerful tool for collecting and forwarding profiling data.
 With the introduction of support for eBPF and continuing support for Golang in pull mode, Grafana Agent has become even more versatile in its capabilities.
-This document provides an overview of these two modes of profiling and guides users on setting them up.
 
 {{< admonition type="note" >}}
 Refer to [Available profiling types]({{< relref "../../view-and-analyze-profile-data/profiling-types#available-profiling-types" >}}) for a list of profile types supported.

--- a/docs/sources/configure-client/grafana-agent/go_pull.md
+++ b/docs/sources/configure-client/grafana-agent/go_pull.md
@@ -44,18 +44,16 @@ This configuration file works for either Grafana Alloy or Grafana Agent in Flow 
 
 Grafana Alloy is the preferred collector.
 
-To install Alloy, refer to [Grafana Alloy installation](https://grafana.com/docs/alloy/latest/get-started/install/).
+To install Alloy, refer to [Grafana Alloy installation](https://grafana.com/docs/alloy/<ALLOY_VERSION>/get-started/install/).
 
 {{< docs/shared lookup="agent-deprecation.md" source="alloy" version="next" >}}
 
-If you are using legacy Grafana Agent Flow, use the [Grafana Agent in Flow mode](https://grafana.com/docs/agent/latest/flow/get-started/install/) documentation to install.
-
 ### Prepare the collector configuration file
 
-In the Grafana Alloy or Grafana Agent Flow configuration file, you need to add at least two blocks: `pyroscope.write`
-and `pyroscope.scrape`.
+In the Grafana Alloy or Grafana Agent Flow configuration file, you need to add at least two blocks: `pyroscope.write` and `pyroscope.scrape`.
 
 1. Add `pyroscope.write` block.
+
     ```river
     pyroscope.write "write_job_name" {
             endpoint {
@@ -65,6 +63,7 @@ and `pyroscope.scrape`.
     ```
 
 1. Add `pyroscope.scrape` block.
+
     ```river
     pyroscope.scrape "scrape_job_name" {
             targets    = [{"__address__" = "localhost:4040", "service_name" = "example_service"}]
@@ -120,7 +119,7 @@ and `pyroscope.scrape`.
 
   * To start Grafana Alloy v1.2: Replace `configuration.alloy` with your configuration file name: <br> `alloy run configuration.alloy`
   * To start Grafana Alloy v1.0/1.1: Replace `configuration.alloy` with your configuration file name: <br> `alloy run --stability.level=public-preview configuration.alloy`
-    The `stability.level` option is required for `pyroscope.scrape` with Alloy v1.0 or v1.1. For more information about `stability.level`, refer to [The run command](https://grafana.com/docs/alloy/latest/reference/cli/run/#permitted-stability-levels) documentation.
+    The `stability.level` option is required for `pyroscope.scrape` with Alloy v1.0 or v1.1. For more information about `stability.level`, refer to [The run command](https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/cli/run/#permitted-stability-levels) documentation.
   * To start Grafana Agent, replace `configuration.river` with your configuration file name: <br> ` grafana-agent-flow run configuration.river`
 
 1. Open a browser to http://localhost:4040. The page should list profiles.
@@ -244,14 +243,14 @@ router.PathPrefix("/debug/pprof").Handler(http.DefaultServeMux)
 - [pyroscope.scrape](https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/pyroscope/pyroscope.scrape/)
 - [pyroscope.write](https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/pyroscope/pyroscope.write/)
 - [discovery.kubernetes](https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/discovery/discovery.kubernetes/)
-- [discovery.docker](/docs/alloy/<ALLOY_VERSION>/reference/components/discovery/discovery.docker/)
-- [discovery.relabel](/docs/alloy/<ALLOY_VERSION>/reference/components/discovery/discovery.relabel/)
+- [discovery.docker](https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/discovery/discovery.docker/)
+- [discovery.relabel](https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/discovery/discovery.relabel/)
 
 ### Grafana Agent
 
 - [Example using grafana-agent](https://github.com/grafana/pyroscope/tree/main/examples/grafana-agent-auto-instrumentation).
-- [pyroscope.scrape](/docs/agent/latest/flow/reference/components/pyroscope.scrape/)
-- [pyroscope.write](https://grafana.com/docs/agent/latest/flow/reference/components/pyroscope.write/)
-- [discovery.kubernetes](https://grafana.com/docs/agent/latest/flow/reference/components/discovery.kubernetes/)
-- [discovery.docker](https://grafana.com/docs/agent/latest/flow/reference/components/discovery.docker/)
-- [discovery.relabel](/docs/agent/latest/flow/reference/components/discovery.relabel/)
+- [pyroscope.scrape](https://grafana.com/docs/agent/<AGENT_VERSION>/flow/reference/components/pyroscope.scrape/)
+- [pyroscope.write](https://grafana.com/docs/agent/<AGENT_VERSION>/flow/reference/components/pyroscope.write/)
+- [discovery.kubernetes](https://grafana.com/docs/agent/<AGENT_VERSION>/flow/reference/components/discovery.kubernetes/)
+- [discovery.docker](https://grafana.com/docs/agent/<AGENT_VERSION>/flow/reference/components/discovery.docker/)
+- [discovery.relabel](https://grafana.com/docs/agent/<AGENT_VERSION>/flow/reference/components/discovery.relabel/)

--- a/docs/sources/configure-client/grafana-agent/java/_index.md
+++ b/docs/sources/configure-client/grafana-agent/java/_index.md
@@ -302,8 +302,8 @@ For more information:
 - [pyroscope.scrape](https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/pyroscope/pyroscope.scrape/)
 - [pyroscope.write](https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/pyroscope/pyroscope.write/)
 - [discovery.kubernetes](https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/discovery/discovery.kubernetes/)
-- [discovery.docker](/docs/alloy/<ALLOY_VERSION>/reference/components/discovery/discovery.docker/)
-- [discovery.relabel](/docs/alloy/<ALLOY_VERSION>/reference/components/discovery/discovery.relabel/)
+- [discovery.docker](https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/discovery/discovery.docker/)
+- [discovery.relabel](https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/discovery/discovery.relabel/)
 
 ### Grafana Agent
 

--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -100,9 +100,9 @@ Verify that you have installed [Docker](https://docs.docker.com/engine/install/)
    | Field | Value                                                                |
    | ----- | -------------------------------------------------------------------- |
    | Name  | Pyroscope                                                            |
-   | URL   | [http://pyroscope:4040/](http://pyroscope:4040/)                     |
+   | URL   | [http://pyroscope:4040/](http://pyroscope:4040/) OR [http://host.docker.internal:4040/](http://host.docker.internal:4040/) if using Docker  |
 
-  To learn more about adding data sources, see [Add a data source](/docs/grafana/latest/datasources/add-a-data-source/).
+  To learn more about adding data sources, refer to [Add a data source](/docs/grafana/<GRAFANA_VERSION>/datasources/add-a-data-source/).
 
-When you have completed the tasks in this getting started guide, you can query profiles in [Grafana Explore](/docs/grafana/latest/explore/)
-and create dashboard panels using the newly configured Pyroscope data source. For more information on working with dashboards with Grafana, see [Panels and visualizations](/docs/grafana/latest/panels-visualizations/) in the Grafana documentation.
+When you have completed the tasks in this getting started guide, you can query profiles in [Grafana Explore](/docs/grafana/<GRAFANA_VERSION>/explore/)
+and create dashboard panels using the newly configured Pyroscope data source. For more information on working with dashboards with Grafana, see [Panels and visualizations](/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/) in the Grafana documentation.

--- a/docs/sources/introduction/pyroscope-in-grafana.md
+++ b/docs/sources/introduction/pyroscope-in-grafana.md
@@ -16,7 +16,7 @@ keywords:
 Pyroscope can be used alongside the other Grafana tools such as Loki, Tempo, Mimir, and k6.
 You can use Pyroscope to get the most granular insight into your application and how you can use it to fix issues that you may have identified via metrics, logs, traces, or anything else.
 
-You can use Pyroscope within Grafana by using the [Pyroscope data source plugin](https://grafana.com/docs/grafana/<GRAFANA_VERSION>datasources/grafana-pyroscope/).
+You can use Pyroscope within Grafana by using the [Pyroscope data source plugin](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/grafana-pyroscope/).
 This plugin lets you query Pyroscope data from within Grafana and visualize it alongside your other Grafana data.
 
 ## Visualize traces and profiles data


### PR DESCRIPTION
Fix broken links reported for the Pyroscope docs. Includes community fixes from 

https://github.com/grafana/pyroscope/pull/3611
https://github.com/grafana/pyroscope/pull/3333

Partial fix for https://github.com/grafana/tempo-squad/issues/495