### PR TITLE
chore: update updater

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,7 @@ $(BIN)/mockery: Makefile go.mod
 
 $(BIN)/updater: Makefile
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) GOPRIVATE=github.com/grafana/deployment_tools $(GO) install github.com/grafana/deployment_tools/drone/plugins/cmd/updater@d64d509
+	GOBIN=$(abspath $(@D)) GOPRIVATE=github.com/grafana/deployment_tools $(GO) install github.com/grafana/deployment_tools/docker/updater/cmd/updater@bd5794b4e488
 
 # Note: When updating the goreleaser version also update .github/workflow/release.yml and .git/workflow/weekly-release.yaml
 $(BIN)/goreleaser: Makefile go.mod


### PR DESCRIPTION
CI pipeline fails on `main` due to:

> GOBIN=/home/runner/work/pyroscope/pyroscope/.tmp/bin GOPRIVATE=github.com/grafana/deployment_tools go install github.com/grafana/deployment_tools/drone/plugins/cmd/updater@d64d509
go: downloading github.com/grafana/deployment_tools/drone/plugins v0.0.0-20220712102523-d64d5092c42b
go: downloading github.com/grafana/deployment_tools v0.0.0-20220712102523-d64d5092c42b
go: github.com/grafana/deployment_tools/drone/plugins/cmd/updater@d64d509: loading deprecation for github.com/grafana/deployment_tools/drone/plugins: no matching versions for query "latest"
make: *** [Makefile:353: /home/runner/work/pyroscope/pyroscope/.tmp/bin/updater] Error 1 

I'm not entirely sure what caused this (it may be modcache, or expired token), but it looks like we haven't been updating the tool for a while. Since then it changed its package path. I hope updating it will resolve the problem, although I can't reproduce it locally 