### PR TITLE
chore: make the update-contributors workflow run monthly

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -2,7 +2,7 @@ name: Update Contributors in README
 
 on:
   schedule:
-    - cron: '0 0 1 * *'
+    - cron: '0 0 1-7 * SUN'
 
 jobs:
   update-contributors:

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -1,8 +1,8 @@
 name: Update Contributors in README
 
 on:
-  push:
-    branches: [main]
+  schedule:
+    - cron: '0 0 1 * *'
 
 jobs:
   update-contributors:
@@ -24,7 +24,7 @@ jobs:
           git config --local user.email 'dmitry+bot@pyroscope.io'
           if ! git diff --exit-code README.md; then
               git add README.md
-              git commit -m 'docs: updates the list of contributors in README [skip ci]'
+              git commit -m 'docs: updates the list of contributors in README'
               gh auth status
               git push --force https://x-access-token:${{ secrets.BOT_GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:main
           fi


### PR DESCRIPTION
Fixes #3574 by scheduling the workflow to run on the first ~~day~~ Sunday of every month and removing the [skip ci] flag in the commit. 

We don't really need frequent updates imo and if we run it monthly we don't have to worry about it being wasteful. 

~~There is a small chance of jobs getting cancelled if someone merges a PR right around when this runs (midnight UTC, on the first day of the month), I don't think this is a real problem but we could update the concurrency config if it becomes an issue.~~
This probability is now reduced by having it run on the first Sunday of the month, at 00:00 UTC.