### PR TITLE
fix(v2): opening tsdb: read postings table: invalid checksum

### DIFF
--- a/pkg/experiment/query_backend/block/dataset.go
+++ b/pkg/experiment/query_backend/block/dataset.go
@@ -55,15 +55,18 @@ func WithDatasetMaxSizeLoadInMemory(size int) DatasetOption {
 // is only initialized once. While it is possible to open the dataset
 // repeatedly after close, the caller must pass the failure reason to
 // the CloseWithError call, preventing further use, if applicable.
-func (s *Dataset) Open(ctx context.Context, sections ...Section) (err error) {
+func (s *Dataset) Open(ctx context.Context, sections ...Section) error {
 	return s.refs.IncErr(func() error {
-		return s.open(ctx, sections...)
+		if err := s.open(ctx, sections...); err != nil {
+			return fmt.Errorf("%w (%s)", err, s.obj.meta.Id)
+		}
+		return nil
 	})
 }
 
 func (s *Dataset) open(ctx context.Context, sections ...Section) (err error) {
 	if s.err != nil {
-		// The tenant dataset has been already closed with an error.
+		// The tenant dataset has already been closed with an error.
 		return s.err
 	}
 	if err = s.obj.Open(ctx); err != nil {

--- a/pkg/experiment/query_backend/block/section_tsdb.go
+++ b/pkg/experiment/query_backend/block/section_tsdb.go
@@ -39,11 +39,13 @@ type tsdbBuffer struct {
 }
 
 func (b *tsdbBuffer) Close() (err error) {
-	if b.buf != nil {
-		bufferpool.Put(b.buf)
-	}
 	if b.index != nil {
 		err = b.index.Close()
+		b.index = nil
+	}
+	if b.buf != nil {
+		bufferpool.Put(b.buf)
+		b.buf = nil
 	}
 	return err
 }

--- a/pkg/objstore/read_only_file.go
+++ b/pkg/objstore/read_only_file.go
@@ -54,6 +54,9 @@ func download(ctx context.Context, name string, src BucketReader, dir string) (f
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		_ = dst.Close()
+	}()
 	buf := bufferpool.GetBuffer(32 << 10)
 	defer bufferpool.Put(buf)
 	buf.B = buf.B[:cap(buf.B)]


### PR DESCRIPTION
This fixes cryptic errors like `failed to initialize query context: openning section tsdb: opening tsdb: read postings table: invalid checksum` that may occur if the tsdb index uses memory referenced from the shared buffer pool after disposal.