### PR TITLE
fix: helm release secret key

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -27,4 +27,4 @@ jobs:
       ct_configfile: operations/pyroscope/helm/ct.yaml
     secrets:
       github_app_id: ${{ secrets.GH_RELEASES_APP_ID }}
-      github_app_private_key: ${{ secrets.GH_RELEASES_APP_PRIVATE_KEY }}
+      github_app_pem: ${{ secrets.GH_RELEASES_APP_PRIVATE_KEY }}


### PR DESCRIPTION
As per https://github.com/grafana/helm-charts/blob/main/.github/workflows/update-helm-repo.yaml#L27-L32

Related to https://github.com/grafana/pyroscope/actions/runs/11386238456