### PR TITLE
feat(v2): revive grpc health checks

### DIFF
--- a/pkg/experiment/metastore/client/client.go
+++ b/pkg/experiment/metastore/client/client.go
@@ -3,12 +3,14 @@ package metastoreclient
 import (
 	"context"
 	"fmt"
-	"github.com/go-kit/log"
-	"github.com/grafana/pyroscope/pkg/experiment/metastore/discovery"
-	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/raft"
 	"io"
 	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/raft"
+
+	"github.com/grafana/pyroscope/pkg/experiment/metastore/discovery"
 
 	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/services"
@@ -162,8 +164,14 @@ func dial(address string, grpcClientConfig grpcclient.Config, _ log.Logger) (*gr
 	}
 	// TODO: https://github.com/grpc/grpc-proto/blob/master/grpc/service_config/service_config.proto
 	options = append(options,
-		//grpc.WithDefaultServiceConfig(grpcServiceConfig),
+		grpc.WithDefaultServiceConfig(grpcServiceConfig),
 		grpc.WithUnaryInterceptor(otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer())),
 	)
 	return grpc.Dial(address, options...)
 }
+
+const grpcServiceConfig = `{
+	"healthCheckConfig": {
+		"serviceName": "pyroscope.metastore"
+	}
+}`

--- a/pkg/experiment/metastore/client/methods.go
+++ b/pkg/experiment/metastore/client/methods.go
@@ -3,15 +3,17 @@ package metastoreclient
 import (
 	"context"
 	"fmt"
-	compactorv1 "github.com/grafana/pyroscope/api/gen/proto/go/compactor/v1"
-	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
-	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	"math/rand"
+	"time"
+
 	"github.com/hashicorp/raft"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"math/rand"
-	"time"
+
+	compactorv1 "github.com/grafana/pyroscope/api/gen/proto/go/compactor/v1"
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 )
 
 func invoke[R any](ctx context.Context, cl *Client,
@@ -19,7 +21,7 @@ func invoke[R any](ctx context.Context, cl *Client,
 ) (*R, error) {
 	const (
 		n        = 50
-		backoff  = 11 * time.Millisecond
+		backoff  = 51 * time.Millisecond
 		deadline = 500000000 * time.Millisecond
 	)
 

--- a/pkg/util/inflight_requets.go
+++ b/pkg/util/inflight_requets.go
@@ -1,0 +1,60 @@
+package util
+
+import (
+	"sync"
+)
+
+// InflightRequests utility emerged due to the need to handle request draining
+// at the service level.
+//
+// Ideally, this should be the responsibility of the server using the service.
+// However, since the server is a dependency of the service and is only shut
+// down after the service is stopped, requests may still arrive after the Stop
+// call. This issue arises from how we initialize modules.
+//
+// In other scenarios, request draining could be managed at a higher level,
+// such as in a load balancer or service discovery mechanism. The goal would
+// be to stop routing requests to an instance that is about to shut down.
+//
+// In our case, service instances that are not directly exposed to the outside
+// world but are discoverable via e.g, ring, kubernetes, or DNS. There's no a
+// _reliable_ mechanism to ensure that all the clients are aware of fact that
+// the instance is leaving, so requests may continue to arrive within a short
+// period of time. InflightRequests ensure that such requests will be rejected.
+type InflightRequests struct {
+	mu      sync.RWMutex
+	wg      sync.WaitGroup
+	allowed bool
+}
+
+// Open allows new requests.
+func (r *InflightRequests) Open() {
+	r.mu.Lock()
+	r.allowed = true
+	r.mu.Unlock()
+}
+
+// Add adds a new request if allowed.
+func (r *InflightRequests) Add() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if !r.allowed {
+		return false
+	}
+	r.wg.Add(1)
+	return true
+}
+
+// Done completes a request.
+func (r *InflightRequests) Done() {
+	r.wg.Done()
+}
+
+// Drain prevents new requests from being accepted
+// and waits for all ongoing requests to complete.
+func (r *InflightRequests) Drain() {
+	r.mu.Lock()
+	r.allowed = false
+	r.mu.Unlock()
+	r.wg.Wait()
+}

--- a/pkg/util/recovery.go
+++ b/pkg/util/recovery.go
@@ -38,7 +38,7 @@ var (
 	})
 
 	RecoveryInterceptor     recoveryInterceptor
-	GRPCRecoveryInterceptor = grpc_recovery.UnaryServerInterceptor(grpc_recovery.WithRecoveryHandler(PanicError))
+	RecoveryInterceptorGRPC = grpc_recovery.UnaryServerInterceptor(grpc_recovery.WithRecoveryHandler(PanicError))
 )
 
 func PanicError(p interface{}) error {


### PR DESCRIPTION
Due to how the grpc server and services are managed, we can't rely on the (de-)initialization order, which causes major issues. Moreover, many of the components are accessed directly through various discovery mechanisms, which provide different (and, generally, week) guarantees on the instance readiness.

Health checks at the connection level help to partially eliminate the problem: a well behaving client won't experience any significant issues when server instances go offline.