### PR TITLE
Use uint64 for `proc` offset

### DIFF
--- a/ebpf/symtab/proc.go
+++ b/ebpf/symtab/proc.go
@@ -82,7 +82,6 @@ func (p *ProcTable) Refresh() {
 	p.err = p.refreshProcMap(procMaps)
 	if p.err != nil {
 		_ = level.Error(p.logger).Log("err", p.err)
-	} else {
 	}
 }
 

--- a/ebpf/symtab/procmap.go
+++ b/ebpf/symtab/procmap.go
@@ -63,7 +63,7 @@ type ProcMap struct {
 	// The permissions for this mapping
 	Perms *ProcMapPermissions
 	// The current offset into the file/fd (e.g., shared libs)
-	Offset int64
+	Offset uint64
 	// Device owner of this mapping (major:minor) in Mkdev format.
 	Dev uint64
 	// The inode of the device above
@@ -246,7 +246,7 @@ func ParseProcMapLine(line []byte, executableOnly bool) (*ProcMap, error) {
 		return nil, err
 	}
 
-	offset, err := strconv.ParseInt(tokenToStringUnsafe(offsetBytes), 16, 0)
+	offset, err := strconv.ParseUint(tokenToStringUnsafe(offsetBytes), 16, 0)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #3650

@korniltsev I think this should be fine? 