### PR TITLE
[DOC] Update and expand profiling types doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For more documentation on how to configure Pyroscope server, see [our server doc
 The app UI and server are both installed and running automatically -- just start sending data!
 
 ### Grafana OSS
-You can run the Explore profiles UI in Grafana by installing the plugin from the [Grafana Plugin Directory](https://grafana.com/grafana/plugins/grafana-pyroscope-app/) 
+You can run the Explore profiles UI in Grafana by installing the plugin from the [Grafana Plugin Directory](https://grafana.com/grafana/plugins/grafana-pyroscope-app/)
 
 For more information, check out the [Explore Profiles README](https://github.com/grafana/explore-profiles)
 
@@ -137,7 +137,7 @@ Our documentation contains the most recent list of [supported languages] and als
 Let us know what other integrations you want to see in [our issues](https://github.com/grafana/pyroscope/issues?q=is%3Aissue+is%3Aopen+label%3Anew-profilers) or in [our slack](https://slack.grafana.com).
 
 [supported languages]: https://grafana.com/docs/pyroscope/latest/configure-client/
-[profile-types-languages]: https://grafana.com/docs/pyroscope/latest/view-and-analyze-profile-data/profiling-types/#available-profiling-types
+[profile-types-languages]: https://grafana.com/docs/pyroscope/latest/configure-client/profile-types/
 
 ## Credits
 

--- a/docs/sources/configure-client/aws-lambda.md
+++ b/docs/sources/configure-client/aws-lambda.md
@@ -2,7 +2,7 @@
 title: "AWS Lambda profiling extension"
 menuTitle: "AWS Lambda profiling extension"
 description: "Profiling AWS Lambda functions with Pyroscope"
-weight: 100
+weight: 500
 ---
 
 # AWS Lambda profiling extension

--- a/docs/sources/configure-client/grafana-alloy/_index.md
+++ b/docs/sources/configure-client/grafana-alloy/_index.md
@@ -2,7 +2,7 @@
 title: "Grafana Alloy"
 menuTitle: "Grafana Alloy"
 description: "Send data from your application using Grafana Alloy."
-weight: 10
+weight: 200
 aliases:
   - /docs/phlare/latest/configure-client/grafana-agent/
   - ./grafana-agent # /docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/grafana-agent/
@@ -24,7 +24,7 @@ New installations should use Alloy.
 The instructions in this section explain how to use Alloy.
 
 {{< admonition type="note" >}}
-Refer to [Available profiling types]({{< relref "../../view-and-analyze-profile-data/profiling-types#available-profiling-types" >}}) for a list of supported profile types.
+Refer to [Available profiling types](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/profile-types/) for a list of supported profile types.
 {{< /admonition >}}
 
 ## Legacy collector, Grafana Agent

--- a/docs/sources/configure-client/grafana-alloy/ebpf/_index.md
+++ b/docs/sources/configure-client/grafana-alloy/ebpf/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Profiling with eBPF with Grafana Alloy"
-menuTitle: "Profiling with eBPF"
+title: "Set up profiling with eBPF with Grafana Alloy"
+menuTitle: "Set up profiling with eBPF"
 description: "Learn about using eBPF for continuous profiling for performance optimization."
 weight: 20
 aliases:
@@ -8,17 +8,17 @@ aliases:
   - /docs/pyroscope/next/configure-client/language-sdks/ebpf
 ---
 
-# Profiling with eBPF with Grafana Alloy
+# Set up profiling with eBPF with Grafana Alloy
+
+eBPF is an advanced technology embedded into the Linux kernel. It stands for enhanced [Berkeley Packet Filter](https://en.wikipedia.org/wiki/EBPF) and revolutionizes the capability to run sandboxed code safely within the kernel space. This technology serves multiple use cases, such as networking, security, and performance monitoring without the need to alter kernel code or load additional modules.
 
 <img src="/media/docs/pyroscope/ebpf_logo_color_on_white.png" width="100px;" alt="eBPF"/>
 
 {{< youtube id="UX5aeL5KeZs" >}}
 
-eBPF is an advanced technology embedded into the Linux kernel. It stands for enhanced [Berkeley Packet Filter](https://en.wikipedia.org/wiki/EBPF) and revolutionizes the capability to run sandboxed code safely within the kernel space. This technology serves multiple use cases, such as networking, security, and performance monitoring without the need to alter kernel code or load additional modules.
-
 ## Benefits and tradeoffs of using eBPF for continuous profiling
 
-When it comes to application profiling, eBPF shines due to its high efficiency and minimal performance overhead.
+When it comes to application profiling, eBPF offers high efficiency and minimal performance overhead.
 eBPF enables the dynamic insertion of powerful monitoring code into live production systems.
 By leveraging eBPF, developers can gain insights into application behavior, track resource usage, and detect bottlenecks in a way that traditional profiling tools cannot match.
 eBPF's low overhead and fine-grained data collection make it an ideal choice for continuous, real-time profiling in performance-sensitive environments.

--- a/docs/sources/configure-client/grafana-alloy/java/_index.md
+++ b/docs/sources/configure-client/grafana-alloy/java/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Set up Java profiling using Grafana Alloy"
 menuTitle: "Set up Java profiling"
-description: "Learn about using Grafana Alloy for continuous profiling Java processes for performance optimization."
+description: "Learn about using Grafana Alloy for continuous Java profiling processes for performance optimization."
 weight: 20
 ---
 

--- a/docs/sources/configure-client/grafana-alloy/java/_index.md
+++ b/docs/sources/configure-client/grafana-alloy/java/_index.md
@@ -1,11 +1,11 @@
 ---
-title: "Profiling Java using Grafana Alloy"
-menuTitle: "Profiling Java using Alloy"
+title: "Set up Java profiling using Grafana Alloy"
+menuTitle: "Set up Java profiling"
 description: "Learn about using Grafana Alloy for continuous profiling Java processes for performance optimization."
 weight: 20
 ---
 
-# Profiling Java using Grafana Alloy
+# Set up Java profilng using Grafana Alloy
 
 Grafana Alloy supports Java profiling.
 The collector configuration file is composed of components that are used to collect,

--- a/docs/sources/configure-client/grafana-alloy/java/_index.md
+++ b/docs/sources/configure-client/grafana-alloy/java/_index.md
@@ -5,7 +5,7 @@ description: "Learn about using Grafana Alloy for continuous profiling Java proc
 weight: 20
 ---
 
-# Set up Java profilng using Grafana Alloy
+# Set up Java profiling using Grafana Alloy
 
 Grafana Alloy supports Java profiling.
 The collector configuration file is composed of components that are used to collect,

--- a/docs/sources/configure-client/language-sdks/_index.md
+++ b/docs/sources/configure-client/language-sdks/_index.md
@@ -2,7 +2,7 @@
 title: "Pyroscope language SDKs"
 menuTitle: "Language SDKs"
 description: "Send data from your application using language SDKs."
-weight: 20
+weight: 300
 aliases:
   - /docs/phlare/latest/configure-client/language-sdks/
 ---
@@ -59,7 +59,7 @@ The following languages SDKs provide support for sending profiles from your appl
 </table>
 
 {{< admonition type="note" >}}
-Refer to [Available profiling types]({{< relref "../../view-and-analyze-profile-data/profiling-types#available-profiling-types" >}}) for a list of profile types supported by each language.
+Refer to [Available profiling types](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/profile-types/) for a list of profile types supported by each language.
 {{< /admonition >}}
 
 If you're interested in integrating other ecosystems, reach out to us on [GitHub](https://github.com/grafana/pyroscope/).

--- a/docs/sources/configure-client/language-sdks/dotnet.md
+++ b/docs/sources/configure-client/language-sdks/dotnet.md
@@ -12,7 +12,7 @@ aliases:
 Our .NET Profiler is a powerful tool designed to enhance the performance analysis and optimization of .NET applications. It seamlessly integrates with Pyroscope, offering real-time insights into the resource usage and bottlenecks within your .NET codebase. This integration empowers developers to pinpoint inefficiencies, improve application speed, and ensure resource-efficient operation.
 
 {{< admonition type="note" >}}
-Refer to [Available profiling types]({{< relref "../../view-and-analyze-profile-data/profiling-types#available-profiling-types" >}}) for a list of profile types supported by each language.
+Refer to [Available profiling types](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/profile-types/) for a list of profile types supported by each language.
 {{< /admonition >}}
 
 ## Supported profiling types

--- a/docs/sources/configure-client/language-sdks/go_push.md
+++ b/docs/sources/configure-client/language-sdks/go_push.md
@@ -17,7 +17,7 @@ Pyroscope uses the standard `runtime/pprof` package to collect profiling data.
 Refer to [the official documentation](https://golang.org/doc/diagnostics#profiling) for details.
 
 {{< admonition type="note" >}}
-Refer to [Available profiling types]({{< relref "../../view-and-analyze-profile-data/profiling-types#available-profiling-types" >}}) for a list of profile types supported by Go.
+Refer to [Available profiling types](https://grafana.com/docs/pyroscope/latest/configure-client/profile-types/) for a list of profile types supported by Go.
 {{< /admonition >}}
 
 ## Before you begin

--- a/docs/sources/configure-client/language-sdks/java.md
+++ b/docs/sources/configure-client/language-sdks/java.md
@@ -14,7 +14,7 @@ It provides real-time insights, enabling developers to understand and optimize t
 This tool is crucial for improving application responsiveness, reducing resource consumption, and ensuring top-notch performance in Java environments.
 
 {{< admonition type="note" >}}
-Refer to [Available profiling types]({{< relref "../../view-and-analyze-profile-data/profiling-types#available-profiling-types" >}}) for a list of profile types supported by each language.
+Refer to [Available profiling types](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/profile-types/) for a list of profile types supported by each language.
 {{< /admonition >}}
 
 ## Before you begin

--- a/docs/sources/configure-client/language-sdks/nodejs.md
+++ b/docs/sources/configure-client/language-sdks/nodejs.md
@@ -12,7 +12,7 @@ aliases:
 Enhance your Node.js application's performance with our Node.js Profiler. Seamlessly integrated with Pyroscope, it provides real-time insights into your application’s operation, helping you identify and resolve performance bottlenecks. This integration is key for Node.js developers aiming to boost efficiency, reduce latency, and maintain optimal application performance.
 
 {{< admonition type="note" >}}
-Refer to [Available profiling types]({{< relref "../../view-and-analyze-profile-data/profiling-types#available-profiling-types" >}}) for a list of profile types supported by each language.
+Refer to [Available profiling types](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/profile-types/) for a list of profile types supported by each language.
 {{< /admonition >}}
 
 ## Before you begin

--- a/docs/sources/configure-client/language-sdks/python.md
+++ b/docs/sources/configure-client/language-sdks/python.md
@@ -14,7 +14,7 @@ This combination provides unparalleled real-time insights into your Python codeb
 It's an essential tool for Python developers focused on enhancing code efficiency and application speed.
 
 {{< admonition type="note" >}}
-Refer to [Available profiling types]({{< relref "../../view-and-analyze-profile-data/profiling-types#available-profiling-types" >}}) for a list of profile types supported by each language.
+Refer to [Available profiling types](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/profile-types/) for a list of profile types supported by each language.
 {{< /admonition >}}
 
 ## Before you begin

--- a/docs/sources/configure-client/language-sdks/ruby.md
+++ b/docs/sources/configure-client/language-sdks/ruby.md
@@ -14,7 +14,7 @@ Integrated with Pyroscope, it offers real-time performance data, allowing develo
 This tool is essential for identifying performance issues, optimizing code efficiency, and enhancing the overall speed and reliability of Ruby applications.
 
 {{< admonition type="note" >}}
-Refer to [Available profiling types]({{< relref "../../view-and-analyze-profile-data/profiling-types#available-profiling-types" >}}) for a list of profile types supported by Ruby.
+Refer to [Available profiling types](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/profile-types/) for a list of profile types supported by Ruby.
 {{< /admonition >}}
 
 ## Before you begin

--- a/docs/sources/configure-client/language-sdks/rust.md
+++ b/docs/sources/configure-client/language-sdks/rust.md
@@ -14,7 +14,7 @@ In collaboration with Pyroscope, it offers real-time profiling capabilities, she
 This integration is invaluable for developers seeking to enhance performance, reduce resource usage, and achieve efficient code execution in Rust applications.
 
 {{< admonition type="note" >}}
-Refer to [Available profiling types]({{< relref "../../view-and-analyze-profile-data/profiling-types#available-profiling-types" >}}) for a list of profile types supported by Rust.
+Refer to [Available profiling types](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/profile-types/) for a list of profile types supported by Rust.
 {{< /admonition >}}
 
 ## Before you begin

--- a/docs/sources/configure-client/memory-overhead.md
+++ b/docs/sources/configure-client/memory-overhead.md
@@ -2,7 +2,7 @@
 title: Pyroscope memory overhead
 menuTitle: Memory overhead
 description: Learn about memory overhead for the Pyroscope client.
-weight: 200
+weight: 600
 ---
 
 # Pyroscope memory overhead

--- a/docs/sources/configure-client/profile-types.md
+++ b/docs/sources/configure-client/profile-types.md
@@ -17,20 +17,18 @@ keywords:
 
 Profiling is an essential tool for understanding and optimizing application performance. In Pyroscope, various profiling types allow for an in-depth analysis of different aspects of your application. This guide explores these types and explain their impact on your program.
 
-In Pyroscope, profiling types refer to different dimensions of application performance analysis, focusing on specific aspects like CPU usage, memory allocation, or thread synchronization.
+Profiling types refer to different dimensions of application performance analysis, focusing on specific aspects like CPU usage, memory allocation, or thread synchronization.
 
 Pyroscope supports these profile types:
 
-* CPU
-* Memory (allocation objects, allocation space)
+* CPU (CPU time, wall time)
+* Memory (allocation objects, allocation space, heap)
 * In use objects and in-use space
 * Goroutines
 * Mutex count and duration
 * Block count and duration
 * Lock count and duration
 * Exceptions
-* Wall
-* Heap
 
 Refer to [Understand profiling types and their uses in Pyroscope](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/introduction/profiling-types/) for more details about the profile types.
 
@@ -94,13 +92,12 @@ This table lists the available profile types based on the language SDK.
 
 Pyroscope can integrate with distributed tracing systems supporting the OpenTelemetry standard. This integration lets you link traces with the profiling data and find resource usage for specific lines of code for your trace spans.
 
-This table lists the available profile types for span profiles.
 
 Only CPU profile type is supported for span profiles.
 
 The following languages are supported:
 
--  [Go](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/trace-span-profiles/go-span-profiles/)
+- [Go](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/trace-span-profiles/go-span-profiles/)
 - [Java](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/trace-span-profiles/java-span-profiles/)
 - [Ruby](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/trace-span-profiles/ruby-span-profiles/)
 - [.NET](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/trace-span-profiles/dotnet-span-profiles/)

--- a/docs/sources/configure-client/profile-types.md
+++ b/docs/sources/configure-client/profile-types.md
@@ -19,16 +19,10 @@ Profiling is an essential tool for understanding and optimizing application perf
 
 Profiling types refer to different dimensions of application performance analysis, focusing on specific aspects like CPU usage, memory allocation, or thread synchronization.
 
-Pyroscope supports these profile types:
+[//]: # 'Shared content for available profile types'
+[//]: # 'This content is located in /pyroscope/docs/sources/shared/available-profile-types.md'
 
-* CPU (CPU time, wall time)
-* Memory (allocation objects, allocation space, heap)
-* In use objects and in-use space
-* Goroutines
-* Mutex count and duration
-* Block count and duration
-* Lock count and duration
-* Exceptions
+{{< docs/shared source="pyroscope" lookup="available-profile-types.md" version="latest" >}}
 
 Refer to [Understand profiling types and their uses in Pyroscope](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/introduction/profiling-types/) for more details about the profile types.
 
@@ -44,23 +38,23 @@ For more information, refer to [Configure the client to send profiles with Grafa
 
 This table lists the available profile types based on auto instrumentation using Alloy.
 
-| Profile type   | Go (pull) | Java | eBPF (Go) | eBPF (Python) |
-| -------------- | --------- | ---- | --------- | ------------- |
-| CPU            | Yes       | Yes  | Yes       | Yes           |
-| Alloc Objects  | Yes       | Yes  |           |               |
-| Alloc Space    | Yes       | Yes  |           |               |
-| Inuse Objects  |           |      |           |               |
-| Inuse Space    |           |      |           |               |
-| Goroutines     | Yes       |      |           |               |
-| Mutex Count    |           |      |           |               |
-| Mutex Duration |           |      |           |               |
-| Block Count    | Yes       |      |           |               |
-| Block Duration | Yes       |      |           |               |
-| Lock Count     |           | Yes  |           |               |
-| Lock Duration  |           | Yes  |           |               |
-| Exceptions     |           |      |           |               |
-| Wall           |           |      |           |               |
-| Heap           |           |      |           |               |
+| Profile type   | Go (pull) | Java | eBPF (Go) |
+| -------------- | --------- | ---- | --------- |
+| CPU            | Yes       | Yes  | Yes       |
+| Alloc Objects  | Yes       | Yes  |           |
+| Alloc Space    | Yes       | Yes  |           |
+| Inuse Objects  |           |      |           |
+| Inuse Space    |           |      |           |
+| Goroutines     | Yes       |      |           |
+| Mutex Count    |           |      |           |
+| Mutex Duration |           |      |           |
+| Block Count    | Yes       |      |           |
+| Block Duration | Yes       |      |           |
+| Lock Count     |           | Yes  |           |
+| Lock Duration  |           | Yes  |           |
+| Exceptions     |           |      |           |
+| Wall           |           |      |           |
+| Heap           |           |      |           |
 
 ### Instrumentation with SDKs
 
@@ -85,7 +79,7 @@ This table lists the available profile types based on the language SDK.
 | Lock Count     |           | Yes  | Yes        |      |        |      |         |
 | Lock Duration  |           | Yes  | Yes        |      |        |      |         |
 | Exceptions     |           |      | Yes        |      |        |      |         |
-| Wall           |           |      | Yes        |      |        |      |         |
+| Wall           |           |      | Yes        |      |        |      | Yes     |
 | Heap           |           |      | Yes (7.0+) |      |        |      | Yes     |
 
 ## Profile types supported with span profiles

--- a/docs/sources/configure-client/profile-types.md
+++ b/docs/sources/configure-client/profile-types.md
@@ -38,7 +38,7 @@ For more information, refer to [Configure the client to send profiles with Grafa
 
 This table lists the available profile types based on auto instrumentation using Alloy.
 
-| Profile type   | Go (pull) | Java | eBPF (Go) |
+| Profile type   | Go (pull) | Java | eBPF      |
 | -------------- | --------- | ---- | --------- |
 | CPU            | Yes       | Yes  | Yes       |
 | Alloc Objects  | Yes       | Yes  |           |

--- a/docs/sources/configure-client/profile-types.md
+++ b/docs/sources/configure-client/profile-types.md
@@ -1,0 +1,107 @@
+---
+title: Profile types and instrumentation
+menuTitle: Profile types and instrumentation
+description: Learn about the different profiling types available in Pyroscope and
+weight: 100
+aliases:
+  - ../ingest-and-analyze-profile-data/profiling-types/
+  - ../view-and-analyze-profile-data/profiling-types/ # /docs/pyroscope/latest/view-and-analyze-profile-data/profiling-types/
+keywords:
+  - pyroscope
+  - profiling types
+  - application performance
+  - flame graphs
+---
+
+# Profile types and instrumentation
+
+Profiling is an essential tool for understanding and optimizing application performance. In Pyroscope, various profiling types allow for an in-depth analysis of different aspects of your application. This guide explores these types and explain their impact on your program.
+
+In Pyroscope, profiling types refer to different dimensions of application performance analysis, focusing on specific aspects like CPU usage, memory allocation, or thread synchronization.
+
+Pyroscope supports these profile types:
+
+* CPU
+* Memory (allocation objects, allocation space)
+* In use objects and in-use space
+* Goroutines
+* Mutex count and duration
+* Block count and duration
+* Lock count and duration
+* Exceptions
+* Wall
+* Heap
+
+Refer to [Understand profiling types and their uses in Pyroscope](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/introduction/profiling-types/) for more details about the profile types.
+
+## Profile type support by instrumentation method
+
+The instrumentation method you use determines which profile types are available. You can use either auto or manual instrumentation.
+
+### Auto-instrumentation with Grafana Alloy
+
+You can send data from your application using Grafana Alloy collector. Alloy supports profiling with eBPF, Java, and Golang in pull mode.
+
+For more information, refer to [Configure the client to send profiles with Grafana Alloy](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/grafana-alloy/).
+
+This table lists the available profile types based on auto instrumentation using Alloy.
+
+| Profile type   | Go (pull) | Java | eBPF (Go) | eBPF (Python) |
+| -------------- | --------- | ---- | --------- | ------------- |
+| CPU            | Yes       | Yes  | Yes       | Yes           |
+| Alloc Objects  | Yes       | Yes  |           |               |
+| Alloc Space    | Yes       | Yes  |           |               |
+| Inuse Objects  |           |      |           |               |
+| Inuse Space    |           |      |           |               |
+| Goroutines     | Yes       |      |           |               |
+| Mutex Count    |           |      |           |               |
+| Mutex Duration |           |      |           |               |
+| Block Count    | Yes       |      |           |               |
+| Block Duration | Yes       |      |           |               |
+| Lock Count     |           | Yes  |           |               |
+| Lock Duration  |           | Yes  |           |               |
+| Exceptions     |           |      |           |               |
+| Wall           |           |      |           |               |
+| Heap           |           |      |           |               |
+
+### Instrumentation with SDKs
+
+Using the Pyroscope language SDKs lets you instrument your application directly for precise profiling. You can customize the profiling process according to your application’s specific requirements.
+
+For more information on the language SDKs, refer to [Pyroscope language SDKs](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/language-sdks/).
+
+This table lists the available profile types based on the language SDK.
+
+| Profile type   | Go (push) | Java | .NET       | Ruby | Python | Rust | Node.js |
+| -------------- | --------- | ---- | ---------- | ---- | ------ | ---- | ------- |
+| CPU            | Yes       | Yes  | Yes        | Yes  | Yes    | Yes  | Yes     |
+| Alloc Objects  | Yes       | Yes  | Yes        |      |        |      |         |
+| Alloc Space    | Yes       | Yes  | Yes        |      |        |      |         |
+| Inuse Objects  | Yes       |      | Yes (7.0+) |      |        |      |         |
+| Inuse Space    | Yes       |      | Yes (7.0+) |      |        |      |         |
+| Goroutines     | Yes       |      |            |      |        |      |         |
+| Mutex Count    | Yes       |      | Yes        |      |        |      |         |
+| Mutex Duration | Yes       |      | Yes        |      |        |      |         |
+| Block Count    | Yes       |      |            |      |        |      |         |
+| Block Duration | Yes       |      |            |      |        |      |         |
+| Lock Count     |           | Yes  | Yes        |      |        |      |         |
+| Lock Duration  |           | Yes  | Yes        |      |        |      |         |
+| Exceptions     |           |      | Yes        |      |        |      |         |
+| Wall           |           |      | Yes        |      |        |      |         |
+| Heap           |           |      | Yes (7.0+) |      |        |      | Yes     |
+
+## Profile types supported with span profiles
+
+Pyroscope can integrate with distributed tracing systems supporting the OpenTelemetry standard. This integration lets you link traces with the profiling data and find resource usage for specific lines of code for your trace spans.
+
+This table lists the available profile types for span profiles.
+
+Only CPU profile type is supported for span profiles.
+
+The following languages are supported:
+
+-  [Go](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/trace-span-profiles/go-span-profiles/)
+- [Java](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/trace-span-profiles/java-span-profiles/)
+- [Ruby](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/trace-span-profiles/ruby-span-profiles/)
+- [.NET](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/trace-span-profiles/dotnet-span-profiles/)
+- [Python](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/trace-span-profiles/python-span-profiles/)

--- a/docs/sources/configure-client/profile-types.md
+++ b/docs/sources/configure-client/profile-types.md
@@ -86,7 +86,6 @@ This table lists the available profile types based on the language SDK.
 
 Pyroscope can integrate with distributed tracing systems supporting the OpenTelemetry standard. This integration lets you link traces with the profiling data and find resource usage for specific lines of code for your trace spans.
 
-
 Only CPU profile type is supported for span profiles.
 
 The following languages are supported:

--- a/docs/sources/configure-client/trace-span-profiles/_index.md
+++ b/docs/sources/configure-client/trace-span-profiles/_index.md
@@ -19,8 +19,7 @@ Key benefits and features:
 - Efficiency and cost savings: Quickly identify and address performance issues, reducing troubleshooting time and operational costs
 
 {{< admonition type="note">}}
-Span profiling is not effective on short spans (<20ms) because there are only a couple sampled profiles.
-This results in a statistically inaccurate profile.
+Span profiling is only effective on spans longer than 20ms to ensure statistical accuracy. 
 {{< /admonition >}}
 
 ## Get started

--- a/docs/sources/configure-client/trace-span-profiles/_index.md
+++ b/docs/sources/configure-client/trace-span-profiles/_index.md
@@ -1,11 +1,11 @@
 ---
-title: "Linking tracing and profiling with Span Profiles"
-menuTitle: "Linking traces and profiles"
+title: "Link tracing and profiling with Span Profiles"
+menuTitle: "Link traces and profiles"
 description: "Learn how to configure the client to Link tracing and profiling with span profiles."
-weight: 35
+weight: 400
 ---
 
-# Linking tracing and profiling with Span Profiles
+# Link tracing and profiling with Span Profiles
 
 Span Profiles are a powerful feature that further enhances the value of continuous profiling.
 Span Profiles offer a novel approach to profiling by providing detailed insights into specific execution scopes of applications, moving beyond the traditional system-wide analysis to offer a more dynamic, focused analysis of individual requests or trace spans.
@@ -24,11 +24,11 @@ Select an option from the list below:
 
 - Configure Pyroscope: Begin sending profiling data to unlock the full potential of Span Profiles
 - Client-side packages: Easily link traces and profiles using available packages for Go, Java, Ruby, .NET, and Python
-  - Go: [Span profiles with Traces to profiles (Go)]({{< relref "./go-span-profiles" >}})
-  - Java: [Span profiles with Traces to profiles (Java)]({{< relref "./java-span-profiles" >}})
-  - Ruby: [Span profiles with Traces to profiles (Ruby)]({{< relref "./ruby-span-profiles" >}})
-  - .NET: [Span profiles with Traces to profiles (.NET)]({{< relref "./dotnet-span-profiles" >}})
-  - Python: [Span profiles with Traces to profiles (Python)]({{< relref "./python-span-profiles" >}})
-- Grafana Tempo: Visualize and analyze Span Profiles within the Grafana using a Tempo data source.
+  - Go: [Span profiles with Traces to profiles (Go)](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/trace-span-profiles/go-span-profiles/)
+  - Java: [Span profiles with Traces to profiles (Java)](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/trace-span-profiles/java-span-profiles/)
+  - Ruby: [Span profiles with Traces to profiles (Ruby)](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/trace-span-profiles/ruby-span-profiles/)
+  - .NET: [Span profiles with Traces to profiles (.NET)](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/trace-span-profiles/dotnet-span-profiles/)
+  - Python: [Span profiles with Traces to profiles (Python)](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/trace-span-profiles/python-span-profiles/)
+- [Configure the Tempo data source in Grafana or Grafana Cloud](/docs/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/) to discover linked traces and profiles.
 
-To learn more, check out our product announcement blog: [Introducing Span Profiles](/blog/2024/02/06/combining-tracing-and-profiling-for-enhanced-observability-introducing-span-profiles/).
+To learn more, check out the product announcement blog: [Introducing Span Profiles](/blog/2024/02/06/combining-tracing-and-profiling-for-enhanced-observability-introducing-span-profiles/).

--- a/docs/sources/configure-client/trace-span-profiles/_index.md
+++ b/docs/sources/configure-client/trace-span-profiles/_index.md
@@ -18,6 +18,11 @@ Key benefits and features:
 - Seamless integration: Smoothly transition from a high-level trace overview to detailed profiling of specific trace spans within Grafana’s trace view
 - Efficiency and cost savings: Quickly identify and address performance issues, reducing troubleshooting time and operational costs
 
+{{< admonition type="note">}}
+Span profiling is not effective on short spans (<20ms) because there are only a couple sampled profiles.
+This results in a statistically inaccurate profile.
+{{< /admonition >}}
+
 ## Get started
 
 Select an option from the list below:

--- a/docs/sources/configure-client/trace-span-profiles/dotnet-span-profiles.md
+++ b/docs/sources/configure-client/trace-span-profiles/dotnet-span-profiles.md
@@ -25,7 +25,7 @@ This integration lets you link traces with the profiling data and find resource 
 * Because of how sampling profilers work, spans shorter than the sample interval may not be captured.
 {{< /admonition >}}
 
-For a more detailed list of supported profile types, refer to [Profile types]().
+For a more detailed list of supported profile types, refer to [Profile types](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION/configure-client/profile-types/>).
 
 ## Before you begin
 

--- a/docs/sources/configure-client/trace-span-profiles/dotnet-span-profiles.md
+++ b/docs/sources/configure-client/trace-span-profiles/dotnet-span-profiles.md
@@ -7,15 +7,15 @@ weight: 103
 
 # Span profiles with Traces to profiles for .NET
 
-Span Profiles represents a major shift in profiling methodology, enabling deeper analysis of both tracing and profiling data.
+Span Profiles represents a shift in profiling methodology.
 Traditional continuous profiling provides an application-wide view over fixed intervals.
 In contrast, Span Profiles delivers focused, dynamic analysis on specific execution scopes within applications, such as individual requests or specific trace spans.
-
-This shift enables a more granular view of performance, enhancing the utility of profiles by linking them directly with traces for a comprehensive understanding of application behavior. As a result, engineering teams can more efficiently identify and address performance bottlenecks.
 
 To learn more about Span Profiles, refer to [Combining tracing and profiling for enhanced observability: Introducing Span Profiles](/blog/2024/02/06/combining-tracing-and-profiling-for-enhanced-observability-introducing-span-profiles/).
 
 ![span-profiles screenshot](https://grafana.com/static/img/docs/tempo/profiles/tempo-profiles-Span-link-profile-data-source.png)
+
+## Supported profile types
 
 Pyroscope integrates with distributed tracing systems supporting the [**OpenTelemetry**](https://opentelemetry.io/docs/languages/net/getting-started/) standard.
 This integration lets you link traces with the profiling data and find resource usage for specific lines of code for your trace spans.
@@ -25,13 +25,17 @@ This integration lets you link traces with the profiling data and find resource 
 * Because of how sampling profilers work, spans shorter than the sample interval may not be captured.
 {{< /admonition >}}
 
+For a more detailed list of supported profile types, refer to [Profile types]().
+
+## Before you begin
+
 To use Span Profiles, you need to:
 
-* [Configure Pyroscope to send profiling data]({{< relref "../../configure-client" >}})
+* [Configure Pyroscope to send profiling data](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/)
 * Configure a client-side package to link traces and profiles: [.NET](https://github.com/grafana/pyroscope-dotnet/tree/main/Pyroscope/Pyroscope.OpenTelemetry)
 * [Configure the Tempo data source in Grafana or Grafana Cloud to discover linked traces and profiles](/docs/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/)
 
-## Before you begin
+### Instrument your application for profiles
 
 Your applications must be instrumented for profiling and tracing before you can use span profiles.
 
@@ -68,11 +72,11 @@ builder.Services.AddOpenTelemetry()
 
 With the span processor registered, spans created automatically (for example, HTTP handlers) and manually (`ActivitySource.StartActivity()`) have profiling data associated with them.
 
-## View the span profiles in Grafana Tempo
+## View the span profiles in Grafana
 
-To view the span profiles in Grafana Tempo, you need to have a Grafana instance running and a data source configured to link traces and profiles.
+To view the span profiles in Grafana Explore or Grafana Explore Traces, you need to have a Grafana instance running and a Tempo data source configured to link traces and profiles.
 
-Refer to the [data source configuration documentation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source) to see how to configure the visualization to link traces with profiles.
+Refer to the [Tempo data source configuration documentation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source) to see how to configure the visualization to link traces with profiles.
 
 ## Examples
 

--- a/docs/sources/configure-server/about-server-api.md
+++ b/docs/sources/configure-server/about-server-api.md
@@ -1,6 +1,6 @@
 ---
 description: Learn about the Pyrocope server API
-menuTitle: Server HTTP API 
+menuTitle: Server HTTP API
 title: Pyroscope server HTTP API
 weight: 20
 ---
@@ -249,7 +249,7 @@ In a Kubernetes environment, a query could also look like:
 `process_cpu:cpu:nanoseconds:cpu:nanoseconds{namespace="dev", container="my_application_name"}`
 
 {{% admonition type="note" %}}
-Refer to the [profiling types documentation]({{< relref "../view-and-analyze-profile-data/profiling-types" >}}) for more information and [profile-metrics.json](https://github.com/grafana/pyroscope/blob/main/public/app/constants/profile-metrics.json) for a list of valid profile types.
+Refer to the [profiling types documentation](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/profile-types/) for more information and [profile-metrics.json](https://github.com/grafana/pyroscope/blob/main/public/app/constants/profile-metrics.json) for a list of valid profile types.
 {{% /admonition %}}
 
 #### `from` and `until`

--- a/docs/sources/introduction/continuous-profiling/_index.md
+++ b/docs/sources/introduction/continuous-profiling/_index.md
@@ -2,7 +2,7 @@
 title: When to use continuous profiling
 menuTitle: When to use continuous profiling
 description: Discover the benefits of continuous profiling and its role in modern application performance analysis.
-weight: 20
+weight: 200
 keywords:
   - pyroscope
   - phlare

--- a/docs/sources/introduction/profiling-types/_index.md
+++ b/docs/sources/introduction/profiling-types/_index.md
@@ -18,18 +18,10 @@ Profiling is an essential tool for understanding and optimizing application perf
 
 In Pyroscope, profiling types refer to different dimensions of application performance analysis, focusing on specific aspects like CPU usage, memory allocation, or thread synchronization.
 
-Pyroscope supports these profile types:
+[//]: # 'Shared content for available profile types'
+[//]: # 'This content is located in /pyroscope/docs/sources/shared/available-profile-types.md'
 
-* CPU
-* Memory (allocation objects, allocation space)
-* In use objects and in-use space
-* Goroutines
-* Mutex count and duration
-* Block count and duration
-* Lock count and duration
-* Exceptions
-* Wall
-* Heap
+{{< docs/shared source="pyroscope" lookup="available-profile-types.md" version="latest" >}}
 
 Refer to the Profile types tables for information on supported profile types based on instrumentation method.
 

--- a/docs/sources/introduction/profiling-types/_index.md
+++ b/docs/sources/introduction/profiling-types/_index.md
@@ -2,11 +2,9 @@
 title: Understand profiling types and their uses in Pyroscope
 menuTitle: Understand profiling types
 description: Learn about the different profiling types available in Pyroscope and how to effectively use them in your application performance analysis.
-weight: 30
-aliases:
-  - ../ingest-and-analyze-profile-data/profiling-types/
+weight: 300
 keywords:
-  - pyroscope
+  - profiles
   - profiling types
   - application performance
   - flame graphs
@@ -20,34 +18,24 @@ Profiling is an essential tool for understanding and optimizing application perf
 
 In Pyroscope, profiling types refer to different dimensions of application performance analysis, focusing on specific aspects like CPU usage, memory allocation, or thread synchronization.
 
-For information on auto-instrumentation and supported language SDKs, refer to [Configure the client]({{< relref "../../configure-client" >}}).
+Pyroscope supports these profile types:
 
-### Available profiling types
+* CPU
+* Memory (allocation objects, allocation space)
+* In use objects and in-use space
+* Goroutines
+* Mutex count and duration
+* Block count and duration
+* Lock count and duration
+* Exceptions
+* Wall
+* Heap
 
-Various languages support different profiling types.
-Pyroscope supports the following profiling types:
+Refer to the Profile types tables for information on supported profile types based on instrumentation method.
 
-| Profile Type       | Go    | Java  | .NET       | Ruby  | Python | Rust  | Node.js | eBPF (Go) | eBPF (Python)|
-|--------------------|-------|-------|------------|-------|--------|-------|---------|-----------|--------------|
-| CPU                | Yes   | Yes   | Yes        | Yes   | Yes    | Yes   | Yes     | Yes       | Yes          |
-| Alloc Objects      | Yes   | Yes   | Yes        |       |        |       |         |           |              |
-| Alloc Space        | Yes   | Yes   | Yes        |       |        |       |         |           |              |
-| Inuse Objects      | Yes   |       | Yes (7.0+) |       |        |       |         |           |              |
-| Inuse Space        | Yes   |       | Yes (7.0+) |       |        |       |         |           |              |
-| Goroutines         | Yes   |       |            |       |        |       |         |           |              |
-| Mutex Count        | Yes   |       | Yes        |       |        |       |         |           |              |
-| Mutex Duration     | Yes   |       | Yes        |       |        |       |         |           |              |
-| Block Count        | Yes   |       |            |       |        |       |         |           |              |
-| Block Duration     | Yes   |       |            |       |        |       |         |           |              |
-| Lock Count         |       | Yes   | Yes        |       |        |       |         |           |              |
-| Lock Duration      |       | Yes   | Yes        |       |        |       |         |           |              |
-| Exceptions         |       |       | Yes        |       |        |       |         |           |              |
-| Wall               |       |       | Yes        |       |        |       |         |           |              |
-| Heap               |       |       |            |       |        |       | Yes     |           |              |
+For information on auto-instrumentation and supported language SDKs, refer to [Configure the client](https://grafana.com/docs/pyroscope/latest/configure-client/).
 
 ## CPU profiling
-
-<!-- We can link to each of these from within the Pyroscope UI in the little (i) icon. -->
 
 CPU profiling measures the amount of CPU time consumed by different parts of your application code.
 High CPU usage can indicate inefficient code, leading to poor performance and increased operational costs.

--- a/docs/sources/introduction/profiling.md
+++ b/docs/sources/introduction/profiling.md
@@ -2,7 +2,7 @@
 title: Profiling fundamentals
 menuTitle: Profiling fundamentals
 description: Discover the benefits of continuous profiling and its role in modern application performance analysis.
-weight: 20
+weight: 100
 keywords:
   - pyroscope
   - continuous profiling

--- a/docs/sources/introduction/pyroscope-in-grafana.md
+++ b/docs/sources/introduction/pyroscope-in-grafana.md
@@ -2,7 +2,7 @@
 title: Pyroscope and profiling in Grafana
 menuTitle: Pyroscope in Grafana
 description: Learn about how you can use profile data in Grafana.
-weight: 200
+weight: 400
 keywords:
   - Pyroscope
   - Profiling

--- a/docs/sources/shared/available-profile-types.md
+++ b/docs/sources/shared/available-profile-types.md
@@ -1,10 +1,6 @@
 ---
 headless: true
 description: Shared file for available profile types.
-labels:
-  products:
-    - enterprise
-    - oss
 ---
 
 [//]: # 'This file documents the available profile types in Pyroscope.'

--- a/docs/sources/shared/available-profile-types.md
+++ b/docs/sources/shared/available-profile-types.md
@@ -1,0 +1,27 @@
+---
+headless: true
+description: Shared file for available profile types.
+labels:
+  products:
+    - enterprise
+    - oss
+---
+
+[//]: # 'This file documents the available profile types in Pyroscope.'
+[//]: # 'This shared file is included in these locations:'
+[//]: # '/pyroscope/docs/sources/configure-client/profile-types.md'
+[//]: # '/pyroscope/docs/sources/introduction/profiling-types.md'
+[//]: #
+[//]: # 'If you make changes to this file, verify that the meaning and content are not changed in any place where the file is included.'
+[//]: # 'Any links should be fully qualified and not relative: /docs/grafana/ instead of ../grafana/.'
+
+Pyroscope supports these profile types:
+
+* CPU (CPU time, wall time)
+* Memory (allocation objects, allocation space, heap)
+* In use objects and in-use space
+* Goroutines
+* Mutex count and duration
+* Block count and duration
+* Lock count and duration
+* Exceptions

--- a/docs/sources/shared/index.md
+++ b/docs/sources/shared/index.md
@@ -1,0 +1,4 @@
+---
+description: No description necessary for a shared file index.
+headless: true
+---


### PR DESCRIPTION
Updates and expands the supported profiling content. 

- Splits the profile type by instrumentation method table into three tables:  SDK vs auto instrumentation, language SDK, and span profiles.
- Puts the tables on it’s own page and moves it to the Configure the client section on a new page
- Change links to the profile types page in the other Configure the client pages
- Updates the page weight for Introduction and Configure the client sections
- Updates any links to the new page

Fixes: https://github.com/grafana/pyroscope/issues/3259
