### PR TITLE
fix(docs): update examples fixes

### DIFF
--- a/examples/language-sdk-instrumentation/dotnet/rideshare/Dockerfile
+++ b/examples/language-sdk-instrumentation/dotnet/rideshare/Dockerfile
@@ -17,7 +17,7 @@ RUN sed -i -E 's|<TargetFramework>.*</TargetFramework>|<TargetFramework>net'$SDK
 RUN dotnet publish -o . --framework net$SDK_VERSION --runtime linux-x64 --no-self-contained
 
 # This fetches the SDK
-FROM --platform=linux/amd64 pyroscope/pyroscope-dotnet:0.8.20-glibc AS sdk
+FROM --platform=linux/amd64 pyroscope/pyroscope-dotnet:0.9.0-glibc AS sdk
 
 # Runtime only image of the targetplatfrom, so the platform the image will be running on.
 FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:$SDK_VERSION

--- a/examples/language-sdk-instrumentation/dotnet/rideshare/musl.Dockerfile
+++ b/examples/language-sdk-instrumentation/dotnet/rideshare/musl.Dockerfile
@@ -17,7 +17,7 @@ RUN sed -i -E 's|<TargetFramework>.*</TargetFramework>|<TargetFramework>net'$SDK
 RUN dotnet publish -o . --framework net$SDK_VERSION --runtime linux-musl-x64 --no-self-contained
 
 # This fetches the SDK
-FROM --platform=linux/amd64 pyroscope/pyroscope-dotnet:0.8.20-musl AS sdk
+FROM --platform=linux/amd64 pyroscope/pyroscope-dotnet:0.9.0-musl AS sdk
 
 # Runtime only image of the targetplatfrom, so the platform the image will be running on.
 FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:$SDK_VERSION-alpine

--- a/tools/update_examples.go
+++ b/tools/update_examples.go
@@ -73,15 +73,15 @@ func updateDotnet() {
 	last := tags[len(tags)-1]
 	fmt.Println(last)
 
-	reDockerGlibc := regexp.MustCompile("COPY --from=pyroscope/pyroscope-dotnet:\\d+\\.\\d+\\.\\d+-glibc")
-	replDockerGlibc := fmt.Sprintf("COPY --from=pyroscope/pyroscope-dotnet:%s-glibc", last.version())
+	reDockerGlibc := regexp.MustCompile("pyroscope/pyroscope-dotnet:\\d+\\.\\d+\\.\\d+-glibc")
+	replDockerGlibc := fmt.Sprintf("pyroscope/pyroscope-dotnet:%s-glibc", last.version())
 	replaceInplace(reDockerGlibc, "examples/language-sdk-instrumentation/dotnet/fast-slow/Dockerfile", replDockerGlibc)
 	replaceInplace(reDockerGlibc, "examples/language-sdk-instrumentation/dotnet/rideshare/Dockerfile", replDockerGlibc)
 	replaceInplace(reDockerGlibc, "examples/language-sdk-instrumentation/dotnet/web-new/Dockerfile", replDockerGlibc)
 	replaceInplace(reDockerGlibc, "docs/sources/configure-client/language-sdks/dotnet.md", replDockerGlibc)
 
-	reDockerMusl := regexp.MustCompile("COPY --from=pyroscope/pyroscope-dotnet:\\d+\\.\\d+\\.\\d+-musl")
-	replDockerMusl := fmt.Sprintf("COPY --from=pyroscope/pyroscope-dotnet:%s-musl", last.version())
+	reDockerMusl := regexp.MustCompile("pyroscope/pyroscope-dotnet:\\d+\\.\\d+\\.\\d+-musl")
+	replDockerMusl := fmt.Sprintf("pyroscope/pyroscope-dotnet:%s-musl", last.version())
 	replaceInplace(reDockerMusl, "examples/language-sdk-instrumentation/dotnet/fast-slow/musl.Dockerfile", replDockerMusl)
 	replaceInplace(reDockerMusl, "examples/language-sdk-instrumentation/dotnet/rideshare/musl.Dockerfile", replDockerMusl)
 


### PR DESCRIPTION
There were some changes in examples/language-sdk-instrumentation/dotnet/rideshare/Dockerfile and old regex does not work anymore