### PR TITLE
docs: add home link and sources in Helm chart

### DIFF
--- a/operations/pyroscope/helm/pyroscope/Chart.yaml
+++ b/operations/pyroscope/helm/pyroscope/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: pyroscope
 description: 🔥 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
+home: https://grafana.com/oss/pyroscope/
 type: application
 version: 1.9.1
 appVersion: 1.9.1
@@ -20,3 +21,6 @@ dependencies:
     version: 4.0.12
     repository: https://charts.min.io/
     condition: minio.enabled
+sources:
+  - https://github.com/grafana/pyroscope
+  - https://github.com/grafana/pyroscope/tree/main/operations/pyroscope/helm/pyroscope

--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -4,6 +4,13 @@
 
 🔥 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 
+**Homepage:** <https://grafana.com/oss/pyroscope/>
+
+## Source Code
+
+* <https://github.com/grafana/pyroscope>
+* <https://github.com/grafana/pyroscope/tree/main/operations/pyroscope/helm/pyroscope>
+
 ## Requirements
 
 | Repository | Name | Version |


### PR DESCRIPTION
This is useful to display some links on the artifacthub page: https://artifacthub.io/packages/helm/grafana/pyroscope

For example, you can check the cert-manager one: https://artifacthub.io/packages/helm/cert-manager/cert-manager

![image](https://github.com/user-attachments/assets/9e660a07-2b81-4154-a98d-e784bb7f64e7)
