### PR TITLE
fix(v2): set grpc.WithMaxCallAttempts() for the query backend client

### DIFF
--- a/pkg/experiment/query_backend/client/client.go
+++ b/pkg/experiment/query_backend/client/client.go
@@ -37,6 +37,7 @@ func dial(address string, grpcClientConfig grpcclient.Config) (*grpc.ClientConn,
 	options = append(options,
 		grpc.WithUnaryInterceptor(otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer())),
 		grpc.WithDefaultServiceConfig(grpcServiceConfig),
+		grpc.WithMaxCallAttempts(500),
 	)
 	return grpc.NewClient(address, options...)
 }
@@ -64,6 +65,6 @@ const grpcServiceConfig = `{
               "RESOURCE_EXHAUSTED"
             ]
         },
-        "timeout": "20s"
+        "timeout": "30s"
     }]
 }`

--- a/pkg/experiment/query_backend/client/client.go
+++ b/pkg/experiment/query_backend/client/client.go
@@ -65,6 +65,6 @@ const grpcServiceConfig = `{
               "RESOURCE_EXHAUSTED"
             ]
         },
-        "timeout": "30s"
+        "timeout": "20s"
     }]
 }`

--- a/pkg/experiment/query_backend/concurrency.go
+++ b/pkg/experiment/query_backend/concurrency.go
@@ -38,6 +38,7 @@ var (
 
 func CreateConcurrencyInterceptor(logger log.Logger) (grpc.UnaryServerInterceptor, error) {
 	gclLog := newGclLogger(logger)
+	// TODO(aleks-p): Implement metric registry
 	serverLimit, err := limit.NewGradient2Limit("query-backend-concurrency-limit", minLimit, maxLimit, initialLimit, queueSizeFn, smoothing, longWindow, gclLog, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I missed one important change in #3675, it got accidentally reverted in one of my tests. We need to set the global `grpc.WithMaxCallAttempts(500)` in addition to the `"MaxAttempts": 500` on the method retry policy.

As per https://github.com/grpc/grpc-go/blob/5e99daea2f11c6f9fab99470e71c6a92138f1875/service_config.go#L284-L286, the per-method `maxAttempts` is only used if it is smaller than the global `maxAttempts` which defaults to 5.