### PR TITLE
doc(docs.sources.configureServer.aboutServerAPI): fix typo

### DIFF
--- a/docs/sources/configure-server/about-server-api.md
+++ b/docs/sources/configure-server/about-server-api.md
@@ -144,7 +144,7 @@ JFR ingestion support uses the profile metadata to determine which profile types
 * `alloc_in_new_tlab_objects`, which indicates the number of new TLAB objects created.
 * `alloc_in_new_tlab_bytes`, which indicates the size in bytes of new TLAB objects created.
 * `alloc_outside_tlab_objects`, which indicates the number of new allocated objects outside any TLAB.
-* `alloc_in_new_tlab_bytes`, which indicates the size in bytes of new allocated objects outside any TLAB.
+* `alloc_outside_tlab_bytes`, which indicates the size in bytes of new allocated objects outside any TLAB.
 
 #### JFR with labels
 


### PR DESCRIPTION
## Description
* Fix typo

## Context
* About [JFR format](https://github.com/grafana/pyroscope/blob/main/docs/sources/configure-server/about-server-api.md#jfr-format), and describing the supported profile types

## How to review?
* Check that 
  * the description referes to the outside of tlab
  * the referered to the tlab was defined previosly