### PR TITLE
[DOC] Add v1.10 release notes and fix page weights

### DIFF
--- a/docs/sources/release-notes/v1-10.md
+++ b/docs/sources/release-notes/v1-10.md
@@ -1,0 +1,36 @@
+---
+title: Version 1.10 release notes
+menuTitle: V1.10
+description: Release notes for Grafana Pyroscope 1.10
+weight: 400
+---
+
+# Version 1.10 release notes
+
+The Pyroscope team is excited to present Grafana Pyroscope 1.10.
+
+This version of Pyroscope adds experimental support for OpenTelemetry profiles ([#2177](https://github.com/grafana/pyroscope/pull/2177)).
+The OTLP protocol is not stable. For more information about the protocol, refer to [OpenTelemetry announces support for profiling](https://opentelemetry.io/blog/2024/profiling/).
+
+In addition, this release improves stability, performance, and documentation.
+
+Notable changes are listed below. For more details, check out the [1.10.0 changelog](https://github.com/grafana/pyroscope/compare/v1.9.0...v1.10.0).
+
+## Improvements and updates
+
+* Use `profilecli admin blocks query` to execute queries directly to single or multiple blocks hosted in your local host or remote bucket. ([#3618](https://github.com/grafana/pyroscope/pull/3618), [#3625](https://github.com/grafana/pyroscope/pull/3625), [#3610](https://github.com/grafana/pyroscope/pull/3610))
+* Rename `merge` commands to `profile` in [Profile CLI (`profilecli`)](https://grafana.com/docs/pyroscope/v1.10.x/view-and-analyze-profile-data/profile-cli/) ([#3630](https://github.com/grafana/pyroscope/pull/3630))
+* Deprecate cookie generated on server for GitHub integration ([#3573](https://github.com/grafana/pyroscope/pull/3573))
+* Add k6 middleware to Pyroscope ([#3580](https://github.com/grafana/pyroscope/pull/3580))
+
+## Fixes
+
+* (eBPF) Use uint64 for proc offset ([#3656](https://github.com/grafana/pyroscope/pull/3656))
+* CI fixes ([#3634](https://github.com/grafana/pyroscope/pull/3634), [#3629](https://github.com/grafana/pyroscope/pull/3629), [#3632](https://github.com/grafana/pyroscope/pull/3632), [#3631](https://github.com/grafana/pyroscope/pull/3631), [#3636](https://github.com/grafana/pyroscope/pull/3636), [#3605](https://github.com/grafana/pyroscope/pull/3605), [#3525](https://github.com/grafana/pyroscope/pull/3625))
+
+## Documentation
+
+* Add instructions for [how to receive profiles from Pyroscope SDKs](https://grafana.com/docs/pyroscope/v1.10.x/configure-client/grafana-alloy/receive_profiles//) for Grafana Alloy ([#3685](https://github.com/grafana/pyroscope/pull/3658))
+* Update [examples and references to Grafana Alloy](https://grafana.com/docs/pyroscope/v1.10.x/configure-client/grafana-alloy/) from Grafana Agent ([#3621](https://github.com/grafana/pyroscope/pull/3621))
+* Update and expand profiling types documentation for the [introduction](https://grafana.com/docs/pyroscope/v1.10.x/introduction/profiling-types/) and [instrumentation](https://grafana.com/docs/pyroscope/v1.10.x/configure-client/profile-types/) ([#3659](https://github.com/grafana/pyroscope/pull/3659))
+* Other documentation and example updates ([#3662](https://github.com/grafana/pyroscope/pull/3662), [#3644](https://github.com/grafana/pyroscope/pull/3644), [#3607](https://github.com/grafana/pyroscope/pull/3607), [#3655](https://github.com/grafana/pyroscope/pull/3655), [#3611](https://github.com/grafana/pyroscope/pull/3611), [#3638](https://github.com/grafana/pyroscope/pull/3638), [#3661](https://github.com/grafana/pyroscope/pull/3661), [#3614](https://github.com/grafana/pyroscope/pull/3614), [#3612](https://github.com/grafana/pyroscope/pull/3612), [#3648](https://github.com/grafana/pyroscope/pull/3648))

--- a/docs/sources/release-notes/v1-3.md
+++ b/docs/sources/release-notes/v1-3.md
@@ -19,7 +19,7 @@ Several major improvements were made to the compaction process:
 * Improved system stability during compaction shutdown
 * Added a `profilecli compact` command
 
-Notable changes are listed below. For more details, check out the **Full 1.3.0 Changelog**: https://github.com/grafana/pyroscope/compare/v1.2.1...v1.3.0
+Notable changes are listed below. For more details, check out the [1.3.0 changelog](https://github.com/grafana/pyroscope/compare/v1.2.1...v1.3.0).
 
 ## Features and enhancements
 

--- a/docs/sources/release-notes/v1-4.md
+++ b/docs/sources/release-notes/v1-4.md
@@ -17,7 +17,7 @@ This release includes several new features which are precursors to larger projec
 
 Additionally, numerous other changes improve stability, performance, and documentation.
 
-Notable changes are listed below. For more details, check out the Full 1.4.0 Changelog: https://github.com/grafana/pyroscope/compare/v1.3.0...v1.4.0.
+Notable changes are listed below. For more details, check out the [1.4.0 changelog](https://github.com/grafana/pyroscope/compare/v1.3.0...v1.4.0).
 
 ## Features and enhancements
 

--- a/docs/sources/release-notes/v1-5.md
+++ b/docs/sources/release-notes/v1-5.md
@@ -11,7 +11,7 @@ We are excited to present Grafana Pyroscope 1.5.
 
 This release focuses on improving stability and interoperability to make Pyroscope more reliable and easier to use.
 
-Notable changes are listed below. For more details, check out the Full 1.5.0 Changelog: https://github.com/grafana/pyroscope/compare/v1.4.0...v1.5.0.
+Notable changes are listed below. For more details, check out the [1.5.0 changelog](https://github.com/grafana/pyroscope/compare/v1.4.0...v1.5.0).
 
 ### Improvements and updates
 

--- a/docs/sources/release-notes/v1-6.md
+++ b/docs/sources/release-notes/v1-6.md
@@ -13,7 +13,7 @@ This release focuses on improving stability and performance to make Pyroscope mo
 
 Notable changes are listed below. For more details, check out the Full 1.6.0 Changelog: https://github.com/grafana/pyroscope/compare/v1.5.0...v1.6.0.
 
-### Improvements and updates
+## Improvements and updates
 
 Version 1.6 includes the following improvements and updates:
 
@@ -27,7 +27,6 @@ Version 1.6 includes the following improvements and updates:
 * Config: Add S3 force-path-style parameter (https://github.com/grafana/pyroscope/pull/3158)
 * Config: Add flag to disable printing banner (https://github.com/grafana/pyroscope/pull/3123)
 
-
 ## Fixes
 
 Version 1.6 includes the following fixes:
@@ -39,7 +38,6 @@ Version 1.6 includes the following fixes:
 * Fix pprof merge profiles ignoring sample type stub (https://github.com/grafana/pyroscope/pull/3198)
 * eBPF: Fix issue when a cls arg is a cell (https://github.com/grafana/pyroscope/pull/3280)
 * eBPF: handle case when self is put in cell (https://github.com/grafana/pyroscope/pull/3284)
-
 
 ## Documentation improvements
 

--- a/docs/sources/release-notes/v1-7.md
+++ b/docs/sources/release-notes/v1-7.md
@@ -18,7 +18,7 @@ This release includes several new features:
 
 Additionally, we've improved stability, performance, and documentation.
 
-Notable changes are listed below. For more details, check out the full 1.7.0 changelog: https://github.com/grafana/pyroscope/compare/v1.6.0...v1.7.0.
+Notable changes are listed below. For more details, check out the [1.7.0 changelog](https://github.com/grafana/pyroscope/compare/v1.6.0...v1.7.0).
 
 ## Improvements and updates
 

--- a/docs/sources/release-notes/v1-8.md
+++ b/docs/sources/release-notes/v1-8.md
@@ -2,7 +2,7 @@
 title: Version 1.8 release notes
 menuTitle: V1.8
 description: Release notes for Grafana Pyroscope 1.8
-weight: 550
+weight: 500
 ---
 
 # Version 1.8 release notes
@@ -11,7 +11,7 @@ We are excited to present Grafana Pyroscope 1.8.
 
 We've improved stability, performance, and documentation.
 
-Notable changes are listed below. For more details, check out the full 1.8.0 changelog: https://github.com/grafana/pyroscope/compare/v1.7.0...v1.8.0.
+Notable changes are listed below. For more details, check out the [1.8.0 changelog](https://github.com/grafana/pyroscope/compare/v1.7.0...v1.8.0).
 
 ## Improvements and updates
 

--- a/docs/sources/release-notes/v1-9.md
+++ b/docs/sources/release-notes/v1-9.md
@@ -2,7 +2,7 @@
 title: Version 1.9 release notes
 menuTitle: V1.9
 description: Release notes for Grafana Pyroscope 1.9
-weight: 550
+weight: 450
 ---
 
 # Version 1.9 release notes
@@ -11,23 +11,26 @@ We are excited to present Grafana Pyroscope 1.9.
 
 We've improved stability, performance, and documentation.
 
-Notable changes are listed below. For more details, check out the full 1.9.0 changelog: https://github.com/grafana/pyroscope/compare/v1.8.0...v1.9.0.
+Notable changes are listed below. For more details, check out the [1.9.0 changelog](https://github.com/grafana/pyroscope/compare/v1.8.0...v1.9.0).
 
-## Improvements and Updates
+## Improvements and updates
+
 * Performance improvement during profile ingestion (https://github.com/grafana/pyroscope/pull/3569, https://github.com/grafana/pyroscope/pull/3561)
 * Support resolve symbols in mini debug info (https://github.com/grafana/pyroscope/pull/3590)
 * Make service_name configurable through environment variable (https://github.com/grafana/pyroscope/pull/3589)
 * Add limit to SelectSeries API (https://github.com/grafana/pyroscope/pull/3602)
 * Add topologySpreadConstraint in Helm (https://github.com/grafana/pyroscope/pull/3539)
-* Rename GitSession to pyroscope_git_session (https://github.com/grafana/pyroscope/pull/3542)
+* Rename GitSession to `pyroscope_git_session` (https://github.com/grafana/pyroscope/pull/3542)
 
 ## Fixes
+
 * Make pprof merge thread-safe (https://github.com/grafana/pyroscope/pull/3564)
 * Fix flaky tests (https://github.com/grafana/pyroscope/pull/3571)
 * Fix slice init length (https://github.com/grafana/pyroscope/pull/3600)
 * Fix issues when porting alloy/pyroscope to android (https://github.com/grafana/pyroscope/pull/3582)
 
-## Documentation Improvements
-* Update readme to highlight explore profiles (https://github.com/grafana/pyroscope/pull/3581)
-* Update nodejs examples (https://github.com/grafana/pyroscope/pull/3555)
+## Documentation improvements
+
+* Update the README to highlight explore profiles (https://github.com/grafana/pyroscope/pull/3581)
+* Update NodeJS examples (https://github.com/grafana/pyroscope/pull/3555)
 * Example for Java profiling using Grafana Alloy in Kubernetes (https://github.com/grafana/pyroscope/pull/3603)

--- a/docs/sources/view-and-analyze-profile-data/profile-cli.md
+++ b/docs/sources/view-and-analyze-profile-data/profile-cli.md
@@ -12,11 +12,15 @@ weight: 60
 
 # Profile CLI
 
-`profilecli` is a command-line utility that enables various productivity flows such as:
+Pyroscope provides a command-line interface (CLI), `profilecli`.
+This utility enables various productivity flows such as:
+
 - Interacting with a running Pyroscope server to upload profiles, query data, and more
 - Inspecting [Parquet](https://parquet.apache.org/docs/) files
 
-> Hint: Use the `help` command (`profilecli help`) to get a full list of capabilities as well as additional help information.
+{{< admonition type="tip">}}
+Use the `help` command (`profilecli help`) for a full list of capabilities and help information.
+{{< /admonition>}}
 
 ## Install Profile CLI
 
@@ -113,11 +117,11 @@ profilecli <command>
 If you're querying data from Cloud Profiles, be sure to use the url of your Cloud Profiles server in `PROFILECLI_URL` (e.g. `https://profiles-prod-001.grafana.net`) and **not** the url of your Grafana Cloud tenant (e.g. `<your tenant>.grafana.net`).
 {{< /admonition >}}
 
-## Uploading a profile to a Pyroscope server using `profilecli`
+## Upload a profile to a Pyroscope server using `profilecli`
 
 Using `profilecli` streamlines the process of uploading profiles to Pyroscope, making it a convenient alternative to manual HTTP requests.
 
-### Prerequisites
+### Before you begin
 
 - Ensure you have `profilecli` installed on your system by following the [installation](#install-profile-cli) steps above.
 - Have a profile file ready for upload. Note that you can only upload pprof files at this time.
@@ -170,11 +174,12 @@ Using `profilecli` streamlines the process of uploading profiles to Pyroscope, m
 
    - After running the command, you should see a confirmation message indicating a successful upload. If there are any issues, `profilecli` provides error messages to help you troubleshoot.
 
-## Querying a Pyroscope server using `profilecli`
+## Query a Pyroscope server using `profilecli`
 
-You can use the `profilecli query` command to look up the available profiles on a Pyroscope server and read actual profile data. This can be useful for debugging purposes or for integrating profiling in CI pipelines (for example to facilitate [profile-guided optimization](https://go.dev/doc/pgo)).
+You can use the `profilecli query` command to look up the available profiles on a Pyroscope server and read actual profile data.
+This can be useful for debugging purposes or for integrating profiling in CI pipelines (for example to facilitate [profile-guided optimization](https://go.dev/doc/pgo)).
 
-### Looking up available profiles on a Pyroscope server
+### Look up available profiles on a Pyroscope server
 
 You can use the `profilecli query series` command to look up the available profiles on a Pyroscope server.
 By default, it queries the last hour of data, though this can be controlled with the `--from` and `--to` flags.
@@ -182,7 +187,7 @@ You can narrow the results down with the `--query` flag. See `profilecli help qu
 
 #### Query series steps
 
-1. Optional: Specify a Query and a Time Range.
+1. Optional: Specify a query and a time range.
 
    - You can provide a label selector using the `--query` flag, for example: `--query='{service_name="my_application_name"}'`.
    - You can provide a custom time range using the `--from` and `--to` flags, for example, `--from="now-3h" --to="now"`.
@@ -222,7 +227,7 @@ You can narrow the results down with the `--query` flag. See `profilecli help qu
       }
      ```
 
-### Reading a raw profile from a Pyroscope server
+### Read a raw profile from a Pyroscope server
 
 You can use the `profilecli query profile` command to retrieve a merged (aggregated) profile from a Pyroscope server.
 The command merges all samples found in the profile store for the specified query and time range.
@@ -275,7 +280,7 @@ By default it looks for samples within the last hour, though this can be control
      ...
      ```
 
-### Exporting a profile for Go PGO
+### Export a profile for Go PGO
 
 You can use the `profilecli query go-pgo` command to retrieve an aggregated profile from a Pyroscope server for use with Go PGO.
 Profiles retrieved with `profilecli query profile` include all samples found in the profile store, resulting in a large profile size.


### PR DESCRIPTION
Add release notes for Pyroscope v1.10, fix the page weights for the release notes pages, and add links to documentation, when available. 

Fixes #3689 