### PR TITLE
doc(docs.sources.introduction.profiling): fix wrong indentation

### DIFF
--- a/docs/sources/introduction/profiling.md
+++ b/docs/sources/introduction/profiling.md
@@ -54,7 +54,7 @@ Continuous profiling provides:
     - **Resource optimization**: Continual monitoring ensures resources aren't wasted, leading to cost savings.
     - **Rapid problem resolution**: Faster troubleshooting means reduced time and monetary investment in issue rectification, letting developers channel their efforts into productive endeavors.
 - **Non-intrusive operation**: Specifically designed to work quietly in the background, continuous profiling doesn't compromise the performance of live environments.
-7. **Real-time response**: It equips teams with the ability to act instantly, addressing issues as they arise rather than post-occurrence, which is crucial for maintaining high system availability.
+- **Real-time response**: It equips teams with the ability to act instantly, addressing issues as they arise rather than post-occurrence, which is crucial for maintaining high system availability.
 
 ## How to choose between traditional and continuous profiling
 


### PR DESCRIPTION
## Description
* Fix wrong indentation

## Context
* In profiling fundamentals, https://grafana.com/docs/pyroscope/latest/introduction/profiling/#benefits-1, you can realize about the wrong indentation typo at the end

## How to review?
* Check that it's marked as 7, matching with the sequence of benefits referred