### PR TITLE
docs: Add example for OTel eBPF profiler

### DIFF
--- a/examples/grafana-agent-auto-instrumentation/ebpf-otel/README.md
+++ b/examples/grafana-agent-auto-instrumentation/ebpf-otel/README.md
@@ -1,0 +1,67 @@
+# OpenTelemetry eBPF Profiler Example
+
+**⚠️ Important: Linux-only Support**
+This example can only be run on Linux systems (amd64/arm64) as it relies on eBPF technology which is specific to the Linux kernel. The profiler requires privileged access to system resources.
+For more details refer to the OpenTelemetry ebpf profiler [docs](https://github.com/open-telemetry/opentelemetry-ebpf-profiler).
+
+These examples demonstrates:
+1. OpenTelemetry eBPF profiler collecting system-wide profiles
+2. OpenTelemetry Collector receiving and processing the data from the profiler
+3. Pyroscope receiving and visualizing the profiles via Grafana
+
+## Prerequisites
+**⚠️ Important:** Since the [profiler image](https://hub.docker.com/r/otel/opentelemetry-ebpf-profiler-dev) is not publicly available yet, you need to build the profiler binary first:
+
+Follow the build instructions:
+
+```bash
+# Clone the repository
+git clone https://github.com/open-telemetry/opentelemetry-ebpf-profiler
+cd opentelemetry-ebpf-profiler
+
+# Build the environment
+make docker-image
+
+# Build the profiler binary
+make agent
+```
+**Note:** The following examples will consider that an `ebpf-profiler` binary is already existing on each example root directory.
+
+For more details, please refer to opentelemetry-ebpf-profiler [docs](https://github.com/open-telemetry/opentelemetry-ebpf-profiler?tab=readme-ov-file#building)
+
+## Docker Example
+
+After building the profiler binary, start the environment:
+
+```bash
+# Start all services
+docker-compose up --build
+
+# To clean up
+docker-compose down
+```
+
+## Kubernetes Example
+
+1. After building the profiler binary, build and prepare the profiler image:
+
+```bash
+# Build the image with the binary
+docker build -t test-ebpf-profiler:latest .
+
+# Make the image available if necessary. e.g in Minikube
+minikube image load test-ebpf-profiler:latest
+```
+2. Deploy to Kubernetes:
+```bash
+# Apply the manifests
+kubectl apply -f kubernetes/
+
+# Clean up
+kubectl delete -f kubernetes/
+```
+3. Access the UI:
+```bash
+# Port forward Grafana
+kubectl port-forward svc/grafana-service 3000:3000
+```

--- a/examples/grafana-agent-auto-instrumentation/ebpf-otel/README.md
+++ b/examples/grafana-agent-auto-instrumentation/ebpf-otel/README.md
@@ -1,16 +1,16 @@
-# OpenTelemetry eBPF Profiler Example
+# OpenTelemetry eBPF profiler example
 
 **⚠️ Important: Linux-only Support**
 This example can only be run on Linux systems (amd64/arm64) as it relies on eBPF technology which is specific to the Linux kernel. The profiler requires privileged access to system resources.
 For more details refer to the OpenTelemetry ebpf profiler [docs](https://github.com/open-telemetry/opentelemetry-ebpf-profiler).
 
-These examples demonstrates:
+These examples demonstrate:
 1. OpenTelemetry eBPF profiler collecting system-wide profiles
 2. OpenTelemetry Collector receiving and processing the data from the profiler
 3. Pyroscope receiving and visualizing the profiles via Grafana
 
 ## Prerequisites
-**⚠️ Important:** Since the [profiler image](https://hub.docker.com/r/otel/opentelemetry-ebpf-profiler-dev) is not publicly available yet, you need to build the profiler binary first:
+**⚠️ Important:** Since the [profiler image](https://hub.docker.com/r/otel/opentelemetry-ebpf-profiler-dev) is not publicly available yet, you need to build the profiler binary first.
 
 Follow the build instructions:
 
@@ -29,7 +29,7 @@ make agent
 
 For more details, please refer to opentelemetry-ebpf-profiler [docs](https://github.com/open-telemetry/opentelemetry-ebpf-profiler?tab=readme-ov-file#building)
 
-## Docker Example
+## Docker example
 
 After building the profiler binary, start the environment:
 
@@ -41,7 +41,7 @@ docker-compose up --build
 docker-compose down
 ```
 
-## Kubernetes Example
+## Kubernetes example
 
 1. After building the profiler binary, build and prepare the profiler image:
 

--- a/examples/grafana-agent-auto-instrumentation/ebpf-otel/README.md
+++ b/examples/grafana-agent-auto-instrumentation/ebpf-otel/README.md
@@ -1,4 +1,4 @@
-# OpenTelemetry eBPF profiler example
+# OpenTelemetry eBPF profiler examples
 
 **⚠️ Important: Linux-only Support**
 This example can only be run on Linux systems (amd64/arm64) as it relies on eBPF technology which is specific to the Linux kernel. The profiler requires privileged access to system resources.
@@ -14,6 +14,8 @@ These examples demonstrate:
 
 Follow the build instructions:
 
+1. Build the profiler binary:
+
 ```bash
 # Clone the repository
 git clone https://github.com/open-telemetry/opentelemetry-ebpf-profiler
@@ -25,13 +27,18 @@ make docker-image
 # Build the profiler binary
 make agent
 ```
+
+2. Copy the built binary to the example directory:
+```bash
+# Copy the ebpf-profiler binary to the example directory
+cp ebpf-profiler /path/to/example/directory/
+```
 **Note:** The following examples will consider that an `ebpf-profiler` binary is already existing on each example root directory.
 
-For more details, please refer to opentelemetry-ebpf-profiler [docs](https://github.com/open-telemetry/opentelemetry-ebpf-profiler?tab=readme-ov-file#building)
+For more details, please refer to opentelemetry-ebpf-profiler [repository](https://github.com/open-telemetry/opentelemetry-ebpf-profiler)
 
 ## Docker example
-
-After building the profiler binary, start the environment:
+1. Start the environment:
 
 ```bash
 # Start all services
@@ -40,10 +47,15 @@ docker-compose up --build
 # To clean up
 docker-compose down
 ```
+2. Access the UI:
+```bash
+# Access Grafana
+http://localhost:3000
+```
 
 ## Kubernetes example
 
-1. After building the profiler binary, build and prepare the profiler image:
+1. Build and prepare the profiler image:
 
 ```bash
 # Build the image with the binary
@@ -64,4 +76,7 @@ kubectl delete -f kubernetes/
 ```bash
 # Port forward Grafana
 kubectl port-forward svc/grafana-service 3000:3000
+
+# Access Grafana
+http://localhost:3000
 ```

--- a/examples/grafana-agent-auto-instrumentation/ebpf-otel/docker/Dockerfile
+++ b/examples/grafana-agent-auto-instrumentation/ebpf-otel/docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    apt-get install -y linux-headers-generic && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY ebpf-profiler /usr/local/bin/
+
+ENTRYPOINT ["/usr/local/bin/ebpf-profiler", "-collection-agent", "otel-collector:4317", "-no-kernel-version-check", "-disable-tls"]

--- a/examples/grafana-agent-auto-instrumentation/ebpf-otel/docker/config/otel-collector-config.yaml
+++ b/examples/grafana-agent-auto-instrumentation/ebpf-otel/docker/config/otel-collector-config.yaml
@@ -1,0 +1,39 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:4317"
+      http:
+
+processors:
+  batch:
+
+exporters:
+  debug:
+    verbosity: detailed
+  otlp:
+    endpoint: "http://pyroscope:4040"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+    profiles:
+      receivers: [otlp]
+      exporters: [otlp]
+
+  telemetry:
+    logs:
+      level: debug

--- a/examples/grafana-agent-auto-instrumentation/ebpf-otel/docker/docker-compose.yml
+++ b/examples/grafana-agent-auto-instrumentation/ebpf-otel/docker/docker-compose.yml
@@ -1,0 +1,53 @@
+version: '3'
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    command: ["--config=/etc/otel-collector-config.yaml", "--feature-gates=service.profilesSupport"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+    networks:
+      - otel-net
+    depends_on:
+      - pyroscope
+
+  otel-ebpf-profiler:
+    build: .
+    hostname: ebpf-profiler
+    privileged: true
+    pid: "host"
+    volumes:
+      - /sys/kernel/debug:/sys/kernel/debug
+      - /sys/fs/cgroup:/sys/fs/cgroup
+      - /proc:/proc
+    networks:
+      - otel-net
+    depends_on:
+      - otel-collector
+
+  pyroscope:
+    image: grafana/pyroscope:latest
+    ports:
+      - "4040:4040"
+    networks:
+      - otel-net
+
+  grafana:
+    image: grafana/grafana:latest
+    environment:
+      - GF_INSTALL_PLUGINS=grafana-pyroscope-app
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+    volumes:
+      - ./grafana-provisioning:/etc/grafana/provisioning
+    ports:
+      - "3000:3000"
+    networks:
+      - otel-net
+
+networks:
+  otel-net:
+    driver: bridge

--- a/examples/grafana-agent-auto-instrumentation/ebpf-otel/docker/docker-compose.yml
+++ b/examples/grafana-agent-auto-instrumentation/ebpf-otel/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: otel/opentelemetry-collector-contrib:latest
     command: ["--config=/etc/otel-collector-config.yaml", "--feature-gates=service.profilesSupport"]
     volumes:
-      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+      - ./config/otel-collector-config.yaml:/etc/otel-collector-config.yaml
     ports:
       - "4317:4317"
       - "4318:4318"
@@ -29,6 +29,7 @@ services:
 
   pyroscope:
     image: grafana/pyroscope:latest
+    command: ["-self-profiling.disable-push=true"]
     ports:
       - "4040:4040"
     networks:

--- a/examples/grafana-agent-auto-instrumentation/ebpf-otel/docker/grafana-provisioning/datasources/pyroscope.yml
+++ b/examples/grafana-agent-auto-instrumentation/ebpf-otel/docker/grafana-provisioning/datasources/pyroscope.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: 1
+datasources:
+  - uid: local-pyroscope
+    type: grafana-pyroscope-datasource
+    name: Pyroscope
+    url: http://pyroscope:4040
+    jsonData:
+      keepCookies: [pyroscope_git_session]
+    # Uncomment these if using with Grafana Cloud
+    # basicAuth: true
+    # basicAuthUser: '123456'
+    # secureJsonData:
+      # basicAuthPassword: PASSWORD

--- a/examples/grafana-agent-auto-instrumentation/ebpf-otel/kubernetes/Dockerfile
+++ b/examples/grafana-agent-auto-instrumentation/ebpf-otel/kubernetes/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    apt-get install -y linux-headers-generic && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY ebpf-profiler /usr/local/bin/
+
+ENTRYPOINT ["/usr/local/bin/ebpf-profiler", "-collection-agent", "otel-collector-service:4317", "-no-kernel-version-check", "-disable-tls"]

--- a/examples/grafana-agent-auto-instrumentation/ebpf-otel/kubernetes/cpu-stress.yaml
+++ b/examples/grafana-agent-auto-instrumentation/ebpf-otel/kubernetes/cpu-stress.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cpu-stress
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cpu-stress
+  template:
+    metadata:
+      labels:
+        app: cpu-stress
+    spec:
+      containers:
+        - name: stress
+          image: polinux/stress
+          command: ["stress"]
+          args: ["--cpu", "2"]
+          resources:
+            limits:
+              cpu: "2"
+            requests:
+              cpu: "1"

--- a/examples/grafana-agent-auto-instrumentation/ebpf-otel/kubernetes/grafana.yaml
+++ b/examples/grafana-agent-auto-instrumentation/ebpf-otel/kubernetes/grafana.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+spec:
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:latest
+          ports:
+            - containerPort: 3000
+          env:
+            - name: GF_INSTALL_PLUGINS
+              value: grafana-pyroscope-app
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "true"
+            - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+              value: Admin
+            - name: GF_AUTH_DISABLE_LOGIN_FORM
+              value: "true"
+          volumeMounts:
+            - name: grafana-provisioning
+              mountPath: /etc/grafana/provisioning
+      volumes:
+        - name: grafana-provisioning
+          configMap:
+            name: grafana-provisioning
+            items:
+              - key: datasources
+                path: datasources/datasources.yaml
+              - key: plugins
+                path: plugins/plugins.yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-service
+spec:
+  selector:
+    app: grafana
+  ports:
+    - protocol: TCP
+      port: 3000
+      targetPort: 3000
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-provisioning
+data:
+  "datasources": |
+    apiVersion: 1
+    datasources:
+      - uid: local-pyroscope
+        type: grafana-pyroscope-datasource
+        name: Pyroscope
+        url: http://pyroscope-service:4040
+        jsonData:
+          keepCookies: [pyroscope_git_session]
+
+  "plugins": |
+    apiVersion: 1
+    apps:
+      - type: grafana-pyroscope-app
+        jsonData:
+          backendUrl: http://pyroscope-service:4040
+        secureJsonData:

--- a/examples/grafana-agent-auto-instrumentation/ebpf-otel/kubernetes/otel-collector.yaml
+++ b/examples/grafana-agent-auto-instrumentation/ebpf-otel/kubernetes/otel-collector.yaml
@@ -11,24 +11,6 @@ spec:
       labels:
         app: otel-collector
     spec:
-#      initContainers:
-#      - name: wait-for-pyroscope
-#        image: busybox
-#        command: [ 'sh', '-c', '
-#          timeout=10;
-#          counter=0;
-#          while [ $counter -lt $timeout ]; do
-#            if nc -z pyroscope-service 4040; then
-#              echo "Pyroscope is up!";
-#              exit 0;
-#            fi;
-#            echo "Waiting for pyroscope... ($counter/$timeout)";
-#            counter=$((counter+1));
-#            sleep 1;
-#          done;
-#          echo "Timeout waiting for pyroscope";
-#          exit 1
-#        ' ]
       containers:
         - name: otel-collector
           image: otel/opentelemetry-collector-contrib:latest

--- a/examples/grafana-agent-auto-instrumentation/ebpf-otel/kubernetes/otel-collector.yaml
+++ b/examples/grafana-agent-auto-instrumentation/ebpf-otel/kubernetes/otel-collector.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+spec:
+  selector:
+    matchLabels:
+      app: otel-collector
+  template:
+    metadata:
+      labels:
+        app: otel-collector
+    spec:
+#      initContainers:
+#      - name: wait-for-pyroscope
+#        image: busybox
+#        command: [ 'sh', '-c', '
+#          timeout=10;
+#          counter=0;
+#          while [ $counter -lt $timeout ]; do
+#            if nc -z pyroscope-service 4040; then
+#              echo "Pyroscope is up!";
+#              exit 0;
+#            fi;
+#            echo "Waiting for pyroscope... ($counter/$timeout)";
+#            counter=$((counter+1));
+#            sleep 1;
+#          done;
+#          echo "Timeout waiting for pyroscope";
+#          exit 1
+#        ' ]
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector-contrib:latest
+          args:
+            - "--config=/etc/otel-collector-config.yaml"
+            - "--feature-gates=service.profilesSupport"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otel-collector-config.yaml
+              subPath: config.yaml
+      volumes:
+        - name: config
+          configMap:
+            name: otel-collector-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector-service
+spec:
+  selector:
+    app: otel-collector
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+
+    processors:
+      batch:
+
+    exporters:
+      debug:
+        verbosity: detailed
+      otlp:
+        endpoint: pyroscope-service:4040
+        tls:
+          insecure: true
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug]
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug]
+        logs:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug]
+        profiles:
+          receivers: [otlp]
+          exporters: [otlp]
+      
+      telemetry:
+        logs:
+          level: debug

--- a/examples/grafana-agent-auto-instrumentation/ebpf-otel/kubernetes/profiler.yaml
+++ b/examples/grafana-agent-auto-instrumentation/ebpf-otel/kubernetes/profiler.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ebpf-profiler
+spec:
+  selector:
+    matchLabels:
+      app: ebpf-profiler
+  template:
+    metadata:
+      labels:
+        app: ebpf-profiler
+    spec:
+      hostPID: true
+      initContainers:
+        - name: wait-for-collector
+          image: busybox
+          command: [ 'sh', '-c', 'echo "Waiting 15s for collector to be ready..." && sleep 15' ]
+      containers:
+        - name: profiler
+          image: test-ebpf-profiler:latest
+          imagePullPolicy: Never # Use local image
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: kernel-debug
+              mountPath: /sys/kernel/debug
+            - name: proc
+              mountPath: /proc
+            - name: cgroup
+              mountPath: /sys/fs/cgroup
+      volumes:
+        - name: kernel-debug
+          hostPath:
+            path: /sys/kernel/debug
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup

--- a/examples/grafana-agent-auto-instrumentation/ebpf-otel/kubernetes/pyroscope.yaml
+++ b/examples/grafana-agent-auto-instrumentation/ebpf-otel/kubernetes/pyroscope.yaml
@@ -15,6 +15,8 @@ spec:
       containers:
         - name: pyroscope
           image: grafana/pyroscope:latest
+          args:
+            - "-self-profiling.disable-push=true"
           ports:
             - containerPort: 4040
 ---

--- a/examples/grafana-agent-auto-instrumentation/ebpf-otel/kubernetes/pyroscope.yaml
+++ b/examples/grafana-agent-auto-instrumentation/ebpf-otel/kubernetes/pyroscope.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pyroscope
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pyroscope
+  template:
+    metadata:
+      labels:
+        app: pyroscope
+    spec:
+      containers:
+        - name: pyroscope
+          image: grafana/pyroscope:latest
+          ports:
+            - containerPort: 4040
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pyroscope-service
+spec:
+  selector:
+    app: pyroscope
+  ports:
+    - protocol: TCP
+      port: 4040
+      targetPort: 4040


### PR DESCRIPTION
This PR adds examples for running the OpenTelemetry eBPF profiler on both Docker and Kubernetes. These examples demonstrate the following:

- The OTel eBPF profiler collecting system-wide profiles.
- The OpenTelemetry Collector receiving and processing profiler data.
- Pyroscope visualizing the profiles via Grafana.