### PR TITLE
fix(ebpf): improve python process detection

### DIFF
--- a/ebpf/python/pyperf_pid_data.go
+++ b/ebpf/python/pyperf_pid_data.go
@@ -1,7 +1,6 @@
 package python
 
 import (
-	"bufio"
 	"debug/elf"
 	"fmt"
 	"os"
@@ -12,16 +11,9 @@ import (
 )
 
 func GetPyPerfPidData(l log.Logger, pid uint32, collectKernel bool) (*PerfPyPidData, error) {
-	mapsFD, err := os.Open(fmt.Sprintf("/proc/%d/maps", pid))
+	info, err := GetProcInfoForPid(pid)
 	if err != nil {
-		return nil, fmt.Errorf("reading proc maps %d: %w", pid, err)
-	}
-	defer mapsFD.Close()
-
-	info, err := GetProcInfo(bufio.NewScanner(mapsFD))
-
-	if err != nil {
-		return nil, fmt.Errorf("GetPythonProcInfo error %s: %w", fmt.Sprintf("/proc/%d/maps", pid), err)
+		return nil, err
 	}
 	var pythonMeat []*symtab.ProcMap
 	if info.LibPythonMaps == nil {

--- a/ebpf/sd/target.go
+++ b/ebpf/sd/target.go
@@ -41,6 +41,7 @@ const (
 	OptionCollectKernel            = labelMetaPyroscopeOptionsPrefix + "collect_kernel"
 	OptionPythonFullFilePath       = labelMetaPyroscopeOptionsPrefix + "python_full_file_path"
 	OptionPythonEnabled            = labelMetaPyroscopeOptionsPrefix + "python_enabled"
+	OptionPythonProfilingType      = labelMetaPyroscopeOptionsPrefix + "python_profiling_type"
 	OptionPythonBPFDebugLogEnabled = labelMetaPyroscopeOptionsPrefix + "python_bpf_debug_log"
 	OptionPythonBPFErrorLogEnabled = labelMetaPyroscopeOptionsPrefix + "python_bpf_error_log"
 	OptionDemangle                 = labelMetaPyroscopeOptionsPrefix + "demangle"


### PR DESCRIPTION
- allow forcing python profiling type with `__meta_pyroscope_ebpf_options_python_profiling_type=true` target label.
- assume `streamlit` is python
- assume a process is python if the process has `python` or `libpython` proc mappings