### PR TITLE
docs: add otel ebpf profiling support

### DIFF
--- a/docs/sources/configure-client/opentelemetry/ebpf-profiler.md
+++ b/docs/sources/configure-client/opentelemetry/ebpf-profiler.md
@@ -1,15 +1,15 @@
 ---
-title: OpenTelemetry profiles support (experimental)
-menuTitle: OpenTelemetry Profiles
-description: Pyroscope's experimental support for OpenTelemetry profiles
+title: OpenTelemetry profiling support
+menuTitle: OpenTelemetry profiling
+description: OpenTelemetry profiling support in Pyroscope
 weight: 10
 ---
 
-# OpenTelemetry profiles support (experimental)
+# OpenTelemetry profiling support
 
 {{< docs/experimental product="OpenTelemetry profiles" >}}
 
-Pyroscope includes experimental support for receiving and visualizing profiles from OpenTelemetry sources. This integration allows you to:
+Pyroscope includes **experimental** support for receiving and visualizing profiles from OpenTelemetry sources. This integration allows you to:
 
 - Collect system-wide profiles using the [OpenTelemetry eBPF profiler](https://github.com/open-telemetry/opentelemetry-ebpf-profiler)
 - Process profile data through the OpenTelemetry Collector

--- a/docs/sources/configure-client/opentelemetry/ebpf-profiler.md
+++ b/docs/sources/configure-client/opentelemetry/ebpf-profiler.md
@@ -5,7 +5,7 @@ description: Pyroscope's experimental support for OpenTelemetry profiles
 weight: 10
 ---
 
-# OpenTelemetry Profiles Support (Experimental)
+# OpenTelemetry profiles support (experimental)
 
 Pyroscope now includes experimental support for receiving and visualizing profiles from OpenTelemetry sources. This integration allows you to:
 

--- a/docs/sources/configure-client/opentelemetry/ebpf-profiler.md
+++ b/docs/sources/configure-client/opentelemetry/ebpf-profiler.md
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry Profiles Support (Experimental)
+title: OpenTelemetry profiles support (experimental)
 menuTitle: OpenTelemetry Profiles
 description: Pyroscope's experimental support for OpenTelemetry profiles
 weight: 10
@@ -7,15 +7,17 @@ weight: 10
 
 # OpenTelemetry profiles support (experimental)
 
-Pyroscope now includes experimental support for receiving and visualizing profiles from OpenTelemetry sources. This integration allows you to:
+{{< docs/experimental product="OpenTelemetry profiles" >}}
+
+Pyroscope includes experimental support for receiving and visualizing profiles from OpenTelemetry sources. This integration allows you to:
 
 - Collect system-wide profiles using the [OpenTelemetry eBPF profiler](https://github.com/open-telemetry/opentelemetry-ebpf-profiler)
 - Process profile data through the OpenTelemetry Collector
 - Visualize profiles in Grafana using Pyroscope
 
-## Important Notes About Current Status
+## Considerations
 
-Before getting started, please be aware of the following limitations:
+Before getting started, you should consider the following limitations:
 
 - The OpenTelemetry profiles protocol ([proto files](https://github.com/open-telemetry/opentelemetry-proto/tree/main/opentelemetry/proto/profiles)) is under active development:
     - Breaking changes are expected and have occurred
@@ -43,8 +45,8 @@ The profile collection pipeline consists of:
 3. **Pyroscope**: Stores and processes profiles
 4. **Grafana**: Visualizes profile data
 
-## Getting Started
+## Get started
 
-For detailed setup instructions and working examples, refer to our [examples repository](https://github.com/grafana/pyroscope/tree/main/examples/grafana-agent-auto-instrumentation/ebpf-otel).
+For detailed setup instructions and working examples, refer to the [examples repository](https://github.com/grafana/pyroscope/tree/main/examples/grafana-agent-auto-instrumentation/ebpf-otel).
 
 The examples demonstrate deployments for both Docker and Kubernetes environments.

--- a/docs/sources/configure-client/opentelemetry/ebpf-profiler.md
+++ b/docs/sources/configure-client/opentelemetry/ebpf-profiler.md
@@ -1,0 +1,50 @@
+---
+title: OpenTelemetry Profiles Support (Experimental)
+menuTitle: OpenTelemetry Profiles
+description: Pyroscope's experimental support for OpenTelemetry profiles
+weight: 10
+---
+
+# OpenTelemetry Profiles Support (Experimental)
+
+Pyroscope now includes experimental support for receiving and visualizing profiles from OpenTelemetry sources. This integration allows you to:
+
+- Collect system-wide profiles using the [OpenTelemetry eBPF profiler](https://github.com/open-telemetry/opentelemetry-ebpf-profiler)
+- Process profile data through the OpenTelemetry Collector
+- Visualize profiles in Grafana using Pyroscope
+
+## Important Notes About Current Status
+
+Before getting started, please be aware of the following limitations:
+
+- The OpenTelemetry profiles protocol ([proto files](https://github.com/open-telemetry/opentelemetry-proto/tree/main/opentelemetry/proto/profiles)) is under active development:
+    - Breaking changes are expected and have occurred
+    - Compatibility between components (profiler, collector, backend) requires careful version management
+    - We maintain support for the latest protocol version, but updates may be required frequently
+
+- Symbolization support is currently limited:
+  - Function names may not appear in flamegraphs for some programs
+  - We're working on improving symbol resolution and adding support for manual symbol uploads
+
+- We recommend evaluating this feature for development and testing purposes, but waiting for protocol stabilization before production use
+
+## Requirements
+
+- Linux system (amd64/arm64) for eBPF profiler
+- OpenTelemetry Collector with profiles feature gate enabled
+- Grafana with Pyroscope data source enabled
+
+## Architecture
+
+The profile collection pipeline consists of:
+
+1. **OpenTelemetry eBPF Profiler**: Collects system-wide profiles
+2. **OpenTelemetry Collector**: Receives and forwards profile data
+3. **Pyroscope**: Stores and processes profiles
+4. **Grafana**: Visualizes profile data
+
+## Getting Started
+
+For detailed setup instructions and working examples, refer to our [examples repository](https://github.com/grafana/pyroscope/tree/main/examples/grafana-agent-auto-instrumentation/ebpf-otel).
+
+The examples demonstrate deployments for both Docker and Kubernetes environments.


### PR DESCRIPTION
Adds the OpenTelemetry profiles documentation to:

- Add current limitations
- Clarify protocol development status and compatibility concerns
- Add link to OpenTelemetry proto files
- Add link to examples repository