### PR TITLE
fix(flameql): allow slashes in tag name

### DIFF
--- a/pkg/og/flameql/flameql.go
+++ b/pkg/og/flameql/flameql.go
@@ -97,7 +97,7 @@ func ValidateAppName(n string) error {
 }
 
 func IsTagKeyRuneAllowed(r rune) bool {
-	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '.'
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '.' || r == '/'
 }
 
 func IsAppNameRuneAllowed(r rune) bool {

--- a/pkg/og/flameql/flameql.go
+++ b/pkg/og/flameql/flameql.go
@@ -97,11 +97,11 @@ func ValidateAppName(n string) error {
 }
 
 func IsTagKeyRuneAllowed(r rune) bool {
-	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '.' || r == '/'
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '.'
 }
 
 func IsAppNameRuneAllowed(r rune) bool {
-	return r == '-' || r == '.' || IsTagKeyRuneAllowed(r)
+	return r == '-' || r == '.' || r == '/' || IsTagKeyRuneAllowed(r)
 }
 
 func IsTagKeyReserved(k string) bool {

--- a/pkg/og/flameql/flameql_test.go
+++ b/pkg/og/flameql/flameql_test.go
@@ -44,7 +44,6 @@ var _ = Describe("ValidateTagKey", func() {
 		testCases := []testCase{
 			{"foo_BAR_12_baz_qux", nil},
 			{"service.namespace", nil},
-			{"namespace/service", nil},
 
 			{ReservedTagKeyName, ErrTagKeyReserved},
 			{"", ErrTagKeyIsRequired},
@@ -71,6 +70,7 @@ var _ = Describe("ValidateAppName", func() {
 
 		testCases := []testCase{
 			{"foo.BAR-1.2_baz_qux", nil},
+			{"namespace/service", nil},
 
 			{"", ErrAppNameIsRequired},
 			{"#", ErrInvalidAppName},

--- a/pkg/og/flameql/flameql_test.go
+++ b/pkg/og/flameql/flameql_test.go
@@ -44,6 +44,7 @@ var _ = Describe("ValidateTagKey", func() {
 		testCases := []testCase{
 			{"foo_BAR_12_baz_qux", nil},
 			{"service.namespace", nil},
+			{"namespace/service", nil},
 
 			{ReservedTagKeyName, ErrTagKeyReserved},
 			{"", ErrTagKeyIsRequired},


### PR DESCRIPTION
This was originally reported in Alloy grafana/alloy#2158.

The change extends service name validation to allow slashes, enabling hierarchical service naming patterns. After this change is validated, I'll create the proper PR in Alloy since the validation isn't reused in Alloy but ported from Pyroscope.


Closes grafana/pyroscope#3721
