### PR TITLE
fix(v2): object downloading goroutine leak

### DIFF
--- a/pkg/objstore/read_only_file.go
+++ b/pkg/objstore/read_only_file.go
@@ -44,8 +44,8 @@ func download(ctx context.Context, name string, src BucketReader, dir string) (f
 	defer func() {
 		if err != nil {
 			_ = f.Close()
-			_ = r.Close()
 		}
+		_ = r.Close()
 	}()
 	if err = os.MkdirAll(dir, 0755); err != nil {
 		return nil, err


### PR DESCRIPTION
During compaction, we download the entire object if it exceeds a certain threshold. However, there's a goroutine leak: the object reader is not being closed properly, causing all associated resources to remain in memory indefinitely.

This is the goroutine profile of one of the instances:
<img width="1708" alt="image" src="https://github.com/user-attachments/assets/7a1d03c6-3f44-46b5-b1a4-fe05c1f8f8c2">
