### PR TITLE
fix(v2): compaction worker drops final status updates

### DIFF
--- a/pkg/experiment/compactor/compaction_worker.go
+++ b/pkg/experiment/compactor/compaction_worker.go
@@ -118,7 +118,11 @@ func (w *Worker) running(ctx context.Context) error {
 		for {
 			select {
 			case <-stopPolling:
+				// Now that all the threads are done, we need to
+				// send the final status updates.
+				w.poll()
 				return
+
 			case <-ticker.C:
 				w.poll()
 			}


### PR DESCRIPTION
It is currently possible that during shutdown, the compaction worker may skip sending status updates for jobs that finish between the last poll and the exit of the poll loop. While this is a rare occurrence in practice, we want to avoid unnecessary job reassignments and reprocessing.