### PR TITLE
perf(v2): tune parquet row iterator batching

### DIFF
--- a/pkg/experiment/query_backend/query_time_series.go
+++ b/pkg/experiment/query_backend/query_time_series.go
@@ -40,7 +40,7 @@ func queryTimeSeries(q *queryContext, query *queryv1.Query) (r *queryv1.Report, 
 		return nil, err
 	}
 
-	rows := parquetquery.NewRepeatedRowIterator(q.ctx, entries, q.ds.Profiles().RowGroups(), column.ColumnIndex)
+	rows := parquetquery.NewRepeatedRowIteratorBatchSize(q.ctx, entries, q.ds.Profiles().RowGroups(), bigBatchSize, column.ColumnIndex)
 	defer runutil.CloseWithErrCapture(&err, rows, "failed to close column iterator")
 
 	builder := phlaremodel.NewTimeSeriesBuilder(query.TimeSeries.GroupBy...)


### PR DESCRIPTION
Overly conservative row batch size in time series queries makes use of batching very inefficient in certain cases:

<img width="1692" alt="image" src="https://github.com/user-attachments/assets/6db0af26-81b5-4d59-a1f6-c8c4a171c087">

We use the default batch size, which is reasonably small in the cases where it's applied (see the comment). In v2, we should tune this parameter. However, in practice, the parameter should be adaptive