### PR TITLE
Update examples and docs with the latest java sdk

### DIFF
--- a/docs/sources/configure-client/language-sdks/java.md
+++ b/docs/sources/configure-client/language-sdks/java.md
@@ -51,12 +51,12 @@ First, add the Pyroscope dependency:
 <dependency>
   <groupId>io.pyroscope</groupId>
   <artifactId>agent</artifactId>
-  <version>0.14.0</version>
+  <version>0.15.0</version>
 </dependency>
 ```
 
 ```gradle
-implementation("io.pyroscope:agent:0.14.0")
+implementation("io.pyroscope:agent:0.15.0")
 ```
 
 {{< /code >}}

--- a/examples/language-sdk-instrumentation/java/fib/Dockerfile
+++ b/examples/language-sdk-instrumentation/java/fib/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /opt/app
 
 RUN apt-get update && apt-get install ca-certificates -y && update-ca-certificates && apt-get install -y git
 
-ADD https://github.com/grafana/pyroscope-java/releases/download/v0.14.0/pyroscope.jar /opt/app/pyroscope.jar
+ADD https://github.com/grafana/pyroscope-java/releases/download/v0.15.0/pyroscope.jar /opt/app/pyroscope.jar
 
 COPY Main.java ./
 

--- a/examples/language-sdk-instrumentation/java/rideshare/Dockerfile
+++ b/examples/language-sdk-instrumentation/java/rideshare/Dockerfile
@@ -37,6 +37,6 @@ COPY --from=builder /opt/app/build/libs/rideshare-1.0-SNAPSHOT.jar /opt/app/buil
 
 WORKDIR /opt/app
 
-ADD https://github.com/grafana/pyroscope-java/releases/download/v0.14.0/pyroscope.jar /opt/app/pyroscope.jar
+ADD https://github.com/grafana/pyroscope-java/releases/download/v0.15.0/pyroscope.jar /opt/app/pyroscope.jar
 
 CMD sh -c "exec java -Dserver.port=${RIDESHARE_LISTEN_PORT} -javaagent:pyroscope.jar -jar ./build/libs/rideshare-1.0-SNAPSHOT.jar"

--- a/examples/language-sdk-instrumentation/java/rideshare/build.gradle.kts
+++ b/examples/language-sdk-instrumentation/java/rideshare/build.gradle.kts
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    implementation("io.pyroscope:agent:0.14.0")
+    implementation("io.pyroscope:agent:0.15.0")
     implementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.2")

--- a/examples/language-sdk-instrumentation/java/simple/Dockerfile
+++ b/examples/language-sdk-instrumentation/java/simple/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:11.0.11-jdk
 
 WORKDIR /opt/app
 
-ADD https://github.com/grafana/pyroscope-java/releases/download/v0.14.0/pyroscope.jar /opt/app/pyroscope.jar
+ADD https://github.com/grafana/pyroscope-java/releases/download/v0.15.0/pyroscope.jar /opt/app/pyroscope.jar
 
 COPY Main.java ./Main.java
 RUN javac Main.java


### PR DESCRIPTION
Update java examples to the latest SDK version (`0.15.0`). See https://github.com/grafana/pyroscope-java/pull/170 for more information.