### PR TITLE
fix(examples): Update python rideshare to latest otel-profiling-python

### DIFF
--- a/examples/language-sdk-instrumentation/python/rideshare/flask/Dockerfile
+++ b/examples/language-sdk-instrumentation/python/rideshare/flask/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9
 
-RUN pip3 install flask pyroscope-io==0.8.8 pyroscope-otel==0.1.0
+RUN pip3 install flask pyroscope-io==0.8.8 pyroscope-otel==0.4.0
 RUN pip3 install opentelemetry-api opentelemetry-sdk opentelemetry-instrumentation-flask opentelemetry-exporter-otlp-proto-grpc
 
 ENV FLASK_ENV=development


### PR DESCRIPTION
This fixes this build error:

```
ERROR: Cannot install pyroscope-io==0.8.8 and pyroscope-otel==0.1.0 because these package versions have conflicting dependencies.
```