### PR TITLE
NOMERGE:  allow overriding service_name label from sample label

### DIFF
--- a/pkg/ingester/otlp/convert.go
+++ b/pkg/ingester/otlp/convert.go
@@ -177,6 +177,11 @@ func convertSampleAttributesToLabelsBack(p *otelProfile.Profile, os *otelProfile
 				Key: addstr(att.Key),
 				Str: addstr(att.Value.GetStringValue()),
 			})
+		} else if att.Value.GetIntValue() != 0 {
+			gs.Label = append(gs.Label, &googleProfile.Label{
+				Key: addstr(att.Key),
+				Str: addstr(fmt.Sprintf("%d", att.Value.GetIntValue())),
+			})
 		}
 	}
 }


### PR DESCRIPTION
POC Hack: allow overriding service_name label from sample label
otel POC Hack: add pid(numeric) label