### PR TITLE
Helm: Remove misleading annotations for minio

### DIFF
--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -27,7 +27,7 @@
 | alloy | object | `{"alloy":{"clustering":{"enabled":true},"configMap":{"create":false,"name":"alloy-config-pyroscope"},"stabilityLevel":"public-preview"},"controller":{"podAnnotations":{"profiles.grafana.com/cpu.port_name":"http-metrics","profiles.grafana.com/cpu.scrape":"true","profiles.grafana.com/goroutine.port_name":"http-metrics","profiles.grafana.com/goroutine.scrape":"true","profiles.grafana.com/memory.port_name":"http-metrics","profiles.grafana.com/memory.scrape":"true"},"replicas":1,"type":"statefulset"},"enabled":true}` | ----------------------------------- |
 | ingress.className | string | `""` |  |
 | ingress.enabled | bool | `false` |  |
-| minio | object | `{"buckets":[{"name":"grafana-pyroscope-data","policy":"none","purge":false}],"drivesPerNode":2,"enabled":false,"persistence":{"size":"5Gi"},"podAnnotations":{"phlare.grafana.com/port":"9000","phlare.grafana.com/scrape":"true"},"replicas":1,"resources":{"requests":{"cpu":"100m","memory":"128Mi"}},"rootPassword":"supersecret","rootUser":"grafana-pyroscope"}` | ----------------------------------- |
+| minio | object | `{"buckets":[{"name":"grafana-pyroscope-data","policy":"none","purge":false}],"drivesPerNode":2,"enabled":false,"persistence":{"size":"5Gi"},"podAnnotations":{},"replicas":1,"resources":{"requests":{"cpu":"100m","memory":"128Mi"}},"rootPassword":"supersecret","rootUser":"grafana-pyroscope"}` | ----------------------------------- |
 | pyroscope.affinity | object | `{}` |  |
 | pyroscope.cluster_domain | string | `".cluster.local."` | Kubernetes cluster domain suffix for DNS discovery |
 | pyroscope.components | object | `{}` |  |

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services-hpa.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services-hpa.yaml
@@ -2713,8 +2713,6 @@ spec:
       annotations:
         checksum/secrets: 2e760de5dbcac8daf468cd56713bca0aac7d7adc4445e2488b352dbb2b529507
         checksum/config: 925d78a7321daaaa06a6dc4ee47dbaf5b8952be192bdbb57f13805ad472ce4e1
-        phlare.grafana.com/port: "9000"
-        phlare.grafana.com/scrape: "true"
     spec:
       securityContext:
         runAsUser: 1000

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -2948,8 +2948,6 @@ spec:
       annotations:
         checksum/secrets: 2e760de5dbcac8daf468cd56713bca0aac7d7adc4445e2488b352dbb2b529507
         checksum/config: 925d78a7321daaaa06a6dc4ee47dbaf5b8952be192bdbb57f13805ad472ce4e1
-        phlare.grafana.com/port: "9000"
-        phlare.grafana.com/scrape: "true"
     spec:
       securityContext:
         runAsUser: 1000

--- a/operations/pyroscope/helm/pyroscope/values.yaml
+++ b/operations/pyroscope/helm/pyroscope/values.yaml
@@ -115,7 +115,7 @@ pyroscope:
 
   ## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
   ## If you set enabled as "True", you need :
-  ## - create a pv which above 10Gi and has same namespace with phlare
+  ## - create a pv which above 10Gi and has same namespace with pyroscope
   ## - keep storageClassName same with below setting
   persistence:
     enabled: false
@@ -125,7 +125,7 @@ pyroscope:
     annotations: {}
     # selector:
     #   matchLabels:
-    #     app.kubernetes.io/name: phlare
+    #     app.kubernetes.io/name: pyroscope
     # subPath: ""
     # existingClaim:
 

--- a/operations/pyroscope/helm/pyroscope/values.yaml
+++ b/operations/pyroscope/helm/pyroscope/values.yaml
@@ -243,9 +243,7 @@ minio:
     requests:
       cpu: 100m
       memory: 128Mi
-  podAnnotations:
-    phlare.grafana.com/scrape: "true"
-    phlare.grafana.com/port: "9000"
+  podAnnotations: {}
 
 ingress:
   enabled: false

--- a/operations/pyroscope/jsonnet/values.json
+++ b/operations/pyroscope/jsonnet/values.json
@@ -65,10 +65,7 @@
     "persistence": {
       "size": "5Gi"
     },
-    "podAnnotations": {
-      "phlare.grafana.com/port": "9000",
-      "phlare.grafana.com/scrape": "true"
-    },
+    "podAnnotations": {},
     "replicas": 1,
     "resources": {
       "requests": {


### PR DESCRIPTION
This removes misleading annotations for minion:

 * Minio cannot be profiled without authentication
 * phlare.grafana.com annotations were invalid for a while

Also noticed an old phlare reference.