### PR TITLE
docs(examples): Remove version statement

### DIFF
--- a/examples/base-url/docker-compose.yml
+++ b/examples/base-url/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   pyroscope:
     image: grafana/pyroscope

--- a/examples/golang-pgo/docker-compose.yml
+++ b/examples/golang-pgo/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   rideshare-go:
     environment:

--- a/examples/grafana-agent-auto-instrumentation/ebpf-otel/docker/docker-compose.yml
+++ b/examples/grafana-agent-auto-instrumentation/ebpf-otel/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   otel-collector:
     image: otel/opentelemetry-collector-contrib:latest

--- a/examples/grafana-agent-auto-instrumentation/ebpf/docker/docker-compose.yml
+++ b/examples/grafana-agent-auto-instrumentation/ebpf/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   pyroscope:
     image: grafana/pyroscope

--- a/examples/grafana-agent-auto-instrumentation/ebpf/local/docker-compose.yml
+++ b/examples/grafana-agent-auto-instrumentation/ebpf/local/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   pyroscope:
     image: grafana/pyroscope

--- a/examples/grafana-agent-auto-instrumentation/golang-pull/docker-compose.yml
+++ b/examples/grafana-agent-auto-instrumentation/golang-pull/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   grafana:
     image: grafana/grafana:latest

--- a/examples/grafana-agent-auto-instrumentation/java/docker/docker-compose.yml
+++ b/examples/grafana-agent-auto-instrumentation/java/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   java:
     build:

--- a/examples/language-sdk-instrumentation/dotnet/fast-slow/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/dotnet/fast-slow/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   pyroscope:
     image: grafana/pyroscope

--- a/examples/language-sdk-instrumentation/dotnet/rideshare/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/dotnet/rideshare/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   pyroscope:
     image: grafana/pyroscope:latest

--- a/examples/language-sdk-instrumentation/dotnet/web-new/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/dotnet/web-new/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   pyroscope:
     image: grafana/pyroscope

--- a/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   us-east:
     ports:

--- a/examples/language-sdk-instrumentation/golang-push/rideshare/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   us-east:
     ports:

--- a/examples/language-sdk-instrumentation/golang-push/simple/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/golang-push/simple/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   pyroscope:
     image: grafana/pyroscope:latest

--- a/examples/language-sdk-instrumentation/java/fib/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/java/fib/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   pyroscope:
     image: grafana/pyroscope

--- a/examples/language-sdk-instrumentation/java/rideshare/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/java/rideshare/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   pyroscope:
     image: grafana/pyroscope

--- a/examples/language-sdk-instrumentation/java/simple/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/java/simple/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   pyroscope:
     image: grafana/pyroscope

--- a/examples/language-sdk-instrumentation/nodejs/express-pull/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/nodejs/express-pull/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   pyroscope:
     image: grafana/pyroscope

--- a/examples/language-sdk-instrumentation/nodejs/express-ts-inline/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/nodejs/express-ts-inline/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   pyroscope:
     image: grafana/pyroscope:latest

--- a/examples/language-sdk-instrumentation/nodejs/express-ts/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/nodejs/express-ts/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   pyroscope:
     image: grafana/pyroscope:latest

--- a/examples/language-sdk-instrumentation/nodejs/express/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/nodejs/express/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   pyroscope:
     image: grafana/pyroscope

--- a/examples/language-sdk-instrumentation/nodejs/tinyhttp/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/nodejs/tinyhttp/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   pyroscope:
     image: grafana/pyroscope

--- a/examples/language-sdk-instrumentation/python/rideshare/django/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/python/rideshare/django/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   pyroscope:
     image: grafana/pyroscope

--- a/examples/language-sdk-instrumentation/python/rideshare/fastapi/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/python/rideshare/fastapi/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   pyroscope:
     image: grafana/pyroscope

--- a/examples/language-sdk-instrumentation/python/rideshare/flask/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/python/rideshare/flask/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   pyroscope:
     image: grafana/pyroscope

--- a/examples/language-sdk-instrumentation/python/simple/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/python/simple/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   pyroscope:
     image: grafana/pyroscope

--- a/examples/language-sdk-instrumentation/ruby/rideshare/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/ruby/rideshare/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   pyroscope:
     image: grafana/pyroscope

--- a/examples/language-sdk-instrumentation/ruby/rideshare_rails/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/ruby/rideshare_rails/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   pyroscope:
     image: grafana/pyroscope

--- a/examples/language-sdk-instrumentation/ruby/simple/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/ruby/simple/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   pyroscope:
     image: grafana/pyroscope

--- a/examples/language-sdk-instrumentation/rust/rideshare/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/rust/rideshare/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   pyroscope:
     image: grafana/pyroscope

--- a/examples/tracing/java/docker-compose.yml
+++ b/examples/tracing/java/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   pyroscope:
     image: grafana/pyroscope

--- a/examples/tracing/tempo/docker-compose.yml
+++ b/examples/tracing/tempo/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 
 services:
   rideshare-go-ap-south:


### PR DESCRIPTION
This addresses the version flag from all docker-compose.yml in examples/

```
WARN[0000] /Users/christian/git/github.com/grafana/pyroscope/examples/language-sdk-instrumentation/golang-push/rideshare/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```
