### PR TITLE
chore(examples): rename flask-ride-sharing-app in tutorial

### DIFF
--- a/docs/sources/get-started/ride-share-tutorial.md
+++ b/docs/sources/get-started/ride-share-tutorial.md
@@ -186,7 +186,7 @@ To discover this, you can use the **Flame graph** view:
 
 1. Open Explore Profiles using the following url: [http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer](http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer).
 1. Select **Flame graph** from the **Exploration** path.
-1. Verify that  `flask-ride-sharing-app` is selected in the **Service** drop-down menu and `process_cpu/cpu` in the **Profile type** drop-down menu.
+1. Verify that  `ride-sharing-app` is selected in the **Service** drop-down menu and `process_cpu/cpu` in the **Profile type** drop-down menu.
 
 It should look something like this:
 

--- a/examples/language-sdk-instrumentation/python/README.md
+++ b/examples/language-sdk-instrumentation/python/README.md
@@ -10,6 +10,10 @@
 
 Note: For documentation on the Pyroscope pip package visit [our website](https://grafana.com/docs/pyroscope/latest/configure-client/language-sdks/python/)
 
+## Interactive Tutorial
+
+Explore our [interactive Ride Share tutorial](https://killercoda.com/grafana-labs/course/pyroscope/ride-share-tutorial) on KillerCoda, where you can learn how to use Pyroscope by profiling a "Ride Share" application.
+
 ## Live Demo
 
 Feel free to check out the [live demo](https://play.grafana.org/a/grafana-pyroscope-app/profiles-explorer?searchText=&panelType=time-series&layout=grid&hideNoData=off&explorationType=flame-graph&var-serviceName=pyroscope-rideshare-python&var-profileMetricId=process_cpu:cpu:nanoseconds:cpu:nanoseconds&var-dataSource=grafanacloud-profiles) of this example on our demo page.


### PR DESCRIPTION
In #3769 I renamed the `flask-ride-sharing-app` to `ride-sharing-app` to align with the shared README, where it is referred to in this way. However, in the KillerCoda tutorial, we're still using `flask-ride-sharing-app`. I'm updating the tutorial to reflect the new name and add a link to README.