### PR TITLE
Added bucket-lookup-type field to s3 config

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -899,6 +899,8 @@ Usage of ./pyroscope:
     	JSON either from a Google Developers Console client_credentials.json file, or a Google Developers service account key. Needs to be valid JSON, not a filesystem path.
   -storage.s3.access-key-id string
     	S3 access key ID
+  -storage.s3.bucket-lookup-type string
+    	S3 bucket lookup style, use one of: [path-style virtual-hosted-style auto] (default "auto")
   -storage.s3.bucket-name string
     	S3 bucket name
   -storage.s3.endpoint string
@@ -906,7 +908,7 @@ Usage of ./pyroscope:
   -storage.s3.expect-continue-timeout duration
     	The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. 0 to send the request body immediately. (default 1s)
   -storage.s3.force-path-style
-    	Set this to `true` to force the bucket lookup to be using path-style.
+    	Deprecated, use s3.bucket-lookup-type instead. Set this to `true` to force the bucket lookup to be using path-style.
   -storage.s3.http.idle-conn-timeout duration
     	The time an idle connection will remain idle before closing. (default 1m30s)
   -storage.s3.http.insecure-skip-verify

--- a/pkg/objstore/providers/s3/bucket_client.go
+++ b/pkg/objstore/providers/s3/bucket_client.go
@@ -7,6 +7,7 @@ package s3
 
 import (
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/common/model"
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/objstore/providers/s3"
@@ -19,6 +20,8 @@ func NewBucketClient(cfg Config, name string, logger log.Logger) (objstore.Bucke
 		return nil, err
 	}
 
+	warnForDeprecatedConfigFields(cfg, logger)
+
 	return s3.NewBucketWithConfig(logger, s3Cfg, name)
 }
 
@@ -28,6 +31,8 @@ func NewBucketReaderClient(cfg Config, name string, logger log.Logger) (objstore
 	if err != nil {
 		return nil, err
 	}
+
+	warnForDeprecatedConfigFields(cfg, logger)
 
 	return s3.NewBucketWithConfig(logger, s3Cfg, name)
 }
@@ -68,4 +73,10 @@ func newS3Config(cfg Config) (s3.Config, error) {
 		// Enforce signature version 2 if CLI flag is set
 		SignatureV2: cfg.SignatureVersion == SignatureVersionV2,
 	}, nil
+}
+
+func warnForDeprecatedConfigFields(cfg Config, logger log.Logger) {
+	if cfg.ForcePathStyle {
+		level.Warn(logger).Log("msg", "S3 bucket client config has a deprecated s3.force-path-style flag set. Please, use s3.bucket-lookup-type instead.")
+	}
 }

--- a/pkg/objstore/providers/s3/bucket_client.go
+++ b/pkg/objstore/providers/s3/bucket_client.go
@@ -39,8 +39,10 @@ func newS3Config(cfg Config) (s3.Config, error) {
 	}
 
 	bucketLookupType := s3.AutoLookup
-	if cfg.ForcePathStyle {
+	if cfg.ForcePathStyle || cfg.BucketLookupType == PathStyleLookup {
 		bucketLookupType = s3.PathLookup
+	} else if cfg.BucketLookupType == VirtualHostedStyleLookup {
+		bucketLookupType = s3.VirtualHostLookup
 	}
 
 	return s3.Config{

--- a/pkg/objstore/providers/s3/config.go
+++ b/pkg/objstore/providers/s3/config.go
@@ -121,7 +121,7 @@ func (cfg *Config) Validate() error {
 		return errUnsupportedSignatureVersion
 	}
 
-	if cfg.ForcePathStyle && cfg.BucketLookupType == VirtualHostedStyleLookup {
+	if cfg.ForcePathStyle && cfg.BucketLookupType != AutoLookup && cfg.BucketLookupType != PathStyleLookup {
 		return errBucketLookupConfigConflict
 	}
 

--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -39,6 +39,7 @@ import (
 	"google.golang.org/grpc/health"
 
 	"github.com/grafana/pyroscope-go"
+
 	"github.com/grafana/pyroscope/pkg/api"
 	apiversion "github.com/grafana/pyroscope/pkg/api/version"
 	"github.com/grafana/pyroscope/pkg/cfg"

--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -31,7 +31,6 @@ import (
 	"github.com/grafana/dskit/signals"
 	"github.com/grafana/dskit/spanprofiler"
 	wwtracing "github.com/grafana/dskit/tracing"
-	"github.com/grafana/pyroscope-go"
 	grpcgw "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
@@ -39,6 +38,7 @@ import (
 	"github.com/samber/lo"
 	"google.golang.org/grpc/health"
 
+	"github.com/grafana/pyroscope-go"
 	"github.com/grafana/pyroscope/pkg/api"
 	apiversion "github.com/grafana/pyroscope/pkg/api/version"
 	"github.com/grafana/pyroscope/pkg/cfg"


### PR DESCRIPTION
Hi Pyroscope Team!
This pull request targets the [issue](https://github.com/grafana/pyroscope/issues/3451). 
There are a few details I would like to point out:
- We have discussed previously that it would be great to show `a warning if force-path is set to true, that this flag is deprecated and might be removed going forward`. Unfortunately, I haven't found an elegant solution to do that and just put a deprecation message to flag's usage. There are [flagext](https://github.com/grafana/dskit/blob/main/flagext/deprecated.go) package, but it is used to replace deprecated flag completely. [Pflag](https://github.com/spf13/pflag?tab=readme-ov-file#deprecating-a-flag-or-its-shorthand) library has deprecation feature, but you use plain flag library here.
- It seems that s3 config is not validated with the application start. I may fix that in this PR, if you wish. But it may require thorough testing to ensure that validation won't break anything.