### PR TITLE
feat: configurable symbols partitioning

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -498,7 +498,7 @@ Usage of ./pyroscope:
   -pyroscopedb.row-group-target-size uint
     	How big should a single row group be uncompressed (default 1342177280)
   -pyroscopedb.symbols-partition-label string
-    	Specifies the dimension by which symbols are partitioned. By default, the partitioning is determined automatically..
+    	Specifies the dimension by which symbols are partitioned. By default, the partitioning is determined automatically.
   -querier.client-cleanup-period duration
     	How frequently to clean up clients for ingesters that have gone away. (default 15s)
   -querier.frontend-client.backoff-max-period duration

--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -497,6 +497,8 @@ Usage of ./pyroscope:
     	How much available disk space to keep in GiB (default 10)
   -pyroscopedb.row-group-target-size uint
     	How big should a single row group be uncompressed (default 1342177280)
+  -pyroscopedb.symbols-partition-label string
+    	Specifies the dimension by which symbols are partitioned. By default, the partitioning is determined automatically..
   -querier.client-cleanup-period duration
     	How frequently to clean up clients for ingesters that have gone away. (default 15s)
   -querier.frontend-client.backoff-max-period duration

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -150,7 +150,7 @@ Usage of ./pyroscope:
   -pyroscopedb.row-group-target-size uint
     	How big should a single row group be uncompressed (default 1342177280)
   -pyroscopedb.symbols-partition-label string
-    	Specifies the dimension by which symbols are partitioned. By default, the partitioning is determined automatically..
+    	Specifies the dimension by which symbols are partitioned. By default, the partitioning is determined automatically.
   -querier.client-cleanup-period duration
     	How frequently to clean up clients for ingesters that have gone away. (default 15s)
   -querier.health-check-ingesters

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -149,6 +149,8 @@ Usage of ./pyroscope:
     	How much available disk space to keep in GiB (default 10)
   -pyroscopedb.row-group-target-size uint
     	How big should a single row group be uncompressed (default 1342177280)
+  -pyroscopedb.symbols-partition-label string
+    	Specifies the dimension by which symbols are partitioned. By default, the partitioning is determined automatically..
   -querier.client-cleanup-period duration
     	How frequently to clean up clients for ingesters that have gone away. (default 15s)
   -querier.health-check-ingesters

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -115,6 +115,11 @@ pyroscopedb:
   # CLI flag: -pyroscopedb.row-group-target-size
   [row_group_target_size: <int> | default = 1342177280]
 
+  # Specifies the dimension by which symbols are partitioned. By default, the
+  # partitioning is determined automatically.
+  # CLI flag: -pyroscopedb.symbols-partition-label
+  [symbols_partition_label: <string> | default = ""]
+
   # How much available disk space to keep in GiB
   # CLI flag: -pyroscopedb.retention-policy-min-free-disk-gb
   [min_free_disk_gb: <int> | default = 10]

--- a/pkg/phlaredb/phlaredb.go
+++ b/pkg/phlaredb/phlaredb.go
@@ -48,7 +48,8 @@ type Config struct {
 	MaxBlockDuration time.Duration `yaml:"max_block_duration,omitempty"`
 
 	// TODO: docs
-	RowGroupTargetSize uint64 `yaml:"row_group_target_size"`
+	RowGroupTargetSize    uint64 `yaml:"row_group_target_size"`
+	SymbolsPartitionLabel string `yaml:"symbols_partition_label"`
 
 	// Those configs should not be exposed to the user, rather they should be determined by pyroscope itself.
 	// Currently, they are solely used for test cases.
@@ -71,6 +72,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.DataPath, "pyroscopedb.data-path", "./data", "Directory used for local storage.")
 	f.DurationVar(&cfg.MaxBlockDuration, "pyroscopedb.max-block-duration", 1*time.Hour, "Upper limit to the duration of a Pyroscope block.")
 	f.Uint64Var(&cfg.RowGroupTargetSize, "pyroscopedb.row-group-target-size", 10*128*1024*1024, "How big should a single row group be uncompressed") // This should roughly be 128MiB compressed
+	f.StringVar(&cfg.SymbolsPartitionLabel, "pyroscopedb.symbols-partition-label", "", "Specifies the dimension by which symbols are partitioned. By default, the partitioning is determined automatically.")
 	f.Uint64Var(&cfg.MinFreeDisk, "pyroscopedb.retention-policy-min-free-disk-gb", DefaultMinFreeDisk, "How much available disk space to keep in GiB")
 	f.Float64Var(&cfg.MinDiskAvailablePercentage, "pyroscopedb.retention-policy-min-disk-available-percentage", DefaultMinDiskAvailablePercentage, "Which percentage of free disk space to keep")
 	f.DurationVar(&cfg.EnforcementInterval, "pyroscopedb.retention-policy-enforcement-interval", DefaultRetentionPolicyEnforcementInterval, "How often to enforce disk retention")


### PR DESCRIPTION
Resolves #3262 

The PR adds a configuration option (`-pyroscopedb.symbols-partition-label`) to control how symbols are partitioned. 

Currently, we infer the partition key based on the main binary mapping, aiming to create shared partitions for binaries with the same name. This helps optimize memory usage during writes when the same binary runs in different contexts. As a fallback, the `service_name` label value is used as the symbols partition key.

However, this approach is quite fragile and may result in poor performance during query or compaction operations.