### PR TITLE
fix: revive stack trace range chunking

### DIFF
--- a/pkg/experiment/ingester/memdb/head.go
+++ b/pkg/experiment/ingester/memdb/head.go
@@ -49,6 +49,9 @@ func NewHead(metrics *HeadMetrics) *Head {
 		metrics: metrics,
 		symbols: symdb.NewPartitionWriter(0, &symdb.Config{
 			Version: symdb.FormatV3,
+			Stacktraces: symdb.StacktracesConfig{
+				MaxNodesPerChunk: 4 << 20,
+			},
 		}),
 		totalSamples: atomic.NewUint64(0),
 		minTimeNanos: math.MaxInt64,

--- a/pkg/experiment/ingester/memdb/head.go
+++ b/pkg/experiment/ingester/memdb/head.go
@@ -45,21 +45,17 @@ type Head struct {
 }
 
 func NewHead(metrics *HeadMetrics) *Head {
-	h := &Head{
+	return &Head{
 		metrics: metrics,
 		symbols: symdb.NewPartitionWriter(0, &symdb.Config{
-			Version: symdb.FormatV3,
-			Stacktraces: symdb.StacktracesConfig{
-				MaxNodesPerChunk: 4 << 20,
-			},
+			Version:     symdb.FormatV3,
+			Stacktraces: symdb.StacktracesConfig{MaxNodesPerChunk: math.MaxUint32},
 		}),
 		totalSamples: atomic.NewUint64(0),
 		minTimeNanos: math.MaxInt64,
 		maxTimeNanos: 0,
 		profiles:     newProfileIndex(metrics),
 	}
-
-	return h
 }
 
 func (h *Head) Ingest(p *profilev1.Profile, id uuid.UUID, externalLabels []*typesv1.LabelPair) {

--- a/pkg/phlaredb/compact.go
+++ b/pkg/phlaredb/compact.go
@@ -750,7 +750,10 @@ func newSymbolsCompactor(path string, version symdb.FormatVersion) *symbolsCompa
 		version: symdb.FormatV2,
 		w: symdb.NewSymDB(symdb.DefaultConfig().
 			WithVersion(symdb.FormatV2).
-			WithDirectory(dst)),
+			WithDirectory(dst).
+			WithParquetConfig(symdb.ParquetConfig{
+				MaxBufferRowCount: defaultParquetConfig.MaxBufferRowCount,
+			})),
 		dst:       dst,
 		rewriters: make(map[BlockReader]*symdb.Rewriter),
 	}

--- a/pkg/phlaredb/symdb/block_writer_v2.go
+++ b/pkg/phlaredb/symdb/block_writer_v2.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
-	"math"
 	"os"
 	"path/filepath"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/grafana/pyroscope/pkg/phlaredb/block"
 	schemav1 "github.com/grafana/pyroscope/pkg/phlaredb/schemas/v1"
 	"github.com/grafana/pyroscope/pkg/util/build"
+	"github.com/grafana/pyroscope/pkg/util/math"
 )
 
 type writerV2 struct {
@@ -138,20 +138,30 @@ func (w *writerV2) Flush() (err error) {
 }
 
 func (w *writerV2) writeStacktraces(partition *PartitionWriter) (err error) {
-	h := StacktraceBlockHeader{
-		Offset:             w.stacktraces.w.offset,
-		Partition:          partition.header.Partition,
-		Encoding:           StacktraceEncodingGroupVarint,
-		Stacktraces:        uint32(len(partition.stacktraces.hashToIdx)),
-		StacktraceNodes:    partition.stacktraces.tree.len(),
-		StacktraceMaxNodes: math.MaxUint32,
+	for ci, c := range partition.stacktraces.chunks {
+		stacks := c.stacks
+		if stacks == 0 {
+			stacks = uint32(len(partition.stacktraces.hashToIdx))
+		}
+		h := StacktraceBlockHeader{
+			Offset:             w.stacktraces.w.offset,
+			Size:               0, // Set later.
+			Partition:          partition.header.Partition,
+			BlockIndex:         uint16(ci),
+			Encoding:           StacktraceEncodingGroupVarint,
+			Stacktraces:        stacks,
+			StacktraceNodes:    c.tree.len(),
+			StacktraceMaxDepth: 0, // TODO
+			StacktraceMaxNodes: c.partition.maxNodesPerChunk,
+			CRC:                0, // Set later.
+		}
+		crc := crc32.New(castagnoli)
+		if h.Size, err = c.WriteTo(io.MultiWriter(crc, w.stacktraces)); err != nil {
+			return fmt.Errorf("writing stacktrace chunk data: %w", err)
+		}
+		h.CRC = crc.Sum32()
+		partition.header.Stacktraces = append(partition.header.Stacktraces, h)
 	}
-	crc := crc32.New(castagnoli)
-	if h.Size, err = partition.stacktraces.WriteTo(io.MultiWriter(crc, w.stacktraces)); err != nil {
-		return fmt.Errorf("writing stacktrace chunk data: %w", err)
-	}
-	h.CRC = crc.Sum32()
-	partition.header.Stacktraces = append(partition.header.Stacktraces, h)
 	return nil
 }
 
@@ -210,7 +220,7 @@ func (s *parquetWriter[M, P]) init(dir string, c ParquetConfig) (err error) {
 		return err
 	}
 	s.rowsBatch = make([]parquet.Row, 0, 128)
-	s.buffer = parquet.NewBuffer(s.persister.Schema())
+	s.buffer = parquet.NewBuffer(s.persister.Schema(), parquet.ColumnBufferCapacity(s.config.MaxBufferRowCount))
 	s.writer = parquet.NewGenericWriter[P](s.file, s.persister.Schema(),
 		parquet.CreatedBy("github.com/grafana/pyroscope/", build.Version, build.Revision),
 		parquet.PageBufferSize(3*1024*1024),
@@ -255,7 +265,7 @@ func (s *parquetWriter[M, P]) writeRows(values []M) (r RowRangeReference, err er
 }
 
 func (s *parquetWriter[M, P]) fillBatch(values []M) int {
-	m := min(len(values), cap(s.rowsBatch))
+	m := math.Min(len(values), cap(s.rowsBatch))
 	s.rowsBatch = s.rowsBatch[:m]
 	for i := 0; i < m; i++ {
 		row := s.rowsBatch[i][:0]

--- a/pkg/phlaredb/symdb/block_writer_v3.go
+++ b/pkg/phlaredb/symdb/block_writer_v3.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
-	"math"
 	"os"
 	"path/filepath"
 
@@ -89,22 +88,27 @@ func writePartitionV3(w *writerOffset, e *encodersV3, p *PartitionWriter) (err e
 	if p.header.V3.Locations, err = writeSymbolsBlock(w, p.locations.slice, e.locationsEncoder); err != nil {
 		return err
 	}
-
-	h := StacktraceBlockHeader{
-		Offset:             w.offset,
-		Partition:          p.header.Partition,
-		Encoding:           StacktraceEncodingGroupVarint,
-		Stacktraces:        uint32(len(p.stacktraces.hashToIdx)),
-		StacktraceNodes:    p.stacktraces.tree.len(),
-		StacktraceMaxNodes: math.MaxUint32,
+	for ci, c := range p.stacktraces.chunks {
+		stacks := c.stacks
+		if stacks == 0 {
+			stacks = uint32(len(p.stacktraces.hashToIdx))
+		}
+		h := StacktraceBlockHeader{
+			Offset:             w.offset,
+			Partition:          p.header.Partition,
+			BlockIndex:         uint16(ci),
+			Encoding:           StacktraceEncodingGroupVarint,
+			Stacktraces:        stacks,
+			StacktraceNodes:    c.tree.len(),
+			StacktraceMaxNodes: c.partition.maxNodesPerChunk,
+		}
+		crc := crc32.New(castagnoli)
+		if h.Size, err = c.WriteTo(io.MultiWriter(crc, w)); err != nil {
+			return fmt.Errorf("writing stacktrace chunk data: %w", err)
+		}
+		h.CRC = crc.Sum32()
+		p.header.Stacktraces = append(p.header.Stacktraces, h)
 	}
-	crc := crc32.New(castagnoli)
-	if h.Size, err = p.stacktraces.WriteTo(io.MultiWriter(crc, w)); err != nil {
-		return fmt.Errorf("writing stacktrace chunk data: %w", err)
-	}
-	h.CRC = crc.Sum32()
-	p.header.Stacktraces = append(p.header.Stacktraces, h)
-
 	return nil
 }
 

--- a/pkg/phlaredb/symdb/partition_memory.go
+++ b/pkg/phlaredb/symdb/partition_memory.go
@@ -5,13 +5,14 @@ import (
 	"io"
 	"sync"
 
+	"github.com/grafana/pyroscope/pkg/iter"
 	schemav1 "github.com/grafana/pyroscope/pkg/phlaredb/schemas/v1"
 )
 
 type PartitionWriter struct {
 	header PartitionHeader
 
-	stacktraces *stacktraces
+	stacktraces *stacktracesPartition
 	strings     deduplicatingSlice[string, string, *stringsHelper]
 	mappings    deduplicatingSlice[schemav1.InMemoryMapping, mappingsKey, *mappingsHelper]
 	functions   deduplicatingSlice[schemav1.InMemoryFunction, functionsKey, *functionsHelper]
@@ -31,36 +32,99 @@ func (p *PartitionWriter) ResolveStacktraceLocations(_ context.Context, dst Stac
 
 func (p *PartitionWriter) LookupLocations(dst []uint64, stacktraceID uint32) []uint64 {
 	dst = dst[:0]
-	if stacktraceID == 0 {
+	if len(p.stacktraces.chunks) == 0 {
 		return dst
 	}
-	return p.stacktraces.tree.resolveUint64(dst, stacktraceID)
+	chunkID := stacktraceID / p.stacktraces.maxNodesPerChunk
+	localSID := stacktraceID % p.stacktraces.maxNodesPerChunk
+	if localSID == 0 || int(chunkID) > len(p.stacktraces.chunks) {
+		return dst
+	}
+	return p.stacktraces.chunks[chunkID].tree.resolveUint64(dst, localSID)
 }
 
-func newStacktraces() *stacktraces {
-	p := &stacktraces{
-		hashToIdx: make(map[uint64]uint32),
-		tree:      newStacktraceTree(defaultStacktraceTreeSize),
+type stacktracesPartition struct {
+	maxNodesPerChunk uint32
+
+	m         sync.RWMutex
+	hashToIdx map[uint64]uint32
+	chunks    []*stacktraceChunk
+}
+
+func (p *PartitionWriter) SplitStacktraceIDRanges(appender *SampleAppender) iter.Iterator[*StacktraceIDRange] {
+	if len(p.stacktraces.chunks) == 0 {
+		return iter.NewEmptyIterator[*StacktraceIDRange]()
 	}
+	var n int
+	samples := appender.Samples()
+	ranges := SplitStacktraces(samples.StacktraceIDs, p.stacktraces.maxNodesPerChunk)
+	for _, sr := range ranges {
+		c := p.stacktraces.chunks[sr.chunk]
+		sr.ParentPointerTree = c.tree
+		sr.Samples = samples.Range(n, n+len(sr.IDs))
+		n += len(sr.IDs)
+	}
+	return iter.NewSliceIterator(ranges)
+}
+
+func newStacktracesPartition(maxNodesPerChunk uint32) *stacktracesPartition {
+	p := &stacktracesPartition{
+		maxNodesPerChunk: maxNodesPerChunk,
+		hashToIdx:        make(map[uint64]uint32, defaultStacktraceTreeSize/2),
+	}
+	p.chunks = append(p.chunks, &stacktraceChunk{
+		tree:      newStacktraceTree(defaultStacktraceTreeSize),
+		partition: p,
+	})
 	return p
 }
 
-type stacktraces struct {
-	m         sync.RWMutex
-	hashToIdx map[uint64]uint32
-	tree      *stacktraceTree
-	stacks    uint32
-}
-
-func (p *stacktraces) size() uint64 {
+func (p *stacktracesPartition) size() uint64 {
 	p.m.RLock()
 	// TODO: map footprint isn't accounted
-	v := stacktraceTreeNodeSize * cap(p.tree.nodes)
+	v := 0
+	for _, c := range p.chunks {
+		v += stacktraceTreeNodeSize * cap(c.tree.nodes)
+	}
 	p.m.RUnlock()
 	return uint64(v)
 }
 
-func (p *stacktraces) append(dst []uint32, s []*schemav1.Stacktrace) {
+// stacktraceChunkForInsert returns a chunk for insertion:
+// if the existing one has capacity, or a new one, if the former is full.
+// Must be called with the stracktraces mutex write lock held.
+func (p *stacktracesPartition) stacktraceChunkForInsert(x int) *stacktraceChunk {
+	c := p.currentStacktraceChunk()
+	if n := c.tree.len() + uint32(x); p.maxNodesPerChunk > 0 && n >= p.maxNodesPerChunk {
+		// Calculate number of stacks in the chunk.
+		s := uint32(len(p.hashToIdx))
+		c.stacks = s - c.stacks
+		c = &stacktraceChunk{
+			partition: p,
+			tree:      newStacktraceTree(defaultStacktraceTreeSize),
+			stid:      c.stid + p.maxNodesPerChunk,
+			stacks:    s,
+		}
+		p.chunks = append(p.chunks, c)
+	}
+	return c
+}
+
+// stacktraceChunkForRead returns a chunk for reads.
+// Must be called with the stracktraces mutex read lock held.
+func (p *stacktracesPartition) stacktraceChunkForRead(i int) (*stacktraceChunk, bool) {
+	if i < len(p.chunks) {
+		return p.chunks[i], true
+	}
+	return nil, false
+}
+
+func (p *stacktracesPartition) currentStacktraceChunk() *stacktraceChunk {
+	// Assuming there is at least one chunk.
+	return p.chunks[len(p.chunks)-1]
+}
+
+func (p *stacktracesPartition) append(dst []uint32, s []*schemav1.Stacktrace) {
 	if len(s) == 0 {
 		return
 	}
@@ -96,16 +160,29 @@ func (p *stacktraces) append(dst []uint32, s []*schemav1.Stacktrace) {
 
 	p.m.Lock()
 	defer p.m.Unlock()
+	chunk := p.currentStacktraceChunk()
+
+	m := int(p.maxNodesPerChunk)
+	t, j := chunk.tree, chunk.stid
 	for i, v := range dst[:len(s)] {
 		if v != 0 {
 			// Already resolved. ID 0 is reserved
 			// as it is the tree root.
 			continue
 		}
+
 		x := s[i].LocationIDs
+		if m > 0 && len(t.nodes)+len(x) >= m {
+			// If we're close to the max nodes limit and can
+			// potentially exceed it, we take the next chunk,
+			// even if there are some space.
+			chunk = p.stacktraceChunkForInsert(len(x))
+			t, j = chunk.tree, chunk.stid
+		}
+
 		// Tree insertion is idempotent,
 		// we don't need to check the map.
-		id = p.tree.insert(x)
+		id = t.insert(x) + j
 		h := hashLocations(x)
 		p.hashToIdx[h] = id
 		dst[i] = id
@@ -128,9 +205,30 @@ func (p *stacktraceLocationsPool) put(x []int32) {
 	stacktraceLocations.Put(x)
 }
 
-func (p *stacktraces) resolve(dst StacktraceInserter, stacktraces []uint32) (err error) {
+func (p *stacktracesPartition) resolve(dst StacktraceInserter, stacktraces []uint32) (err error) {
+	for _, sr := range SplitStacktraces(stacktraces, p.maxNodesPerChunk) {
+		if err = p.ResolveChunk(dst, sr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// NOTE(kolesnikovae):
+//  Caller is able to split a range of stacktrace IDs into chunks
+//  with SplitStacktraces, and then resolve them concurrently:
+//  StacktraceInserter could be implemented as a dense set, map,
+//  slice, or an n-ary tree: the stacktraceTree should be one of
+//  the options, the package provides.
+
+func (p *stacktracesPartition) ResolveChunk(dst StacktraceInserter, sr *StacktraceIDRange) error {
 	p.m.RLock()
-	t := stacktraceTree{nodes: p.tree.nodes}
+	c, found := p.stacktraceChunkForRead(int(sr.chunk))
+	if !found {
+		p.m.RUnlock()
+		return ErrInvalidStacktraceRange
+	}
+	t := stacktraceTree{nodes: c.tree.nodes}
 	// tree.resolve is thread safe: only the parent node index (p)
 	// and the reference to location (r) node fields are accessed,
 	// which are never modified after insertion.
@@ -141,16 +239,25 @@ func (p *stacktraces) resolve(dst StacktraceInserter, stacktraces []uint32) (err
 	// the call.
 	p.m.RUnlock()
 	s := stacktraceLocations.get()
-	for _, sid := range stacktraces {
+	// Restore the original stacktrace ID.
+	off := sr.Offset()
+	for _, sid := range sr.IDs {
 		s = t.resolve(s, sid)
-		dst.InsertStacktrace(sid, s)
+		dst.InsertStacktrace(off+sid, s)
 	}
 	stacktraceLocations.put(s)
 	return nil
 }
 
-func (p *stacktraces) WriteTo(dst io.Writer) (int64, error) {
-	return p.tree.WriteTo(dst)
+type stacktraceChunk struct {
+	partition *stacktracesPartition
+	tree      *stacktraceTree
+	stid      uint32 // Initial stack trace ID.
+	stacks    uint32 //
+}
+
+func (s *stacktraceChunk) WriteTo(dst io.Writer) (int64, error) {
+	return s.tree.WriteTo(dst)
 }
 
 func (p *PartitionWriter) AppendLocations(dst []uint32, locations []schemav1.InMemoryLocation) {
@@ -181,7 +288,8 @@ func (p *PartitionWriter) Symbols() *Symbols {
 
 func (p *PartitionWriter) WriteStats(s *PartitionStats) {
 	p.stacktraces.m.RLock()
-	s.MaxStacktraceID = int(p.stacktraces.tree.len())
+	c := p.stacktraces.currentStacktraceChunk()
+	s.MaxStacktraceID = int(c.stid + c.tree.len())
 	s.StacktracesTotal = len(p.stacktraces.hashToIdx)
 	p.stacktraces.m.RUnlock()
 

--- a/pkg/phlaredb/symdb/partition_memory_test.go
+++ b/pkg/phlaredb/symdb/partition_memory_test.go
@@ -13,19 +13,75 @@ import (
 	"github.com/grafana/pyroscope/pkg/pprof"
 )
 
-func Test_Stacktrace_append_empty(t *testing.T) {
-	db := NewSymDB(new(Config))
-	w := db.PartitionWriter(0)
+func Test_StacktraceAppender_shards(t *testing.T) {
+	t.Run("WithMaxStacktraceTreeNodesPerChunk", func(t *testing.T) {
+		db := NewSymDB(&Config{
+			Stacktraces: StacktracesConfig{
+				MaxNodesPerChunk: 7,
+			},
+		})
 
-	sids := make([]uint32, 2)
-	w.AppendStacktraces(sids, nil)
-	assert.Equal(t, []uint32{0, 0}, sids)
+		w := db.PartitionWriter(0)
+		sids := make([]uint32, 4)
+		w.AppendStacktraces(sids, []*schemav1.Stacktrace{
+			{LocationIDs: []uint64{3, 2, 1}},
+			{LocationIDs: []uint64{2, 1}},
+			{LocationIDs: []uint64{4, 3, 2, 1}},
+			{LocationIDs: []uint64{3, 1}},
+		})
+		assert.Equal(t, []uint32{3, 2, 11, 16}, sids)
 
-	w.AppendStacktraces(sids, []*schemav1.Stacktrace{})
-	assert.Equal(t, []uint32{0, 0}, sids)
+		w.AppendStacktraces(sids[:3], []*schemav1.Stacktrace{
+			{LocationIDs: []uint64{3, 2, 1}},
+			{LocationIDs: []uint64{2, 1}},
+			{LocationIDs: []uint64{4, 3, 2, 1}},
+		})
+		// Same input. Note that len(sids) > len(schemav1.Stacktrace)
+		assert.Equal(t, []uint32{3, 2, 11}, sids[:3])
 
-	w.AppendStacktraces(sids, []*schemav1.Stacktrace{{}})
-	assert.Equal(t, []uint32{0, 0}, sids)
+		w.AppendStacktraces(sids[:1], []*schemav1.Stacktrace{
+			{LocationIDs: []uint64{5, 2, 1}},
+		})
+		assert.Equal(t, []uint32{18}, sids[:1])
+
+		require.Len(t, db.partitions, 1)
+		m := db.partitions[0]
+		require.Len(t, m.stacktraces.chunks, 3)
+
+		c1 := m.stacktraces.chunks[0]
+		assert.Equal(t, uint32(0), c1.stid)
+		assert.Equal(t, uint32(4), c1.tree.len())
+
+		c2 := m.stacktraces.chunks[1]
+		assert.Equal(t, uint32(7), c2.stid)
+		assert.Equal(t, uint32(5), c2.tree.len())
+
+		c3 := m.stacktraces.chunks[2]
+		assert.Equal(t, uint32(14), c3.stid)
+		assert.Equal(t, uint32(5), c3.tree.len())
+	})
+
+	t.Run("WithoutMaxStacktraceTreeNodesPerChunk", func(t *testing.T) {
+		db := NewSymDB(new(Config))
+		w := db.PartitionWriter(0)
+		sids := make([]uint32, 5)
+		w.AppendStacktraces(sids, []*schemav1.Stacktrace{
+			{LocationIDs: []uint64{3, 2, 1}},
+			{LocationIDs: []uint64{2, 1}},
+			{LocationIDs: []uint64{4, 3, 2, 1}},
+			{LocationIDs: []uint64{3, 1}},
+			{LocationIDs: []uint64{5, 3, 2, 1}},
+		})
+		assert.Equal(t, []uint32{3, 2, 4, 5, 6}, sids)
+
+		require.Len(t, db.partitions, 1)
+		m := db.partitions[0]
+		require.Len(t, m.stacktraces.chunks, 1)
+
+		c1 := m.stacktraces.chunks[0]
+		assert.Equal(t, uint32(0), c1.stid)
+		assert.Equal(t, uint32(7), c1.tree.len())
+	})
 }
 
 func Test_Stacktrace_append_existing(t *testing.T) {
@@ -43,6 +99,144 @@ func Test_Stacktrace_append_existing(t *testing.T) {
 		{LocationIDs: []uint64{6, 5, 4, 3, 2, 1}},
 	})
 	assert.Equal(t, []uint32{5, 6}, sids)
+}
+
+func Test_Stacktrace_append_empty(t *testing.T) {
+	db := NewSymDB(new(Config))
+	w := db.PartitionWriter(0)
+
+	sids := make([]uint32, 2)
+	w.AppendStacktraces(sids, nil)
+	assert.Equal(t, []uint32{0, 0}, sids)
+
+	w.AppendStacktraces(sids, []*schemav1.Stacktrace{})
+	assert.Equal(t, []uint32{0, 0}, sids)
+
+	w.AppendStacktraces(sids, []*schemav1.Stacktrace{{}})
+	assert.Equal(t, []uint32{0, 0}, sids)
+}
+
+func Test_Stacktraces_append_resolve(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("single chunk", func(t *testing.T) {
+		db := NewSymDB(new(Config))
+		w := db.PartitionWriter(0)
+
+		sids := make([]uint32, 5)
+		w.AppendStacktraces(sids, []*schemav1.Stacktrace{
+			{LocationIDs: []uint64{3, 2, 1}},
+			{LocationIDs: []uint64{2, 1}},
+			{LocationIDs: []uint64{4, 3, 2, 1}},
+			{LocationIDs: []uint64{3, 1}},
+			{LocationIDs: []uint64{5, 2, 1}},
+		})
+
+		r, ok := db.lookupPartition(0)
+		require.True(t, ok)
+		dst := new(mockStacktraceInserter)
+		dst.On("InsertStacktrace", uint32(2), []int32{2, 1})
+		dst.On("InsertStacktrace", uint32(3), []int32{3, 2, 1})
+		dst.On("InsertStacktrace", uint32(4), []int32{4, 3, 2, 1})
+		dst.On("InsertStacktrace", uint32(5), []int32{3, 1})
+		dst.On("InsertStacktrace", uint32(6), []int32{5, 2, 1})
+		require.NoError(t, r.ResolveStacktraceLocations(ctx, dst, []uint32{2, 3, 4, 5, 6}))
+	})
+
+	t.Run("multiple chunks", func(t *testing.T) {
+		db := NewSymDB(&Config{
+			Stacktraces: StacktracesConfig{
+				MaxNodesPerChunk: 7,
+			},
+		})
+
+		w := db.PartitionWriter(0)
+		stacktraces := []*schemav1.Stacktrace{ // ID, Chunk ID:
+			{LocationIDs: []uint64{3, 2, 1}},        // 3  0
+			{LocationIDs: []uint64{2, 1}},           // 2  0
+			{LocationIDs: []uint64{4, 3, 2, 1}},     // 11 1
+			{LocationIDs: []uint64{3, 1}},           // 16 2
+			{LocationIDs: []uint64{5, 2, 1}},        // 18 2
+			{LocationIDs: []uint64{13, 12, 11}},     // 24 3
+			{LocationIDs: []uint64{12, 11}},         // 23 3
+			{LocationIDs: []uint64{14, 13, 12, 11}}, // 32 4
+			{LocationIDs: []uint64{13, 11}},         // 37 5
+			{LocationIDs: []uint64{15, 12, 11}},     // 39 5
+		}
+		/*
+			// TODO(kolesnikovae): Add test cases:
+			// Invariants:
+			//        0
+			//      1
+			//      1 0
+			//    2
+			//    2   0
+			//    2 1
+			//    2 1 0
+			//  3
+			//  3     0
+			//  3   1
+			//  3   1 0
+			//  3 2
+			//  3 2   0
+			//  3 2 1
+			//  3 2 1 0
+		*/
+		sids := make([]uint32, len(stacktraces))
+		w.AppendStacktraces(sids, stacktraces)
+		require.Len(t, db.partitions[0].stacktraces.chunks, 6)
+
+		t.Run("adjacent shards at beginning", func(t *testing.T) {
+			r, _ := db.lookupPartition(0)
+			dst := new(mockStacktraceInserter)
+			dst.On("InsertStacktrace", uint32(2), []int32{2, 1})
+			dst.On("InsertStacktrace", uint32(3), []int32{3, 2, 1})
+			dst.On("InsertStacktrace", uint32(11), []int32{4, 3, 2, 1})
+			dst.On("InsertStacktrace", uint32(16), []int32{3, 1})
+			dst.On("InsertStacktrace", uint32(18), []int32{5, 2, 1})
+			require.NoError(t, r.ResolveStacktraceLocations(ctx, dst, []uint32{2, 3, 11, 16, 18}))
+		})
+
+		t.Run("adjacent shards at end", func(t *testing.T) {
+			r, _ := db.lookupPartition(0)
+			dst := new(mockStacktraceInserter)
+			dst.On("InsertStacktrace", uint32(23), []int32{12, 11})
+			dst.On("InsertStacktrace", uint32(24), []int32{13, 12, 11})
+			dst.On("InsertStacktrace", uint32(32), []int32{14, 13, 12, 11})
+			dst.On("InsertStacktrace", uint32(37), []int32{13, 11})
+			dst.On("InsertStacktrace", uint32(39), []int32{15, 12, 11})
+			require.NoError(t, r.ResolveStacktraceLocations(ctx, dst, []uint32{23, 24, 32, 37, 39}))
+		})
+
+		t.Run("non-adjacent shards", func(t *testing.T) {
+			r, _ := db.lookupPartition(0)
+			dst := new(mockStacktraceInserter)
+			dst.On("InsertStacktrace", uint32(11), []int32{4, 3, 2, 1})
+			dst.On("InsertStacktrace", uint32(32), []int32{14, 13, 12, 11})
+			require.NoError(t, r.ResolveStacktraceLocations(ctx, dst, []uint32{11, 32}))
+		})
+	})
+}
+
+func Test_hashLocations(t *testing.T) {
+	t.Run("hashLocations is thread safe", func(t *testing.T) {
+		b := []uint64{123, 234, 345, 456, 567}
+		h := hashLocations(b)
+		const N, M = 10, 10 << 10
+		var wg sync.WaitGroup
+		wg.Add(N)
+		for i := 0; i < N; i++ {
+			go func() {
+				defer wg.Done()
+				for j := 0; j < M; j++ {
+					if hashLocations(b) != h {
+						panic("hash mismatch")
+					}
+				}
+			}()
+		}
+		wg.Wait()
+	})
 }
 
 func Test_Stacktraces_memory_resolve_pprof(t *testing.T) {
@@ -71,7 +265,12 @@ func Test_Stacktraces_memory_resolve_chunked(t *testing.T) {
 	stacktraces := pprofSampleToStacktrace(p.Sample)
 	sids := make([]uint32, len(stacktraces))
 
-	db := NewSymDB(new(Config))
+	cfg := &Config{
+		Stacktraces: StacktracesConfig{
+			MaxNodesPerChunk: 256,
+		},
+	}
+	db := NewSymDB(cfg)
 	w := db.PartitionWriter(0)
 	w.AppendStacktraces(sids, stacktraces)
 
@@ -97,9 +296,15 @@ func Test_Stacktraces_memory_resolve_concurrency(t *testing.T) {
 	require.NoError(t, err)
 	stacktraces := pprofSampleToStacktrace(p.Sample)
 
+	cfg := &Config{
+		Stacktraces: StacktracesConfig{
+			MaxNodesPerChunk: 256,
+		},
+	}
+
 	// Allocate stacktrace IDs.
 	sids := make([]uint32, len(stacktraces))
-	db := NewSymDB(new(Config))
+	db := NewSymDB(cfg)
 	w := db.PartitionWriter(0)
 	w.AppendStacktraces(sids, stacktraces)
 
@@ -112,7 +317,7 @@ func Test_Stacktraces_memory_resolve_concurrency(t *testing.T) {
 
 	runTest := func(t *testing.T) {
 		t.Helper()
-		db := NewSymDB(new(Config))
+		db := NewSymDB(cfg)
 
 		var wg sync.WaitGroup
 		wg.Add(appenders)

--- a/pkg/phlaredb/symdb/resolver_tree_test.go
+++ b/pkg/phlaredb/symdb/resolver_tree_test.go
@@ -87,8 +87,8 @@ func Test_memory_Resolver_ResolveTree_copied_nodes(t *testing.T) {
 	// The only reason we perform this assertion is to make sure that
 	// truncation did take place, and the number of nodes is close to
 	// the target (we actually keep all nodes with top 16K values).
-	assert.Equal(t, int64(1585462), nodesFull)
-	assert.Equal(t, int64(22461), nodesTrunc)
+	assert.Equal(t, nodesFull, int64(1585462))
+	assert.Equal(t, nodesTrunc, int64(22407))
 	require.Equal(t, totalFull, totalTrunc)
 }
 
@@ -151,11 +151,8 @@ func Test_buildTreeFromParentPointerTrees(t *testing.T) {
 	const partition = 0
 	indexed := s.db.WriteProfileSymbols(partition, p)
 	assert.Equal(t, expectedSamples, indexed[partition].Samples)
-	b := blockSuite{memSuite: s}
-	b.flush()
-	pr, err := b.reader.Partition(context.Background(), partition)
-	require.NoError(t, err)
-	symbols := pr.Symbols()
+
+	symbols := s.db.partitions[partition].Symbols()
 	iterator, ok := symbols.Stacktraces.(StacktraceIDRangeIterator)
 	require.True(t, ok)
 


### PR DESCRIPTION
Resolves https://github.com/grafana/pyroscope/issues/3817.

The PR reverts https://github.com/grafana/pyroscope/pull/3583 as it causes a performance regression in compactors (issue https://github.com/grafana/pyroscope/issues/3817) in certain cases. You can find more details in our slack channel ([thread](https://grafana.slack.com/archives/C049PLMV8TB/p1735948533932149)).

The change affects only ingesters and is fully backward-compatible. I'm hesitant to make this configurable because it's very easy to misinterpret and misconfigure the parameter.

