### PR TITLE
feat: Log 400 and 500 errors

### DIFF
--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -219,7 +219,7 @@ func (l Log) Wrap(next http.Handler) http.Handler {
 					n, err := next(p)
 					headerWritten = true
 					httpErr.Add(err)
-					if httpCode >= 500 && httpCode < 600 {
+					if httpCode >= 400 && httpCode < 600 {
 						bodyLeft = captureResponseBody(p, bodyLeft, &buf)
 					}
 					return n, err
@@ -267,7 +267,8 @@ func (l Log) Wrap(next http.Handler) http.Handler {
 
 			return
 		}
-		if 100 <= statusCode && statusCode < 500 {
+
+		if 100 <= statusCode && statusCode < 400 {
 			if l.LogRequestAtInfoLevel {
 				level.Info(requestLogD).Log("msg", "http request processed")
 			} else {


### PR DESCRIPTION
When debugging a possible issue with the `vcs` API, I realized we don't log 400 family errors. This makes it appear as if the requests succeeded, when in reality they may not have.