### PR TITLE
Fix: Acutally validate config struct

### DIFF
--- a/pkg/objstore/client/config.go
+++ b/pkg/objstore/client/config.go
@@ -89,6 +89,10 @@ func (cfg *StorageBackendConfig) RegisterFlagsWithPrefix(prefix string, f *flag.
 }
 
 func (cfg *StorageBackendConfig) Validate() error {
+	if cfg.Backend == None {
+		return nil
+	}
+
 	if !lo.Contains(cfg.supportedBackends(), cfg.Backend) {
 		return ErrUnsupportedStorageBackend
 	}

--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -234,10 +234,44 @@ func (c *Config) Validate() error {
 	if len(c.Target) == 0 {
 		return errors.New("no modules specified")
 	}
+
+	if err := c.Frontend.Validate(); err != nil {
+		return err
+	}
+
+	if err := c.Worker.Validate(util.Logger); err != nil {
+		return err
+	}
+
+	if err := c.LimitsConfig.Validate(); err != nil {
+		return err
+	}
+
+	if err := c.QueryScheduler.Validate(); err != nil {
+		return err
+	}
+
+	if err := c.Ingester.Validate(); err != nil {
+		return err
+	}
+
+	if err := c.StoreGateway.Validate(c.LimitsConfig); err != nil {
+		return err
+	}
+
+	if err := c.OverridesExporter.Validate(); err != nil {
+		return err
+	}
+
 	if err := c.Compactor.Validate(c.PhlareDB.MaxBlockDuration); err != nil {
 		return err
 	}
-	return c.Ingester.Validate()
+
+	if err := c.Storage.Bucket.Validate(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (c *Config) ApplyDynamicConfig() cfg.Source {


### PR DESCRIPTION
We seem to have not linked up the validation for a few components.
