### PR TITLE
chore: add check for generated files drift

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: lts/hydrogen
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: lts/hydrogen

--- a/.github/workflows/fuzzer.yml
+++ b/.github/workflows/fuzzer.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set GIT_LAST_COMMIT_DATE

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,18 +18,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.22.10
       - name: Format
         run: make fmt check/unstaged-changes
+  check-generated:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22.10
+      - name: Check generated files
+        run: make generate check/unstaged-changes
   test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
@@ -42,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
@@ -56,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
       - name: "Test docs"
         run: make docs/test
 
@@ -87,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -109,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -140,7 +151,7 @@ jobs:
     needs: [build-push]
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get github app token (valid for an hour)
         id: app-release
         uses: tibdex/github-app-token@v1

--- a/.github/workflows/test_ebpf.yml
+++ b/.github/workflows/test_ebpf.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Checkout code with submodule
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install Go

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -8,7 +8,7 @@ jobs:
   goreleaser-weekly:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set GORELEASER_CURRENT_TAG

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -634,7 +634,7 @@ ring:
 
       # Override the default cipher suite list (separated by commas). Allowed
       # values:
-      #
+      # 
       # Secure Ciphers:
       # - TLS_AES_128_GCM_SHA256
       # - TLS_AES_256_GCM_SHA384
@@ -649,7 +649,7 @@ ring:
       # - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
       # - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
       # - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
-      #
+      # 
       # Insecure Ciphers:
       # - TLS_RSA_WITH_RC4_128_SHA
       # - TLS_RSA_WITH_3DES_EDE_CBC_SHA
@@ -817,7 +817,7 @@ lifecycler:
 
         # Override the default cipher suite list (separated by commas). Allowed
         # values:
-        #
+        # 
         # Secure Ciphers:
         # - TLS_AES_128_GCM_SHA256
         # - TLS_AES_256_GCM_SHA384
@@ -832,7 +832,7 @@ lifecycler:
         # - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
         # - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         # - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
-        #
+        # 
         # Insecure Ciphers:
         # - TLS_RSA_WITH_RC4_128_SHA
         # - TLS_RSA_WITH_3DES_EDE_CBC_SHA
@@ -1183,7 +1183,7 @@ sharding_ring:
 
       # Override the default cipher suite list (separated by commas). Allowed
       # values:
-      #
+      # 
       # Secure Ciphers:
       # - TLS_AES_128_GCM_SHA256
       # - TLS_AES_256_GCM_SHA384
@@ -1198,7 +1198,7 @@ sharding_ring:
       # - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
       # - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
       # - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
-      #
+      # 
       # Insecure Ciphers:
       # - TLS_RSA_WITH_RC4_128_SHA
       # - TLS_RSA_WITH_3DES_EDE_CBC_SHA
@@ -1532,7 +1532,7 @@ sharding_ring:
 
       # Override the default cipher suite list (separated by commas). Allowed
       # values:
-      #
+      # 
       # Secure Ciphers:
       # - TLS_AES_128_GCM_SHA256
       # - TLS_AES_256_GCM_SHA384
@@ -1547,7 +1547,7 @@ sharding_ring:
       # - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
       # - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
       # - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
-      #
+      # 
       # Insecure Ciphers:
       # - TLS_RSA_WITH_RC4_128_SHA
       # - TLS_RSA_WITH_3DES_EDE_CBC_SHA
@@ -1740,7 +1740,7 @@ backoff_config:
 [tls_insecure_skip_verify: <boolean> | default = false]
 
 # Override the default cipher suite list (separated by commas). Allowed values:
-#
+# 
 # Secure Ciphers:
 # - TLS_AES_128_GCM_SHA256
 # - TLS_AES_256_GCM_SHA384
@@ -1755,7 +1755,7 @@ backoff_config:
 # - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 # - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
 # - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
-#
+# 
 # Insecure Ciphers:
 # - TLS_RSA_WITH_RC4_128_SHA
 # - TLS_RSA_WITH_3DES_EDE_CBC_SHA
@@ -1953,7 +1953,7 @@ The `memberlist` block configures the Gossip memberlist.
 [tls_insecure_skip_verify: <boolean> | default = false]
 
 # Override the default cipher suite list (separated by commas). Allowed values:
-#
+# 
 # Secure Ciphers:
 # - TLS_AES_128_GCM_SHA256
 # - TLS_AES_256_GCM_SHA384
@@ -1968,7 +1968,7 @@ The `memberlist` block configures the Gossip memberlist.
 # - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 # - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
 # - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
-#
+# 
 # Insecure Ciphers:
 # - TLS_RSA_WITH_RC4_128_SHA
 # - TLS_RSA_WITH_3DES_EDE_CBC_SHA
@@ -2253,9 +2253,14 @@ The s3_backend block configures the connection to Amazon S3 object storage backe
 # CLI flag: -storage.s3.signature-version
 [signature_version: <string> | default = "v4"]
 
-# Set this to `true` to force the bucket lookup to be using path-style.
+# Deprecated, use s3.bucket-lookup-type instead. Set this to `true` to force the
+# bucket lookup to be using path-style.
 # CLI flag: -storage.s3.force-path-style
 [force_path_style: <boolean> | default = false]
+
+# S3 bucket lookup style, use one of: [path-style virtual-hosted-style auto]
+# CLI flag: -storage.s3.bucket-lookup-type
+[bucket_lookup_type: <string> | default = "auto"]
 
 sse:
   # Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.


### PR DESCRIPTION
This PR adds a new job `check-generated` to verify that all generated files (documentation, protobuf, etc.) are up to date with their sources. This helps prevent situations where generated files drift from their sources.

Also, bumping workflows checkout action.