### PR TITLE
Metastore client fix + admin test page

### DIFF
--- a/pkg/api/api_experimental.go
+++ b/pkg/api/api_experimental.go
@@ -30,7 +30,9 @@ func (a *API) RegisterQueryBackend(svc *querybackend.QueryBackend) {
 
 func (a *API) RegisterMetastoreAdmin(adm *metastoreadmin.Admin) {
 	a.RegisterRoute("/metastore-nodes", adm.NodeListHandler(), false, true, "GET", "POST")
+	a.RegisterRoute("/metastore-client-test", adm.ClientTestHandler(), false, true, "GET", "POST")
 	a.indexPage.AddLinks(defaultWeight, "Metastore", []IndexPageLink{
 		{Desc: "Nodes", Path: "/metastore-nodes"},
+		{Desc: "Client Test", Path: "/metastore-client-test"},
 	})
 }

--- a/pkg/experiment/metastore/admin/metastore.client.gohtml
+++ b/pkg/experiment/metastore/admin/metastore.client.gohtml
@@ -17,25 +17,30 @@
             display: flex;
             margin-bottom: 0.5rem;
         }
+
         .card-detail-label {
             flex: 0 0 20%;
             font-weight: bold;
             text-align: right;
             padding-right: 1rem;
         }
+
         .card-detail-value {
             flex: 0 0 80%;
         }
+
         @media (max-width: 768px) {
             .card-detail-row {
                 flex-direction: column;
             }
+
             .card-detail-label {
                 text-align: left;
                 padding-right: 0;
                 margin-bottom: 0.25rem;
             }
         }
+
         .card {
             margin-bottom: 1rem;
         }
@@ -54,78 +59,71 @@
                 </a>
             </div>
         </div>
-        <div class="row my-3">
-            <h2>
-                Observed Leaders
-                <span
-                        class="text-info ms-2"
-                        data-bs-toggle="tooltip"
-                        data-bs-placement="right"
-                        title="Lists the leaders reported by individual Raft nodes, as well how many times each leader was observed.
-                        In a healthy cluster this should show a single leader, though this may not be the case during leadership transitions.">
-                <i class="bi bi-info-circle"></i>
-            </span>
-            </h2>
-            {{ range $server, $count := .Raft.ObservedLeaders }}
-            <div class="col-12">
-                <div class="alert alert-success" role="alert">
-                    <strong>{{ $server }}</strong> <span class="badge rounded-pill text-bg-info">{{ $count }}</span>
-                </div>
-            </div>
-            {{ end }}
-        </div>
-
         <div class="row gy-4">
             <h2>Nodes</h2>
             <form action="" method="POST">
                 <input type="hidden" name="current-term" value="{{ .Raft.CurrentTerm }}">
                 {{ $numNodes := .Raft.NumNodes }}
                 {{ range $index, $node := .Raft.Nodes }}
-                <div class="col-12">
-                    <div class="card">
-                        <div class="card-header">
-                            {{ $node.DiscoveryServerId }}
-                        </div>
-                        <div class="card-body">
-                            <div class="card-detail-row">
-                                <div class="card-detail-label">Resolved Address:</div>
-                                <div class="card-detail-value">{{ $node.ResolvedAddress }}</div>
+                    <div class="col-12">
+                        <div class="card">
+                            <div class="card-header">
+                                {{ $node.RaftServerId }}
                             </div>
-                            <div class="card-detail-row">
-                                <div class="card-detail-label">Raft Member:</div>
-                                <div class="card-detail-value">
-                                    {{ if $node.Member }}
-                                        <span class="badge text-bg-success">yes</span> ({{ $node.State }})
-                                    {{ else }}
-                                        <span class="badge text-bg-warning">no</span>
-                                    {{ end }}
+                            <div class="card-body">
+                                <div class="card-detail-row">
+                                    <div class="card-detail-label">Resolved Address:</div>
+                                    <div class="card-detail-value">{{ $node.ResolvedAddress }}</div>
                                 </div>
-                            </div>
-                            <div class="card-detail-row">
-                                <div class="card-detail-label">Raft Server ID:</div>
-                                <div class="card-detail-value">{{ $node.RaftServerId }}</div>
-                            </div>
-                            <div class="card-detail-row">
-                                <div class="card-detail-label">Observed Leader:</div>
-                                {{ $leaderId := $node.LeaderId }}
-                                {{ if eq $leaderId ""}}
-                                    {{ $leaderId = "n/a "}}
-                                {{ end }}
-                                <div class="card-detail-value">{{ $leaderId }} (term {{ $node.CurrentTerm }})</div>
+                                <div class="card-detail-row">
+                                    <div class="card-detail-label">Raft Member:</div>
+                                    <div class="card-detail-value">
+                                        {{ if $node.Member }}
+                                            <span class="badge text-bg-success">yes</span> ({{ $node.State }})
+                                        {{ else }}
+                                            <span class="badge text-bg-warning">no</span>
+                                        {{ end }}
+                                    </div>
+                                </div>
+                                <div class="card-detail-row">
+                                    <div class="card-detail-label">Raft Server ID:</div>
+                                    <div class="card-detail-value">{{ $node.RaftServerId }}</div>
+                                </div>
+                                <div class="card-detail-row">
+                                    <div class="card-detail-label">Observed Leader:</div>
+                                    {{ $leaderId := $node.LeaderId }}
+                                    {{ if eq $leaderId ""}}
+                                        {{ $leaderId = "n/a "}}
+                                    {{ end }}
+                                    <div class="card-detail-value">{{ $leaderId }} (term {{ $node.CurrentTerm }})</div>
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
                 {{ end }}
             </form>
         </div>
 
         <div class="row gy-4">
-            <h2>Client Test</h2>
-            <form action="" method="POST">
-                <button class="btn btn-info me-2" name="test" type="submit">Test</button>
-                {{ .TestResponse }}
-            </form>
+            <h2>Client Test</h2><div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <form action="" method="POST">
+                            <button class="btn btn-info me-2" name="test" type="submit">Test</button>
+                        </form>
+                    </div>
+                    <div class="card-body">
+                        <div class="card-detail-row">
+                            <div class="card-detail-label">Response</div>
+                            <div class="card-detail-value">{{ .TestResponse }}</div>
+                        </div>
+                        <div class="card-detail-row">
+                            <div class="card-detail-label">Response Time</div>
+                            <div class="card-detail-value">{{ .TestResponseTime }}</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </main>

--- a/pkg/experiment/metastore/admin/metastore.client.gohtml
+++ b/pkg/experiment/metastore/admin/metastore.client.gohtml
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>Metastore Admin - Client Test</title>
+
+    <link rel="stylesheet" href="/static/bootstrap-5.3.3.min.css">
+    <link rel="stylesheet" href="/static/bootstrap-icons-1.8.1.css">
+    <link rel="stylesheet" href="/static/pyroscope-styles.css">
+    <script src="/static/bootstrap-5.3.3.bundle.min.js"></script>
+
+    <style>
+        .card-detail-row {
+            display: flex;
+            margin-bottom: 0.5rem;
+        }
+        .card-detail-label {
+            flex: 0 0 20%;
+            font-weight: bold;
+            text-align: right;
+            padding-right: 1rem;
+        }
+        .card-detail-value {
+            flex: 0 0 80%;
+        }
+        @media (max-width: 768px) {
+            .card-detail-row {
+                flex-direction: column;
+            }
+            .card-detail-label {
+                text-align: left;
+                padding-right: 0;
+                margin-bottom: 0.25rem;
+            }
+        }
+        .card {
+            margin-bottom: 1rem;
+        }
+    </style>
+</head>
+<body>
+<main>
+    <div class="container mt-5">
+        <div class="header row border-bottom py-3 flex-column-reverse flex-sm-row">
+            <div class="col-12 col-sm-9 text-center text-sm-start">
+                <h1>Metastore: Grafana Pyroscope</h1>
+            </div>
+            <div class="col-12 col-sm-3 text-center text-sm-end mb-3 mb-sm-0">
+                <a href="/">
+                    <img alt="Pyroscope logo" class="pyroscope-brand" src="/static/pyroscope-logo.png">
+                </a>
+            </div>
+        </div>
+        <div class="row my-3">
+            <h2>
+                Observed Leaders
+                <span
+                        class="text-info ms-2"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="right"
+                        title="Lists the leaders reported by individual Raft nodes, as well how many times each leader was observed.
+                        In a healthy cluster this should show a single leader, though this may not be the case during leadership transitions.">
+                <i class="bi bi-info-circle"></i>
+            </span>
+            </h2>
+            {{ range $server, $count := .Raft.ObservedLeaders }}
+            <div class="col-12">
+                <div class="alert alert-success" role="alert">
+                    <strong>{{ $server }}</strong> <span class="badge rounded-pill text-bg-info">{{ $count }}</span>
+                </div>
+            </div>
+            {{ end }}
+        </div>
+
+        <div class="row gy-4">
+            <h2>Nodes</h2>
+            <form action="" method="POST">
+                <input type="hidden" name="current-term" value="{{ .Raft.CurrentTerm }}">
+                {{ $numNodes := .Raft.NumNodes }}
+                {{ range $index, $node := .Raft.Nodes }}
+                <div class="col-12">
+                    <div class="card">
+                        <div class="card-header">
+                            {{ $node.DiscoveryServerId }}
+                        </div>
+                        <div class="card-body">
+                            <div class="card-detail-row">
+                                <div class="card-detail-label">Resolved Address:</div>
+                                <div class="card-detail-value">{{ $node.ResolvedAddress }}</div>
+                            </div>
+                            <div class="card-detail-row">
+                                <div class="card-detail-label">Raft Member:</div>
+                                <div class="card-detail-value">
+                                    {{ if $node.Member }}
+                                        <span class="badge text-bg-success">yes</span> ({{ $node.State }})
+                                    {{ else }}
+                                        <span class="badge text-bg-warning">no</span>
+                                    {{ end }}
+                                </div>
+                            </div>
+                            <div class="card-detail-row">
+                                <div class="card-detail-label">Raft Server ID:</div>
+                                <div class="card-detail-value">{{ $node.RaftServerId }}</div>
+                            </div>
+                            <div class="card-detail-row">
+                                <div class="card-detail-label">Observed Leader:</div>
+                                {{ $leaderId := $node.LeaderId }}
+                                {{ if eq $leaderId ""}}
+                                    {{ $leaderId = "n/a "}}
+                                {{ end }}
+                                <div class="card-detail-value">{{ $leaderId }} (term {{ $node.CurrentTerm }})</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                {{ end }}
+            </form>
+        </div>
+
+        <div class="row gy-4">
+            <h2>Client Test</h2>
+            <form action="" method="POST">
+                <button class="btn btn-info me-2" name="test" type="submit">Test</button>
+                {{ .TestResponse }}
+            </form>
+        </div>
+    </div>
+</main>
+<footer class="footer mt-auto py-3">
+    <div class="container">
+        <small class="text-muted">Status @ {{ .Now.Format "2006-01-02 15:04:05.000" }}</small>
+    </div>
+</footer>
+<script type="text/javascript">
+    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
+    const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+</script>
+</body>
+</html>

--- a/pkg/experiment/metastore/admin/pages.go
+++ b/pkg/experiment/metastore/admin/pages.go
@@ -49,9 +49,10 @@ type nodesPageContent struct {
 }
 
 type clientTestPageContent struct {
-	Raft         *raftNodeState
-	Now          time.Time
-	TestResponse string
+	Raft             *raftNodeState
+	Now              time.Time
+	TestResponse     string
+	TestResponseTime time.Duration
 }
 
 type templates struct {

--- a/pkg/experiment/metastore/admin/pages.go
+++ b/pkg/experiment/metastore/admin/pages.go
@@ -11,6 +11,9 @@ import (
 //go:embed metastore.nodes.gohtml
 var nodesPageHtml string
 
+//go:embed metastore.client.gohtml
+var clientTestPageHtml string
+
 type metastoreNode struct {
 	// from Discovery
 	DiscoveryServerId string
@@ -45,8 +48,15 @@ type nodesPageContent struct {
 	Now               time.Time
 }
 
+type clientTestPageContent struct {
+	Raft         *raftNodeState
+	Now          time.Time
+	TestResponse string
+}
+
 type templates struct {
-	nodesTemplate *template.Template
+	nodesTemplate      *template.Template
+	clientTestTemplate *template.Template
 }
 
 var pageTemplates = initTemplates()
@@ -54,8 +64,11 @@ var pageTemplates = initTemplates()
 func initTemplates() *templates {
 	nodesTemplate := template.New("nodes")
 	template.Must(nodesTemplate.Parse(nodesPageHtml))
+	clientTestTemplate := template.New("clientTest")
+	template.Must(clientTestTemplate.Parse(clientTestPageHtml))
 	t := &templates{
-		nodesTemplate: nodesTemplate,
+		nodesTemplate:      nodesTemplate,
+		clientTestTemplate: clientTestTemplate,
 	}
 	return t
 }

--- a/pkg/experiment/metastore/client/client.go
+++ b/pkg/experiment/metastore/client/client.go
@@ -89,7 +89,8 @@ func (c *Client) updateServers(servers []discovery.Server) {
 	c.logger.Log("msg", "updating servers", "servers", fmt.Sprintf("%+v", servers))
 	byID := make(map[raft.ServerID][]discovery.Server, len(servers))
 	for _, srv := range servers {
-		byID[srv.Raft.ID] = append(byID[srv.Raft.ID], srv)
+		id := stripPort(string(srv.Raft.ID))
+		byID[id] = append(byID[id], srv)
 	}
 	for k, ss := range byID {
 		if len(ss) > 1 {

--- a/pkg/experiment/metastore/client/methods.go
+++ b/pkg/experiment/metastore/client/methods.go
@@ -2,12 +2,12 @@ package metastoreclient
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"strings"
 	"time"
 
 	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/backoff"
 	"github.com/hashicorp/raft"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -21,39 +21,40 @@ import (
 func invoke[R any](ctx context.Context, cl *Client,
 	f func(ctx context.Context, instance instance) (*R, error),
 ) (*R, error) {
+	backoffConfig := backoff.Config{
+		MinBackoff: 10 * time.Millisecond,
+		MaxBackoff: 100 * time.Millisecond,
+		MaxRetries: 50,
+	}
 	const (
-		n        = 50
-		backoff  = 51 * time.Millisecond
-		deadline = 500000000 * time.Millisecond
+		deadline = 20 * time.Second
 	)
 
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(deadline))
 	defer cancel()
 
-	for i := 0; i < n; i++ {
-		err := ctx.Err()
-		if err != nil {
-			return nil, fmt.Errorf("metastore client timeout %w", err)
-		}
+	var res *R
+	var err error
+
+	attempt := func() (done bool) {
 		it := cl.selectInstance(false)
 		if it == nil {
 			cl.logger.Log("msg", "no instances available, backoff and retry")
-			time.Sleep(backoff)
-			cl.discovery.Rediscover()
-			continue
+			return false
 		}
-		res, err := f(ctx, it)
-		if err == nil {
-			return res, nil
+		responseFromAttempt, errFromAttempt := f(ctx, it)
+		if errFromAttempt == nil {
+			res = responseFromAttempt
+			return true
 		}
 		cl.logger.Log(
 			"msg", "metastore client error",
-			"err", err,
+			"err", errFromAttempt,
 			"server_id", it.srv.Raft.ID,
 			"server_address", it.srv.Raft.Address,
 			"server_resolved_address", it.srv.ResolvedAddress,
 		)
-		node, ok := raftnode.RaftLeaderFromStatusDetails(err)
+		node, ok := raftnode.RaftLeaderFromStatusDetails(errFromAttempt)
 		if ok {
 			cl.mu.Lock()
 			if strings.Contains(string(it.srv.Raft.ID), string(cl.leader)) {
@@ -67,15 +68,27 @@ func invoke[R any](ctx context.Context, cl *Client,
 			cl.selectInstance(true)
 		}
 		// A workaround to prevent retries for specific error codes. This needs a larger refactoring later on.
-		switch status.Code(err) {
+		switch status.Code(errFromAttempt) {
 		case codes.InvalidArgument:
 			cl.logger.Log("msg", "skip metastore retries", "err", err, "leader", cl.leader)
-			return nil, err
+			err = errFromAttempt
+			return true
 		}
-		time.Sleep(backoff)
-		cl.discovery.Rediscover()
+		return false
 	}
-	return nil, fmt.Errorf("metastore client retries failed")
+
+	b := backoff.New(ctx, backoffConfig)
+
+	for b.Ongoing() {
+		if !attempt() {
+			b.Wait()
+			cl.discovery.Rediscover()
+		} else {
+			return res, err
+		}
+	}
+
+	return nil, b.Err()
 }
 
 func (c *Client) selectInstance(override bool) *client {

--- a/pkg/experiment/metastore/discovery/kuberesolver.go
+++ b/pkg/experiment/metastore/discovery/kuberesolver.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/hashicorp/raft"
 	"google.golang.org/grpc/resolver"
 
@@ -39,7 +40,7 @@ func NewKubeResolverDiscovery(l log.Logger, target string, client kuberesolver2.
 	if err != nil {
 		return nil, err
 	}
-	l.Log("msg", "parsed target", "target_namespace", ti.namespace, "target_service", ti.service, "target_port", ti.port)
+	level.Info(l).Log("msg", "parsed target", "target_namespace", ti.namespace, "target_service", ti.service, "target_port", ti.port)
 
 	res := &KubeDiscovery{
 		l:  l,
@@ -79,7 +80,7 @@ func (g *KubeDiscovery) Close() {
 func (g *KubeDiscovery) resolved(e kuberesolver2.Endpoints) {
 	for _, subset := range e.Subsets {
 		for _, addr := range subset.Addresses {
-			g.l.Log("msg", "resolved", "ip", addr.IP, "targetRef", fmt.Sprintf("%+v", addr.TargetRef))
+			level.Debug(g.l).Log("msg", "resolved", "ip", addr.IP, "targetRef", fmt.Sprintf("%+v", addr.TargetRef))
 		}
 	}
 	g.updLock.Lock()

--- a/pkg/experiment/metastore/discovery/kuberesolver.go
+++ b/pkg/experiment/metastore/discovery/kuberesolver.go
@@ -2,13 +2,15 @@ package discovery
 
 import (
 	"fmt"
-	"github.com/go-kit/log"
-	kuberesolver2 "github.com/grafana/pyroscope/pkg/experiment/metastore/discovery/kuberesolver"
-	"github.com/hashicorp/raft"
-	"google.golang.org/grpc/resolver"
 	"net/url"
 	"strings"
 	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/hashicorp/raft"
+	"google.golang.org/grpc/resolver"
+
+	kuberesolver2 "github.com/grafana/pyroscope/pkg/experiment/metastore/discovery/kuberesolver"
 )
 
 type KubeDiscovery struct {
@@ -97,7 +99,7 @@ func convertEndpoints(e kuberesolver2.Endpoints, ti targetInfo) []Server {
 					continue
 				}
 				podName := addr.TargetRef.Name
-				raftServerId := fmt.Sprintf("%s.%s.%s:%d", podName, ti.service, ti.namespace, port.Port)
+				raftServerId := fmt.Sprintf("%s.%s.%s.svc.cluster.local.:%d", podName, ti.service, ti.namespace, port.Port)
 
 				servers = append(servers, Server{
 					ResolvedAddress: fmt.Sprintf("%s:%d", addr.IP, port.Port),

--- a/pkg/experiment/metastore/discovery/kuberesolver_test.go
+++ b/pkg/experiment/metastore/discovery/kuberesolver_test.go
@@ -2,12 +2,14 @@ package discovery
 
 import (
 	"fmt"
-	kuberesolver2 "github.com/grafana/pyroscope/pkg/experiment/metastore/discovery/kuberesolver"
+	"testing"
+	"time"
+
 	"github.com/hashicorp/raft"
 	"github.com/prometheus/prometheus/util/testutil"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
+
+	kuberesolver2 "github.com/grafana/pyroscope/pkg/experiment/metastore/discovery/kuberesolver"
 )
 
 func TestDebugLocalhost(t *testing.T) {
@@ -91,22 +93,22 @@ func TestConvert(t *testing.T) {
 		{
 			ResolvedAddress: "10.244.1.5:9095",
 			Raft: raft.Server{
-				ID:      raft.ServerID("pyroscope-metastore-0.pyroscope-metastore-headless.pyroscope-test:9095"),
-				Address: raft.ServerAddress("pyroscope-metastore-0.pyroscope-metastore-headless.pyroscope-test:9095"),
+				ID:      raft.ServerID("pyroscope-metastore-0.pyroscope-metastore-headless.pyroscope-test.svc.cluster.local.:9095"),
+				Address: raft.ServerAddress("pyroscope-metastore-0.pyroscope-metastore-headless.pyroscope-test.svc.cluster.local.:9095"),
 			},
 		},
 		{
 			ResolvedAddress: "10.244.2.7:9095",
 			Raft: raft.Server{
-				ID:      raft.ServerID("pyroscope-metastore-1.pyroscope-metastore-headless.pyroscope-test:9095"),
-				Address: raft.ServerAddress("pyroscope-metastore-1.pyroscope-metastore-headless.pyroscope-test:9095"),
+				ID:      raft.ServerID("pyroscope-metastore-1.pyroscope-metastore-headless.pyroscope-test.svc.cluster.local.:9095"),
+				Address: raft.ServerAddress("pyroscope-metastore-1.pyroscope-metastore-headless.pyroscope-test.svc.cluster.local.:9095"),
 			},
 		},
 		{
 			ResolvedAddress: "10.244.3.7:9095",
 			Raft: raft.Server{
-				ID:      raft.ServerID("pyroscope-metastore-2.pyroscope-metastore-headless.pyroscope-test:9095"),
-				Address: raft.ServerAddress("pyroscope-metastore-2.pyroscope-metastore-headless.pyroscope-test:9095"),
+				ID:      raft.ServerID("pyroscope-metastore-2.pyroscope-metastore-headless.pyroscope-test.svc.cluster.local.:9095"),
+				Address: raft.ServerAddress("pyroscope-metastore-2.pyroscope-metastore-headless.pyroscope-test.svc.cluster.local.:9095"),
 			},
 		},
 	}

--- a/pkg/phlare/modules_experimental.go
+++ b/pkg/phlare/modules_experimental.go
@@ -163,7 +163,7 @@ func (f *Phlare) initMetastoreAdmin() (services.Service, error) {
 	}
 
 	var err error
-	f.metastoreAdmin, err = metastoreadmin.New(f.metastoreClient, f.logger, f.Cfg.Metastore.Address)
+	f.metastoreAdmin, err = metastoreadmin.New(f.metastoreClient, f.logger, f.Cfg.Metastore.Address, f.metastoreClient)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -433,7 +433,7 @@ func (f *Phlare) setupModuleManager() error {
 		RuntimeConfig:     {API},
 		IngesterRing:      {API, MemberlistKV},
 		MemberlistKV:      {API},
-		Admin:             {API, Storage},
+		Admin:             {API, Storage, MetastoreAdmin},
 		Version:           {API, MemberlistKV},
 		TenantSettings:    {API, Storage},
 		AdHocProfiles:     {API, Overrides, Storage},

--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -433,7 +433,7 @@ func (f *Phlare) setupModuleManager() error {
 		RuntimeConfig:     {API},
 		IngesterRing:      {API, MemberlistKV},
 		MemberlistKV:      {API},
-		Admin:             {API, Storage, MetastoreAdmin},
+		Admin:             {API, Storage},
 		Version:           {API, MemberlistKV},
 		TenantSettings:    {API, Storage},
 		AdHocProfiles:     {API, Overrides, Storage},


### PR DESCRIPTION
**Background**
We have observed metastore client latency spikes during rollouts / leadership changes.

The client relies on error responses containing the new leader, however there is a mismatch in what the client expects and what metastore nodes return.

**Problem**
The metastore client discovers servers using the grpc port (9095) and maintains a map with addresses such as 
```pyroscope-metastore-0.pyroscope-metastore-headless.profiles-dev-003:9095```

Metastore nodes return the leader using the Raft port (9099) and the `svc.cluster.local` domain:
```pyroscope-metastore-0.pyroscope-metastore-headless.profiles-dev-003.svc.cluster.local.:9099```

This causes a failed check here: https://github.com/grafana/pyroscope/blob/f4cec5d93dfbb8b49940e569520655ef1a47731b/pkg/experiment/metastore/client/methods.go#L83-L85
As a result we resort to random selections until we hit the right node.

**Fix**
The main options are to “hack” the client and massage the data or change the Raft server identity. This PR does the former, it is however messy and ideally we should align the two components. I will give the second option a try as well.

Either way we go the latency becomes stable, however we can't go lower than 51ms because of the fixed backoff here: https://github.com/grafana/pyroscope/blob/f4cec5d93dfbb8b49940e569520655ef1a47731b/pkg/experiment/metastore/client/methods.go#L24
For this, we can consider switching to a more aggressive and maybe exponential backoff.

**Bonus**
I've added a metastore client test page to make testing easier. 

![Screenshot 2025-01-17 at 17 53 19](https://github.com/user-attachments/assets/4df841bc-f910-4693-ba40-8cd06100805b)
