### PR TITLE
fix(v2): ignore client timeouts in write-path circuit breaker

### DIFF
--- a/pkg/experiment/ingester/client/client_test.go
+++ b/pkg/experiment/ingester/client/client_test.go
@@ -163,6 +163,15 @@ func (s *segwriterClientSuite) Test_Push_ClientError_Cancellation() {
 	s.Assert().Equal(codes.Canceled.String(), status.Code(err).String())
 }
 
+func (s *segwriterClientSuite) Test_Push_ClientError_Deadline() {
+	s.service.On("Push", mock.Anything, mock.Anything).
+		Return(new(segmentwriterv1.PushResponse), context.DeadlineExceeded).
+		Once()
+
+	_, err := s.client.Push(context.Background(), &segmentwriterv1.PushRequest{})
+	s.Assert().Equal(codes.DeadlineExceeded.String(), status.Code(err).String())
+}
+
 func (s *segwriterClientSuite) Test_Push_ClientError_InvalidArgument() {
 	s.service.On("Push", mock.Anything, mock.Anything).
 		Return(new(segmentwriterv1.PushResponse), status.Error(codes.InvalidArgument, errServiceUnavailableMsg)).


### PR DESCRIPTION
Currently, client timeouts may trigger the segment-writer client circuit breaker, causing a specific segment-writer service instance to be temporarily removed from the connection pool. On one hand, this behavior is justified because if one of the instances is temporarily overloaded (e.g., due to a burst), we want to send fewer requests to it.

In practice, however, this is a very rare case, and the adaptive load balancing we have is usually fast enough to prevent hot spots. What we may observe instead is that either all the instances are overloaded (evenly) or the client (the distributor) itself is overloaded. In such cases, the availability of the write path might degrade due to circuit breaker flapping. Another interesting side effect is an increase in the number of segments created (because more than one segment-writer will be uploading data for each shard), leading to additional pressure on the compaction process.