### PR TITLE
chore(v2): improve error handling in compaction-worker

### DIFF
--- a/pkg/experiment/metastore/compaction_raft_handler.go
+++ b/pkg/experiment/metastore/compaction_raft_handler.go
@@ -163,8 +163,8 @@ func (h *CompactionCommandHandler) UpdateCompactionPlan(
 
 	for _, job := range req.PlanUpdate.CompletedJobs {
 		compacted := job.GetCompactedBlocks()
-		if compacted == nil {
-			level.Error(h.logger).Log("msg", "compacted blocks are missing", "job", job.State.Name)
+		if compacted == nil || compacted.SourceBlocks == nil || len(compacted.NewBlocks) == 0 {
+			level.Warn(h.logger).Log("msg", "compacted blocks are missing; skipping", "job", job.State.Name)
 			continue
 		}
 		if err := h.tombstones.AddTombstones(tx, cmd, blockTombstonesForCompletedJob(job)); err != nil {


### PR DESCRIPTION
Currently, a compaction job is abandoned by compaction workers if the blocks cannot be found in storage or if the metadata for the blocks cannot be retrieved. Such jobs remain incomplete and linger in the scheduler table indefinitely. This change enforces that compaction workers report an "empty" result for jobs that are known a priori to be uncompletable. The job entry is then removed from the compaction planner queue and the job scheduler, without replacing any blocks.

We need a mechanism that will evict such jobs, but this is out of scope of the PR. 