### PR TITLE
fix(otel): ignore empty offcpu profile

### DIFF
--- a/pkg/ingester/otlp/ingest_handler.go
+++ b/pkg/ingester/otlp/ingest_handler.go
@@ -130,6 +130,9 @@ func (h *ingestHandler) Export(ctx context.Context, er *pprofileotlp.ExportProfi
 					}
 					req.Series = append(req.Series, s)
 				}
+				if len(req.Series) == 0 {
+					continue
+				}
 				_, err := h.svc.PushParsed(ctx, req)
 				if err != nil {
 					h.log.Log("msg", "failed to push profile", "err", err)


### PR DESCRIPTION
With the new offcpu profiler, the profiler sends two profiles in a single request and the offcpu profile is empty if it is not enabled.



https://github.com/open-telemetry/opentelemetry-ebpf-profiler/blob/10b4b224857bcaab2fb0819e5a5c7c0cf6e03b07/reporter/internal/pdata/generate.go#L32-L36

Which leads to us sending empty requests 
```
 time="2025-01-22T06:23:24Z" level=error msg="Request failed: rpc error: code = Unknown desc = failed to make a GRPC request: invalid_argument: no │
│  profiles received"            
```