### PR TITLE
chore: migrate main builds from gcr to dockerhub

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,23 +130,18 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.22.11
-      - uses: actions/setup-node@v3
-        with:
-          node-version: lts/hydrogen
-          cache: yarn
-      - name: Login to GCR
+      - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
-          registry: us.gcr.io
-          username: _json_key
-          password: ${{ secrets.GCR_JSON_KEY }}
-      - name: Pyroscope Build & push multi-arch image
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Pyroscope Build & push multi-arch image # todo make it multi-arch
         id: build-push
         run: |
           make docker-image/pyroscope/push docker-image/pyroscope/push-debug "BUILDX_ARGS=--cache-from=type=gha --cache-to=type=gha"
 
   deploy-dev-001:
-    if: github.event_name == 'push' && github.repository == 'grafana/pyroscope'
+    if: github.event_name == 'push' && github.repository == 'grafana/pyroscope' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [build-push]
     steps:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GOPRIVATE=github.com/grafana/frostdb
 
 # Boiler plate for building Docker containers.
 # All this must go at top of file I'm afraid.
-IMAGE_PREFIX ?= us.gcr.io/kubernetes-dev/
+IMAGE_PREFIX ?= grafana/
 
 IMAGE_TAG ?= $(shell ./tools/image-tag)
 GIT_REVISION := $(shell git rev-parse --short HEAD)
@@ -197,7 +197,7 @@ check/go/mod: go/mod
 
 
 define docker_buildx
-	docker buildx build $(1) --platform $(IMAGE_PLATFORM) $(BUILDX_ARGS) --build-arg=revision=$(GIT_REVISION) -t $(IMAGE_PREFIX)$(shell basename $(@D)):$(2)latest -t $(IMAGE_PREFIX)$(shell basename $(@D)):$(2)$(IMAGE_TAG) -f cmd/$(shell basename $(@D))/$(2)Dockerfile .
+	docker buildx build $(1) --platform $(IMAGE_PLATFORM) $(BUILDX_ARGS) --build-arg=revision=$(GIT_REVISION) -t $(IMAGE_PREFIX)$(shell basename $(@D)):$(2)$(IMAGE_TAG) -f cmd/$(shell basename $(@D))/$(2)Dockerfile .
 endef
 
 define deploy

--- a/docs/internal/contributing/README.md
+++ b/docs/internal/contributing/README.md
@@ -81,7 +81,7 @@ replace `image: grafana/pyroscope` with the local tag name you got from docker-i
 
 ```
   pyroscope:
-    image: us.gcr.io/kubernetes-dev/pyroscope:main-470125e1-WIP
+    image: grafana/pyroscope:main-470125e1-WIP
     ports:
       - '4040:4040'
 ```


### PR DESCRIPTION
- push to `grafana/` in dockerhub instead of `gcr`
- do not push `latest` tag