### PR TITLE
chore(ci): push multi-arch image for main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Pyroscope Build & push multi-arch image
         id: build-push
         run: |
-          make docker-image/pyroscope/push docker-image/pyroscope/push-debug "BUILDX_ARGS=--cache-from=type=gha --cache-to=type=gha"
+          make docker-image/pyroscope/push-multiarch "BUILDX_ARGS=--cache-from=type=gha --cache-to=type=gha"
 
   deploy-dev-001:
     if: github.event_name == 'push' && github.repository == 'grafana/pyroscope'

--- a/Makefile
+++ b/Makefile
@@ -274,8 +274,8 @@ docker-image/pyroscope/push: frontend/build go/bin
 
 .PHONY: docker-image/pyroscope/dlv
 docker-image/pyroscope/dlv:
-    # dlv is not intended for local use and is to be installed in the
-    # platform-specific docker image together with the main Pyroscope binary.
+	# dlv is not intended for local use and is to be installed in the
+	# platform-specific docker image together with the main Pyroscope binary.
 	@mkdir -p $(@D)
 	GOPATH=$(CURDIR)/.tmp CGO_ENABLED=0 $(GO) install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@v1.23.0
 	mv $(CURDIR)/.tmp/bin/$(GOOS)_$(GOARCH)/dlv $(CURDIR)/.tmp/bin/dlv

--- a/cmd/pyroscope/debug.Dockerfile
+++ b/cmd/pyroscope/debug.Dockerfile
@@ -12,7 +12,7 @@ VOLUME /data
 VOLUME /data-compactor
 RUN mkdir -p /data-compactor && chown pyroscope:pyroscope /data /data-compactor
 
-COPY .tmp/bin/linux_amd64/dlv /usr/bin/dlv
+COPY .tmp/bin/dlv /usr/bin/dlv
 COPY cmd/pyroscope/pyroscope.yaml /etc/pyroscope/config.yaml
 COPY profilecli /usr/bin/profilecli
 COPY pyroscope /usr/bin/pyroscope


### PR DESCRIPTION
Currently, we build only `linux/amd64` images on the main branch. This change adds support for the `linux/arm64` platform.

In addition, I disabled `debug` builds in CI for _the main branch_: they are rarely needed, especially urgently (since no guarantees are provided for the main branch builds). The debug image can still be built on demand, as debugging often requires multiple iterations, making `main` debug images less useful. Debug images for weekly builds and release versions are preserved.
