### PR TITLE
fix(ci): push multi-arch manifest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,7 +113,7 @@ jobs:
           node-version: lts/hydrogen
           cache: yarn
       - name: Build image Pyroscope
-        run: make docker-image/pyroscope/build "BUILDX_ARGS=--cache-from=type=gha --cache-to=type=gha"
+        run: make docker-image/pyroscope/build-multiarch "BUILDX_ARGS=--cache-from=type=gha --cache-to=type=gha"
 
   build-push:
     if: github.event_name == 'push' && github.repository == 'grafana/pyroscope'

--- a/Makefile
+++ b/Makefile
@@ -232,10 +232,10 @@ define multiarch_build
 	$(eval build_cmd=docker-image/pyroscope/$(if $(push_image),push,build)$(if $(debug_build),-debug))
 	$(eval image_name=$(IMAGE_PREFIX)$(shell basename $(@D)):$(if $(debug_build),debug.)$(IMAGE_TAG))
 
-	GOOS=linux GOARCH=arm64 IMAGE_TAG="$(IMAGE_TAG)-arm64" IMAGE_PLATFORM=linux/arm64 $(MAKE) $(build_cmd)
-	GOOS=linux GOARCH=amd64 IMAGE_TAG="$(IMAGE_TAG)-amd64" IMAGE_PLATFORM=linux/amd64 $(MAKE) $(build_cmd)
+	GOOS=linux GOARCH=arm64 IMAGE_TAG="$(IMAGE_TAG)-arm64" $(MAKE) $(build_cmd) IMAGE_PLATFORM=linux/arm64
+	GOOS=linux GOARCH=amd64 IMAGE_TAG="$(IMAGE_TAG)-amd64" $(MAKE) $(build_cmd) IMAGE_PLATFORM=linux/amd64
 
-	$(if $(PUSH_IMAGE), \
+	$(if $(push_image), \
 		docker manifest create --amend "$(image_name)" "$(image_name)-amd64" "$(image_name)-arm64" && \
 		docker manifest push "$(image_name)")
 endef


### PR DESCRIPTION
There are two issues in #3877: the multi-arch manifest is not pushed and the arch override may not be propagated properly. The PR fixes both.

I'm also adding `arm64` to the `build-image` step, so it runs on PRs.