### PR TITLE
fix(ci): multi-arch build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,9 +235,7 @@ define multiarch_build
 	GOOS=linux GOARCH=arm64 IMAGE_TAG="$(IMAGE_TAG)-arm64" $(MAKE) $(build_cmd) IMAGE_PLATFORM=linux/arm64
 	GOOS=linux GOARCH=amd64 IMAGE_TAG="$(IMAGE_TAG)-amd64" $(MAKE) $(build_cmd) IMAGE_PLATFORM=linux/amd64
 
-	$(if $(push_image), \
-		docker manifest create --amend "$(image_name)" "$(image_name)-amd64" "$(image_name)-arm64" && \
-		docker manifest push "$(image_name)")
+	$(if $(push_image), docker buildx imagetools create --tag "$(image_name)" "$(image_name)-amd64" "$(image_name)-arm64")
 endef
 
 .PHONY: docker-image/pyroscope/build-multiarch


### PR DESCRIPTION
Starting from `buildx` v0.10.0, `docker manifest` can no longer be used to create multi-platform images. This is due to a change in the output format, which now includes a _provenance attestation_ and creates a manifest list – something that `docker manifest` does not expect and cannot handle. Instead, `docker buildx imagetools` should be used to craft multi-architecture manifests.

We should also consider using `docker buildx imagetools` in weekly builds, where we re-push images using the standard Docker, which does not add attestation and, therefore, avoids this issue.