### PR TITLE
chore(ci): run tests on both amd64 and arm64

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,7 +14,14 @@ concurrency:
 
 jobs:
   regular-path:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: github-hosted-ubuntu-arm64
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -27,10 +34,11 @@ jobs:
         with:
           go-version: "1.22.11"
           cache: true
-      - run: yarn --frozen-lockfile
+      - name: Install node-canvas
+        run: sudo apt-get update && sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
       - run: make build
       - name: Cypress run
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           wait-on: http://localhost:4040/ready
           start: make run
@@ -57,12 +65,13 @@ jobs:
         with:
           go-version: "1.22.11"
           cache: true
-      - run: yarn --frozen-lockfile
+      - name: Install node-canvas
+        run: sudo apt-get update && sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
       - run: make build
       - name: run nginx with /foobar/
         run: docker compose -f scripts/base-url/docker-compose.yaml up -d
       - name: Cypress run
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           wait-on: http://localhost:8080/foobar/ready
           start: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - arch: arm64
-            runner: github-hosted-ubuntu-arm64
+            runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,9 +41,9 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - arch: arm64
-            runner: github-hosted-ubuntu-arm64
+            runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,14 @@ jobs:
       - name: Check generated files
         run: make generate check/unstaged-changes
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: github-hosted-ubuntu-arm64
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
* Enables Go unit tests on arm64.
* arm64 e2e: enabled for the `regular path` only. The canvas library cypress depends on is not released for `linux/arm64`, so I had to add some dependencies.
  * The test will take longer and will likely determine the overall CI workflow duration. Given that the test is not very extensive, we may consider disabling it. However, even a smoke test is better than nothing – this is why I kept it.
* Linting is still only run for `linux/amd64`. As long as we don't have arch-dependent code, this is fine. Let me know if you want to enable linting for arm64 as well.

Resolves #3880
