### PR TITLE
examples: Add pyroscope relabel componet in rideshare-alloy example

### DIFF
--- a/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/README.md
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/README.md
@@ -45,7 +45,7 @@ pyroscope.write "backend" {
 # Pull latest images
 docker pull grafana/pyroscope:latest
 docker pull grafana/grafana:latest
-docker pull grafana/alloy:latest
+docker pull grafana/grafana/alloy-dev:latest
 
 # Run the example
 docker-compose up --build

--- a/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/config.alloy
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/config.alloy
@@ -7,35 +7,41 @@ pyroscope.receive_http "default" {
 }
 
 pyroscope.relabel "filter_profiles" {
-    // Convert region to datacenter
+    // Group regions into geographical areas for better aggregation
     rule {
         action = "replace"
         source_labels = ["region"]
-        target_label = "datacenter"
+        target_label = "geo_area"
+        regex = "(us-.*)"
+        replacement = "americas"
+    }
+    rule {
+        action = "replace"
+        source_labels = ["region"]
+        target_label = "geo_area"
+        regex = "(eu-.*)"
+        replacement = "emea"
+    }
+    rule {
+        action = "replace"
+        source_labels = ["region"]
+        target_label = "geo_area"
+        regex = "(ap-.*)"
+        replacement = "apac"
     }
 
-    // Add environment label
-    rule {
-        action = "replace"
-        target_label = "environment"
-        replacement = "demo"
-    }
-
-    // Add component label based on application name
-    rule {
-        action = "replace"
-        source_labels = ["__name__"]
-        target_label = "component"
-        regex = "ride-sharing-app.*"
-        replacement = "backend"
-    }
-    rule {
-        action = "replace"
-        source_labels = ["__name__"]
-        target_label = "component"
-        regex = "load-generator.*"
-        replacement = "load-generator"
-    }
+    // Example: Sample profiles by service_name (drop 30% of services)
+    // rule {
+    //     action = "hashmod"
+    //     source_labels = ["service_name"]
+    //     target_label = "__tmp_hash"
+    //     modulus = 10
+    //}
+    // rule {
+    //     action = "drop"
+    //     source_labels = ["__tmp_hash"]
+    //     regex = "^(0|1|2)$"  // Drop profiles from services that hash to 0-2
+    // }
 
     forward_to = [pyroscope.write.backend.receiver]
 }

--- a/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/config.alloy
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/config.alloy
@@ -3,6 +3,40 @@ pyroscope.receive_http "default" {
         listen_address = "0.0.0.0"
         listen_port = 9999
     }
+    forward_to = [pyroscope.relabel.filter_profiles.receiver]
+}
+
+pyroscope.relabel "filter_profiles" {
+    // Convert region to datacenter
+    rule {
+        action = "replace"
+        source_labels = ["region"]
+        target_label = "datacenter"
+    }
+
+    // Add environment label
+    rule {
+        action = "replace"
+        target_label = "environment"
+        replacement = "demo"
+    }
+
+    // Add component label based on application name
+    rule {
+        action = "replace"
+        source_labels = ["__name__"]
+        target_label = "component"
+        regex = "ride-sharing-app.*"
+        replacement = "backend"
+    }
+    rule {
+        action = "replace"
+        source_labels = ["__name__"]
+        target_label = "component"
+        regex = "load-generator.*"
+        replacement = "load-generator"
+    }
+
     forward_to = [pyroscope.write.backend.receiver]
 }
 

--- a/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       context: .
 
   alloy:
-    image: grafana/alloy:latest
+    image: grafana/alloy-dev:latest
     command:
       - run
       - /etc/alloy/config.alloy
@@ -36,6 +36,7 @@ services:
       - ./config.alloy:/etc/alloy/config.alloy
     ports:
       - "9999:9999"
+      - "12345:12345"
 
   pyroscope:
     image: grafana/pyroscope:latest


### PR DESCRIPTION
This PR extends the rideshare-alloy example by adding label enrichment capabilities to demonstrate how to add meaningful metadata to profiles through the `pyroscope.relabel` component.