### PR TITLE
fix(ring): use net.JoinHostPort to support IPv6 addresses

### DIFF
--- a/pkg/compactor/compactor_ring.go
+++ b/pkg/compactor/compactor_ring.go
@@ -7,7 +7,8 @@ package compactor
 
 import (
 	"flag"
-	"fmt"
+	"net"
+	"strconv"
 	"time"
 
 	"github.com/go-kit/log"
@@ -64,7 +65,7 @@ func (cfg *RingConfig) ToBasicLifecyclerConfig(logger log.Logger) (ring.BasicLif
 
 	return ring.BasicLifecyclerConfig{
 		ID:                              cfg.Common.InstanceID,
-		Addr:                            fmt.Sprintf("%s:%d", instanceAddr, instancePort),
+		Addr:                            net.JoinHostPort(instanceAddr, strconv.Itoa(instancePort)),
 		HeartbeatPeriod:                 cfg.Common.HeartbeatPeriod,
 		HeartbeatTimeout:                cfg.Common.HeartbeatTimeout,
 		TokensObservePeriod:             cfg.ObservePeriod,

--- a/pkg/distributor/distributor_ring.go
+++ b/pkg/distributor/distributor_ring.go
@@ -1,7 +1,8 @@
 package distributor
 
 import (
-	"fmt"
+	"net"
+	"strconv"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/ring"
@@ -26,7 +27,7 @@ func toBasicLifecyclerConfig(cfg util.CommonRingConfig, logger log.Logger) (ring
 
 	return ring.BasicLifecyclerConfig{
 		ID:                              cfg.InstanceID,
-		Addr:                            fmt.Sprintf("%s:%d", instanceAddr, instancePort),
+		Addr:                            net.JoinHostPort(instanceAddr, strconv.Itoa(instancePort)),
 		HeartbeatPeriod:                 cfg.HeartbeatPeriod,
 		HeartbeatTimeout:                cfg.HeartbeatTimeout,
 		TokensObservePeriod:             0,

--- a/pkg/experiment/metastore/discovery/kuberesolver.go
+++ b/pkg/experiment/metastore/discovery/kuberesolver.go
@@ -2,7 +2,9 @@ package discovery
 
 import (
 	"fmt"
+	"net"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -103,7 +105,7 @@ func convertEndpoints(e kuberesolver2.Endpoints, ti targetInfo) []Server {
 				raftServerId := fmt.Sprintf("%s.%s.%s.svc.cluster.local.:%d", podName, ti.service, ti.namespace, port.Port)
 
 				servers = append(servers, Server{
-					ResolvedAddress: fmt.Sprintf("%s:%d", addr.IP, port.Port),
+					ResolvedAddress: net.JoinHostPort(addr.IP, strconv.Itoa(port.Port)),
 					Raft: raft.Server{
 						ID:      raft.ServerID(raftServerId),
 						Address: raft.ServerAddress(raftServerId),

--- a/pkg/scheduler/schedulerdiscovery/ring.go
+++ b/pkg/scheduler/schedulerdiscovery/ring.go
@@ -3,7 +3,8 @@
 package schedulerdiscovery
 
 import (
-	"fmt"
+	"net"
+	"strconv"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/kv"
@@ -42,7 +43,7 @@ func toBasicLifecyclerConfig(cfg util.CommonRingConfig, logger log.Logger) (ring
 
 	return ring.BasicLifecyclerConfig{
 		ID:                              cfg.InstanceID,
-		Addr:                            fmt.Sprintf("%s:%d", instanceAddr, instancePort),
+		Addr:                            net.JoinHostPort(instanceAddr, strconv.Itoa(instancePort)),
 		HeartbeatPeriod:                 cfg.HeartbeatPeriod,
 		HeartbeatTimeout:                cfg.HeartbeatTimeout,
 		TokensObservePeriod:             0,

--- a/pkg/storegateway/gateway_ring.go
+++ b/pkg/storegateway/gateway_ring.go
@@ -2,7 +2,8 @@ package storegateway
 
 import (
 	"flag"
-	"fmt"
+	"net"
+	"strconv"
 	"time"
 
 	"github.com/go-kit/log"
@@ -109,7 +110,7 @@ func (cfg *RingConfig) ToLifecyclerConfig(logger log.Logger) (ring.BasicLifecycl
 
 	return ring.BasicLifecyclerConfig{
 		ID:                              cfg.Ring.InstanceID,
-		Addr:                            fmt.Sprintf("%s:%d", instanceAddr, instancePort),
+		Addr:                            net.JoinHostPort(instanceAddr, strconv.Itoa(instancePort)),
 		Zone:                            cfg.InstanceZone,
 		HeartbeatPeriod:                 cfg.Ring.HeartbeatPeriod,
 		HeartbeatTimeout:                cfg.Ring.HeartbeatTimeout,

--- a/pkg/validation/exporter/ring.go
+++ b/pkg/validation/exporter/ring.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
+	"strconv"
 	"time"
 
 	"github.com/go-kit/log"
@@ -74,7 +76,7 @@ func (c *RingConfig) toBasicLifecyclerConfig(logger log.Logger) (ring.BasicLifec
 
 	return ring.BasicLifecyclerConfig{
 		ID:                              c.Ring.InstanceID,
-		Addr:                            fmt.Sprintf("%s:%d", instanceAddr, instancePort),
+		Addr:                            net.JoinHostPort(instanceAddr, strconv.Itoa(instancePort)),
 		HeartbeatPeriod:                 c.Ring.HeartbeatPeriod,
 		HeartbeatTimeout:                c.Ring.HeartbeatTimeout,
 		TokensObservePeriod:             0,


### PR DESCRIPTION
Use Go's `net.JoinHostPort` instead of string formatting in ring lifecycler configuration to properly handle IPv6 addresses.

Fixes https://github.com/grafana/pyroscope/issues/3900