### PR TITLE
Remove namespace from ClusterRole

### DIFF
--- a/operations/pyroscope/helm/pyroscope/templates/rbac.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/rbac.yaml
@@ -4,7 +4,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Release.Namespace }}-{{ include "pyroscope.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "pyroscope.labels" . | nindent 4 }}
 rules:
@@ -29,7 +28,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Release.Namespace }}-{{ include "pyroscope.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "pyroscope.labels" . | nindent 4 }}
 roleRef:


### PR DESCRIPTION
## Context

Fixes the issue in https://github.com/grafana/pyroscope/issues/3907
Linters/tests catch this redundant namespace parameter on ClusterRole

## Intent

Remove the namespace from ClusterRole and ClusterRoleBinding because they are non-namespaced objects

> If you want to define a role within a namespace, use a Role; if you want to define a role cluster-wide, use a ClusterRole.

https://kubernetes.io/docs/reference/access-authn-authz/rbac/

## Note

Alternatively we could use Role instead of ClusterRole, but I'm not very familiar with why pyroscope needs this role. (It seems to allow pod discovery but I thought alloy should do that)
