### PR TITLE
fix: add IPv6 support in missing places

### DIFF
--- a/pkg/api/version/version.go
+++ b/pkg/api/version/version.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"net"
+	"strconv"
 	"sync"
 	"time"
 
@@ -187,7 +189,7 @@ func New(cfg util.CommonRingConfig, logger log.Logger, reg prometheus.Registerer
 	svc := &Service{
 		store:   client,
 		id:      cfg.InstanceID,
-		addr:    fmt.Sprintf("%s:%d", instanceAddr, instancePort),
+		addr:    net.JoinHostPort(instanceAddr, strconv.Itoa(instancePort)),
 		cfg:     cfg,
 		logger:  log.With(logger, "component", "versions"),
 		cancel:  cancel,

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -10,7 +10,9 @@ import (
 	"flag"
 	"fmt"
 	"math/rand"
+	"net"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -145,7 +147,7 @@ type enqueueResult struct {
 func NewFrontend(cfg Config, limits Limits, log log.Logger, reg prometheus.Registerer) (*Frontend, error) {
 	requestsCh := make(chan *frontendRequest)
 
-	schedulerWorkers, err := newFrontendSchedulerWorkers(cfg, fmt.Sprintf("%s:%d", cfg.Addr, cfg.Port), requestsCh, log, reg)
+	schedulerWorkers, err := newFrontendSchedulerWorkers(cfg, net.JoinHostPort(cfg.Addr, strconv.Itoa(cfg.Port)), requestsCh, log, reg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add IPv6 support in 2 missing places.

Follow-up of https://github.com/grafana/pyroscope/pull/3903.