### PR TITLE
fix(v2): use better seed for shard placement

### DIFF
--- a/pkg/experiment/distributor/distributor.go
+++ b/pkg/experiment/distributor/distributor.go
@@ -326,14 +326,20 @@ func (p *perm) resize(n int) {
 	}
 }
 
-// The value is a random generated with a crypto/rand.Read,
-// and decoded as a little-endian uint64. No fancy math here.
-const randSeed = 4349576827832984783
-
 var steps [4 << 10]uint32
 
 func init() {
-	r := rand.New(rand.NewSource(randSeed))
+	// The seed impacts mapping of shards to nodes.
+	// TODO(kolesnikovae):
+	//  Stochastic approach does not work well
+	//  in all the cases; it should be replaced
+	//  with a deterministic one.
+	const randSeed = -3035313949336265834
+	setSeed(randSeed)
+}
+
+func setSeed(n int64) {
+	r := rand.New(rand.NewSource(n))
 	for i := range steps {
 		steps[i] = uint32(r.Intn(i + 1))
 	}

--- a/pkg/experiment/distributor/distributor_test.go
+++ b/pkg/experiment/distributor/distributor_test.go
@@ -160,7 +160,7 @@ func Test_Distributor_Distribute(t *testing.T) {
 	//   0 1 2 3 4 5 6 7 8 9 10 11  all shards
 	//   * * * *         > * *  *   tenant (size 8, offset 8)
 	//       > *         * *        dataset (size 4, offset 6+8 mod 12 = 2)
-	//   a a a b b b c c a b c  c   shuffling (see d.distribution.shards)
+	//   2 1 0 1 1 2 2 0 1 0 0  2   shuffling (see d.distribution.shards)
 	//   ----------------------------------------------------------------------
 	//       0 1         2 3 4      PickShard 0 (offset within dataset)
 	//                       ^      borrowed from the tenant
@@ -170,13 +170,13 @@ func Test_Distributor_Distribute(t *testing.T) {
 	//       1 2         3 0 4      PickShard 3
 
 	// Identical keys have identical placement.
-	assert.Equal(t, []string{"a", "b", "a", "b", "c"}, collect(0, 5))
-	assert.Equal(t, []string{"a", "b", "a", "b", "c"}, collect(0, 5))
+	assert.Equal(t, []string{"a", "b", "b", "a", "a"}, collect(0, 5))
+	assert.Equal(t, []string{"a", "b", "b", "a", "a"}, collect(0, 5))
 
 	// Placement of different keys in the dataset is bound.
-	assert.Equal(t, []string{"b", "a", "b", "a", "c"}, collect(1, 5))
-	assert.Equal(t, []string{"a", "b", "a", "b", "c"}, collect(2, 5))
-	assert.Equal(t, []string{"b", "a", "b", "a", "c"}, collect(3, 5))
+	assert.Equal(t, []string{"b", "b", "a", "a", "a"}, collect(1, 5))
+	assert.Equal(t, []string{"b", "a", "a", "b", "a"}, collect(2, 5))
+	assert.Equal(t, []string{"a", "a", "b", "b", "a"}, collect(3, 5))
 
 	// Now we're trying to collect more instances than available.
 	//   0 1 2 3 4 5 6  7  8 9 10 11  all shards
@@ -186,8 +186,8 @@ func Test_Distributor_Distribute(t *testing.T) {
 	//   6 7 2 3 8 9 10 11 0 1 4  5
 	//   ^ ^                   ^  ^   borrowed from the tenant
 	//           ^ ^ ^  ^             borrowed from the top ring
-	//   a a a b b b c  c  a b c  c   shuffling (see d.distribution.shards)
-	assert.Equal(t, []string{"a", "b", "a", "b", "c", "c", "a", "a", "b", "b", "c", "c"}, collect(2, 13))
+	//   2 1 0 1 1 2 2  0  1 0 0  2   shuffling (see d.distribution.shards)
+	assert.Equal(t, []string{"b", "a", "a", "b", "a", "c", "c", "b", "b", "c", "c", "a"}, collect(2, 13))
 }
 
 func Test_distribution_iterator(t *testing.T) {
@@ -419,25 +419,24 @@ func Test_permutation(t *testing.T) {
 		p.resize(i)
 		actual = append(actual, copyP(p.v))
 	}
-
 	expected := [][]uint32{
 		{},
-		{2, 3, 1, 0},
-		{2, 3, 1, 5, 6, 4, 7, 0},
-		{2, 3, 1, 5, 6, 4, 9, 11, 0, 7, 8, 10},
-		{2, 3, 1, 5, 12, 4, 14, 11, 15, 7, 8, 13, 6, 10, 9, 0},
-		{2, 3, 18, 5, 12, 4, 14, 11, 15, 7, 8, 13, 6, 10, 9, 19, 17, 16, 1, 0},
-		{2, 3, 18, 5, 12, 4, 14, 11, 15, 22, 8, 13, 6, 10, 9, 19, 17, 21, 1, 20, 0, 16, 23, 7},
-		{2, 3, 18, 5, 12, 4, 14, 11, 15, 22, 8, 13, 6, 27, 9, 19, 24, 21, 1, 20, 0, 16, 23, 26, 17, 10, 7, 25},
-		{28, 3, 18, 5, 12, 29, 14, 11, 15, 22, 8, 13, 31, 27, 9, 19, 24, 21, 1, 20, 0, 16, 23, 26, 30, 10, 7, 25, 2, 4, 17, 6},
-		{28, 3, 18, 5, 12, 29, 14, 11, 15, 22, 8, 13, 31, 27, 9, 19, 24, 21, 1, 20, 0, 16, 23, 26, 30, 10, 7, 25, 2, 4, 17, 6},
-		{2, 3, 18, 5, 12, 4, 14, 11, 15, 22, 8, 13, 6, 27, 9, 19, 24, 21, 1, 20, 0, 16, 23, 26, 17, 10, 7, 25},
-		{2, 3, 18, 5, 12, 4, 14, 11, 15, 22, 8, 13, 6, 10, 9, 19, 17, 21, 1, 20, 0, 16, 23, 7},
-		{2, 3, 18, 5, 12, 4, 14, 11, 15, 7, 8, 13, 6, 10, 9, 19, 17, 16, 1, 0},
-		{2, 3, 1, 5, 12, 4, 14, 11, 15, 7, 8, 13, 6, 10, 9, 0},
-		{2, 3, 1, 5, 6, 4, 9, 11, 0, 7, 8, 10},
-		{2, 3, 1, 5, 6, 4, 7, 0},
-		{2, 3, 1, 0},
+		{3, 1, 0, 2},
+		{3, 6, 0, 5, 7, 4, 1, 2},
+		{11, 6, 0, 5, 7, 8, 9, 2, 4, 1, 3, 10},
+		{11, 6, 0, 5, 14, 8, 15, 2, 12, 1, 3, 13, 4, 10, 7, 9},
+		{11, 6, 0, 19, 14, 8, 15, 2, 12, 17, 3, 18, 4, 16, 7, 9, 10, 1, 13, 5},
+		{11, 6, 0, 19, 14, 8, 15, 2, 21, 17, 3, 18, 4, 16, 7, 22, 10, 1, 23, 5, 9, 12, 20, 13},
+		{11, 6, 0, 19, 14, 8, 15, 2, 26, 17, 25, 18, 24, 16, 7, 22, 10, 1, 23, 5, 9, 12, 20, 13, 4, 3, 27, 21},
+		{11, 6, 0, 28, 31, 8, 15, 2, 26, 17, 25, 18, 24, 16, 7, 22, 10, 1, 23, 5, 30, 12, 20, 13, 4, 29, 27, 21, 19, 3, 9, 14},
+		{11, 6, 0, 28, 31, 8, 15, 2, 26, 17, 25, 18, 24, 16, 7, 22, 10, 1, 23, 5, 30, 12, 20, 13, 4, 29, 27, 21, 19, 3, 9, 14},
+		{11, 6, 0, 19, 14, 8, 15, 2, 26, 17, 25, 18, 24, 16, 7, 22, 10, 1, 23, 5, 9, 12, 20, 13, 4, 3, 27, 21},
+		{11, 6, 0, 19, 14, 8, 15, 2, 21, 17, 3, 18, 4, 16, 7, 22, 10, 1, 23, 5, 9, 12, 20, 13},
+		{11, 6, 0, 19, 14, 8, 15, 2, 12, 17, 3, 18, 4, 16, 7, 9, 10, 1, 13, 5},
+		{11, 6, 0, 5, 14, 8, 15, 2, 12, 1, 3, 13, 4, 10, 7, 9},
+		{11, 6, 0, 5, 7, 8, 9, 2, 4, 1, 3, 10},
+		{3, 6, 0, 5, 7, 4, 1, 2},
+		{3, 1, 0, 2},
 		{},
 	}
 


### PR DESCRIPTION
The PR fixed a bad seed chosen for Fisher-Yates permutations forming the shard mapping in the new distribution algorithm.

I've noticed that in case of unavailability, the data distribution has pronounces skews and decided to test this case. I discovered that with low number of nodes and shards, the mapping we generate is very poor – the random choice is extremely unfortunate: 

```
instance-0 [  35%][   6%] ###################################
instance-1 [  32%][  -3%] ################################
instance-2 [  32%][  -3%] ################################
-
instance-0 [   0%][ -99%]
instance-1 [  68%][ 105%] ####################################################################
instance-2 [  32%][  -3%] ################################
-
instance-0 [  35%][   6%] ###################################
instance-1 [   0%][ -99%]
instance-2 [  64%][  93%] ################################################################
-
instance-0 [  67%][ 102%] ###################################################################
instance-1 [  32%][  -3%] ################################
instance-2 [   0%][ -99%]
```

After some brute force (for 3-10 instances, where distribution skews are especially impactful) I found a better seed that ensures significantly better behaviour in case of node failures/unavailability: 

```
instance-0 [  33%][   0%] #################################
instance-1 [  33%][   0%] #################################
instance-2 [  33%][   0%] #################################
-
instance-0 [   0%][ -99%]
instance-1 [  52%][  57%] ####################################################
instance-2 [  48%][  45%] ################################################
-
instance-0 [  50%][  51%] ##################################################
instance-1 [   0%][ -99%]
instance-2 [  49%][  48%] #################################################
-
instance-0 [  48%][  45%] ################################################
instance-1 [  51%][  54%] ###################################################
instance-2 [   0%][ -99%]
```

I'm not adding the scripts I used to find the seed, because I do not plan to maintain it: it's better to replace the randomized permutations with a knapsack solver or something similar that gives deterministic optimal results.  
