### PR TITLE
fix: add service_name label to the canary exporter

### DIFF
--- a/cmd/profilecli/canary_exporter.go
+++ b/cmd/profilecli/canary_exporter.go
@@ -297,6 +297,7 @@ func (ce *canaryExporter) testPyroscopeCell(ctx context.Context) error {
 	p.Labels = p.Labels[:0]
 	p.CustomProfile("deadmans_switch", "made_up", "profilos", "made_up", "profilos")
 	p.WithLabels(
+		"service_name", "pyroscope-canary-exporter",
 		"job", "canary-exporter",
 		"instance", ce.hostname,
 	)
@@ -351,7 +352,7 @@ func (ce *canaryExporter) testPyroscopeCell(ctx context.Context) error {
 		respQueryInstant, err := ce.params.queryClient().SelectMergeProfile(rCtx, connect.NewRequest(&querierv1.SelectMergeProfileRequest{
 			Start:         now.UnixMilli(),
 			End:           now.Add(5 * time.Second).UnixMilli(),
-			LabelSelector: fmt.Sprintf(`{job="canary-exporter", instance="%s"}`, ce.hostname),
+			LabelSelector: fmt.Sprintf(`{service_name="pyroscope-canary-exporter", job="canary-exporter", instance="%s"}`, ce.hostname),
 			ProfileTypeID: "deadmans_switch:made_up:profilos:made_up:profilos",
 		}))
 		if err != nil {


### PR DESCRIPTION
The change adds `service_name` label to the profiles ingested by canary exporter, and the label selector used to query it back. Without the `service_name` label selector, in the newest versions, the query hits tenant-wide dataset index, which is only created after L0 compaction and is usually delayed by ~15-30s. Therefore, canary-exporter queries return no data until then, and the probe fails due to empty response.