### PR TITLE
Rename Explore Apps to App Drilldown

### DIFF
--- a/docs/sources/configure-client/language-sdks/nodejs.md
+++ b/docs/sources/configure-client/language-sdks/nodejs.md
@@ -40,8 +40,13 @@ Add the following code to your application:
 const Pyroscope = require('@pyroscope/nodejs');
 
 Pyroscope.init({
-  serverAddress: 'http://pyroscope:4040',
-  appName: 'myNodeService'
+    serverAddress: 'http://pyroscope:4040',
+    appName: 'myNodeService',
+    // Enable CPU time collection for wall profiles
+    // This is required for CPU profiling functionality
+    // wall: {
+    //   collectCpuTime: true
+    // }
 });
 
 Pyroscope.start()
@@ -64,9 +69,9 @@ If you'd prefer, you can use Pull mode using [Grafana Alloy](https://grafana.com
 | `flushIntervalMs:`            | `PYROSCOPE_FLUSH_INTERVAL_MS`             | Number         | Interval when profiles are sent to the server (Default `60000`)                   |
 | `heapSamplingIntervalBytes`   | `PYROSCOPE_HEAP_SAMPLING_INTERVAL_BYTES`  | Number         | Average number of bytes between samples. (Default `524288`)                       |
 | `heapStackDepth:`             | `PYROSCOPE_HEAP_STACK_DEPTH`              | Number         | Maximum stack depth for heap samples (Default `64`)                               |
-| `wallSamplingDurationMs:`     | `PYROSCOPE_WALL_SAMPLING_DURATION_MS`     | Number         | Duration of a single wall profile (Default `60000`)                               |
-| `wallSamplingIntervalMicros:` | `PYROSCOPE_WALL_SAMPLING_INTERVAL_MICROS` | Number         | Interval of how often wall samples are collected (Default `10000`                 |
-| `wallCollectCpuTime:`         | `PYROSCOPE_WALL_COLLECT_CPU_TIME`         | Boolean        | Enable CPU time collection for wall profiles (Default `false`)                    |
+| `wall.SamplingDurationMs:`     | `PYROSCOPE_WALL_SAMPLING_DURATION_MS`     | Number         | Duration of a single wall profile (Default `60000`)                               |
+| `wall.SamplingIntervalMicros:` | `PYROSCOPE_WALL_SAMPLING_INTERVAL_MICROS` | Number         | Interval of how often wall samples are collected (Default `10000`                 |
+| `wall.CollectCpuTime:`         | `PYROSCOPE_WALL_COLLECT_CPU_TIME`         | Boolean        | Required for CPU profiling. Enable CPU time collection as part of the wall profiler (Default `false`)                    |
 | `tags:`                       | n/a                                       | [LabelSet]     | Static labels applying to all profiles collected (Default `{}`)                   |
 | `sourceMapper:`               | n/a                                       | [SourceMapper] | Provide source file mapping information (Default `undefined`)                     |
 

--- a/docs/sources/configure-client/language-sdks/nodejs.md
+++ b/docs/sources/configure-client/language-sdks/nodejs.md
@@ -40,13 +40,8 @@ Add the following code to your application:
 const Pyroscope = require('@pyroscope/nodejs');
 
 Pyroscope.init({
-    serverAddress: 'http://pyroscope:4040',
-    appName: 'myNodeService',
-    // Enable CPU time collection for wall profiles
-    // This is required for CPU profiling functionality
-    // wall: {
-    //   collectCpuTime: true
-    // }
+  serverAddress: 'http://pyroscope:4040',
+  appName: 'myNodeService'
 });
 
 Pyroscope.start()
@@ -69,9 +64,9 @@ If you'd prefer, you can use Pull mode using [Grafana Alloy](https://grafana.com
 | `flushIntervalMs:`            | `PYROSCOPE_FLUSH_INTERVAL_MS`             | Number         | Interval when profiles are sent to the server (Default `60000`)                   |
 | `heapSamplingIntervalBytes`   | `PYROSCOPE_HEAP_SAMPLING_INTERVAL_BYTES`  | Number         | Average number of bytes between samples. (Default `524288`)                       |
 | `heapStackDepth:`             | `PYROSCOPE_HEAP_STACK_DEPTH`              | Number         | Maximum stack depth for heap samples (Default `64`)                               |
-| `wall.SamplingDurationMs:`     | `PYROSCOPE_WALL_SAMPLING_DURATION_MS`     | Number         | Duration of a single wall profile (Default `60000`)                               |
-| `wall.SamplingIntervalMicros:` | `PYROSCOPE_WALL_SAMPLING_INTERVAL_MICROS` | Number         | Interval of how often wall samples are collected (Default `10000`                 |
-| `wall.CollectCpuTime:`         | `PYROSCOPE_WALL_COLLECT_CPU_TIME`         | Boolean        | Required for CPU profiling. Enable CPU time collection as part of the wall profiler (Default `false`)                    |
+| `wallSamplingDurationMs:`     | `PYROSCOPE_WALL_SAMPLING_DURATION_MS`     | Number         | Duration of a single wall profile (Default `60000`)                               |
+| `wallSamplingIntervalMicros:` | `PYROSCOPE_WALL_SAMPLING_INTERVAL_MICROS` | Number         | Interval of how often wall samples are collected (Default `10000`                 |
+| `wallCollectCpuTime:`         | `PYROSCOPE_WALL_COLLECT_CPU_TIME`         | Boolean        | Enable CPU time collection for wall profiles (Default `false`)                    |
 | `tags:`                       | n/a                                       | [LabelSet]     | Static labels applying to all profiles collected (Default `{}`)                   |
 | `sourceMapper:`               | n/a                                       | [SourceMapper] | Provide source file mapping information (Default `undefined`)                     |
 

--- a/docs/sources/configure-client/trace-span-profiles/dotnet-span-profiles.md
+++ b/docs/sources/configure-client/trace-span-profiles/dotnet-span-profiles.md
@@ -74,7 +74,7 @@ With the span processor registered, spans created automatically (for example, HT
 
 ## View the span profiles in Grafana
 
-To view the span profiles in Grafana Explore or Grafana Explore Traces, you need to have a Grafana instance running and a Tempo data source configured to link traces and profiles.
+To view the span profiles in Grafana Explore or Grafana Traces Drilldown, you need to have a Grafana instance running and a Tempo data source configured to link traces and profiles.
 
 Refer to the [Tempo data source configuration documentation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source) to see how to configure the visualization to link traces with profiles.
 

--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -106,6 +106,6 @@ Verify that you have installed [Docker](https://docs.docker.com/engine/install/)
 
   To learn more about adding data sources, refer to [Add a data source](/docs/grafana/<GRAFANA_VERSION>/datasources/add-a-data-source/).
 
-1. In a browser, go to [Explore Profiles](/docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/profiles/) in your Grafana instance at [https://localhost:3000/a/grafana-pyroscope-app/profiles-explorer](https://localhost:3000/a/grafana-pyroscope-app/profiles-explorer). This will let you use an intuitive interface for exploring your profile data.
+1. In a browser, go to [Profiles Drilldown](/docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/profiles/) in your Grafana instance at [https://localhost:3000/a/grafana-pyroscope-app/profiles-explorer](https://localhost:3000/a/grafana-pyroscope-app/profiles-explorer). This will let you use an intuitive interface for exploring your profile data.
 
 When you have completed the tasks in this getting started guide, you can create dashboard panels using the newly configured Pyroscope data source. For more information on working with dashboards with Grafana, refer to [Panels and visualizations](/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/) in the Grafana documentation.

--- a/docs/sources/get-started/ride-share-tutorial.md
+++ b/docs/sources/get-started/ride-share-tutorial.md
@@ -52,7 +52,7 @@ In this tutorial, you will profile a simple "Ride Share" application. The applic
 - `/car`     : calls the `order_car(search_radius)` function to order a car
 - `/scooter` : calls the `order_scooter(search_radius)` function to order a scooter
 
-To simulate a highly available and distributed system, the app is deployed on three distinct servers in 3 different regions: 
+To simulate a highly available and distributed system, the app is deployed on three distinct servers in 3 different regions:
 - us-east
 - eu-north
 - ap-south
@@ -101,10 +101,10 @@ This may take a few minutes to download the required images and build the demo a
  ✔ Network flask_default  Created
  ✔ Container flask-ap-south-1  Started
  ✔ Container flask-grafana-1  Started
- ✔ Container flask-pyroscope-1  Started     
- ✔ Container flask-load-generator-1 Started 
- ✔ Container flask-eu-north-1 Started       
- ✔ Container flask-us-east-1 Started  
+ ✔ Container flask-pyroscope-1  Started
+ ✔ Container flask-load-generator-1 Started
+ ✔ Container flask-eu-north-1 Started
+ ✔ Container flask-us-east-1 Started
 ```
 
 Optional: To verify the containers are running, run:
@@ -116,14 +116,14 @@ docker ps -a
 
 <!-- INTERACTIVE page step2.md START -->
 
-## Accessing Explore Profiles in Grafana
+## Accessing Profiles Drilldown in Grafana
 
-Grafana includes the [Explore Profiles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/profiles/) app that you can use to view profile data. To access Explore Profiles, open a browser and navigate to [http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer](http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer).
+Grafana includes the [Profiles Drilldown](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/profiles/) app that you can use to view profile data. To access Profiles Drilldown, open a browser and navigate to [http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer](http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer).
 
 ### How tagging works
 
 In this example, the application is instrumented with Pyroscope using the Python SDK.
-The SDK allows you to tag functions with metadata that can be used to filter and group the profile data in the Explore Profiles.
+The SDK allows you to tag functions with metadata that can be used to filter and group the profile data in the Profiles Drilldown.
 This example uses static and dynamic tagging.
 
 To start, let's take a look at a static tag use case. Within the `server.py` file, find the Pyroscope configuration:
@@ -143,11 +143,11 @@ This tag is considered static is because the tag is set at the start of the appl
 In this case, it's useful for grouping profiles on a per region basis, which lets you see the performance of the application per region.
 
 1. Open Grafana using the following url: [http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer](http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer).
-1. In the main menu, select **Explore** > **Profiles**. 
+1. In the main menu, select **Explore** > **Profiles**.
 1. Select  **Labels** in the **Exploration** path.
-1. Select the **region** tab in the **Group by labels** section. 
+1. Select the **region** tab in the **Group by labels** section.
 
-You should now see a list of regions that the application is running in. You can see that `eu-north` is experiencing the most load. 
+You should now see a list of regions that the application is running in. You can see that `eu-north` is experiencing the most load.
 
 {{< figure max-width="100%" src="/media/docs/pyroscope/ride-share-tag-region-2.png" caption="Region Tag" alt="Region Tag" >}}
 
@@ -168,12 +168,12 @@ This example uses `tag_wrapper` to tag the function with the vehicle type.
 Notice that the tag is dynamic as it changes based on the vehicle type.
 This is useful for grouping profiles on a per vehicle basis. Allowing us to see the performance of the application per vehicle type being requested.
 
-Use Explore Profiles to see how this tag is used:
-1. Open Explore Profiles using the following url: [http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer](http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer).
+Use Profiles Drilldown to see how this tag is used:
+1. Open Profiles Drilldown using the following url: [http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer](http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer).
 1. Select on **Labels** in the **Exploration** path.
-1. In the **Group by labels** section, select the **vehicle** tab. 
+1. In the **Group by labels** section, select the **vehicle** tab.
 
-You should now see a list of vehicle types that the application is using. You can see that `car` is experiencing the most load. 
+You should now see a list of vehicle types that the application is using. You can see that `car` is experiencing the most load.
 
 <!-- INTERACTIVE page step2.md END -->
 
@@ -184,7 +184,7 @@ You should now see a list of vehicle types that the application is using. You ca
 The first step when analyzing a profile outputted from your application, is to take note of the largest node which is where your application is spending the most resources.
 To discover this, you can use the **Flame graph** view:
 
-1. Open Explore Profiles using the following url: [http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer](http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer).
+1. Open Profiles Drilldown using the following url: [http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer](http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer).
 1. Select **Flame graph** from the **Exploration** path.
 1. Verify that  `ride-sharing-app` is selected in the **Service** drop-down menu and `process_cpu/cpu` in the **Profile type** drop-down menu.
 
@@ -202,7 +202,7 @@ By tagging both `region` and `vehicle` and looking at the [**Labels** view](http
 - Something is wrong with the `/car` endpoint code where `car` vehicle tag is consuming **68% of CPU**
 - Something is wrong with one of our regions where `eu-north` region tag is consuming **54% of CPU**
 
-From the flame graph, you can see that for the `eu-north` tag the biggest performance impact comes from the `find_nearest_vehicle()` function which consumes close to **68% of cpu**. 
+From the flame graph, you can see that for the `eu-north` tag the biggest performance impact comes from the `find_nearest_vehicle()` function which consumes close to **68% of cpu**.
 To analyze this, go directly to the comparison page using the comparison dropdown.
 
 ### Comparing two time periods
@@ -211,12 +211,12 @@ The **Diff flame graph** view lets you compare two time periods side by side.
 This is useful for identifying changes in performance over time.
 This example compares the performance of the `eu-north` region within a given time period against the other regions.
 
-1. Open Explore Profiles in Grafana using the following url: [http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer](http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer).
+1. Open Profiles Drilldown in Grafana using the following url: [http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer](http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer).
 1. Select **Diff flame graph** in the **Exploration** path.
 1. In **Baseline**, filter by `region` and select `!= eu-north`.
 1. In **Comparison**, filter by `region` and select `== eu-north`.
 1. In **Baseline**, select the time period you want to compare against.
-   
+
 Scroll down to compare the two time periods side by side.
 Note that the `eu-north` region (right side) shows an excessive amount of time spent in the `find_nearest_vehicle` function.
 This looks to be caused by a mutex lock that is causing the function to block.
@@ -230,7 +230,7 @@ This looks to be caused by a mutex lock that is causing the function to block.
 ## How was Pyroscope integrated with Grafana in this tutorial?
 
 The `docker-compose.yml` file includes a Grafana container that's pre-configured with the Pyroscope plugin:
-    
+
 ```yaml
   grafana:
     image: grafana/grafana:latest
@@ -245,11 +245,11 @@ The `docker-compose.yml` file includes a Grafana container that's pre-configured
     - 3000:3000
 ```
 
-Grafana is also pre-configured with the Pyroscope data source. 
+Grafana is also pre-configured with the Pyroscope data source.
 
 ### Challenge
 
-As a challenge, see if you can generate a similar comparison with the `vehicle` tag. 
+As a challenge, see if you can generate a similar comparison with the `vehicle` tag.
 
 <!-- INTERACTIVE page step4.md END -->
 
@@ -258,13 +258,13 @@ As a challenge, see if you can generate a similar comparison with the `vehicle` 
 ## Summary
 
 In this tutorial, you learned how to profile a simple "Ride Share" application using Pyroscope.
-You have learned some of the core instrumentation concepts such as tagging and how to use Explore Profiles identify performance bottlenecks.
+You have learned some of the core instrumentation concepts such as tagging and how to use Profiles Drilldown identify performance bottlenecks.
 
 ### Next steps
 
 - Learn more about the Pyroscope SDKs and how to [instrument your application with Pyroscope](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/).
 - Deploy Pyroscope in a production environment using the [Pyroscope Helm chart](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/deploy-kubernetes/).
-- Continue exploring your profile data using [Explore Profiles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/profiles/investigate/) 
+- Continue exploring your profile data using [Profiles Drilldown](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/profiles/investigate/)
 <!-- INTERACTIVE page finish.md END -->
 
 

--- a/docs/sources/shared/intro/continuous-profiling.md
+++ b/docs/sources/shared/intro/continuous-profiling.md
@@ -28,7 +28,7 @@ It uses low-overhead sampling to collect profiles from production systems and st
 Using continuous profiling gives you a more holistic view of your application and how it behaves in production.
 
 Grafana offers Grafana Pyroscope and Grafana Cloud Profiles (powered by Pyroscope) to collect and store your profiling data.
-You can use Grafana Explore Profiles to inspect profile data and investigate issues.
+You can use Grafana Profiles Drilldown to inspect profile data and investigate issues.
 
 ## Benefits
 
@@ -41,7 +41,7 @@ Why prioritize continuous profiling?
 
 ## Use cases
 
-Adopting continuous profiling with tools like Grafana Pyroscope and Explore Profiles can lead to significant business advantages:
+Adopting continuous profiling with tools like Grafana Pyroscope and Profiles Drilldown can lead to significant business advantages:
 
 1. **Reduced operational costs:** Optimization of resource usage can significantly cut down cloud and infrastructure expenses
 2. **Reduced latency:** Identifying and addressing performance bottlenecks leads to faster and more efficient applications
@@ -70,5 +70,5 @@ This granular insight allows for targeted optimization, leading to faster applic
 
 ### Enhanced incident management
 
-Pyroscope and Explore Profiles streamline incident management by offering immediate, actionable insights into application performance issues.
+Pyroscope and Profiles Drilldown streamline incident management by offering immediate, actionable insights into application performance issues.
 With continuous profiling, teams can quickly pinpoint the root cause of an incident, reducing the mean time to resolution (MTTR) and enhancing overall system reliability and user satisfaction.

--- a/docs/sources/shared/intro/flame-graphs.md
+++ b/docs/sources/shared/intro/flame-graphs.md
@@ -25,7 +25,7 @@ These graphs provide a clear, intuitive understanding of resource allocation and
 
 <!-- vale Grafana.Spelling = YES -->
 
-## How Pyroscope creates flame graphs 
+## How Pyroscope creates flame graphs
 
 This diagram shows how code is turned into a flame graph.
 In this case, Pyroscope samples the stacktrace of your application to understand how many CPU cycles are spent in each function.
@@ -51,6 +51,6 @@ This is a CPU profile, but profiles can represent many other types of resource s
 
 ## Flame graph visualization panel UI
 
-To learn more about the flame graph user interface in Grafana, Grafana Cloud, and Explore Profiles, refer to [Flame graph visualization panel](https://grafana.com/docs/grafana-cloud/visualizations/panels-visualizations/visualizations/flame-graph).
+To learn more about the flame graph user interface in Grafana, Grafana Cloud, and Grafana Profiles Drilldown, refer to [Flame graph visualization panel](https://grafana.com/docs/grafana-cloud/visualizations/panels-visualizations/visualizations/flame-graph).
 
 To learn more about the flame graph in the Pyroscope UI, refer to [Pyroscope UI](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/view-and-analyze-profile-data/pyroscope-ui/).

--- a/docs/sources/shared/use-explore-profiles.md
+++ b/docs/sources/shared/use-explore-profiles.md
@@ -1,20 +1,20 @@
 ---
 headless: true
-description: Shared file for Explore Profiles overview.
+description: Shared file for Profiles Drilldown overview.
 ---
 
-[//]: # 'This file documents an introduction to Explore Profiles.'
+[//]: # 'This file documents an introduction to Profiles Drilldown.'
 [//]: # 'This shared file is included in these locations:'
 [//]: # '/pyroscope/docs/sources/configure-client/profile-types.md'
 [//]: # '/pyroscope/docs/sources/introduction/profiling-types.md'
 [//]: #
 [//]: # 'If you make changes to this file, verify that the meaning and content are not changed in any place where the file is included.'
 [//]: # 'Any links should be fully qualified and not relative: /docs/grafana/ instead of ../grafana/.'
-<!-- Use Explore Profiles to investigate issues -->
+<!-- Use Profiles Drilldown to investigate issues -->
 
-{{< docs/public-preview product="Explore Profiles" >}}
+{{< docs/public-preview product="Profiles Drilldown" >}}
 
-[Explore Profiles](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/profiles/) is designed to make it easy to visualize and analyze profiling data.
+[Grafana Profiles Drilldown](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/profiles/) is designed to make it easy to visualize and analyze profiling data.
 There are several different modes for viewing, analyzing, and comparing profiling data.
 
 The main use cases are the following:
@@ -22,12 +22,12 @@ The main use cases are the following:
 - Proactive: Cutting costs, addressing latency issues, or optimizing memory usage for applications
 - Reactive: Resolving incidents with line-level accuracy or debugging active latency/memory issues
 
-Explore Profiles provides an intuitive interface to specifically support these use cases.
+Profiles Drilldown provides an intuitive interface to specifically support these use cases.
 You get a holistic view of all of your services and how they're functioning, but also the ability to drill down for more targeted root cause analysis.
 
-![Explore Profiles home screen](/media/docs/explore-profiles/explore-profiles-homescreen-v0.1.17.png)
+![Profiles Drilldown home screen](/media/docs/explore-profiles/explore-profiles-homescreen-v0.1.17.png)
 
-Explore Profiles offers a convenient platform to analyze profiles and get insights that are impossible to get from using other traditional signals like logs, metrics, or tracing.
+Profiles Drilldown offers a convenient platform to analyze profiles and get insights that are impossible to get from using other traditional signals like logs, metrics, or tracing.
 
 {{< youtube id="x9aPw_CbIQc" >}}
 

--- a/docs/sources/shared/use-explore-profiles.md
+++ b/docs/sources/shared/use-explore-profiles.md
@@ -25,7 +25,7 @@ The main use cases are the following:
 Profiles Drilldown provides an intuitive interface to specifically support these use cases.
 You get a holistic view of all of your services and how they're functioning, but also the ability to drill down for more targeted root cause analysis.
 
-![Profiles Drilldown home screen](/media/docs/explore-profiles/explore-profiles-homescreen-v0.1.17.png)
+![Profiles Drilldown home screen](/media/docs/explore-profiles/explore-profiles-homescreen-v1.png)
 
 Profiles Drilldown offers a convenient platform to analyze profiles and get insights that are impossible to get from using other traditional signals like logs, metrics, or tracing.
 

--- a/docs/sources/view-and-analyze-profile-data/_index.md
+++ b/docs/sources/view-and-analyze-profile-data/_index.md
@@ -32,7 +32,7 @@ Integrating Pyroscope with Grafana is a common and recommended approach for visu
 
 Options for visualizing data in Grafana:
 
-- **Explore Profiles app**: This app is specifically designed for Pyroscope data. It allows for easy browsing, analysis, and comparison of multiple profiles across different labels or time periods. This is particularly useful for a comprehensive overview of your application's performance.
+- **Profiles Drilldown app**: This app is specifically designed for Pyroscope data. It allows for easy browsing, analysis, and comparison of multiple profiles across different labels or time periods. This is particularly useful for a comprehensive overview of your application's performance.
 - **Explore tab**: In Grafana, **Explore** is suited for making targeted queries on your profiling data. This is useful for in-depth analysis of specific aspects of your application's performance.
 - **Dashboard**: Grafana dashboards are excellent for integrating profiling data with other metrics. You can display Pyroscope data alongside other dashboard items, creating a unified view of your application’s overall health and performance.
 

--- a/docs/sources/view-and-analyze-profile-data/explore-profiles.md
+++ b/docs/sources/view-and-analyze-profile-data/explore-profiles.md
@@ -1,17 +1,17 @@
 ---
-title: Use Explore Profiles to investigate issues
-menuTitle: Use Explore Profiles
-description: Learn about Explore Profiles app to investigate issues using your profiling data.
+title: Use Profiles Drilldown to investigate issues
+menuTitle: Use Profiles Drilldown
+description: Learn about Profiles Drilldown app to investigate issues using your profiling data.
 weight: 100
 keywords:
   - profiles
   - performance analysis
-  - Explore Profiles
+  - Profiles Drilldown
 ---
 
-# Use Explore Profiles to investigate issues
+# Use Profiles Drilldown to investigate issues
 
-[//]: # 'Introduction to Explore Profiles.'
+[//]: # 'Introduction to Profiles Drilldown.'
 [//]: # 'This content is located in /pyroscope/docs/sources/shared/intro/use-explore-profiles.md'
 
 {{< docs/shared source="pyroscope" lookup="use-explore-profiles.md" version="<PYROSCOPE_VERSION>" >}}

--- a/docs/sources/view-and-analyze-profile-data/pyroscope-ui.md
+++ b/docs/sources/view-and-analyze-profile-data/pyroscope-ui.md
@@ -17,7 +17,7 @@ Pyroscope's UI is designed to make it easy to visualize and analyze profiling da
 There are several different modes for viewing, analyzing, uploading, and comparing profiling data.
 
 The Pyroscope UI is only available with Pyroscope open source.
-In Grafana and Grafana Cloud, you can use [Explore Profiles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/profiles/) to inspect your profiling data.
+In Grafana and Grafana Cloud, you can use [Profiles Drilldown](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/profiles/) to inspect your profiling data.
 
 ![Screenshot of Pyroscope UI](/media/docs/pyroscope/screenshot-pyroscope-comparison-view.png)
 


### PR DESCRIPTION
<!-- vale = NO -->

Updates for renaming Explore Traces to Traces Drilldown.  These changes were originally made in https://github.com/grafana/website/pull/23993

Repository: grafana/pyroscope
