### PR TITLE
Fix goreleaser build of goamd64v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: goreleaser/goreleaser-action@v6
         with:
           # ensure this aligns with the version specified in the /Makefile
-          version: v2.0.1
+          version: v2.7.0
           args: release --clean --timeout 60m
         env:
           GITHUB_TOKEN: ${{ steps.app-goreleaser.outputs.token }}

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: goreleaser/goreleaser-action@v6
         with:
           # ensure this aligns with the version specified in the /Makefile
-          version: v2.0.1
+          version: v2.7.0
           args: release --clean --skip=publish --timeout 60m
         env:
           GITHUB_TOKEN: ${{ steps.app-releaser.outputs.token }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -145,7 +145,7 @@ archives:
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -141,7 +141,7 @@ archives:
       - profilecli
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 checksum:
   name_template: "checksums.txt"
 snapshot:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,6 +66,7 @@ dockers:
   - use: buildx
     goos: linux
     goarch: amd64
+    goamd64: v2
     dockerfile: ./cmd/pyroscope/Dockerfile
     ids:
       - pyroscope
@@ -119,6 +120,7 @@ nfpms:
     vendor: Grafana Labs Inc
     homepage: https://grafana.com/pyroscope
     license: AGPL-3.0
+    file_name_template: '{{ .PackageName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v2") }}{{ .Amd64 }}{{ end }}'
     contents:
       - src: ./tools/packaging/pyroscope.service
         dst: /etc/systemd/system/pyroscope.service
@@ -130,10 +132,11 @@ nfpms:
 
 archives:
   - id: pyroscope
+    name_template: '{{.ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v2") }}{{ .Amd64 }}{{ end }}'
     builds:
       - pyroscope
   - id: profilecli
-    name_template: 'profilecli_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
+    name_template: 'profilecli_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v2") }}{{ .Amd64 }}{{ end }}'
     builds:
       - profilecli
     format_overrides:

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,13 @@ GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 GIT_LAST_COMMIT_DATE := $(shell git log -1 --date=iso-strict --format=%cd)
 EMBEDASSETS ?= embedassets
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	NPROC := $(shell sysctl -n hw.physicalcpu)
+else
+	NPROC := $(shell nproc)
+endif
+
 # Build flags
 VPREFIX := github.com/grafana/pyroscope/pkg/util/build
 GO_LDFLAGS   := -X $(VPREFIX).Branch=$(GIT_BRANCH) -X $(VPREFIX).Version=$(IMAGE_TAG) -X $(VPREFIX).Revision=$(GIT_REVISION) -X $(VPREFIX).BuildDate=$(GIT_LAST_COMMIT_DATE)
@@ -113,19 +120,19 @@ release/prereq: $(BIN)/goreleaser ## Ensure release pre requesites are met
 
 .PHONY: release
 release: release/prereq ## Create a release
-	$(BIN)/goreleaser release -p=$(shell nproc) --rm-dist
+	$(BIN)/goreleaser release -p=$(NPROC) --clean
 
 .PHONY: release/prepare
 release/prepare: release/prereq ## Prepare a release
-	$(BIN)/goreleaser release -p=$(shell nproc) --rm-dist --snapshot
+	$(BIN)/goreleaser release -p=$(NPROC) --clean --snapshot
 
 .PHONY: release/build/all
 release/build/all: release/prereq ## Build all release binaries
-	$(BIN)/goreleaser build -p=$(shell nproc) --rm-dist --snapshot
+	$(BIN)/goreleaser build -p=$(NPROC) --clean --snapshot
 
 .PHONY: release/build
 release/build: release/prereq ## Build current platform release binaries
-	$(BIN)/goreleaser build -p=$(shell nproc) --rm-dist --snapshot --single-target
+	$(BIN)/goreleaser build -p=$(NPROC) --clean --snapshot --single-target
 
 .PHONY: go/deps
 go/deps:

--- a/Makefile
+++ b/Makefile
@@ -400,7 +400,7 @@ $(BIN)/updater: Makefile
 # Note: When updating the goreleaser version also update .github/workflow/release.yml and .git/workflow/weekly-release.yaml
 $(BIN)/goreleaser: Makefile go.mod
 	@mkdir -p $(@D)
-	GOBIN=$(abspath $(@D)) $(GO) install github.com/goreleaser/goreleaser/v2@v2.0.0
+	GOBIN=$(abspath $(@D)) $(GO) install github.com/goreleaser/goreleaser/v2@v2.7.0
 
 $(BIN)/gotestsum: Makefile go.mod
 	@mkdir -p $(@D)


### PR DESCRIPTION
- **Build goamd64 v2 without suffixes**:  This handles the breaking problem from #3948 
  
- **Upgrade goreleser to v2.7.0**: Done it while I am touching this

Address deprecations:

- **Handle nproc correctly, also rm-dist is removed by clean**: 
- **Address DEPRECATED:  archives.format_overrides.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info**
- **Address DEPRECATED:  snapshot.name_template  should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info**
