### PR TITLE
chore(goreleaser): Fix error handling during release

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -73,8 +73,13 @@ jobs:
             IMAGE_AMMENDS+=( "--amend" "${new_image}" )
           done
 
-          if (( ${#IMAGE_AMMENDS[@]} < 2 )); then
-            echo "expected at least two architectures for multi-arch docker images"
+          if [[ ! " ${IMAGE_AMMENDS[*]} " =~ -amd64 ]]; then
+            echo "expected to contain an amd64 image"
+            exit 1
+          fi
+          if [[ ! " ${IMAGE_AMMENDS[*]} " =~ -arm64 ]]; then
+            echo "expected to contain an arm64 image"
+            exit 1
           fi
 
           docker manifest create "grafana/pyroscope:${WEEKLY_IMAGE_TAG}" "${IMAGE_AMMENDS[@]}"

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -73,6 +73,10 @@ jobs:
             IMAGE_AMMENDS+=( "--amend" "${new_image}" )
           done
 
+          if (( ${#IMAGE_AMMENDS[@]} < 2 )); then
+            echo "expected at least two architectures for multi-arch docker images"
+          fi
+
           docker manifest create "grafana/pyroscope:${WEEKLY_IMAGE_TAG}" "${IMAGE_AMMENDS[@]}"
           docker manifest push "grafana/pyroscope:${WEEKLY_IMAGE_TAG}"
       - name: Get github app token (valid for an hour)

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -61,6 +61,7 @@ jobs:
 
       - name: Push per architecture images and create multi-arch manifest
         run: |
+          set -eu -o pipefail
           set +x
           IMAGE_AMMENDS=()
 


### PR DESCRIPTION
This weeks release, did fail but the CI pipeline was successful.  This change "should" prevent this from happening.


I will reproduce it and doublecheck the CI build fails
