### PR TITLE
perf: add async log writer

### DIFF
--- a/pkg/util/logger_test.go
+++ b/pkg/util/logger_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"bytes"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -12,63 +13,52 @@ import (
 
 func TestAsyncWriter_Write(t *testing.T) {
 	var buf bytes.Buffer
-	writer := NewAsyncWriter(&buf, 10, 2, 2, 100*time.Millisecond)
-	n, err := writer.Write([]byte("hello"))
+	w := NewAsyncWriter(&buf, 10, 2, 2, 100*time.Millisecond)
+	n, err := w.Write([]byte("hello"))
 	require.NoError(t, err)
 	assert.Equal(t, 5, n)
-	writer.Close()
+	assert.NoError(t, w.Close())
 	assert.Equal(t, "hello", buf.String())
 }
 
 func TestAsyncWriter_Empty(t *testing.T) {
 	var buf bytes.Buffer
-	writer := NewAsyncWriter(&buf, 10, 2, 2, 100*time.Millisecond)
-	writer.Close()
+	w := NewAsyncWriter(&buf, 10, 2, 2, 100*time.Millisecond)
+	assert.NoError(t, w.Close())
 	assert.EqualValues(t, 0, buf.Len())
 }
 
 func TestAsyncWriter_Overflow(t *testing.T) {
 	var buf bytes.Buffer
-	writer := NewAsyncWriter(&buf, 10, 2, 2, 100*time.Millisecond)
-	_, _ = writer.Write([]byte("hello"))
-	_, _ = writer.Write([]byte("world"))
-	writer.Close()
+	w := NewAsyncWriter(&buf, 10, 2, 2, 100*time.Millisecond)
+	_, _ = w.Write([]byte("hello"))
+	_, _ = w.Write([]byte("world"))
+	assert.NoError(t, w.Close())
 	assert.Equal(t, "helloworld", buf.String())
-}
-
-func TestAsyncWriter_FlushInterval(t *testing.T) {
-	var buf bytes.Buffer
-	writer := NewAsyncWriter(&buf, 10, 2, 2, 10*time.Millisecond)
-	defer writer.Close()
-	_, _ = writer.Write([]byte("hello"))
-	assert.Eventually(t,
-		func() bool { return assert.Equal(t, "hello", buf.String()) },
-		time.Second, 10*time.Millisecond,
-	)
 }
 
 func TestAsyncWriter_Close(t *testing.T) {
 	var buf bytes.Buffer
-	writer := NewAsyncWriter(&buf, 10, 2, 2, 100*time.Millisecond)
-	_, _ = writer.Write([]byte("hello"))
-	assert.NoError(t, writer.Close())
+	w := NewAsyncWriter(&buf, 10, 2, 2, 100*time.Millisecond)
+	_, _ = w.Write([]byte("hello"))
+	assert.NoError(t, w.Close())
 	assert.Equal(t, "hello", buf.String())
-	assert.NoError(t, writer.Close())
+	assert.NoError(t, w.Close())
 }
 
 func TestAsyncWriter_ConcurrentWrites(t *testing.T) {
 	var buf bytes.Buffer
-	writer := NewAsyncWriter(&buf, 10, 2, 2, 100*time.Millisecond)
+	w := NewAsyncWriter(&buf, 50, 2, 10, 100*time.Millisecond)
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			_, _ = writer.Write([]byte("hello"))
+			_, _ = fmt.Fprintf(w, "hello %d\n", i)
 		}(i)
 	}
 	wg.Wait()
 
-	writer.Close()
-	assert.Equal(t, 50, buf.Len())
+	assert.NoError(t, w.Close())
+	assert.Equal(t, 80, buf.Len())
 }

--- a/pkg/util/logger_test.go
+++ b/pkg/util/logger_test.go
@@ -1,0 +1,74 @@
+package util
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAsyncWriter_Write(t *testing.T) {
+	var buf bytes.Buffer
+	writer := NewAsyncWriter(&buf, 10, 2, 2, 100*time.Millisecond)
+	n, err := writer.Write([]byte("hello"))
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+	writer.Close()
+	assert.Equal(t, "hello", buf.String())
+}
+
+func TestAsyncWriter_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	writer := NewAsyncWriter(&buf, 10, 2, 2, 100*time.Millisecond)
+	writer.Close()
+	assert.EqualValues(t, 0, buf.Len())
+}
+
+func TestAsyncWriter_Overflow(t *testing.T) {
+	var buf bytes.Buffer
+	writer := NewAsyncWriter(&buf, 10, 2, 2, 100*time.Millisecond)
+	_, _ = writer.Write([]byte("hello"))
+	_, _ = writer.Write([]byte("world"))
+	writer.Close()
+	assert.Equal(t, "helloworld", buf.String())
+}
+
+func TestAsyncWriter_FlushInterval(t *testing.T) {
+	var buf bytes.Buffer
+	writer := NewAsyncWriter(&buf, 10, 2, 2, 10*time.Millisecond)
+	defer writer.Close()
+	_, _ = writer.Write([]byte("hello"))
+	assert.Eventually(t,
+		func() bool { return assert.Equal(t, "hello", buf.String()) },
+		time.Second, 10*time.Millisecond,
+	)
+}
+
+func TestAsyncWriter_Close(t *testing.T) {
+	var buf bytes.Buffer
+	writer := NewAsyncWriter(&buf, 10, 2, 2, 100*time.Millisecond)
+	_, _ = writer.Write([]byte("hello"))
+	assert.NoError(t, writer.Close())
+	assert.Equal(t, "hello", buf.String())
+	assert.NoError(t, writer.Close())
+}
+
+func TestAsyncWriter_ConcurrentWrites(t *testing.T) {
+	var buf bytes.Buffer
+	writer := NewAsyncWriter(&buf, 10, 2, 2, 100*time.Millisecond)
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, _ = writer.Write([]byte("hello"))
+		}(i)
+	}
+	wg.Wait()
+
+	writer.Close()
+	assert.Equal(t, 50, buf.Len())
+}


### PR DESCRIPTION
The PR adds asynchronous log writer.

Recently implemented buffered logger (#3947) does not address the issue with blocking log writes:

![image](https://github.com/user-attachments/assets/5b4bd629-c505-44e9-9161-69719db055f5)

The implementation we use flushes the buffer synchronously, blocking all callers. To address the problem, we should use asynchronous writer. The implementation in the PR implements a queue that is processed in background:
* when the queue is full, new writes are discarded.
* by default, the queue is large enough to store 20K messages or 5MB.
* errors are ignored since we can't do anything if stderr is not available (which is the cause of errors).