### PR TITLE
fix: Don't 500 when setting services aren't registered

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -208,8 +208,14 @@ func (a *API) RegisterRuntimeConfig(runtimeConfigHandler http.HandlerFunc, userL
 
 func (a *API) RegisterTenantSettings(ts *settings.TenantSettings) {
 	settingsv1connect.RegisterSettingsServiceHandler(a.server.HTTP, ts, a.connectOptionsAuthRecovery()...)
-	settingsv1connect.RegisterCollectionRulesServiceHandler(a.server.HTTP, ts, a.connectOptionsAuthRecovery()...)
-	settingsv1connect.RegisterRecordingRulesServiceHandler(a.server.HTTP, ts, a.connectOptionsAuthRecovery()...)
+
+	if ts.CollectionRulesServiceHandler != nil {
+		settingsv1connect.RegisterCollectionRulesServiceHandler(a.server.HTTP, ts, a.connectOptionsAuthRecovery()...)
+	}
+
+	if ts.RecordingRulesServiceHandler != nil {
+		settingsv1connect.RegisterRecordingRulesServiceHandler(a.server.HTTP, ts, a.connectOptionsAuthRecovery()...)
+	}
 }
 
 // RegisterOverridesExporter registers the endpoints associated with the overrides exporter.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -209,11 +209,13 @@ func (a *API) RegisterRuntimeConfig(runtimeConfigHandler http.HandlerFunc, userL
 func (a *API) RegisterTenantSettings(ts *settings.TenantSettings) {
 	settingsv1connect.RegisterSettingsServiceHandler(a.server.HTTP, ts, a.connectOptionsAuthRecovery()...)
 
-	if ts.CollectionRulesServiceHandler != nil {
+	_, isUnimplemented := ts.CollectionRulesServiceHandler.(*settingsv1connect.UnimplementedCollectionRulesServiceHandler)
+	if !isUnimplemented {
 		settingsv1connect.RegisterCollectionRulesServiceHandler(a.server.HTTP, ts, a.connectOptionsAuthRecovery()...)
 	}
 
-	if ts.RecordingRulesServiceHandler != nil {
+	_, isUnimplemented = ts.RecordingRulesServiceHandler.(*settingsv1connect.UnimplementedRecordingRulesServiceHandler)
+	if !isUnimplemented {
 		settingsv1connect.RegisterRecordingRulesServiceHandler(a.server.HTTP, ts, a.connectOptionsAuthRecovery()...)
 	}
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -47,6 +47,7 @@ func New(cfg Config, bucket objstore.Bucket, logger log.Logger) (*TenantSettings
 
 	ts := &TenantSettings{
 		CollectionRulesServiceHandler: &settingsv1connect.UnimplementedCollectionRulesServiceHandler{},
+		RecordingRulesServiceHandler:  &settingsv1connect.UnimplementedRecordingRulesServiceHandler{},
 		store:                         newBucketStore(bucket),
 		logger:                        logger,
 	}


### PR DESCRIPTION
If one of the new settings services (CollectionRules, RecordingRules) is not enabled, the server will 500 when those endpoints are requested:

Request:
```
curl --request POST \
  --url http://localhost:4040/settings.v1.CollectionRulesService/ListCollectionRules \
  --header 'content-type: application/json' \
  --data '{}'
```

Response:
```
HTTP/1.1 501 Not Implemented
Accept-Encoding: gzip
Content-Type: application/json
Date: Fri, 28 Feb 2025 16:16:59 GMT
Content-Length: 110
Connection: close

{
  "code": "unimplemented",
  "message": "settings.v1.CollectionRulesService.ListCollectionRules is not implemented"
}
```

Instead, we should 404 if the underlying service has not been enabled.

```
HTTP/1.1 404 Not Found
Content-Type: text/plain; charset=utf-8
X-Content-Type-Options: nosniff
Date: Fri, 28 Feb 2025 16:32:24 GMT
Content-Length: 19
Connection: close

404 page not found
```