### PR TITLE
Set `GRAFANA_VERSION` in front matter

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -1,6 +1,8 @@
 ---
 title: "Grafana Pyroscope"
 weight: 1
+cascade:
+  GRAFANA_VERSION: latest
 description: Grafana Pyroscope is an open source software project for aggregating continuous profiling data.
 keywords:
   - Grafana Pyroscope


### PR DESCRIPTION
Currently all links with `<GRAFANA_VERSION>` in them are broken because that resolves to the current version of the Pyroscope documentation. For example, `latest` in `/docs/pyroscope/latest/` but `v1.13.x` in `/docs/pyroscope/v1.13.x/`.

This uses `latest` as a reasonable default.
If specific versions of Pyroscope target specific versions of Grafana, it may be worth updating this on those branches to match.

[About version substitution](https://grafana.com/docs/writers-toolkit/write/shortcodes/#about-version-substitution)

I'd like to backport this to all supported versions and any older ones, I can fix in the website repository