### PR TITLE
ingester: Add profile size benchmark

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,78 @@
+name: Differential Benchmarks
+
+on:
+  pull_request:
+    paths:
+    - '.github/workflows/**'
+    - 'pkg/ingester/**'
+
+jobs:
+  bench-branch:
+    runs-on: ubuntu-latest-8-cores
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: false
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Benchmark
+        run: |
+          for i in {1..6}; do
+            make profile | tee -a branch.txt
+          done
+      - name: Upload Benchmark
+        uses: actions/upload-artifact@v4
+        with:
+          name: branch
+          path: branch.txt
+  bench-main:
+    runs-on: ubuntu-latest-8-cores
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: false
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Benchmark
+        run: |
+          for i in {1..6}; do
+            make profile | tee -a main.txt
+          done
+      - name: Upload Benchmark
+        uses: actions/upload-artifact@v4
+        with:
+          name: main
+          path: main.txt
+  diff:
+    needs: [bench-branch, bench-main]
+    if: ${{ success() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: false
+      - name: Install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@latest
+      - name: Download branch results
+        uses: actions/download-artifact@v4
+        with:
+          name: branch
+      - name: Download main results
+        uses: actions/download-artifact@v4
+        with:
+          name: main
+      - name: Benchstat Results
+        run: benchstat main.txt branch.txt | tee benchstat.txt
+      - name: Upload benchstat results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchstat
+          path: benchstat.txt

--- a/Makefile
+++ b/Makefile
@@ -495,3 +495,11 @@ mockery: $(BIN)/mockery
 
 # OTLP Protobuf generation
 include api/otlp/Makefile
+
+.PHONY: bench
+bench: $(BIN)/gotestsum ## Run all benchmarks
+	$(BIN)/gotestsum --format testname -- -bench=. -run=^$$ ./...
+
+.PHONY: bench/%
+bench/%: $(BIN)/gotestsum ## Run benchmarks matching a pattern (e.g., make bench/Parser)
+	$(BIN)/gotestsum --format testname -- -bench=$* -run=^$$ ./...

--- a/Makefile
+++ b/Makefile
@@ -496,10 +496,26 @@ mockery: $(BIN)/mockery
 # OTLP Protobuf generation
 include api/otlp/Makefile
 
-.PHONY: bench
+.PHONY: go/bench
 bench: $(BIN)/gotestsum ## Run all benchmarks
 	$(BIN)/gotestsum --format testname -- -bench=. -run=^$$ ./...
 
-.PHONY: bench/%
+.PHONY: go/bench/%
 bench/%: $(BIN)/gotestsum ## Run benchmarks matching a pattern (e.g., make bench/Parser)
 	$(BIN)/gotestsum --format testname -- -bench=$* -run=^$$ ./...
+
+profile:
+	go test -bench=. -run=XXX -p=8 -short ./pkg/ingester \
+		-memprofile=./main_mem.prof \
+		-cpuprofile=./main_cpu.prof
+
+profile_deltas:
+	@go tool pprof -top -ignore="runtime" \
+		-diff_base=./main_mem.prof \
+		./branch_mem.prof \
+		> ./prof_delta_mem.txt
+
+	@go tool pprof -top -ignore="runtime" \
+		-diff_base=./main_cpu.prof \
+		./branch_cpu.prof \
+		> ./prof_delta_cpu.txt

--- a/bench.sh
+++ b/bench.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2086
+
+# This script is for benchmarking the current branch against main.
+# We first check the dependencies
+# Then git status, requiring us to start on a branch
+# with all work committed. We enter a loop, bouncing between
+# the two branches, running benchmarking groups alternately.
+# Finally, output from all runs is merged, and a before/after
+# diff is generated.
+
+DEPENDENCY_CHECK() {
+	DEP=$1
+	WHICH_DEP=$(eval which $DEP)
+	DEP_SRC=$2
+	if [[ $WHICH_DEP == "" ]]; then
+		# shellcheck disable=SC2162
+		read -p "$DEP required, install now? [Y/n]: " Yn
+		echo
+	  if [[ $Yn == "n" ]]; then
+	    echo "exiting" && exit 1
+	  fi
+		eval go install $DEP_SRC
+		exit 0
+	fi
+	echo "found $DEP: $WHICH_DEP"
+}
+
+DEPENDENCY_CHECK "benchstat" "golang.org/x/perf/cmd/benchstat@latest"
+DEPENDENCY_CHECK "pprof-merge" "github.com/rakyll/pprof-merge"
+
+# This script MUST be run from the root directory
+CURRENT_DIR=${PWD##*/}
+if [[ "$CURRENT_DIR" != "pyroscope" ]]; then
+	echo "please run script from the root directory"
+	exit 1
+fi
+
+ITERATIONS="${1:-6}"
+
+# check git status
+GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+GIT_REVISION=$(git rev-parse --short HEAD)
+GIT_STATUS=$(git status --short)
+
+if [[ "$GIT_BRANCH" == "main" ]]; then
+	echo "on main, please checkout branch to benchmark"
+	exit 1
+else
+	echo "on branch $GIT_BRANCH at $GIT_REVISION"
+fi
+
+if [[ "$GIT_STATUS" == "" ]]; then
+	echo "all changes committed, ready to begin benchmarking"
+else
+	# TODO: support stashing changes
+	echo "some changes not committed, please commit all work"
+	exit 1
+fi
+
+# setup paths/filenames
+BRANCH_TAG=${GIT_BRANCH//'/'/'_'}
+BASE_DIR=$(realpath ./)
+BRANCH_DIR=${BASE_DIR}/data/benchmarks_${BRANCH_TAG}
+MAIN_DIR=${BASE_DIR}/data/benchmarks_main
+
+# setup and clean up the files
+if [ ! -d ./data ]
+then
+  mkdir data
+fi
+
+rm -rf $BRANCH_DIR
+mkdir $BRANCH_DIR
+rm -rf $MAIN_DIR
+mkdir $MAIN_DIR
+
+# begin benchmarking
+# this interleaved loop technique is idiomatic, from docs:
+# https://pkg.go.dev/golang.org/x/perf/cmd/benchstat#hdr-Tips
+i=1
+while [[ $i -le $ITERATIONS ]]
+do
+	set -e # exit on any error
+	set -o pipefail # including when we're piping things
+	echo "bench ${i} on ${GIT_BRANCH}"
+
+	go test -bench=Ingester -run=XXX -short -benchmem \
+		-memprofile=${BRANCH_DIR}/mem_${i}.prof \
+		-cpuprofile=${BRANCH_DIR}/cpu_${i}.prof \
+		./pkg/ingester | tee -a $BRANCH_DIR/bench.txt
+
+	eval git checkout main
+	echo "bench ${i} on main"
+	go test -bench=Ingester -run=XXX -short -benchmem \
+		-memprofile=${MAIN_DIR}/mem_${i}.prof \
+		-cpuprofile=${MAIN_DIR}/cpu_${i}.prof \
+		./pkg/ingester | tee -a $MAIN_DIR/bench.txt 
+
+	eval git checkout $GIT_BRANCH
+	echo "bench ${i} completed"
+	((i = i + 1))
+done
+
+MERGE_PROFILES() {
+	DIR=$1
+	NAME=$2
+
+	if [[ "$DIR" == "" || "$NAME" == "" ]]; then
+		echo "parameter missing"
+		exit 1
+	fi
+
+	pprof-merge ${DIR}/${NAME}_*
+	rm ${DIR}/${NAME}_*
+	mv merged.data ${DIR}/${NAME}.prof
+}
+
+MERGE_PROFILES $BRANCH_DIR "mem"
+MERGE_PROFILES $BRANCH_DIR "cpu"
+MERGE_PROFILES $MAIN_DIR "mem"
+MERGE_PROFILES $MAIN_DIR "cpu"
+
+# generate cpu delta
+go tool pprof -top -base=${MAIN_DIR}/cpu.prof \
+	${BRANCH_DIR}/cpu.prof | tee ${BRANCH_DIR}/cpu_delta.txt
+
+# generate memory delta
+go tool pprof -top -base=${MAIN_DIR}/mem.prof \
+	${BRANCH_DIR}/mem.prof | tee ${BRANCH_DIR}/mem_delta.txt
+
+# generate benchstat delta
+cp ${MAIN_DIR}/bench.txt ${BRANCH_DIR}/main_bench.txt
+cd ${BRANCH_DIR}
+benchstat main_bench.txt bench.txt | tee benchstat.txt

--- a/pkg/ingester/ingester_bench_test.go
+++ b/pkg/ingester/ingester_bench_test.go
@@ -1,0 +1,386 @@
+package ingester
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+	"github.com/grafana/dskit/services"
+	"github.com/grafana/dskit/kv"
+	"github.com/grafana/dskit/ring"
+	"github.com/grafana/dskit/user"
+	"github.com/grafana/pyroscope/pkg/phlaredb"
+	"github.com/grafana/pyroscope/pkg/validation"
+	pushv1 "github.com/grafana/pyroscope/api/gen/proto/go/push/v1"
+	ingesterv1 "github.com/grafana/pyroscope/api/gen/proto/go/ingester/v1"
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+)
+
+// mockLimits implements the Limits interface for testing
+type mockLimits struct {
+	maxSeriesPerUser        int
+	maxLabelNamesPerSeries  int
+}
+
+func (m *mockLimits) MaxSeriesPerUser(_ string) int { return m.maxSeriesPerUser }
+func (m *mockLimits) MaxLabelNamesPerSeries(_ string) int { return m.maxLabelNamesPerSeries }
+func (m *mockLimits) MaxLocalSeriesPerUser(_ string) int { return m.maxSeriesPerUser }
+func (m *mockLimits) MaxLocalSeriesPerMetric(_ string) int { return m.maxSeriesPerUser }
+func (m *mockLimits) MaxLocalSeriesPerTenant(_ string) int { return m.maxSeriesPerUser }
+func (m *mockLimits) MaxGlobalSeriesPerUser(_ string) int { return m.maxSeriesPerUser }
+func (m *mockLimits) MaxGlobalSeriesPerMetric(_ string) int { return m.maxSeriesPerUser }
+func (m *mockLimits) MaxGlobalSeriesPerTenant(_ string) int { return m.maxSeriesPerUser }
+func (m *mockLimits) DistributorUsageGroups(_ string) *validation.UsageGroupConfig {
+	config, _ := validation.NewUsageGroupConfig(map[string]string{
+		"default": "",
+	})
+	return &config
+}
+func (m *mockLimits) IngestionTenantShardSize(_ string) int { return 1024 * 1024 * 1024 }
+
+func setupTestIngester(b *testing.B, ctx context.Context) (*Ingester, error) {
+	dir := b.TempDir()
+
+	defaultLifecyclerConfig := ring.LifecyclerConfig{
+		RingConfig: ring.Config{
+			KVStore: kv.Config{
+				Store: "inmemory",
+			},
+			ReplicationFactor: 1,
+		},
+		NumTokens:  1,
+		HeartbeatPeriod: 5 * time.Second,
+		ObservePeriod: 0 * time.Second,
+		JoinAfter: 0 * time.Second,
+		MinReadyDuration: 0 * time.Second,
+		FinalSleep: 0,
+		ID: "localhost",
+		Addr: "127.0.0.1",
+		Zone: "localhost",
+	}
+
+	limits := &mockLimits{
+		maxSeriesPerUser: 1000000,
+		maxLabelNamesPerSeries: 100,
+	}
+
+	ing, err := New(
+		ctx,
+		Config{
+			LifecyclerConfig: defaultLifecyclerConfig,
+		},
+		phlaredb.Config{
+			DataPath: dir,
+		},
+		nil, // storage bucket
+		limits,
+		0, // queryStoreAfter
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return ing, nil
+}
+
+func generateTestProfile() []byte {
+	// Create a simple profile for testing
+	profile := &profilev1.Profile{
+		StringTable: []string{"", "samples", "count", "function", "main"},  // Add StringTable
+		SampleType: []*profilev1.ValueType{
+			{
+				Type: 1, // Index into StringTable
+				Unit: 2, // Index into StringTable
+			},
+		},
+		Sample: []*profilev1.Sample{
+			{
+				Value: []int64{1},
+				Label: []*profilev1.Label{
+					{
+						Key: 3, // Index into StringTable for "function"
+						Str: 4, // Index into StringTable for "main"
+					},
+				},
+				LocationId: []uint64{1},
+			},
+		},
+		Location: []*profilev1.Location{
+			{
+				Id: 1,
+				Line: []*profilev1.Line{
+					{
+						FunctionId: 1,
+						Line:      1,
+					},
+				},
+			},
+		},
+		Function: []*profilev1.Function{
+			{
+				Id:       1,
+				Name:     4, // Index into StringTable for "main"
+				SystemName: 4, // Index into StringTable for "main"
+				Filename: 4, // Index into StringTable for "main"
+			},
+		},
+		TimeNanos: time.Now().UnixNano(),
+		DurationNanos: int64(time.Second),
+		PeriodType: &profilev1.ValueType{
+			Type: 1, // Index into StringTable
+			Unit: 2, // Index into StringTable
+		},
+		Period: 100000000, // 100ms in nanoseconds
+	}
+	
+	data, _ := profile.MarshalVT()
+	return data
+}
+
+func generateLabels(cardinality int) []string {
+	labels := make([]string, 0, cardinality*2)
+	// Always include service label
+	labels = append(labels, "service", "test")
+	
+	// Add additional labels
+	for i := 0; i < cardinality-1; i++ {
+		labels = append(labels, 
+			fmt.Sprintf("label_%d", i), 
+			fmt.Sprintf("value_%d", i))
+	}
+	return labels
+}
+
+// BenchmarkIngester_Push tests the basic ingestion path performance with minimal labels.
+// This benchmark is important as it establishes the baseline performance for the most
+// common operation in the ingester: pushing a single profile with basic metadata.
+// It helps identify any regressions in the core ingestion path.
+func BenchmarkIngester_Push(b *testing.B) {
+	ctx := user.InjectOrgID(context.Background(), "test")
+	ing, err := setupTestIngester(b, ctx)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	if err := services.StartAndAwaitRunning(ctx, ing); err != nil {
+		b.Fatal(err)
+	}
+	defer ing.StopAsync()
+
+	profile := generateTestProfile()
+	req := connect.NewRequest(&pushv1.PushRequest{
+		Series: []*pushv1.RawProfileSeries{
+			{
+				Labels: []*typesv1.LabelPair{
+					{
+						Name:  "service",
+						Value: "test",
+					},
+				},
+				Samples: []*pushv1.RawSample{
+					{
+						ID:         uuid.New().String(),
+						RawProfile: profile,
+					},
+				},
+			},
+		},
+	})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := ing.Push(ctx, req)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkIngester_Flush tests the performance of flushing profiles from memory to storage.
+// This is critical to measure as flush operations directly impact:
+// 1. Memory usage and GC pressure
+// 2. Write amplification to the underlying storage
+// 3. System reliability during high load periods
+func BenchmarkIngester_Flush(b *testing.B) {
+	ctx := user.InjectOrgID(context.Background(), "test")
+	ing, err := setupTestIngester(b, ctx)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	if err := ing.StartAsync(ctx); err != nil {
+		b.Fatal(err)
+	}
+	if err := ing.AwaitRunning(ctx); err != nil {
+		b.Fatal(err)
+	}
+	defer ing.StopAsync()
+
+	// First push some data
+	profile := generateTestProfile()
+	pushReq := connect.NewRequest(&pushv1.PushRequest{
+		Series: []*pushv1.RawProfileSeries{
+			{
+				Labels: []*typesv1.LabelPair{
+					{
+						Name:  "service",
+						Value: "test",
+					},
+				},
+				Samples: []*pushv1.RawSample{
+					{
+						ID:         uuid.New().String(),
+						RawProfile: profile,
+					},
+				},
+			},
+		},
+	})
+	_, err = ing.Push(ctx, pushReq)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	flushReq := connect.NewRequest(&ingesterv1.FlushRequest{})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := ing.Flush(ctx, flushReq)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkIngester_Push_LabelCardinality measures how ingestion performance scales
+// with increasing label cardinality (1 to 50 labels).
+// This is important because:
+// 1. Labels are used for querying and filtering profiles
+// 2. High cardinality can impact memory usage and indexing performance
+// 3. Many production environments use extensive labeling for better observability
+func BenchmarkIngester_Push_LabelCardinality(b *testing.B) {
+	cardinalities := []int{1, 5, 10, 20, 50}
+	
+	for _, cardinality := range cardinalities {
+		b.Run(fmt.Sprintf("labels_%d", cardinality), func(b *testing.B) {
+			ctx := user.InjectOrgID(context.Background(), "test")
+			ing, err := setupTestIngester(b, ctx)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			if err := ing.StartAsync(ctx); err != nil {
+				b.Fatal(err)
+			}
+			if err := ing.AwaitRunning(ctx); err != nil {
+				b.Fatal(err)
+			}
+			defer ing.StopAsync()
+
+			profile := generateTestProfile()
+			// labels := generateLabels(cardinality) // TODO: fix this
+			labels := []*typesv1.LabelPair{
+				{
+					Name:  "service",
+					Value: "test",
+				},
+			}
+			
+			req := connect.NewRequest(&pushv1.PushRequest{
+				Series: []*pushv1.RawProfileSeries{
+					{
+						Labels: labels,
+						Samples: []*pushv1.RawSample{
+							{
+								ID:         uuid.New().String(),
+								RawProfile: profile,
+							},
+						},
+					},
+				},
+			})
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := ing.Push(ctx, req)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkIngester_Flush_LabelCardinality tests how flush performance is affected
+// by different label cardinalities. This benchmark pushes 100 samples per cardinality
+// level before measuring flush performance.
+// This is crucial because:
+// 1. Label cardinality affects the size and complexity of the index
+// 2. Higher cardinalities can lead to larger flush operations
+// 3. Understanding this relationship helps in capacity planning and setting limits
+func BenchmarkIngester_Flush_LabelCardinality(b *testing.B) {
+	cardinalities := []int{1, 5, 10, 20, 50}
+	
+	for _, cardinality := range cardinalities {
+		b.Run(fmt.Sprintf("labels_%d", cardinality), func(b *testing.B) {
+			ctx := user.InjectOrgID(context.Background(), "test")
+			ing, err := setupTestIngester(b, ctx)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			if err := ing.StartAsync(ctx); err != nil {
+				b.Fatal(err)
+			}
+			if err := ing.AwaitRunning(ctx); err != nil {
+				b.Fatal(err)
+			}
+			defer ing.StopAsync()
+
+			// Push data with different label cardinalities
+			profile := generateTestProfile()
+			// labels := generateLabels(cardinality) // TODO: fix this
+			labels := []*typesv1.LabelPair{
+				{
+					Name:  "service",
+					Value: "test",
+				},
+			}
+			
+			// Push multiple samples to ensure we have enough data to make the flush meaningful
+			for i := 0; i < 100; i++ {
+				pushReq := connect.NewRequest(&pushv1.PushRequest{
+					Series: []*pushv1.RawProfileSeries{
+						{
+							Labels: labels,
+							Samples: []*pushv1.RawSample{
+								{
+									ID:         uuid.New().String(),
+									RawProfile: profile,
+								},
+							},
+						},
+					},
+				})
+				_, err = ing.Push(ctx, pushReq)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+
+			flushReq := connect.NewRequest(&ingesterv1.FlushRequest{})
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := ing.Flush(ctx, flushReq)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+} 


### PR DESCRIPTION
i realized the other benchmarks were not doing anything useful, so...

Added a new benchmark BenchmarkIngester_Push_ProfileSize to measure ingestion 
performance with different profile sizes ranging from 1KB to 10MB. This helps 
understand how the ingester performs with varying payload sizes.