### PR TITLE
Add missing benchmarks

### DIFF
--- a/pkg/phlaredb/symdb/stacktrace_tree_test.go
+++ b/pkg/phlaredb/symdb/stacktrace_tree_test.go
@@ -2,6 +2,7 @@ package symdb
 
 import (
 	"bytes"
+	"fmt"
 	"math/rand"
 	"testing"
 
@@ -217,12 +218,16 @@ func Benchmark_stacktrace_tree_insert(b *testing.B) {
 	require.NoError(b, err)
 
 	b.ResetTimer()
-	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
-		x := newStacktraceTree(0)
-		for j := range p.Sample {
-			x.insert(p.Sample[j].LocationId)
-		}
+	for _, size := range []int{0, 256, 512, 1024} {
+		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				x := newStacktraceTree(size)
+				for j := range p.Sample {
+					x.insert(p.Sample[j].LocationId)
+				}
+			}
+		})
 	}
 }

--- a/pkg/phlaredb/symdb/symdb_test.go
+++ b/pkg/phlaredb/symdb/symdb_test.go
@@ -227,3 +227,20 @@ func TestWritePartition(t *testing.T) {
 `
 	require.Equal(t, expected, resolved.String())
 }
+
+func BenchmarkPartitionWriter_WriteProfileSymbols(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		p, err := pprof.OpenFile("testdata/profile.pb.gz")
+		require.NoError(b, err)
+		p.Normalize()
+		cfg := DefaultConfig().WithDirectory(b.TempDir())
+		db := NewSymDB(cfg)
+		pw := db.PartitionWriter(0)
+		b.StartTimer()
+
+		pw.WriteProfileSymbols(p.Profile)
+	}
+}


### PR DESCRIPTION
This PR adds two benchmarks:

* `*PartitionWriter.WriteProfileSymbols` benchmark, as it is one of the functions that allocates the most space and I wanted to drill down why;
* `*stacktraceTree.insert` benchmark refactor for comparing the performance when using different tree sizes.