### PR TITLE
chore(v2): enable native histograms in server metrics

### DIFF
--- a/pkg/phlare/modules.go
+++ b/pkg/phlare/modules.go
@@ -531,7 +531,7 @@ func (f *Phlare) initServer() (services.Service, error) {
 	f.Cfg.Server.GRPCMiddleware = append(f.Cfg.Server.GRPCMiddleware, util.RecoveryInterceptorGRPC)
 
 	if f.Cfg.v2Experiment {
-		f.Cfg.Server.MetricsNativeHistogramFactor = 1.1
+		f.Cfg.Server.MetricsNativeHistogramFactor = 1.1 // 10% increase from bucket to bucket
 		if slices.Contains(f.Cfg.Target, QueryBackend) {
 			concurrencyInterceptor, err := query_backend.CreateConcurrencyInterceptor(f.logger)
 			if err != nil {

--- a/pkg/phlare/modules.go
+++ b/pkg/phlare/modules.go
@@ -530,12 +530,15 @@ func (f *Phlare) initServer() (services.Service, error) {
 	f.Cfg.Server.ExcludeRequestInLog = true // gRPC-specific.
 	f.Cfg.Server.GRPCMiddleware = append(f.Cfg.Server.GRPCMiddleware, util.RecoveryInterceptorGRPC)
 
-	if f.Cfg.v2Experiment && slices.Contains(f.Cfg.Target, QueryBackend) {
-		concurrencyInterceptor, err := query_backend.CreateConcurrencyInterceptor(f.logger)
-		if err != nil {
-			return nil, err
+	if f.Cfg.v2Experiment {
+		f.Cfg.Server.MetricsNativeHistogramFactor = 1.1
+		if slices.Contains(f.Cfg.Target, QueryBackend) {
+			concurrencyInterceptor, err := query_backend.CreateConcurrencyInterceptor(f.logger)
+			if err != nil {
+				return nil, err
+			}
+			f.Cfg.Server.GRPCMiddleware = append(f.Cfg.Server.GRPCMiddleware, concurrencyInterceptor)
 		}
-		f.Cfg.Server.GRPCMiddleware = append(f.Cfg.Server.GRPCMiddleware, concurrencyInterceptor)
 	}
 
 	f.setupWorkerTimeout()
@@ -544,13 +547,13 @@ func (f *Phlare) initServer() (services.Service, error) {
 		f.Cfg.Server.HTTPServerReadTimeout = 2 * f.Cfg.Server.HTTPServerReadTimeout
 		f.Cfg.Server.HTTPServerWriteTimeout = 2 * f.Cfg.Server.HTTPServerWriteTimeout
 	}
-	serv, err := server.New(f.Cfg.Server)
-	if err != nil {
+
+	var err error
+	if f.Server, err = server.New(f.Cfg.Server); err != nil {
 		return nil, err
 	}
 
-	f.Server = serv
-	if f.Cfg.v2Experiment {
+	if f.healthServer != nil {
 		grpc_health_v1.RegisterHealthServer(f.Server.GRPC, f.healthServer)
 	}
 


### PR DESCRIPTION
The change enables native histogram buckets for the `pyroscope_request_duration_seconds` metric. As of now, it might be overly coarse, especially if the measured value exceeds 500ms.