### PR TITLE
chore(v2): add segment upload timeout

### DIFF
--- a/pkg/experiment/ingester/service.go
+++ b/pkg/experiment/ingester/service.go
@@ -50,6 +50,7 @@ type Config struct {
 }
 
 type UploadConfig struct {
+	Timeout          time.Duration `yaml:"timeout,omitempty" category:"advanced"`
 	MaxRetries       int           `yaml:"retry_max_retries,omitempty" category:"advanced"`
 	MinBackoff       time.Duration `yaml:"retry_min_period,omitempty" category:"advanced"`
 	MaxBackoff       time.Duration `yaml:"retry_max_period,omitempty" category:"advanced"`
@@ -68,6 +69,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 }
 
 func (cfg *UploadConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.DurationVar(&cfg.Timeout, prefix+".timeout", time.Second, "Timeout for upload requests.")
 	f.IntVar(&cfg.MaxRetries, prefix+".max-retries", 3, "Number of times to backoff and retry before failing.")
 	f.DurationVar(&cfg.MinBackoff, prefix+".retry-min-period", 50*time.Millisecond, "Minimum delay when backing off.")
 	f.DurationVar(&cfg.MaxBackoff, prefix+".retry-max-period", defaultSegmentDuration, "Maximum delay when backing off.")

--- a/pkg/util/retry/hedged_test.go
+++ b/pkg/util/retry/hedged_test.go
@@ -133,9 +133,16 @@ func Test_Hedging(t *testing.T) {
 		c := c
 		t.Run(c.description, func(t *testing.T) {
 			t.Parallel()
+			// With FailFast, it's expected the call returns
+			// immediately after the first response. Increasing
+			// the delay to make sure the test doesn't flake.
+			d := delay
+			if c.failFast {
+				d = time.Second * 10
+			}
 			a := Hedged[bool]{
 				Call:     createCall(c),
-				Trigger:  time.After(delay),
+				Trigger:  time.After(d),
 				FailFast: c.failFast,
 			}
 			r, err := a.Do(ctx)


### PR DESCRIPTION
This change adds an explicit, configurable static timeout for segment uploads.

Currently, the timeout is inherited from the distributor and is too high (5s by default). This makes retries inefficient if the bucket client happens to connect to a slow server or encounters other high-latency issues.

Additionally, I have disabled the FailFast option for hedged requests to prevent a situation where a failed hedged request (which is not retried) cancels the upload.