### PR TITLE
Remove doc-validator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,28 +78,6 @@ jobs:
       - name: "Test docs"
         run: make docs/test
 
-  doc-validator:
-    runs-on: "ubuntu-latest"
-    container:
-      image: "grafana/doc-validator:v5.2.0"
-    steps:
-      - name: "Checkout code"
-        uses: "actions/checkout@v4"
-      - name: "Run doc-validator tool"
-        run: >
-          doc-validator
-          '--skip-checks=^image.+$'
-          docs/sources
-          /docs/writers-toolkit
-          | reviewdog
-          -f=rdjsonl
-          --fail-on-error
-          --filter-mode=nofilter
-          --name=doc-validator
-          --reporter=github-pr-review
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
   build-image:
     if: github.event_name != 'push'
     runs-on: ubuntu-latest


### PR DESCRIPTION
As part of #3961 I noticed the doc-validator having some bugs (or rather more the review dog component).

Speaking with @jdbaldry there is not much maintenance going into the doc-validator and that he's planning to focus on a centralised vale ruleset.

So removing this in the meantime

