### PR TITLE
feat(v2): configurable write-path compression

### DIFF
--- a/pkg/distributor/write_path/write_path.go
+++ b/pkg/distributor/write_path/write_path.go
@@ -100,6 +100,6 @@ func (o *Config) RegisterFlags(f *flag.FlagSet) {
 	f.Float64Var(&o.SegmentWriterWeight, "write-path.segment-writer-weight", 0,
 		"Specifies the fraction [0:1] that should be send to segment-writer in combined mode. 0 means no traffics is sent to segment-writer. 1 means 100% of requests are sent to segment-writer.")
 	f.DurationVar(&o.SegmentWriterTimeout, "write-path.segment-writer-timeout", 5*time.Second, "Timeout for segment writer requests.")
-	f.Var(&o.Compression, "write-path.compression", "Compression algorithm to use for segment writer requests.")
+	f.Var(&o.Compression, "write-path.compression", "Compression algorithm to use for segment writer requests; "+validCompressionOptionsString+".")
 	f.BoolVar(&o.AsyncIngest, "async-ingest", false, "If true, the write path will not wait for the segment-writer to finish processing the request. Writes to ingester always synchronous.")
 }

--- a/pkg/distributor/write_path/write_path.go
+++ b/pkg/distributor/write_path/write_path.go
@@ -38,7 +38,7 @@ var paths = []WritePath{
 	CombinedPath,
 }
 
-const validOptionsString = "valid options: ingester, segment-writer, combined"
+const validWritePathOptionsString = "valid options: ingester, segment-writer, combined"
 
 func (m *WritePath) Set(text string) error {
 	x := WritePath(text)
@@ -48,26 +48,58 @@ func (m *WritePath) Set(text string) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("%w: %s; %s", ErrInvalidWritePath, x, validOptionsString)
+	return fmt.Errorf("%w: %s; %s", ErrInvalidWritePath, x, validWritePathOptionsString)
 }
 
 func (m *WritePath) String() string { return string(*m) }
+
+type Compression string
+
+const (
+	CompressionNone Compression = "none"
+	CompressionGzip Compression = "gzip"
+)
+
+var ErrInvalidCompression = errors.New("invalid write path compression")
+
+var compressions = []Compression{
+	CompressionNone,
+	CompressionGzip,
+}
+
+const validCompressionOptionsString = "valid compression options: none, gzip"
+
+func (m *Compression) Set(text string) error {
+	x := Compression(text)
+	for _, name := range compressions {
+		if x == name {
+			*m = x
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: %s; %s", ErrInvalidCompression, x, validCompressionOptionsString)
+}
+
+func (m *Compression) String() string { return string(*m) }
 
 type Config struct {
 	WritePath            WritePath     `yaml:"write_path" json:"write_path" doc:"hidden"`
 	IngesterWeight       float64       `yaml:"write_path_ingester_weight" json:"write_path_ingester_weight" doc:"hidden"`
 	SegmentWriterWeight  float64       `yaml:"write_path_segment_writer_weight" json:"write_path_segment_writer_weight" doc:"hidden"`
 	SegmentWriterTimeout time.Duration `yaml:"write_path_segment_writer_timeout" json:"write_path_segment_writer_timeout" doc:"hidden"`
+	Compression          Compression   `yaml:"write_path_compression" json:"write_path_compression" doc:"hidden"`
 	AsyncIngest          bool          `yaml:"async_ingest" json:"async_ingest" doc:"hidden"`
 }
 
 func (o *Config) RegisterFlags(f *flag.FlagSet) {
 	o.WritePath = IngesterPath
-	f.Var(&o.WritePath, "write-path", "Controls the write path route; "+validOptionsString+".")
+	o.Compression = CompressionNone
+	f.Var(&o.WritePath, "write-path", "Controls the write path route; "+validWritePathOptionsString+".")
 	f.Float64Var(&o.IngesterWeight, "write-path.ingester-weight", 1,
 		"Specifies the fraction [0:1] that should be send to ingester in combined mode. 0 means no traffics is sent to ingester. 1 means 100% of requests are sent to ingester.")
 	f.Float64Var(&o.SegmentWriterWeight, "write-path.segment-writer-weight", 0,
 		"Specifies the fraction [0:1] that should be send to segment-writer in combined mode. 0 means no traffics is sent to segment-writer. 1 means 100% of requests are sent to segment-writer.")
 	f.DurationVar(&o.SegmentWriterTimeout, "write-path.segment-writer-timeout", 5*time.Second, "Timeout for segment writer requests.")
+	f.Var(&o.Compression, "write-path.compression", "Compression algorithm to use for segment writer requests.")
 	f.BoolVar(&o.AsyncIngest, "async-ingest", false, "If true, the write path will not wait for the segment-writer to finish processing the request. Writes to ingester always synchronous.")
 }


### PR DESCRIPTION
The PR disables pprof gzip compression in the distributor-to-segment-writer path by default. This should be handled at the transport level.

This allows to save roughly 5-10% of CPU time in both distributors and segment-writers. However, this is only beneficial for all-in-one and single-AZ deployments (in cross-AZ deployments, ingest traffic should not leave the home zone).