### PR TITLE
fix(v2): tombstone queue iterator ignores oldest tombstone

### DIFF
--- a/pkg/experiment/metastore/tombstones/tombstone_queue.go
+++ b/pkg/experiment/metastore/tombstones/tombstone_queue.go
@@ -55,21 +55,24 @@ func (q *tombstoneQueue) delete(e *tombstones) *tombstones {
 }
 
 type tombstoneIter struct {
-	head   *tombstones
-	before int64
+	head    *tombstones
+	current *tombstones
+	before  int64
 }
 
 func (t *tombstoneIter) Next() bool {
 	if t.head == nil {
 		return false
 	}
-	if t.head = t.head.next; t.head == nil {
-		return false
+	if t.current == nil {
+		t.current = t.head
+	} else {
+		t.current = t.current.next
 	}
-	return t.head.AppendedAt < t.before
+	return t.current != nil && t.current.AppendedAt < t.before
 }
 
-func (t *tombstoneIter) At() *metastorev1.Tombstones { return t.head.Tombstones }
+func (t *tombstoneIter) At() *metastorev1.Tombstones { return t.current.Tombstones }
 
 func (t *tombstoneIter) Err() error   { return nil }
 func (t *tombstoneIter) Close() error { return nil }

--- a/pkg/experiment/metastore/tombstones/tombstone_queue_test.go
+++ b/pkg/experiment/metastore/tombstones/tombstone_queue_test.go
@@ -1,0 +1,111 @@
+package tombstones
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	"github.com/grafana/pyroscope/pkg/experiment/metastore/tombstones/store"
+)
+
+func TestTombstoneIterator(t *testing.T) {
+	queue := newTombstoneQueue()
+	now := time.Now()
+	entries := []*tombstones{
+		{
+			TombstoneEntry: store.TombstoneEntry{
+				Index:      1,
+				AppendedAt: now.Add(-5 * time.Hour).UnixNano(),
+				Tombstones: &metastorev1.Tombstones{
+					Blocks: &metastorev1.BlockTombstones{Name: "block-1"},
+				},
+			},
+		},
+		{
+			TombstoneEntry: store.TombstoneEntry{
+				Index:      2,
+				AppendedAt: now.Add(-4 * time.Hour).UnixNano(),
+				Tombstones: &metastorev1.Tombstones{
+					Blocks: &metastorev1.BlockTombstones{Name: "block-2"},
+				},
+			},
+		},
+		{
+			TombstoneEntry: store.TombstoneEntry{
+				Index:      3,
+				AppendedAt: now.Add(-3 * time.Hour).UnixNano(),
+				Tombstones: &metastorev1.Tombstones{
+					Blocks: &metastorev1.BlockTombstones{Name: "block-3"},
+				},
+			},
+		},
+		{
+			TombstoneEntry: store.TombstoneEntry{
+				Index:      4,
+				AppendedAt: now.Add(-2 * time.Hour).UnixNano(),
+				Tombstones: &metastorev1.Tombstones{
+					Blocks: &metastorev1.BlockTombstones{Name: "block-4"},
+				},
+			},
+		},
+		{
+			TombstoneEntry: store.TombstoneEntry{
+				Index:      5,
+				AppendedAt: now.Add(-1 * time.Hour).UnixNano(),
+				Tombstones: &metastorev1.Tombstones{
+					Blocks: &metastorev1.BlockTombstones{Name: "block-5"},
+				},
+			},
+		},
+	}
+
+	for _, entry := range entries {
+		queue.push(entry)
+	}
+
+	t.Run("all entries before current time", func(t *testing.T) {
+		iter := &tombstoneIter{
+			head:   queue.head,
+			before: now.UnixNano(),
+		}
+		count := 0
+		for iter.Next() {
+			count++
+			assert.Equal(t, entries[count-1].Tombstones, iter.At())
+		}
+		assert.Equal(t, len(entries), count)
+	})
+
+	t.Run("entries before specific time", func(t *testing.T) {
+		cutoffTime := now.Add(-3 * time.Hour)
+		iter := &tombstoneIter{
+			head:   queue.head,
+			before: cutoffTime.UnixNano(),
+		}
+		expected := []string{"block-1", "block-2"}
+		var actual []string
+		for iter.Next() {
+			actual = append(actual, iter.At().Blocks.Name)
+		}
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("empty queue", func(t *testing.T) {
+		emptyQueue := newTombstoneQueue()
+		iter := &tombstoneIter{
+			head:   emptyQueue.head,
+			before: now.UnixNano(),
+		}
+		assert.False(t, iter.Next())
+	})
+
+	t.Run("no entries before cutoff time", func(t *testing.T) {
+		iter := &tombstoneIter{
+			head:   queue.head,
+			before: now.Add(-10 * time.Hour).UnixNano(),
+		}
+		assert.False(t, iter.Next())
+	})
+}

--- a/pkg/experiment/metastore/tombstones/tombstones_restore_test.go
+++ b/pkg/experiment/metastore/tombstones/tombstones_restore_test.go
@@ -1,0 +1,90 @@
+package tombstones
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	"github.com/grafana/pyroscope/pkg/experiment/metastore/tombstones/store"
+	"github.com/grafana/pyroscope/pkg/test"
+)
+
+func TestTombstonesRestore(t *testing.T) {
+	now := time.Now()
+	db := test.BoltDB(t)
+	tombstoneStore := store.NewTombstoneStore()
+
+	ts := NewTombstones(tombstoneStore)
+	tx, err := db.Begin(true)
+	require.NoError(t, err)
+	require.NoError(t, ts.Init(tx))
+	require.NoError(t, tx.Commit())
+
+	for i, tombstone := range []*metastorev1.Tombstones{
+		{
+			Blocks: &metastorev1.BlockTombstones{
+				Name:   "x-1",
+				Tenant: "tenant-1",
+				Shard:  1,
+				Blocks: []string{"block-1-1", "block-1-2"},
+			},
+		},
+		{
+			Blocks: &metastorev1.BlockTombstones{
+				Name:   "x-2",
+				Tenant: "tenant-1",
+				Shard:  1,
+				Blocks: []string{"block-2-1", "block-2-2"},
+			},
+		},
+		{
+			Blocks: &metastorev1.BlockTombstones{
+				Name:   "x-3",
+				Tenant: "tenant-2",
+				Shard:  2,
+				Blocks: []string{"block-3-1", "block-3-2"},
+			},
+		},
+	} {
+		tx, err := db.Begin(true)
+		require.NoError(t, err)
+		err = ts.AddTombstones(tx, &raft.Log{Index: uint64(i), AppendedAt: now}, tombstone)
+		require.NoError(t, err)
+		require.NoError(t, tx.Commit())
+	}
+
+	assert.True(t, ts.Exists("tenant-1", 1, "block-1-1"))
+	assert.True(t, ts.Exists("tenant-1", 1, "block-1-2"))
+	assert.True(t, ts.Exists("tenant-1", 1, "block-2-1"))
+	assert.True(t, ts.Exists("tenant-1", 1, "block-2-2"))
+	assert.True(t, ts.Exists("tenant-2", 2, "block-3-1"))
+	assert.True(t, ts.Exists("tenant-2", 2, "block-3-2"))
+	assert.Equal(t, 3, countTombstones(ts))
+
+	restored := NewTombstones(tombstoneStore)
+	tx, err = db.Begin(true)
+	require.NoError(t, err)
+	err = restored.Restore(tx)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+
+	assert.True(t, restored.Exists("tenant-1", 1, "block-1-1"))
+	assert.True(t, restored.Exists("tenant-1", 1, "block-1-2"))
+	assert.True(t, restored.Exists("tenant-1", 1, "block-2-1"))
+	assert.True(t, restored.Exists("tenant-1", 1, "block-2-2"))
+	assert.True(t, restored.Exists("tenant-2", 2, "block-3-1"))
+	assert.True(t, restored.Exists("tenant-2", 2, "block-3-2"))
+	assert.Equal(t, 3, countTombstones(restored))
+
+	futureTime := now.Add(time.Hour)
+	iter := restored.ListTombstones(futureTime)
+	count := 0
+	for iter.Next() {
+		count++
+	}
+	assert.Equal(t, 3, count)
+}

--- a/pkg/experiment/metastore/tombstones/tombstones_test.go
+++ b/pkg/experiment/metastore/tombstones/tombstones_test.go
@@ -1,0 +1,98 @@
+package tombstones
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	"github.com/grafana/pyroscope/pkg/experiment/metastore/tombstones/store"
+	"github.com/grafana/pyroscope/pkg/test"
+)
+
+func TestTombstonesIdempotence(t *testing.T) {
+	db := test.BoltDB(t)
+	tombstoneStore := store.NewTombstoneStore()
+
+	ts := NewTombstones(tombstoneStore)
+	tx, err := db.Begin(true)
+	require.NoError(t, err)
+	require.NoError(t, ts.Init(tx))
+	require.NoError(t, tx.Commit())
+
+	now := time.Now()
+	cmd := &raft.Log{
+		Index:      1,
+		Term:       1,
+		Type:       raft.LogCommand,
+		Data:       []byte("test"),
+		AppendedAt: now,
+	}
+
+	x := &metastorev1.Tombstones{
+		Blocks: &metastorev1.BlockTombstones{
+			Name:   "test-block",
+			Tenant: "test-tenant",
+			Shard:  1,
+			Blocks: []string{"block-1", "block-2"},
+		},
+	}
+
+	t.Run("AddTombstones", func(t *testing.T) {
+		tx, err = db.Begin(true)
+		require.NoError(t, err)
+		err = ts.AddTombstones(tx, cmd, x)
+		require.NoError(t, err)
+		require.NoError(t, tx.Commit())
+
+		assert.True(t, ts.Exists("test-tenant", 1, "block-1"))
+		assert.True(t, ts.Exists("test-tenant", 1, "block-2"))
+
+		count := countTombstones(ts)
+
+		tx, err = db.Begin(true)
+		require.NoError(t, err)
+		err = ts.AddTombstones(tx, cmd, x)
+		require.NoError(t, err)
+		require.NoError(t, tx.Commit())
+		assert.Equal(t, count, countTombstones(ts))
+
+		assert.True(t, ts.Exists("test-tenant", 1, "block-1"))
+		assert.True(t, ts.Exists("test-tenant", 1, "block-2"))
+	})
+
+	t.Run("DeleteTombstones", func(t *testing.T) {
+		tx, err := db.Begin(true)
+		require.NoError(t, err)
+		err = ts.DeleteTombstones(tx, cmd, x)
+		require.NoError(t, err)
+		require.NoError(t, tx.Commit())
+
+		assert.False(t, ts.Exists("test-tenant", 1, "block-1"))
+		assert.False(t, ts.Exists("test-tenant", 1, "block-2"))
+
+		count := countTombstones(ts)
+
+		tx, err = db.Begin(true)
+		require.NoError(t, err)
+		err = ts.DeleteTombstones(tx, cmd, x)
+		require.NoError(t, err)
+		require.NoError(t, tx.Commit())
+		assert.Equal(t, count, countTombstones(ts))
+
+		assert.False(t, ts.Exists("test-tenant", 1, "block-1"))
+		assert.False(t, ts.Exists("test-tenant", 1, "block-2"))
+	})
+}
+
+func countTombstones(ts *Tombstones) int {
+	var c int
+	iter := ts.ListTombstones(time.Now().Add(time.Hour))
+	for iter.Next() {
+		c++
+	}
+	return c
+}


### PR DESCRIPTION
The PR fixes a bug that prevented the oldest batch of tombstones from being scheduled for removal, causing it to remain in the queue indefinitely.