### PR TITLE
chore: add optional shutdown delay

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -145,6 +145,8 @@ Usage of ./pyroscope:
     	yaml file to load
   -config.show_banner
     	Prints the application banner at startup. (default true)
+  -config.shutdown-delay duration
+    	Wait time before shutting down after a termination signal.
   -consul.acl-token string
     	ACL Token used to interact with Consul.
   -consul.cas-retry-delay duration

--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -145,8 +145,6 @@ Usage of ./pyroscope:
     	yaml file to load
   -config.show_banner
     	Prints the application banner at startup. (default true)
-  -config.shutdown-delay duration
-    	Wait time before shutting down after a termination signal.
   -consul.acl-token string
     	ACL Token used to interact with Consul.
   -consul.cas-retry-delay duration
@@ -851,6 +849,8 @@ Usage of ./pyroscope:
     	Comma-separated list of cipher suites to use. If blank, the default Go cipher suites is used.
   -server.tls-min-version string
     	Minimum TLS version to use. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13. If blank, the Go TLS minimum version is used.
+  -shutdown-delay duration
+    	Wait time before shutting down after a termination signal.
   -storage.azure.account-key string
     	Azure storage account key. If unset, Azure managed identities will be used for authentication instead.
   -storage.azure.account-name string

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -41,6 +41,8 @@ Usage of ./pyroscope:
     	yaml file to load
   -config.show_banner
     	Prints the application banner at startup. (default true)
+  -config.shutdown-delay duration
+    	Wait time before shutting down after a termination signal.
   -consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")
   -distributor.aggregation-period duration

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -41,8 +41,6 @@ Usage of ./pyroscope:
     	yaml file to load
   -config.show_banner
     	Prints the application banner at startup. (default true)
-  -config.shutdown-delay duration
-    	Wait time before shutting down after a termination signal.
   -consul.hostname string
     	Hostname and port of Consul. (default "localhost:8500")
   -distributor.aggregation-period duration
@@ -289,6 +287,8 @@ Usage of ./pyroscope:
     	Comma-separated list of cipher suites to use. If blank, the default Go cipher suites is used.
   -server.tls-min-version string
     	Minimum TLS version to use. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13. If blank, the Go TLS minimum version is used.
+  -shutdown-delay duration
+    	Wait time before shutting down after a termination signal.
   -storage.azure.account-key string
     	Azure storage account key. If unset, Azure managed identities will be used for authentication instead.
   -storage.azure.account-name string

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -297,6 +297,10 @@ analytics:
 # CLI flag: -config.show_banner
 [show_banner: <boolean> | default = true]
 
+# Wait time before shutting down after a termination signal.
+# CLI flag: -config.shutdown-delay
+[shutdown_delay: <duration> | default = 0s]
+
 embedded_grafana:
   # The directory where the Grafana data will be stored.
   # CLI flag: -embedded-grafana.data-path

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -298,7 +298,7 @@ analytics:
 [show_banner: <boolean> | default = true]
 
 # Wait time before shutting down after a termination signal.
-# CLI flag: -config.shutdown-delay
+# CLI flag: -shutdown-delay
 [shutdown_delay: <duration> | default = 0s]
 
 embedded_grafana:

--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -184,7 +184,7 @@ func (c *Config) RegisterFlagsWithContext(f *flag.FlagSet) {
 		"Expands ${var} in config according to the values of the environment variables.",
 	)
 	f.BoolVar(&c.ShowBanner, "config.show_banner", true, "Prints the application banner at startup.")
-	f.DurationVar(&c.ShutdownDelay, "config.shutdown-delay", 0, "Wait time before shutting down after a termination signal.")
+	f.DurationVar(&c.ShutdownDelay, "shutdown-delay", 0, "Wait time before shutting down after a termination signal.")
 
 	c.registerServerFlagsWithChangedDefaultValues(f)
 	c.MemberlistKV.RegisterFlags(f)

--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -104,6 +104,7 @@ type Config struct {
 	MultitenancyEnabled bool              `yaml:"multitenancy_enabled,omitempty"`
 	Analytics           usagestats.Config `yaml:"analytics"`
 	ShowBanner          bool              `yaml:"show_banner,omitempty"`
+	ShutdownDelay       time.Duration     `yaml:"shutdown_delay,omitempty"`
 
 	EmbeddedGrafana grafana.Config `yaml:"embedded_grafana,omitempty"`
 
@@ -183,6 +184,7 @@ func (c *Config) RegisterFlagsWithContext(f *flag.FlagSet) {
 		"Expands ${var} in config according to the values of the environment variables.",
 	)
 	f.BoolVar(&c.ShowBanner, "config.show_banner", true, "Prints the application banner at startup.")
+	f.DurationVar(&c.ShutdownDelay, "config.shutdown-delay", 0, "Wait time before shutting down after a termination signal.")
 
 	c.registerServerFlagsWithChangedDefaultValues(f)
 	c.MemberlistKV.RegisterFlags(f)
@@ -640,6 +642,10 @@ func (f *Phlare) Run() error {
 	f.SignalHandler = signals.NewHandler(f.Server.Log)
 	go func() {
 		f.SignalHandler.Loop()
+		if f.Cfg.ShutdownDelay > 0 {
+			level.Info(f.logger).Log("msg", "shutdown delayed", "delay", f.Cfg.ShutdownDelay)
+			time.Sleep(f.Cfg.ShutdownDelay)
+		}
 		sm.StopAsync()
 	}()
 


### PR DESCRIPTION
This PR adds a delay before termination.

Microservice deployments typically assume a load balancer in front of the distributor and query-frontend services. During rollouts, load balancers are often updated immediately while a termination signal is sent to pods simultaneously, leading to failed requests.

Kubernetes is known to suffer from this issue. A common mitigation is adding a `preStop` hook with a sleep command in the spec manifest. The newly introduced option helps simplify this process.

The delay is disabled by default, as enabling it may require adjusting the termination timeout (`terminationGracePeriodSeconds` in Kubernetes).