### PR TITLE
doc: fix configure-disk-storage.md default -pyroscopedb.max-block-dur…

### DIFF
--- a/docs/sources/configure-server/storage/configure-disk-storage.md
+++ b/docs/sources/configure-server/storage/configure-disk-storage.md
@@ -12,7 +12,7 @@ aliases:
 The [ingester] component in Grafana Pyroscope processes the received profiling data.
 First it keeps the data organized in memory, in the so-called "head block".
 Once the size of the head block exceeds a threshold or the head block is older than
-`-pyroscopedb.max-block-duration` (by default 3 hours), the ingester writes
+`-pyroscopedb.max-block-duration` (by default 1 hour), the ingester writes
 the block to the local persistent disk.
 Refer to [block format] for more detail about the block's layout.
 


### PR DESCRIPTION
as mentioned [here](https://github.com/grafana/pyroscope/blob/main/cmd/pyroscope/help-all.txt.tmpl#L488C1-L489C72)
![image](https://github.com/user-attachments/assets/702e0f79-8801-4b17-b7f5-f0e007fb3f91)
the actual max-block-duration is by default set to 1 hour