### PR TITLE
Compare `*stacktraceTree.insert` against different initial sizes

### DIFF
--- a/pkg/phlaredb/symdb/stacktrace_tree_test.go
+++ b/pkg/phlaredb/symdb/stacktrace_tree_test.go
@@ -220,7 +220,7 @@ func Benchmark_stacktrace_tree_insert(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		x := newStacktraceTree(0)
+		x := newStacktraceTree(defaultStacktraceTreeSize)
 		for j := range p.Sample {
 			x.insert(p.Sample[j].LocationId)
 		}

--- a/pkg/phlaredb/symdb/stacktrace_tree_test.go
+++ b/pkg/phlaredb/symdb/stacktrace_tree_test.go
@@ -3,7 +3,6 @@ package symdb
 import (
 	"bytes"
 	"math/rand"
-	"os"
 	"strconv"
 	"testing"
 
@@ -230,10 +229,6 @@ func Benchmark_stacktrace_tree_insert(b *testing.B) {
 }
 
 func Benchmark_stacktrace_tree_insert_default_sizes(b *testing.B) {
-	if os.Getenv("COMPARE_STACKTRACETREE_INSERT_DEFAULT_SIZES") != "true" {
-		b.Skip("This benchmark is only used for comparing different initial tree sizes")
-	}
-
 	p, err := pprof.OpenFile("testdata/profile.pb.gz")
 	require.NoError(b, err)
 

--- a/pkg/phlaredb/symdb/stacktrace_tree_test.go
+++ b/pkg/phlaredb/symdb/stacktrace_tree_test.go
@@ -248,7 +248,6 @@ func Benchmark_stacktrace_tree_insert_default_sizes(b *testing.B) {
 				for j := range p.Sample {
 					x.insert(p.Sample[j].LocationId)
 				}
-				// nodes = max(nodes, x.len())
 			}
 
 		})

--- a/pkg/phlaredb/symdb/stacktrace_tree_test.go
+++ b/pkg/phlaredb/symdb/stacktrace_tree_test.go
@@ -243,21 +243,14 @@ func Benchmark_stacktrace_tree_insert_default_sizes(b *testing.B) {
 				for j := range p.Sample {
 					x.insert(p.Sample[j].LocationId)
 				}
-			}
 
+				if testing.Verbose() {
+					c := float64(cap(x.nodes))
+					b.ReportMetric(c, "cap")
+					b.ReportMetric(c*float64(stacktraceTreeNodeSize), "size")
+					b.ReportMetric(float64(x.len())/float64(c)*100, "fill")
+				}
+			}
 		})
-
-		if testing.Verbose() {
-			var nodes uint32
-			b.Logf("init: %d nodes ~ %d bytes", size, size*stacktraceTreeNodeSize)
-
-			x := newStacktraceTree(size)
-			for j := range p.Sample {
-				x.insert(p.Sample[j].LocationId)
-			}
-			nodes = max(nodes, x.len())
-
-			b.Logf("max: %d nodes ~ %d bytes", nodes, nodes*uint32(stacktraceTreeNodeSize))
-		}
 	}
 }


### PR DESCRIPTION
During the past hackathon I was looking at trying to optimize performance of different Grafana products, and I've found that the `*stacktraceTree.insert` method was consuming lots of CPU and memory. Everything indicated that the calls to `append` were the responsible ones, so I've added a new benchmark to compare how the existing benchmark for this operation behaves against different initial sizes (currently `0`).

This benchmark can be slow, thus it won't run unless the `COMPARE_STACKTRACETREE_INSERT_DEFAULT_SIZES` environment variable is set to true. In addition, if the `-v` flag is passed to `go test` it will print the initial and max tree size after inserting all the samples from the test profile.

These are the results I've got on my local development machine:

```
$ env COMPARE_STACKTRACETREE_INSERT_DEFAULT_SIZES=true go test -run='^$' -bench=Benchmark_stacktrace_tree_insert_default_sizes ./pkg/phlaredb/symdb/ -v
goos: darwin
goarch: arm64
pkg: github.com/grafana/pyroscope/pkg/phlaredb/symdb
cpu: Apple M1 Pro
Benchmark_stacktrace_tree_insert_default_sizes
Benchmark_stacktrace_tree_insert_default_sizes/size=0
Benchmark_stacktrace_tree_insert_default_sizes/size=0-10                   12256             97704 ns/op          120049 B/op         14 allocs/op
    stacktrace_tree_test.go:258: init: 0 nodes ~ 0 bytes
    stacktrace_tree_test.go:266: max: 1793 nodes ~ 28688 bytes
Benchmark_stacktrace_tree_insert_default_sizes/size=10
Benchmark_stacktrace_tree_insert_default_sizes/size=10-10                  12475             95883 ns/op          102625 B/op         10 allocs/op
    stacktrace_tree_test.go:258: init: 10 nodes ~ 160 bytes
    stacktrace_tree_test.go:266: max: 1793 nodes ~ 28688 bytes
Benchmark_stacktrace_tree_insert_default_sizes/size=1024
Benchmark_stacktrace_tree_insert_default_sizes/size=1024-10                13028             91745 ns/op           81921 B/op          3 allocs/op
    stacktrace_tree_test.go:258: init: 1024 nodes ~ 16384 bytes
    stacktrace_tree_test.go:266: max: 1793 nodes ~ 28688 bytes
Benchmark_stacktrace_tree_insert_default_sizes/size=2048
Benchmark_stacktrace_tree_insert_default_sizes/size=2048-10                14047             85265 ns/op           32768 B/op          1 allocs/op
    stacktrace_tree_test.go:258: init: 2048 nodes ~ 32768 bytes
    stacktrace_tree_test.go:266: max: 1793 nodes ~ 28688 bytes
Benchmark_stacktrace_tree_insert_default_sizes/size=4096
Benchmark_stacktrace_tree_insert_default_sizes/size=4096-10                13689             89610 ns/op           65536 B/op          1 allocs/op
    stacktrace_tree_test.go:258: init: 4096 nodes ~ 65536 bytes
    stacktrace_tree_test.go:266: max: 1793 nodes ~ 28688 bytes
Benchmark_stacktrace_tree_insert_default_sizes/size=8192
Benchmark_stacktrace_tree_insert_default_sizes/size=8192-10                12843             92649 ns/op          131073 B/op          1 allocs/op
    stacktrace_tree_test.go:258: init: 8192 nodes ~ 131072 bytes
    stacktrace_tree_test.go:266: max: 1793 nodes ~ 28688 bytes
PASS
ok      github.com/grafana/pyroscope/pkg/phlaredb/symdb 13.478s
```

As we can observe, `2048` yields the better results when running the benchmark against the current test profile samples:

```
$ benchstat -col=/size -filter='/size:(0 OR 2048)' bench.stacktracetree-defaultsize.log
goos: darwin
goarch: arm64
pkg: github.com/grafana/pyroscope/pkg/phlaredb/symdb
cpu: Apple M1 Pro
                           │      0      │                2048                 │
                           │   sec/op    │   sec/op     vs base                │
_stacktrace_tree_insert-10   98.20µ ± 1%   85.14µ ± 0%  -13.29% (p=0.000 n=20)

                           │       0       │                 2048                 │
                           │     B/op      │     B/op      vs base                │
_stacktrace_tree_insert-10   117.24Ki ± 0%   32.00Ki ± 0%  -72.70% (p=0.000 n=20)

                           │      0      │                2048                │
                           │  allocs/op  │ allocs/op   vs base                │
_stacktrace_tree_insert-10   14.000 ± 0%   1.000 ± 0%  -92.86% (p=0.000 n=20)
```

These values are of course arbitrary and heavily dependent on the number of samples each profile has, however, it sheds some light on how by just changing the default size we can certainly improve this method without having to refactor it.

One additional idea that I didn't have the time to explore was to turn the `defaultStacktraceTreeSize` constant to a variable and adjust its value using heuristics so the resources consumption of creating and inserting to these stacktrace trees improves over time.

Here you can find the results: [bench.stacktracetree-defaultsize.log](https://github.com/user-attachments/files/19372993/bench.stacktracetree-defaultsize.log)
