### PR TITLE
fix(v2): disable parquet page index

### DIFF
--- a/pkg/experiment/block/dataset.go
+++ b/pkg/experiment/block/dataset.go
@@ -153,7 +153,7 @@ func (s *Dataset) open(ctx context.Context, sections ...Section) (err error) {
 		sc := sc
 		g.Go(util.RecoverPanic(func() error {
 			if openErr := sc.open(ctx, s); openErr != nil {
-				return fmt.Errorf("openning section %v: %w", s.section(sc).name, openErr)
+				return fmt.Errorf("opening section %v: %w", s.section(sc).name, openErr)
 			}
 			return nil
 		}))

--- a/pkg/experiment/block/section_profiles.go
+++ b/pkg/experiment/block/section_profiles.go
@@ -33,6 +33,7 @@ func openProfileTable(_ context.Context, s *Dataset) (err error) {
 			s.inMemoryBucket(buf), s.obj.path, offset, size,
 			0, // Do not prefetch the footer.
 			parquet.SkipBloomFilters(true),
+			parquet.SkipPageIndex(true),
 			parquet.FileReadMode(parquet.ReadModeSync),
 			parquet.ReadBufferSize(4<<10))
 	} else {
@@ -40,6 +41,7 @@ func openProfileTable(_ context.Context, s *Dataset) (err error) {
 			s.obj.storage, s.obj.path, offset, size,
 			estimateFooterSize(size),
 			parquet.SkipBloomFilters(true),
+			parquet.SkipPageIndex(true),
 			parquet.FileReadMode(parquet.ReadModeAsync),
 			parquet.ReadBufferSize(estimateReadBufferSize(size)))
 	}

--- a/pkg/phlaredb/symdb/block_reader.go
+++ b/pkg/phlaredb/symdb/block_reader.go
@@ -246,7 +246,7 @@ func (r *Reader) readIndexSection(ctx context.Context, offset, size int64) error
 	}
 	r.index, err = OpenIndex(buf)
 	if err != nil {
-		return fmt.Errorf("openning index: %w", err)
+		return fmt.Errorf("opening index: %w", err)
 	}
 	return nil
 }

--- a/pkg/phlaredb/symdb/block_reader_parquet.go
+++ b/pkg/phlaredb/symdb/block_reader_parquet.go
@@ -153,7 +153,7 @@ func openParquetFiles(ctx context.Context, r *Reader) error {
 				return err
 			}
 			if err = fp.Open(ctx, r.bucket, fm, options...); err != nil {
-				return fmt.Errorf("openning file %q: %w", n, err)
+				return fmt.Errorf("opening file %q: %w", n, err)
 			}
 			return nil
 		})


### PR DESCRIPTION
I've run into the issue where a parquet table [page index](https://parquet.apache.org/docs/file-format/pageindex/) cannot be read:

```
failed to initialize query context:
opening section profiles:
opening profile parquet table:
reading page index of parquet file:
decoding column index: rowGroup=0 columnChunk=0/18: missing required field: 1:FIELD<LIST>
```

It's worth noting that the problem only manifests in some (unknown) cases. I suspect that the parquet metadata might be incomplete. Disabling the index solves the problem (we don't use it in fact).