### PR TITLE
feat: Align missing service_name behaviour with otel spec

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -291,7 +291,7 @@ func (d *Distributor) PushParsed(ctx context.Context, req *distributormodel.Push
 	for _, series := range req.Series {
 		serviceName := phlaremodel.Labels(series.Labels).Get(phlaremodel.LabelNameServiceName)
 		if serviceName == "" {
-			series.Labels = append(series.Labels, &typesv1.LabelPair{Name: phlaremodel.LabelNameServiceName, Value: "unspecified"})
+			series.Labels = append(series.Labels, &typesv1.LabelPair{Name: phlaremodel.LabelNameServiceName, Value: phlaremodel.AttrServiceNameFallback})
 		}
 		sort.Sort(phlaremodel.Labels(series.Labels))
 	}

--- a/pkg/ingester/otlp/ingest_handler_test.go
+++ b/pkg/ingester/otlp/ingest_handler_test.go
@@ -31,7 +31,7 @@ func TestGetServiceNameFromAttributes(t *testing.T) {
 		{
 			name:     "empty attributes",
 			attrs:    []*v1.KeyValue{},
-			expected: "unknown_service",
+			expected: phlaremodel.AttrServiceNameFallback,
 		},
 		{
 			name: "empty attributes",
@@ -45,7 +45,7 @@ func TestGetServiceNameFromAttributes(t *testing.T) {
 					},
 				},
 			},
-			expected: "unknown_service:bash",
+			expected: phlaremodel.AttrServiceNameFallback + ":bash",
 		},
 		{
 			name: "service name present",
@@ -89,7 +89,7 @@ func TestGetServiceNameFromAttributes(t *testing.T) {
 					},
 				},
 			},
-			expected: "unknown_service",
+			expected: phlaremodel.AttrServiceNameFallback,
 		},
 		{
 			name: "service name among other attributes",

--- a/pkg/ingester/otlp/ingest_handler_test.go
+++ b/pkg/ingester/otlp/ingest_handler_test.go
@@ -31,7 +31,21 @@ func TestGetServiceNameFromAttributes(t *testing.T) {
 		{
 			name:     "empty attributes",
 			attrs:    []*v1.KeyValue{},
-			expected: "unknown",
+			expected: "unknown_service",
+		},
+		{
+			name: "empty attributes",
+			attrs: []*v1.KeyValue{
+				{
+					Key: "process.executable.name",
+					Value: &v1.AnyValue{
+						Value: &v1.AnyValue_StringValue{
+							StringValue: "bash",
+						},
+					},
+				},
+			},
+			expected: "unknown_service:bash",
 		},
 		{
 			name: "service name present",
@@ -41,6 +55,14 @@ func TestGetServiceNameFromAttributes(t *testing.T) {
 					Value: &v1.AnyValue{
 						Value: &v1.AnyValue_StringValue{
 							StringValue: "test-service",
+						},
+					},
+				},
+				{
+					Key: "process.executable.name",
+					Value: &v1.AnyValue{
+						Value: &v1.AnyValue_StringValue{
+							StringValue: "test-executable",
 						},
 					},
 				},
@@ -58,8 +80,16 @@ func TestGetServiceNameFromAttributes(t *testing.T) {
 						},
 					},
 				},
+				{
+					Key: "process.executable.name",
+					Value: &v1.AnyValue{
+						Value: &v1.AnyValue_StringValue{
+							StringValue: "",
+						},
+					},
+				},
 			},
-			expected: "unknown",
+			expected: "unknown_service",
 		},
 		{
 			name: "service name among other attributes",
@@ -568,9 +598,9 @@ func TestDifferentServiceNames(t *testing.T) {
 	require.Equal(t, 3, len(profiles[0].Series))
 
 	expectedProfiles := map[string]string{
-		"{__delta__=\"false\", __name__=\"process_cpu\", __otel__=\"true\", service_name=\"service-a\"}": "testdata/TestDifferentServiceNames_service_a_profile.json",
-		"{__delta__=\"false\", __name__=\"process_cpu\", __otel__=\"true\", service_name=\"service-b\"}": "testdata/TestDifferentServiceNames_service_b_profile.json",
-		"{__delta__=\"false\", __name__=\"process_cpu\", __otel__=\"true\", service_name=\"unknown\"}":   "testdata/TestDifferentServiceNames_unknown_profile.json",
+		"{__delta__=\"false\", __name__=\"process_cpu\", __otel__=\"true\", service_name=\"service-a\"}":       "testdata/TestDifferentServiceNames_service_a_profile.json",
+		"{__delta__=\"false\", __name__=\"process_cpu\", __otel__=\"true\", service_name=\"service-b\"}":       "testdata/TestDifferentServiceNames_service_b_profile.json",
+		"{__delta__=\"false\", __name__=\"process_cpu\", __otel__=\"true\", service_name=\"unknown_service\"}": "testdata/TestDifferentServiceNames_unknown_profile.json",
 	}
 
 	for _, s := range profiles[0].Series {

--- a/pkg/model/labels.go
+++ b/pkg/model/labels.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cespare/xxhash/v2"
 	pmodel "github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
+	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
 
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	"github.com/grafana/pyroscope/pkg/util"
@@ -41,6 +42,11 @@ const (
 	LabelOrderEnforced = "enforced"
 
 	LabelNamePyroscopeSpy = "pyroscope_spy"
+
+	AttrProcessExecutableName = semconv.ProcessExecutableNameKey
+
+	AttrServiceName         = semconv.ServiceNameKey
+	AttrServiceNameFallback = "unknown_service"
 
 	labelSep = '\xfe'
 

--- a/pkg/test/integration/ingest_otlp_test.go
+++ b/pkg/test/integration/ingest_otlp_test.go
@@ -49,12 +49,12 @@ var otlpTestDatas = []otlpTestData{
 		expectedProfiles: []expectedProfile{
 			{
 				"process_cpu:cpu:nanoseconds:cpu:nanoseconds",
-				map[string]string{"service_name": "unknown"},
+				map[string]string{"service_name": "unknown_service"},
 				"testdata/otel-ebpf-profiler-offcpu-cpu.json",
 			},
 			{
 				"off_cpu:events:nanoseconds::",
-				map[string]string{"service_name": "unknown"},
+				map[string]string{"service_name": "unknown_service"},
 				"testdata/otel-ebpf-profiler-offcpu.json",
 			},
 		},
@@ -68,7 +68,7 @@ var otlpTestDatas = []otlpTestData{
 		expectedProfiles: []expectedProfile{
 			{
 				"process_cpu:cpu:nanoseconds:cpu:nanoseconds",
-				map[string]string{"service_name": "unknown"},
+				map[string]string{"service_name": "unknown_service"},
 				"testdata/otel-ebpf-profiler-pyrosymbolized-unknown.json",
 			},
 			{

--- a/pkg/test/integration/ingest_otlp_test.go
+++ b/pkg/test/integration/ingest_otlp_test.go
@@ -35,7 +35,7 @@ var otlpTestDatas = []otlpTestData{
 		expectedProfiles: []expectedProfile{
 			{
 				"process_cpu:cpu:nanoseconds:cpu:nanoseconds",
-				map[string]string{"service_name": "unknown"},
+				map[string]string{"service_name": "unknown_service"},
 				"testdata/otel-ebpf-profiler-unsymbolized.json",
 			},
 		},


### PR DESCRIPTION
When looking at otel-ebpf-profiler I noticed we ignored their specification:

https://github.com/open-telemetry/opentelemetry-go/blob/ecfb73581f1b05af85fc393c3ce996a90cf2a5e2/semconv/v1.30.0/attribute_group.go#L10011-L10025
