### PR TITLE
feat(v2): metastore snapshot compression

### DIFF
--- a/pkg/experiment/metastore/fsm/boltdb.go
+++ b/pkg/experiment/metastore/fsm/boltdb.go
@@ -19,7 +19,7 @@ const (
 	boltDBCompactedName   = "metastore_compacted.boltdb"
 	boltDBInitialMmapSize = 1 << 30
 
-	boltDBCompactionMaxTxnSize = 64 << 10
+	boltDBCompactionMaxTxnSize = 1 << 20
 )
 
 type boltdb struct {

--- a/pkg/experiment/metastore/fsm/boltdb.go
+++ b/pkg/experiment/metastore/fsm/boltdb.go
@@ -127,7 +127,7 @@ func (db *boltdb) restore(snapshot io.Reader) error {
 			}
 		}
 		restored.shutdown()
-		err = os.RemoveAll(restored.path)
+		_ = os.RemoveAll(restored.path)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to restore snapshot: %w", err)

--- a/pkg/experiment/metastore/fsm/fsm.go
+++ b/pkg/experiment/metastore/fsm/fsm.go
@@ -280,7 +280,7 @@ func (fsm *FSM) Read(fn func(*bbolt.Tx)) error {
 func (fsm *FSM) Snapshot() (raft.FSMSnapshot, error) {
 	// Snapshot should only capture a pointer to the state, and any
 	// expensive IO should happen as part of FSMSnapshot.Persist.
-	s := snapshot{logger: fsm.logger, metrics: fsm.metrics}
+	s := snapshotWriter{logger: fsm.logger, metrics: fsm.metrics}
 	tx, err := fsm.db.boltdb.Begin(false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open a transaction for snapshot: %w", err)

--- a/pkg/experiment/metastore/fsm/fsm.go
+++ b/pkg/experiment/metastore/fsm/fsm.go
@@ -145,6 +145,8 @@ func (fsm *FSM) Restore(snapshot io.ReadCloser) (err error) {
 		level.Error(fsm.logger).Log("msg", "failed to create snapshot reader", "err", err)
 		return err
 	}
+	// The wrapper never returns errors on Close.
+	defer r.Close()
 
 	// Block all new transactions until we restore the snapshot.
 	// TODO(kolesnikovae): set not-serving service status to not

--- a/pkg/experiment/metastore/fsm/snapshot.go
+++ b/pkg/experiment/metastore/fsm/snapshot.go
@@ -75,7 +75,7 @@ func (s *snapshot) Release() {
 }
 
 type snapshotReader struct {
-	io.Reader
+	io.ReadCloser
 }
 
 var zstdMagic = []byte{0xFD, 0x2F, 0xB5, 0x28}
@@ -87,13 +87,13 @@ func newSnapshotReader(snapshot io.ReadCloser) (*snapshotReader, error) {
 		return nil, err
 	}
 
-	s := snapshotReader{Reader: io.NopCloser(b)}
+	s := snapshotReader{ReadCloser: io.NopCloser(b)}
 	if bytes.Equal(magic, zstdMagic) {
 		var dec *zstd.Decoder
 		if dec, err = zstd.NewReader(b); err != nil {
 			return nil, err
 		}
-		s.Reader = dec
+		s.ReadCloser = dec.IOReadCloser()
 	}
 
 	return &s, nil

--- a/pkg/experiment/metastore/fsm/snapshot.go
+++ b/pkg/experiment/metastore/fsm/snapshot.go
@@ -15,13 +15,13 @@ import (
 	"go.etcd.io/bbolt"
 )
 
-type snapshot struct {
+type snapshotWriter struct {
 	logger  log.Logger
 	tx      *bbolt.Tx
 	metrics *metrics
 }
 
-func (s *snapshot) Persist(sink raft.SnapshotSink) (err error) {
+func (s *snapshotWriter) Persist(sink raft.SnapshotSink) (err error) {
 	ctx := context.Background()
 	pprof.SetGoroutineLabels(pprof.WithLabels(ctx, pprof.Labels("metastore_op", "persist")))
 	defer pprof.SetGoroutineLabels(ctx)
@@ -67,7 +67,7 @@ func (s *snapshot) Persist(sink raft.SnapshotSink) (err error) {
 	return err
 }
 
-func (s *snapshot) Release() {
+func (s *snapshotWriter) Release() {
 	if s.tx != nil {
 		// This is an in-memory rollback, no error expected.
 		_ = s.tx.Rollback()
@@ -78,7 +78,7 @@ type snapshotReader struct {
 	io.ReadCloser
 }
 
-var zstdMagic = []byte{0xFD, 0x2F, 0xB5, 0x28}
+var zstdMagic = []byte{0x28, 0xB5, 0x2F, 0xFD}
 
 func newSnapshotReader(snapshot io.ReadCloser) (*snapshotReader, error) {
 	b := bufio.NewReader(snapshot)

--- a/pkg/experiment/metastore/metastore.go
+++ b/pkg/experiment/metastore/metastore.go
@@ -33,9 +33,9 @@ import (
 type Config struct {
 	Address          string             `yaml:"address"`
 	GRPCClientConfig grpcclient.Config  `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate with the metastore."`
-	DataDir          string             `yaml:"data_dir"`
 	MinReadyDuration time.Duration      `yaml:"min_ready_duration" category:"advanced"`
 	Raft             raft.Config        `yaml:"raft"`
+	FSM              fsm.Config         `yaml:",inline" category:"advanced"`
 	Index            index.Config       `yaml:",inline" category:"advanced"`
 	DLQRecovery      dlq.RecoveryConfig `yaml:",inline" category:"advanced"`
 	Compactor        compactor.Config   `yaml:",inline" category:"advanced"`
@@ -45,10 +45,10 @@ type Config struct {
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	const prefix = "metastore."
 	f.StringVar(&cfg.Address, prefix+"address", "localhost:9095", "")
-	f.StringVar(&cfg.DataDir, prefix+"data-dir", "./data-metastore/data", "")
 	f.DurationVar(&cfg.MinReadyDuration, prefix+"min-ready-duration", 15*time.Second, "Minimum duration to wait after the internal readiness checks have passed but before succeeding the readiness endpoint. This is used to slowdown deployment controllers (eg. Kubernetes) after an instance is ready and before they proceed with a rolling update, to give the rest of the cluster instances enough time to receive some (DNS?) updates.")
 	cfg.GRPCClientConfig.RegisterFlagsWithPrefix(prefix+"grpc-client-config", f)
 	cfg.Raft.RegisterFlagsWithPrefix(prefix+"raft.", f)
+	cfg.FSM.RegisterFlagsWithPrefix(prefix, f)
 	cfg.Compactor.RegisterFlagsWithPrefix(prefix, f)
 	cfg.Scheduler.RegisterFlagsWithPrefix(prefix, f)
 	cfg.Index.RegisterFlagsWithPrefix(prefix, f)
@@ -117,9 +117,7 @@ func New(
 	}
 
 	var err error
-
-	m.fsm, err = fsm.New(m.logger, m.reg, m.config.DataDir)
-	if err != nil {
+	if m.fsm, err = fsm.New(m.logger, m.reg, m.config.FSM); err != nil {
 		return nil, fmt.Errorf("failed to initialize store: %w", err)
 	}
 

--- a/pkg/experiment/metastore/test/create.go
+++ b/pkg/experiment/metastore/test/create.go
@@ -53,7 +53,7 @@ func NewMetastoreSet(t *testing.T, cfg *metastore.Config, n int, bucket objstore
 		icfg := *cfg
 		icfg.MinReadyDuration = 0
 		icfg.Address = grpcAddresses[i]
-		icfg.DataDir = t.TempDir()
+		icfg.FSM.DataDir = t.TempDir()
 		icfg.Raft.ServerID = raftIds[i]
 		icfg.Raft.Dir = t.TempDir()
 		icfg.Raft.AdvertiseAddress = raftAddresses[i]


### PR DESCRIPTION
The PR enables `zstd` compression for FSM snapshots. It is not configurable, as there is no reason to write uncompressed snapshots. The change is fully backward compatible but not forward-compatible.

The compression ratio is generally very good, with the compressed snapshot being around 30–40% of the original size (given the default compression level). It is much better that `snappy`, and slightly better than `lzma`, while is comparable in terms of CPU time. `gzip` gives decent compression level as well, but utilizes significantly more CPU time.
