### PR TITLE
test: Skip otel ebpf test for now

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -214,6 +214,9 @@ func TestDockerComposeBuildRun(t *testing.T) {
 
 	for i := range envs {
 		t.Run(envs[i].dir, func(t *testing.T) {
+			if envs[i].dir == "grafana-alloy-auto-instrumentation/ebpf-otel/docker" {
+				t.Skip("skipping test for grafana-alloy-auto-instrumentation/ebpf-otel/docker, as it uses more disk than the machine has")
+			}
 			e := envs[i]
 			t.Parallel()
 			ctx, cancel := context.WithTimeout(ctx, timeoutPerExample)


### PR DESCRIPTION
This appears to be using quite a lot of disk


We also might want to investigate, how to clear unused images, between the test runs. 🙂 