### PR TITLE
test: Increase runner size and reduce parallelity

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: github-hosted-ubuntu-x64-large
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ endif
 .PHONY: examples/test
 examples/test: RUN := .*
 examples/test: $(BIN)/gotestsum
-	$(BIN)/gotestsum --format testname --rerun-fails=2 -- --count 1 --timeout 1h --tags examples -run "$(RUN)" ./examples
+	$(BIN)/gotestsum --format testname --rerun-fails=2 -- --count 1 --parallel 2 --timeout 1h --tags examples -run "$(RUN)" ./examples
 
 .PHONY: build
 build: frontend/build go/bin ## Do a production build (requiring the frontend build to be present)

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ endif
 .PHONY: examples/test
 examples/test: RUN := .*
 examples/test: $(BIN)/gotestsum
-	$(BIN)/gotestsum --format testname --rerun-fails=2 -- --count 1 --parallel 2 --timeout 1h --tags examples -run "$(RUN)" ./examples
+	$(BIN)/gotestsum --format testname --rerun-fails=2 --packages ./examples -- --count 1 --parallel 2 --timeout 1h --tags examples -run "$(RUN)"
 
 .PHONY: build
 build: frontend/build go/bin ## Do a production build (requiring the frontend build to be present)

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ endif
 .PHONY: examples/test
 examples/test: RUN := .*
 examples/test: $(BIN)/gotestsum
-	$(BIN)/gotestsum --format testname -- --count 1 --timeout 1h --tags examples -run "$(RUN)" ./examples
+	$(BIN)/gotestsum --format testname --rerun-fails=2 -- --count 1 --timeout 1h --tags examples -run "$(RUN)" ./examples
 
 .PHONY: build
 build: frontend/build go/bin ## Do a production build (requiring the frontend build to be present)

--- a/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       context: .
 
   alloy:
-    image: simonswine/alloy:content-type-only
+    image: grafana/alloy:latest
     command:
       - run
       - /etc/alloy/config.alloy
@@ -39,7 +39,7 @@ services:
       - "12345:12345"
 
   pyroscope:
-    image: grafana/pyroscope:weekly-f110-32faf96b1
+    image: grafana/pyroscope:latest
     ports:
     - 4040:4040
 


### PR DESCRIPTION
This will fix the cronjob which tests our SDK examples on a nightly basis.

- We were running out of disk: bigger runner
- The bigger runner wasn't able to run the test in time before they get shutdown: decrease parallelism
