### PR TITLE
fix(v2): fix tenant settings client address

### DIFF
--- a/pkg/experiment/metrics/ruler.go
+++ b/pkg/experiment/metrics/ruler.go
@@ -12,8 +12,7 @@ import (
 )
 
 const (
-	envVarRecordingRules = "PYROSCOPE_RECORDING_RULES"
-	rulesExpiryTime      = time.Minute
+	rulesExpiryTime = time.Minute
 )
 
 type StaticRuler struct {

--- a/pkg/settings/recording/client/client.go
+++ b/pkg/settings/recording/client/client.go
@@ -27,7 +27,7 @@ func NewClient(address string, logger log.Logger, auth connect.Option) (*Client,
 	opts := connectapi.DefaultClientOptions()
 	opts = append(opts, auth)
 	c := Client{
-		client: settingsv1connect.NewRecordingRulesServiceClient(httpClient, "http://"+address, opts...),
+		client: settingsv1connect.NewRecordingRulesServiceClient(httpClient, address, opts...),
 		logger: logger,
 	}
 	c.service = services.NewIdleService(c.starting, c.stopping)


### PR DESCRIPTION
Fixing the url for the tenant settings client.

Also removing an unused const.