### PR TITLE
fix(ingest pyspy): remove line numbers from synthetic function names …

### DIFF
--- a/pkg/og/convert/pprof/profile.go
+++ b/pkg/og/convert/pprof/profile.go
@@ -289,9 +289,8 @@ func FixFunctionNamesForScriptingLanguages(p *pprof.Profile, md ingestion.Metada
 	for _, location := range p.Location {
 		for _, line := range location.Line {
 			fn := p.Function[funcId2Index[line.FunctionId]]
-			name := fmt.Sprintf("%s:%d - %s",
+			name := fmt.Sprintf("%s %s",
 				p.StringTable[fn.Filename],
-				line.Line,
 				p.StringTable[fn.Name])
 			newFunc, ok := newFunctions[name]
 			if !ok {

--- a/pkg/og/convert/pprof/profile_test.go
+++ b/pkg/og/convert/pprof/profile_test.go
@@ -74,14 +74,14 @@ func TestFixFunctionNamesForScriptingLanguages(t *testing.T) {
 
 	collapsed := bench.StackCollapseProto(profile.Profile, 0, 1)
 	expected := []string{
-		"qwe.py:242 - main;qwe.py:50 - func1 10",
-		"qwe.py:242 - main;qwe.py:8 - func2 13",
+		"qwe.py main;qwe.py func1 10",
+		"qwe.py main;qwe.py func2 13",
 	}
 	assert.Equal(t, expected, collapsed)
 
-	assert.Equal(t, "qwe.py:242 - main", functionNameFromLocation(profile.Location[0].Id))
-	assert.Equal(t, "qwe.py:50 - func1", functionNameFromLocation(profile.Location[1].Id))
-	assert.Equal(t, "qwe.py:8 - func2", functionNameFromLocation(profile.Location[2].Id))
+	assert.Equal(t, "qwe.py main", functionNameFromLocation(profile.Location[0].Id))
+	assert.Equal(t, "qwe.py func1", functionNameFromLocation(profile.Location[1].Id))
+	assert.Equal(t, "qwe.py func2", functionNameFromLocation(profile.Location[2].Id))
 }
 
 func TestCreateLabels(t *testing.T) {

--- a/pkg/test/integration/ingest_pprof_test.go
+++ b/pkg/test/integration/ingest_pprof_test.go
@@ -315,8 +315,8 @@ func TestIngestPPROFFixPythonLinenumbers(t *testing.T) {
 	renderedProfile := rb.SelectMergeProfile("process_cpu:cpu:nanoseconds:cpu:nanoseconds", nil)
 	actual := bench.StackCollapseProto(renderedProfile.Msg, 0, 1)
 	expected := []string{
-		"qwe.py:242 - main;qwe.py:50 - func1 10",
-		"qwe.py:242 - main;qwe.py:8 - func2 13",
+		"qwe.py main;qwe.py func1 10",
+		"qwe.py main;qwe.py func2 13",
 	}
 	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
…(#4076)

cherry-pick 368696096