### PR TITLE
feat(v2): non-blocking metadata queries

### DIFF
--- a/pkg/experiment/metastore/compaction/compactor/store/block_queue_store.go
+++ b/pkg/experiment/metastore/compaction/compactor/store/block_queue_store.go
@@ -57,7 +57,7 @@ type blockEntriesIterator struct {
 }
 
 func newBlockEntriesIterator(bucket *bbolt.Bucket) *blockEntriesIterator {
-	return &blockEntriesIterator{iter: store.NewCursorIter(nil, bucket.Cursor())}
+	return &blockEntriesIterator{iter: store.NewCursorIter(bucket.Cursor())}
 }
 
 func (x *blockEntriesIterator) Next() bool {

--- a/pkg/experiment/metastore/compaction/scheduler/store/job_state_store.go
+++ b/pkg/experiment/metastore/compaction/scheduler/store/job_state_store.go
@@ -58,7 +58,7 @@ type jobEntriesIterator struct {
 }
 
 func newJobEntriesIterator(bucket *bbolt.Bucket) *jobEntriesIterator {
-	return &jobEntriesIterator{iter: store.NewCursorIter(nil, bucket.Cursor())}
+	return &jobEntriesIterator{iter: store.NewCursorIter(bucket.Cursor())}
 }
 
 func (x *jobEntriesIterator) Next() bool {

--- a/pkg/experiment/metastore/dlq/recovery.go
+++ b/pkg/experiment/metastore/dlq/recovery.go
@@ -78,6 +78,9 @@ func (r *Recovery) Stop() {
 }
 
 func (r *Recovery) recoverLoop(ctx context.Context) {
+	if r.config.Period == 0 {
+		return
+	}
 	ticker := time.NewTicker(r.config.Period)
 	defer ticker.Stop()
 	for {

--- a/pkg/experiment/metastore/index/index_cache.go
+++ b/pkg/experiment/metastore/index/index_cache.go
@@ -1,0 +1,135 @@
+package index
+
+import (
+	"sync"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	"github.com/grafana/pyroscope/pkg/experiment/metastore/index/store"
+	kvstore "github.com/grafana/pyroscope/pkg/experiment/metastore/store"
+)
+
+type indexShard struct {
+	*store.Shard
+	readOnly bool
+}
+
+type shardCache struct {
+	mu     sync.RWMutex
+	shards *lru.TwoQueueCache[shardCacheKey, *indexShard]
+}
+
+type shardCacheKey struct {
+	partition store.PartitionKey
+	tenant    string
+	shard     uint32
+}
+
+type blockCache struct {
+	mu    sync.RWMutex
+	reads *lru.TwoQueueCache[blockCacheKey, *metastorev1.BlockMeta]
+	write *lru.Cache[blockCacheKey, *metastorev1.BlockMeta]
+}
+
+type blockCacheKey struct {
+	tenant string
+	shard  uint32
+	block  string
+}
+
+func newShardCache(size int) *shardCache {
+	c, _ := lru.New2Q[shardCacheKey, *indexShard](size)
+	return &shardCache{
+		shards: c,
+	}
+}
+
+func (c *shardCache) get(p store.PartitionKey, tenant string, shard uint32) *indexShard {
+	k := shardCacheKey{
+		partition: p,
+		tenant:    tenant,
+		shard:     shard,
+	}
+	v, _ := c.shards.Get(k)
+	return v
+}
+
+func (c *shardCache) put(s *indexShard) {
+	k := shardCacheKey{
+		partition: s.Shard.Partition,
+		tenant:    s.Shard.Tenant,
+		shard:     s.Shard.Shard,
+	}
+	c.shards.Add(k, s)
+}
+
+func newBlockCache(rcs, wcs int) *blockCache {
+	reads, _ := lru.New2Q[blockCacheKey, *metastorev1.BlockMeta](rcs)
+	write, _ := lru.New[blockCacheKey, *metastorev1.BlockMeta](wcs)
+	return &blockCache{
+		reads: reads,
+		write: write,
+	}
+}
+
+func (c *blockCache) getOrCreate(shard *store.Shard, block kvstore.KV) *metastorev1.BlockMeta {
+	k := blockCacheKey{
+		tenant: shard.Tenant,
+		shard:  shard.Shard,
+		block:  string(block.Key),
+	}
+	c.mu.RLock()
+	v, ok := c.reads.Get(k)
+	if ok {
+		c.mu.RUnlock()
+		return v
+	}
+	v, ok = c.write.Get(k)
+	if ok {
+		c.mu.RUnlock()
+		return v
+	}
+	c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	v, ok = c.reads.Get(k)
+	if ok {
+		return v
+	}
+	v, ok = c.write.Get(k)
+	if ok {
+		return v
+	}
+	var md metastorev1.BlockMeta
+	if err := md.UnmarshalVT(block.Value); err != nil {
+		return &md
+	}
+	c.reads.Add(k, &md)
+	return &md
+}
+
+func (c *blockCache) put(shard *store.Shard, md *metastorev1.BlockMeta) {
+	k := blockCacheKey{
+		tenant: shard.Tenant,
+		shard:  shard.Shard,
+		block:  md.Id,
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if md.CompactionLevel >= 2 {
+		c.reads.Add(k, md)
+		return
+	}
+	c.write.Add(k, md)
+}
+
+func (c *blockCache) delete(shard *store.Shard, block string) {
+	k := blockCacheKey{
+		tenant: shard.Tenant,
+		shard:  shard.Shard,
+		block:  block,
+	}
+	c.write.Remove(k)
+	c.reads.Remove(k)
+}

--- a/pkg/experiment/metastore/index/store/index_store.go
+++ b/pkg/experiment/metastore/index/store/index_store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"time"
 
 	"go.etcd.io/bbolt"
 
@@ -18,16 +19,21 @@ const (
 	partitionBucketName          = "partition"
 	emptyTenantBucketName        = "-"
 	tenantShardStringsBucketName = ".strings"
+	tenantShardIndexKeyName      = ".index"
 )
 
 var (
 	ErrInvalidStringTable = errors.New("malformed string table")
+	ErrInvalidShardIndex  = errors.New("malformed shard index")
 )
 
 var (
 	partitionBucketNameBytes          = []byte(partitionBucketName)
 	emptyTenantBucketNameBytes        = []byte(emptyTenantBucketName)
 	tenantShardStringsBucketNameBytes = []byte(tenantShardStringsBucketName)
+	tenantShardIndexKeyNameBytes      = []byte(tenantShardIndexKeyName)
+
+	blockCursorSkipPrefix = []byte{'.'}
 )
 
 type Entry struct {
@@ -39,12 +45,12 @@ type Entry struct {
 	StringTable *metadata.StringTable
 }
 
-type TenantShard struct {
-	Partition   PartitionKey
-	Tenant      string
-	Shard       uint32
-	Blocks      []*metastorev1.BlockMeta
-	StringTable *metadata.StringTable
+type Shard struct {
+	Partition PartitionKey
+	Tenant    string
+	Shard     uint32
+	*metadata.StringTable
+	ShardIndex
 }
 
 type IndexStore struct{}
@@ -77,32 +83,6 @@ func (m *IndexStore) CreateBuckets(tx *bbolt.Tx) error {
 	return err
 }
 
-func (m *IndexStore) StoreBlock(tx *bbolt.Tx, shard *TenantShard, md *metastorev1.BlockMeta) error {
-	bucket, err := getOrCreateTenantShard(tx, shard.Partition, shard.Tenant, shard.Shard)
-	if err != nil {
-		return err
-	}
-	n := len(shard.StringTable.Strings)
-	shard.StringTable.Import(md)
-	if added := shard.StringTable.Strings[n:]; len(added) > 0 {
-		strings, err := getOrCreateSubBucket(bucket, tenantShardStringsBucketNameBytes)
-		if err != nil {
-			return err
-		}
-		k := binary.BigEndian.AppendUint32(nil, uint32(n))
-		v := encodeStrings(added)
-		if err = strings.Put(k, v); err != nil {
-			return err
-		}
-	}
-	md.StringTable = nil
-	value, err := md.MarshalVT()
-	if err != nil {
-		return err
-	}
-	return bucket.Put([]byte(md.Id), value)
-}
-
 func (m *IndexStore) ListPartitions(tx *bbolt.Tx) ([]*Partition, error) {
 	var partitions []*Partition
 	root := getPartitionsBucket(tx)
@@ -118,6 +98,7 @@ func (m *IndexStore) ListPartitions(tx *bbolt.Tx) ([]*Partition, error) {
 			shards := make(map[uint32]struct{})
 			err := partition.Bucket(tenant).ForEachBucket(func(shard []byte) error {
 				shards[binary.BigEndian.Uint32(shard)] = struct{}{}
+				// TODO: Store tenant shard index in the Partition
 				return nil
 			})
 			if err != nil {
@@ -139,19 +120,6 @@ func (m *IndexStore) ListPartitions(tx *bbolt.Tx) ([]*Partition, error) {
 	})
 }
 
-func (m *IndexStore) DeleteBlockList(tx *bbolt.Tx, p PartitionKey, list *metastorev1.BlockList) error {
-	tenantShard := getTenantShard(tx, p, list.Tenant, list.Shard)
-	if tenantShard == nil {
-		return nil
-	}
-	for _, b := range list.Blocks {
-		if err := tenantShard.Delete([]byte(b)); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func getTenantShard(tx *bbolt.Tx, p PartitionKey, tenant string, shard uint32) *bbolt.Bucket {
 	if partition := getPartitionsBucket(tx).Bucket(p.Bytes()); partition != nil {
 		if shards := partition.Bucket(tenantBucketName(tenant)); shards != nil {
@@ -161,7 +129,7 @@ func getTenantShard(tx *bbolt.Tx, p PartitionKey, tenant string, shard uint32) *
 	return nil
 }
 
-func (m *IndexStore) LoadTenantShard(tx *bbolt.Tx, p PartitionKey, tenant string, shard uint32) (*TenantShard, error) {
+func (m *IndexStore) LoadShard(tx *bbolt.Tx, p PartitionKey, tenant string, shard uint32) (*Shard, error) {
 	s, err := m.loadTenantShard(tx, p, tenant, shard)
 	if err != nil {
 		return nil, fmt.Errorf("error loading tenant shard %s/%d partition %q: %w", tenant, shard, p, err)
@@ -169,13 +137,13 @@ func (m *IndexStore) LoadTenantShard(tx *bbolt.Tx, p PartitionKey, tenant string
 	return s, nil
 }
 
-func (m *IndexStore) loadTenantShard(tx *bbolt.Tx, p PartitionKey, tenant string, shard uint32) (*TenantShard, error) {
+func (m *IndexStore) loadTenantShard(tx *bbolt.Tx, p PartitionKey, tenant string, shard uint32) (*Shard, error) {
 	tenantShard := getTenantShard(tx, p, tenant, shard)
 	if tenantShard == nil {
 		return nil, nil
 	}
 
-	s := TenantShard{
+	s := Shard{
 		Partition:   p,
 		Tenant:      tenant,
 		Shard:       shard,
@@ -186,7 +154,7 @@ func (m *IndexStore) loadTenantShard(tx *bbolt.Tx, p PartitionKey, tenant string
 	if strings == nil {
 		return &s, nil
 	}
-	stringsIter := newStringIter(store.NewCursorIter(nil, strings.Cursor()))
+	stringsIter := newStringIter(store.NewCursorIter(strings.Cursor()))
 	defer func() {
 		_ = stringsIter.Close()
 	}()
@@ -195,19 +163,13 @@ func (m *IndexStore) loadTenantShard(tx *bbolt.Tx, p PartitionKey, tenant string
 		return nil, err
 	}
 
-	err = tenantShard.ForEach(func(k, v []byte) error {
-		if bytes.Equal(k, tenantShardStringsBucketNameBytes) {
-			return nil
+	if b := tenantShard.Get(tenantShardIndexKeyNameBytes); len(b) > 0 {
+		var tsi ShardIndex
+		if err = tsi.UnmarshalBinary(b); err != nil {
+			return nil, err
 		}
-		var md metastorev1.BlockMeta
-		if err = md.UnmarshalVT(v); err != nil {
-			return fmt.Errorf("failed to unmarshal block %q: %w", string(k), err)
-		}
-		s.Blocks = append(s.Blocks, &md)
-		return nil
-	})
-	if err != nil {
-		return nil, err
+		s.MinTime = tsi.MinTime
+		s.MaxTime = tsi.MaxTime
 	}
 
 	return &s, nil
@@ -227,6 +189,117 @@ func getOrCreateTenantShard(tx *bbolt.Tx, p PartitionKey, tenant string, shard u
 		return nil, fmt.Errorf("error creating shard bucket for partiton %s and shard %d: %w", p, shard, err)
 	}
 	return tenantShard, nil
+}
+
+func (s *Shard) Store(tx *bbolt.Tx, md *metastorev1.BlockMeta) error {
+	bucket, err := getOrCreateTenantShard(tx, s.Partition, s.Tenant, s.Shard)
+	if err != nil {
+		return err
+	}
+	n := len(s.StringTable.Strings)
+	s.StringTable.Import(md)
+	if added := s.StringTable.Strings[n:]; len(added) > 0 {
+		strings, err := getOrCreateSubBucket(bucket, tenantShardStringsBucketNameBytes)
+		if err != nil {
+			return err
+		}
+		k := binary.BigEndian.AppendUint32(nil, uint32(n))
+		v := encodeStrings(added)
+		if err = strings.Put(k, v); err != nil {
+			return err
+		}
+	}
+	md.StringTable = nil
+	value, err := md.MarshalVT()
+	if err != nil {
+		return err
+	}
+
+	var updateIndex bool
+	if s.MinTime == 0 || s.MinTime > md.MinTime {
+		s.MinTime = md.MinTime
+		updateIndex = true
+	}
+	if s.MaxTime < md.MaxTime {
+		s.MaxTime = md.MaxTime
+		updateIndex = true
+	}
+	if updateIndex {
+		tsi := ShardIndex{
+			MinTime: s.MinTime,
+			MaxTime: s.MaxTime,
+		}
+		if err = bucket.Put(tenantShardIndexKeyNameBytes, tsi.MarshalBinary()); err != nil {
+			return err
+		}
+	}
+
+	return bucket.Put([]byte(md.Id), value)
+}
+
+func (s *Shard) Find(tx *bbolt.Tx, blocks ...string) []store.KV {
+	bucket := getTenantShard(tx, s.Partition, s.Tenant, s.Shard)
+	if bucket == nil {
+		return nil
+	}
+	kv := make([]store.KV, 0, len(blocks))
+	for _, b := range blocks {
+		k := []byte(b)
+		if v := bucket.Get(k); v != nil {
+			kv = append(kv, store.KV{Key: k, Value: v})
+		}
+	}
+	return kv
+}
+
+func (s *Shard) Blocks(tx *bbolt.Tx) *store.CursorIterator {
+	bucket := getTenantShard(tx, s.Partition, s.Tenant, s.Shard)
+	if bucket == nil {
+		return nil
+	}
+	cursor := store.NewCursorIter(bucket.Cursor())
+	cursor.SkipPrefix = blockCursorSkipPrefix
+	return cursor
+}
+
+func (s *Shard) Delete(tx *bbolt.Tx, blocks ...string) error {
+	tenantShard := getTenantShard(tx, s.Partition, s.Tenant, s.Shard)
+	if tenantShard == nil {
+		return nil
+	}
+	for _, b := range blocks {
+		if err := tenantShard.Delete([]byte(b)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ShallowCopy creates a shallow copy: no deep copy of the string table.
+// The copy can be accessed safely by multiple readers, and it represents
+// a snapshot of the string table at the time of the copy.
+//
+// Strings added after the copy is made won't be visible to the reader.
+// The writer MUST invalidate the cache before access: copies in-use can
+// still be used (strings is a header copy of append-only slice).
+func (s *Shard) ShallowCopy() *Shard {
+	return &Shard{
+		Partition:  s.Partition,
+		Tenant:     s.Tenant,
+		Shard:      s.Shard,
+		ShardIndex: s.ShardIndex,
+		StringTable: &metadata.StringTable{
+			Strings: s.StringTable.Strings,
+		},
+	}
+}
+
+func (s *Shard) Overlaps(start, end time.Time) bool {
+	// For backward compatibility.
+	if s.MinTime == 0 || s.MaxTime == 0 {
+		return true
+	}
+	return start.Before(time.UnixMilli(s.MaxTime)) && !end.Before(time.UnixMilli(s.MinTime))
 }
 
 type stringIterator struct {
@@ -301,4 +374,25 @@ func decodeStrings(dst []string, data []byte) ([]string, error) {
 		offset += int(size)
 	}
 	return dst, nil
+}
+
+type ShardIndex struct {
+	MinTime int64
+	MaxTime int64
+}
+
+func (i *ShardIndex) UnmarshalBinary(data []byte) error {
+	if len(data) != 16 {
+		return ErrInvalidShardIndex
+	}
+	i.MinTime = int64(binary.BigEndian.Uint64(data[0:8]))
+	i.MaxTime = int64(binary.BigEndian.Uint64(data[8:16]))
+	return nil
+}
+
+func (i *ShardIndex) MarshalBinary() []byte {
+	b := make([]byte, 16)
+	binary.BigEndian.PutUint64(b[0:8], uint64(i.MinTime))
+	binary.BigEndian.PutUint64(b[8:16], uint64(i.MaxTime))
+	return b
 }

--- a/pkg/experiment/metastore/metastore.go
+++ b/pkg/experiment/metastore/metastore.go
@@ -36,7 +36,7 @@ type Config struct {
 	MinReadyDuration time.Duration      `yaml:"min_ready_duration" category:"advanced"`
 	Raft             raft.Config        `yaml:"raft"`
 	FSM              fsm.Config         `yaml:",inline" category:"advanced"`
-	Index            index.Config       `yaml:",inline" category:"advanced"`
+	Index            index.Config       `yaml:"index" category:"advanced"`
 	DLQRecovery      dlq.RecoveryConfig `yaml:",inline" category:"advanced"`
 	Compactor        compactor.Config   `yaml:",inline" category:"advanced"`
 	Scheduler        scheduler.Config   `yaml:",inline" category:"advanced"`
@@ -51,7 +51,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.FSM.RegisterFlagsWithPrefix(prefix, f)
 	cfg.Compactor.RegisterFlagsWithPrefix(prefix, f)
 	cfg.Scheduler.RegisterFlagsWithPrefix(prefix, f)
-	cfg.Index.RegisterFlagsWithPrefix(prefix, f)
+	cfg.Index.RegisterFlagsWithPrefix(prefix+"index.", f)
 	cfg.DLQRecovery.RegisterFlagsWithPrefix(prefix, f)
 }
 

--- a/pkg/experiment/metastore/tombstones/store/tombstone_store.go
+++ b/pkg/experiment/metastore/tombstones/store/tombstone_store.go
@@ -53,7 +53,7 @@ type tombstoneEntriesIterator struct {
 }
 
 func newTombstoneEntriesIterator(bucket *bbolt.Bucket) *tombstoneEntriesIterator {
-	return &tombstoneEntriesIterator{iter: store.NewCursorIter(nil, bucket.Cursor())}
+	return &tombstoneEntriesIterator{iter: store.NewCursorIter(bucket.Cursor())}
 }
 
 func (x *tombstoneEntriesIterator) Next() bool {

--- a/pkg/test/mocks/mockindex/mock_store.go
+++ b/pkg/test/mocks/mockindex/mock_store.go
@@ -5,8 +5,6 @@ package mockindex
 import (
 	bbolt "go.etcd.io/bbolt"
 
-	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
-
 	mock "github.com/stretchr/testify/mock"
 
 	store "github.com/grafana/pyroscope/pkg/experiment/metastore/index/store"
@@ -71,54 +69,6 @@ func (_c *MockStore_CreateBuckets_Call) RunAndReturn(run func(*bbolt.Tx) error) 
 	return _c
 }
 
-// DeleteBlockList provides a mock function with given fields: _a0, _a1, _a2
-func (_m *MockStore) DeleteBlockList(_a0 *bbolt.Tx, _a1 store.PartitionKey, _a2 *metastorev1.BlockList) error {
-	ret := _m.Called(_a0, _a1, _a2)
-
-	if len(ret) == 0 {
-		panic("no return value specified for DeleteBlockList")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*bbolt.Tx, store.PartitionKey, *metastorev1.BlockList) error); ok {
-		r0 = rf(_a0, _a1, _a2)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// MockStore_DeleteBlockList_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteBlockList'
-type MockStore_DeleteBlockList_Call struct {
-	*mock.Call
-}
-
-// DeleteBlockList is a helper method to define mock.On call
-//   - _a0 *bbolt.Tx
-//   - _a1 store.PartitionKey
-//   - _a2 *metastorev1.BlockList
-func (_e *MockStore_Expecter) DeleteBlockList(_a0 interface{}, _a1 interface{}, _a2 interface{}) *MockStore_DeleteBlockList_Call {
-	return &MockStore_DeleteBlockList_Call{Call: _e.mock.On("DeleteBlockList", _a0, _a1, _a2)}
-}
-
-func (_c *MockStore_DeleteBlockList_Call) Run(run func(_a0 *bbolt.Tx, _a1 store.PartitionKey, _a2 *metastorev1.BlockList)) *MockStore_DeleteBlockList_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*bbolt.Tx), args[1].(store.PartitionKey), args[2].(*metastorev1.BlockList))
-	})
-	return _c
-}
-
-func (_c *MockStore_DeleteBlockList_Call) Return(_a0 error) *MockStore_DeleteBlockList_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockStore_DeleteBlockList_Call) RunAndReturn(run func(*bbolt.Tx, store.PartitionKey, *metastorev1.BlockList) error) *MockStore_DeleteBlockList_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // ListPartitions provides a mock function with given fields: _a0
 func (_m *MockStore) ListPartitions(_a0 *bbolt.Tx) ([]*store.Partition, error) {
 	ret := _m.Called(_a0)
@@ -177,24 +127,24 @@ func (_c *MockStore_ListPartitions_Call) RunAndReturn(run func(*bbolt.Tx) ([]*st
 	return _c
 }
 
-// LoadTenantShard provides a mock function with given fields: _a0, _a1, _a2, _a3
-func (_m *MockStore) LoadTenantShard(_a0 *bbolt.Tx, _a1 store.PartitionKey, _a2 string, _a3 uint32) (*store.TenantShard, error) {
+// LoadShard provides a mock function with given fields: _a0, _a1, _a2, _a3
+func (_m *MockStore) LoadShard(_a0 *bbolt.Tx, _a1 store.PartitionKey, _a2 string, _a3 uint32) (*store.Shard, error) {
 	ret := _m.Called(_a0, _a1, _a2, _a3)
 
 	if len(ret) == 0 {
-		panic("no return value specified for LoadTenantShard")
+		panic("no return value specified for LoadShard")
 	}
 
-	var r0 *store.TenantShard
+	var r0 *store.Shard
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*bbolt.Tx, store.PartitionKey, string, uint32) (*store.TenantShard, error)); ok {
+	if rf, ok := ret.Get(0).(func(*bbolt.Tx, store.PartitionKey, string, uint32) (*store.Shard, error)); ok {
 		return rf(_a0, _a1, _a2, _a3)
 	}
-	if rf, ok := ret.Get(0).(func(*bbolt.Tx, store.PartitionKey, string, uint32) *store.TenantShard); ok {
+	if rf, ok := ret.Get(0).(func(*bbolt.Tx, store.PartitionKey, string, uint32) *store.Shard); ok {
 		r0 = rf(_a0, _a1, _a2, _a3)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*store.TenantShard)
+			r0 = ret.Get(0).(*store.Shard)
 		}
 	}
 
@@ -207,81 +157,33 @@ func (_m *MockStore) LoadTenantShard(_a0 *bbolt.Tx, _a1 store.PartitionKey, _a2 
 	return r0, r1
 }
 
-// MockStore_LoadTenantShard_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LoadTenantShard'
-type MockStore_LoadTenantShard_Call struct {
+// MockStore_LoadShard_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LoadShard'
+type MockStore_LoadShard_Call struct {
 	*mock.Call
 }
 
-// LoadTenantShard is a helper method to define mock.On call
+// LoadShard is a helper method to define mock.On call
 //   - _a0 *bbolt.Tx
 //   - _a1 store.PartitionKey
 //   - _a2 string
 //   - _a3 uint32
-func (_e *MockStore_Expecter) LoadTenantShard(_a0 interface{}, _a1 interface{}, _a2 interface{}, _a3 interface{}) *MockStore_LoadTenantShard_Call {
-	return &MockStore_LoadTenantShard_Call{Call: _e.mock.On("LoadTenantShard", _a0, _a1, _a2, _a3)}
+func (_e *MockStore_Expecter) LoadShard(_a0 interface{}, _a1 interface{}, _a2 interface{}, _a3 interface{}) *MockStore_LoadShard_Call {
+	return &MockStore_LoadShard_Call{Call: _e.mock.On("LoadShard", _a0, _a1, _a2, _a3)}
 }
 
-func (_c *MockStore_LoadTenantShard_Call) Run(run func(_a0 *bbolt.Tx, _a1 store.PartitionKey, _a2 string, _a3 uint32)) *MockStore_LoadTenantShard_Call {
+func (_c *MockStore_LoadShard_Call) Run(run func(_a0 *bbolt.Tx, _a1 store.PartitionKey, _a2 string, _a3 uint32)) *MockStore_LoadShard_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(*bbolt.Tx), args[1].(store.PartitionKey), args[2].(string), args[3].(uint32))
 	})
 	return _c
 }
 
-func (_c *MockStore_LoadTenantShard_Call) Return(_a0 *store.TenantShard, _a1 error) *MockStore_LoadTenantShard_Call {
+func (_c *MockStore_LoadShard_Call) Return(_a0 *store.Shard, _a1 error) *MockStore_LoadShard_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockStore_LoadTenantShard_Call) RunAndReturn(run func(*bbolt.Tx, store.PartitionKey, string, uint32) (*store.TenantShard, error)) *MockStore_LoadTenantShard_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// StoreBlock provides a mock function with given fields: tx, shard, md
-func (_m *MockStore) StoreBlock(tx *bbolt.Tx, shard *store.TenantShard, md *metastorev1.BlockMeta) error {
-	ret := _m.Called(tx, shard, md)
-
-	if len(ret) == 0 {
-		panic("no return value specified for StoreBlock")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*bbolt.Tx, *store.TenantShard, *metastorev1.BlockMeta) error); ok {
-		r0 = rf(tx, shard, md)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// MockStore_StoreBlock_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'StoreBlock'
-type MockStore_StoreBlock_Call struct {
-	*mock.Call
-}
-
-// StoreBlock is a helper method to define mock.On call
-//   - tx *bbolt.Tx
-//   - shard *store.TenantShard
-//   - md *metastorev1.BlockMeta
-func (_e *MockStore_Expecter) StoreBlock(tx interface{}, shard interface{}, md interface{}) *MockStore_StoreBlock_Call {
-	return &MockStore_StoreBlock_Call{Call: _e.mock.On("StoreBlock", tx, shard, md)}
-}
-
-func (_c *MockStore_StoreBlock_Call) Run(run func(tx *bbolt.Tx, shard *store.TenantShard, md *metastorev1.BlockMeta)) *MockStore_StoreBlock_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*bbolt.Tx), args[1].(*store.TenantShard), args[2].(*metastorev1.BlockMeta))
-	})
-	return _c
-}
-
-func (_c *MockStore_StoreBlock_Call) Return(_a0 error) *MockStore_StoreBlock_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockStore_StoreBlock_Call) RunAndReturn(run func(*bbolt.Tx, *store.TenantShard, *metastorev1.BlockMeta) error) *MockStore_StoreBlock_Call {
+func (_c *MockStore_LoadShard_Call) RunAndReturn(run func(*bbolt.Tx, store.PartitionKey, string, uint32) (*store.Shard, error)) *MockStore_LoadShard_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
The PR addresses an issue with blocking metadata queries.

Currently, we have a thick cache layer over the index stored in BoltDB, which is fully loaded into memory. The problem is that the cache is too coarse: an entire partition shard is used as a cache item. This requires broad locks and sophisticated cache management to ensure consistency with the on-disk state. Worse still, in certain cases, reads block writes for an extended period (seconds).

In the new version, we have two caches: one for partition shards (without blocks) and another for individual blocks. The first is primarily used as a skip index, while the latter is used to minimize resources spent on unmarshaling.

Queries never block the writer for longer than the time it takes to load the shard into memory (without blocks, just the shard index and the string table – a few dozen keys or hundreds of kilobytes), and they always read block keys from the DB in their own transaction, making locks unnecessary.