### PR TITLE
feat(v2): metastore snapshot write rate limit

### DIFF
--- a/pkg/experiment/metastore/fsm/fsm.go
+++ b/pkg/experiment/metastore/fsm/fsm.go
@@ -39,6 +39,7 @@ type StateRestorer interface {
 
 type Config struct {
 	SnapshotCompression string `yaml:"snapshot_compression"`
+	SnapshotRateLimit   int    `yaml:"snapshot_rate_limit"`
 	// Where the FSM BoltDB data is located.
 	// Does not have to be a persistent volume.
 	DataDir string `yaml:"data_dir"`
@@ -46,6 +47,7 @@ type Config struct {
 
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.StringVar(&cfg.SnapshotCompression, prefix+"snapshot-compression", "zstd", "Compression algorithm to use for snapshots. Supported compressions: zstd.")
+	f.IntVar(&cfg.SnapshotRateLimit, prefix+"snapshot-rate-limit", 15, "Rate limit for snapshot writer in MB/s.")
 	f.StringVar(&cfg.DataDir, prefix+"data-dir", "./data-metastore/data", "Directory to store the data.")
 }
 
@@ -299,6 +301,7 @@ func (fsm *FSM) Snapshot() (raft.FSMSnapshot, error) {
 		logger:      fsm.logger,
 		metrics:     fsm.metrics,
 		compression: fsm.config.SnapshotCompression,
+		rate:        fsm.config.SnapshotRateLimit,
 	}
 	tx, err := fsm.db.boltdb.Begin(false)
 	if err != nil {

--- a/pkg/util/ratelimit/ratelimit.go
+++ b/pkg/util/ratelimit/ratelimit.go
@@ -1,0 +1,42 @@
+package ratelimit
+
+import "time"
+
+// Limiter implements a simple token-bucket rate limiter.
+// Tokens are replenished over time.
+type Limiter struct {
+	rate    float64
+	tokens  float64
+	updated time.Time
+	// For testing purposes.
+	sleep func(time.Duration)
+	now   func() time.Time
+}
+
+func NewLimiter(rate float64) *Limiter {
+	return &Limiter{
+		rate:   rate,
+		tokens: rate,
+		sleep:  time.Sleep,
+		now:    time.Now,
+	}
+}
+
+func (l *Limiter) Wait(n int) {
+	for {
+		now := l.now()
+		elapsed := now.Sub(l.updated).Seconds()
+		l.updated = now
+		l.tokens += elapsed * l.rate
+		if l.tokens > l.rate {
+			l.tokens = l.rate
+		}
+		if l.tokens >= float64(n) {
+			l.tokens -= float64(n)
+			return
+		}
+		missing := float64(n) - l.tokens
+		delay := time.Duration(missing/l.rate*1e9) * time.Nanosecond
+		l.sleep(delay)
+	}
+}

--- a/pkg/util/ratelimit/ratelimit_test.go
+++ b/pkg/util/ratelimit/ratelimit_test.go
@@ -1,0 +1,32 @@
+package ratelimit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimiter(t *testing.T) {
+	var sleptFor []time.Duration
+	now := time.Unix(0, 0)
+
+	l := NewLimiter(100)
+	l.now = func() time.Time { return now }
+	l.sleep = func(d time.Duration) {
+		sleptFor = append(sleptFor, d)
+		now = now.Add(d)
+	}
+
+	l.Wait(100)
+	assert.Len(t, sleptFor, 0)
+
+	l.Wait(100)
+	require.Len(t, sleptFor, 1)
+	assert.Equal(t, time.Second, sleptFor[0])
+
+	l.Wait(100)
+	require.Len(t, sleptFor, 2)
+	assert.Equal(t, time.Second, sleptFor[1])
+}

--- a/pkg/util/ratelimit/writer.go
+++ b/pkg/util/ratelimit/writer.go
@@ -1,0 +1,35 @@
+package ratelimit
+
+import (
+	"io"
+	"time"
+)
+
+type Writer struct {
+	w io.Writer
+	l *Limiter
+
+	sleep func(time.Duration)
+}
+
+func NewWriter(w io.Writer, l *Limiter) *Writer {
+	return &Writer{w: w, l: l}
+}
+
+func (rw *Writer) Write(p []byte) (int, error) {
+	var total int
+	for len(p) > 0 {
+		n := len(p)
+		if n > int(rw.l.rate) {
+			n = int(rw.l.rate)
+		}
+		rw.l.Wait(n)
+		written, err := rw.w.Write(p[:n])
+		total += written
+		p = p[written:]
+		if err != nil {
+			return total, err
+		}
+	}
+	return total, nil
+}

--- a/pkg/util/ratelimit/writer.go
+++ b/pkg/util/ratelimit/writer.go
@@ -2,14 +2,11 @@ package ratelimit
 
 import (
 	"io"
-	"time"
 )
 
 type Writer struct {
 	w io.Writer
 	l *Limiter
-
-	sleep func(time.Duration)
 }
 
 func NewWriter(w io.Writer, l *Limiter) *Writer {

--- a/pkg/util/ratelimit/writer_test.go
+++ b/pkg/util/ratelimit/writer_test.go
@@ -1,0 +1,33 @@
+package ratelimit
+
+import (
+	"io"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriter(t *testing.T) {
+	var sleptFor time.Duration
+	now := time.Unix(0, 0)
+
+	limiter := NewLimiter(100)
+	limiter.now = func() time.Time { return now }
+	limiter.sleep = func(d time.Duration) {
+		sleptFor += d
+		now = now.Add(d)
+	}
+
+	w := NewWriter(io.Discard, limiter)
+
+	const N = 1 << 10
+	n, err := io.CopyN(w, rand.New(rand.NewSource(42)), N)
+	require.NoError(t, err)
+	assert.EqualValues(t, n, N)
+
+	t.Log("written in", sleptFor)
+	assert.Greater(t, sleptFor, time.Second*9)
+}


### PR DESCRIPTION
The PR adds a configuration option to limit the rate at which FSM snapshots are written on disk. This is useful in cases when the same disk is used for both WAL and snapshots. 