### PR TITLE
chore(v2): add segment-writer metastore client options

### DIFF
--- a/pkg/experiment/ingester/segment.go
+++ b/pkg/experiment/ingester/segment.go
@@ -613,7 +613,7 @@ func (sw *segmentsWriter) uploadBlock(ctx context.Context, blockData []byte, met
 
 	hedgedUpload := retry.Hedged[any]{
 		Call:      uploadWithRetry,
-		Trigger:   time.After(sw.config.UploadHedgeUploadAfter),
+		Trigger:   time.After(sw.config.UploadHedgeAfter),
 		Throttler: sw.retryLimiter,
 		FailFast:  false,
 	}

--- a/pkg/experiment/ingester/segment_test.go
+++ b/pkg/experiment/ingester/segment_test.go
@@ -477,14 +477,10 @@ func newTestSegmentWriter(t *testing.T, cfg Config) sw {
 
 func defaultTestConfig() Config {
 	return Config{
-		SegmentDuration: 100 * time.Millisecond,
-		Upload: UploadConfig{
-			Timeout: time.Second,
-		},
-		Metadata: MetadataConfig{
-			Timeout:    time.Second,
-			DLQEnabled: true,
-		},
+		SegmentDuration:       100 * time.Millisecond,
+		UploadTimeout:         time.Second,
+		MetadataUpdateTimeout: time.Second,
+		MetadataDLQEnabled:    true,
 	}
 }
 

--- a/pkg/experiment/ingester/segment_test.go
+++ b/pkg/experiment/ingester/segment_test.go
@@ -121,9 +121,7 @@ func ingestWithDLQ(t *testing.T, chunks []inputChunk) {
 }
 
 func TestIngestWait(t *testing.T) {
-	sw := newTestSegmentWriter(t, Config{
-		SegmentDuration: 100 * time.Millisecond,
-	})
+	sw := newTestSegmentWriter(t, defaultTestConfig())
 
 	defer sw.stop()
 	sw.client.On("AddBlock", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
@@ -143,9 +141,7 @@ func TestIngestWait(t *testing.T) {
 
 func TestBusyIngestLoop(t *testing.T) {
 
-	sw := newTestSegmentWriter(t, Config{
-		SegmentDuration: 100 * time.Millisecond,
-	})
+	sw := newTestSegmentWriter(t, defaultTestConfig())
 	defer sw.stop()
 
 	writeCtx, writeCancel := context.WithCancel(context.Background())
@@ -244,9 +240,7 @@ func TestDLQFail(t *testing.T) {
 		l,
 		newSegmentMetrics(nil),
 		memdb.NewHeadMetricsWithPrefix(nil, ""),
-		Config{
-			SegmentDuration: 100 * time.Millisecond,
-		},
+		defaultTestConfig(),
 		validation.MockDefaultOverrides(),
 		bucket,
 		client,
@@ -289,9 +283,7 @@ func TestDatasetMinMaxTime(t *testing.T) {
 		l,
 		newSegmentMetrics(nil),
 		memdb.NewHeadMetricsWithPrefix(nil, ""),
-		Config{
-			SegmentDuration: 100 * time.Millisecond,
-		},
+		defaultTestConfig(),
 		validation.MockDefaultOverrides(),
 		bucket,
 		client,
@@ -330,9 +322,7 @@ func TestDatasetMinMaxTime(t *testing.T) {
 func TestQueryMultipleSeriesSingleTenant(t *testing.T) {
 	metas := make(chan *metastorev1.BlockMeta, 1)
 
-	sw := newTestSegmentWriter(t, Config{
-		SegmentDuration: 100 * time.Millisecond,
-	})
+	sw := newTestSegmentWriter(t, defaultTestConfig())
 	defer sw.stop()
 	sw.client.On("AddBlock", mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -379,9 +369,7 @@ func TestDLQRecoveryMock(t *testing.T) {
 		{shard: 1, tenant: "tb", profile: cpuProfile(42, 239, "svc1", "kek", "foo", "bar")},
 	})
 
-	sw := newTestSegmentWriter(t, Config{
-		SegmentDuration: 100 * time.Millisecond,
-	})
+	sw := newTestSegmentWriter(t, defaultTestConfig())
 	sw.client.On("AddBlock", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, fmt.Errorf("mock metastore unavailable"))
 
@@ -419,9 +407,7 @@ func TestDLQRecovery(t *testing.T) {
 		{shard: 1, tenant: tenant, profile: cpuProfile(42, int(ts), "svc1", "kek", "foo", "bar")},
 	})
 
-	sw := newTestSegmentWriter(t, Config{
-		SegmentDuration: 100 * time.Millisecond,
-	})
+	sw := newTestSegmentWriter(t, defaultTestConfig())
 	sw.client.On("AddBlock", mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, fmt.Errorf("mock metastore unavailable"))
 
@@ -491,7 +477,14 @@ func newTestSegmentWriter(t *testing.T, cfg Config) sw {
 
 func defaultTestConfig() Config {
 	return Config{
-		SegmentDuration: 1 * time.Second,
+		SegmentDuration: 100 * time.Millisecond,
+		Upload: UploadConfig{
+			Timeout: time.Second,
+		},
+		Metadata: MetadataConfig{
+			Timeout:    time.Second,
+			DLQEnabled: true,
+		},
 	}
 }
 

--- a/pkg/experiment/ingester/service.go
+++ b/pkg/experiment/ingester/service.go
@@ -42,19 +42,19 @@ const (
 )
 
 type Config struct {
-	GRPCClientConfig       grpcclient.Config     `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate with the segment writer."`
-	LifecyclerConfig       ring.LifecyclerConfig `yaml:"lifecycler,omitempty"`
-	SegmentDuration        time.Duration         `yaml:"segment_duration,omitempty" category:"advanced"`
-	FlushConcurrency       uint                  `yaml:"flush_concurrency,omitempty" category:"advanced"`
-	UploadTimeout          time.Duration         `yaml:"upload-timeout,omitempty" category:"advanced"`
-	UploadMaxRetries       int                   `yaml:"upload-retry_max_retries,omitempty" category:"advanced"`
-	UploadMinBackoff       time.Duration         `yaml:"upload-retry_min_period,omitempty" category:"advanced"`
-	UploadMaxBackoff       time.Duration         `yaml:"upload-retry_max_period,omitempty" category:"advanced"`
-	UploadHedgeUploadAfter time.Duration         `yaml:"upload-hedge_upload_after,omitempty" category:"advanced"`
-	UploadHedgeRateMax     float64               `yaml:"upload-hedge_rate_max,omitempty" category:"advanced"`
-	UploadHedgeRateBurst   uint                  `yaml:"upload-hedge_rate_burst,omitempty" category:"advanced"`
-	MetadataDLQEnabled     bool                  `yaml:"metadata_dlq_enabled,omitempty" category:"advanced"`
-	MetadataUpdateTimeout  time.Duration         `yaml:"metadata_update_timeout,omitempty" category:"advanced"`
+	GRPCClientConfig      grpcclient.Config     `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate with the segment writer."`
+	LifecyclerConfig      ring.LifecyclerConfig `yaml:"lifecycler,omitempty"`
+	SegmentDuration       time.Duration         `yaml:"segment_duration,omitempty" category:"advanced"`
+	FlushConcurrency      uint                  `yaml:"flush_concurrency,omitempty" category:"advanced"`
+	UploadTimeout         time.Duration         `yaml:"upload-timeout,omitempty" category:"advanced"`
+	UploadMaxRetries      int                   `yaml:"upload-retry_max_retries,omitempty" category:"advanced"`
+	UploadMinBackoff      time.Duration         `yaml:"upload-retry_min_period,omitempty" category:"advanced"`
+	UploadMaxBackoff      time.Duration         `yaml:"upload-retry_max_period,omitempty" category:"advanced"`
+	UploadHedgeAfter      time.Duration         `yaml:"upload-hedge_upload_after,omitempty" category:"advanced"`
+	UploadHedgeRateMax    float64               `yaml:"upload-hedge_rate_max,omitempty" category:"advanced"`
+	UploadHedgeRateBurst  uint                  `yaml:"upload-hedge_rate_burst,omitempty" category:"advanced"`
+	MetadataDLQEnabled    bool                  `yaml:"metadata_dlq_enabled,omitempty" category:"advanced"`
+	MetadataUpdateTimeout time.Duration         `yaml:"metadata_update_timeout,omitempty" category:"advanced"`
 }
 
 func (cfg *Config) Validate() error {
@@ -75,7 +75,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.UploadMaxRetries, prefix+".upload-max-retries", 3, "Number of times to backoff and retry before failing.")
 	f.DurationVar(&cfg.UploadMinBackoff, prefix+".upload-retry-min-period", 50*time.Millisecond, "Minimum delay when backing off.")
 	f.DurationVar(&cfg.UploadMaxBackoff, prefix+".upload-retry-max-period", defaultSegmentDuration, "Maximum delay when backing off.")
-	f.DurationVar(&cfg.UploadHedgeUploadAfter, prefix+".upload-hedge-upload-after", defaultSegmentDuration, "Time after which to hedge the upload request.")
+	f.DurationVar(&cfg.UploadHedgeAfter, prefix+".upload-hedge-after", defaultSegmentDuration, "Time after which to hedge the upload request.")
 	f.Float64Var(&cfg.UploadHedgeRateMax, prefix+".upload-hedge-rate-max", defaultHedgedRequestMaxRate, "Maximum number of hedged requests per second.")
 	f.UintVar(&cfg.UploadHedgeRateBurst, prefix+".upload-hedge-rate-burst", defaultHedgedRequestBurst, "Maximum number of hedged requests in a burst.")
 	f.BoolVar(&cfg.MetadataDLQEnabled, prefix+".metadata-dlq-enabled", true, "Enables dead letter queue (DLQ) for metadata. If the metadata update fails, it will be stored and updated asynchronously.")


### PR DESCRIPTION
The PR adds configuration options to control the metastore client in the segment-writer service.