### PR TITLE
perf(v2): metadata label query optimization

### DIFF
--- a/pkg/experiment/metastore/index/index.go
+++ b/pkg/experiment/metastore/index/index.go
@@ -19,6 +19,7 @@ import (
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	"github.com/grafana/pyroscope/pkg/experiment/block/metadata"
 	"github.com/grafana/pyroscope/pkg/experiment/metastore/index/store"
+	"github.com/grafana/pyroscope/pkg/model"
 )
 
 var ErrBlockExists = fmt.Errorf("block already exists")
@@ -259,11 +260,13 @@ func (i *Index) QueryMetadataLabels(tx *bbolt.Tx, query MetadataQuery) ([]*types
 	if err != nil {
 		return nil, err
 	}
-	r, err := newMetadataLabelQuerier(tx, q).queryLabels()
+	c, err := newMetadataLabelQuerier(tx, q).queryLabels()
 	if err != nil {
 		return nil, err
 	}
-	return r.Labels(), nil
+	l := slices.Collect(c.Unique())
+	slices.SortFunc(l, model.CompareLabels)
+	return l, nil
 }
 
 func (i *Index) getOrCreatePartitionForBlock(b *metastorev1.BlockMeta) *store.Partition {

--- a/pkg/model/labels.go
+++ b/pkg/model/labels.go
@@ -346,8 +346,8 @@ func CompareLabelPairs(a, b []*typesv1.LabelPair) int {
 	return len(a) - len(b)
 }
 
-func CompareLabels(a, b Labels) int {
-	return CompareLabelPairs(a, b)
+func CompareLabels(a, b *typesv1.Labels) int {
+	return CompareLabelPairs(a.Labels, b.Labels)
 }
 
 // LabelsBuilder allows modifying Labels.


### PR DESCRIPTION
The change eliminates the majority of allocations in metadata label queries. Currently, we use the standard label merger; however, this approach doesn't scale well on large datasets. Querying thousands (5–10K) of services over the past 7–14 days takes around 10 seconds.

While the change doesn't fully solve the problem – we still scan all metadata entries within the time range – it lays the groundwork for further improvements. Additional speedups (2–10×) could be achieved by storing a shard-level index.

In the meantime, the optimization significantly reduces CPU consumption and GC pressure, and speeds up queries by 2–4×. I'll attach some flame graphs after more intensive testing.

Depends on #4079