### PR TITLE
docs: State which versions we do maintain

### DIFF
--- a/docs/sources/release-notes/_index.md
+++ b/docs/sources/release-notes/_index.md
@@ -9,6 +9,8 @@ weight: 100
 Release notes for Grafana Pyroscope are in the CHANGELOG for the release and
 listed here by version number.
 
+The last two minor versions of Grafana Pyroscope are supported and get security updates and bug fixes.
+
 Packages are linked in the [Assets section for each Pyroscope release](https://github.com/grafana/pyroscope/releases).
 
 {{< section >}}


### PR DESCRIPTION
As pointed out on the community slack, we don't document what releases are supported.
