### PR TITLE
fix(v2): query series labels from dataset index

### DIFF
--- a/pkg/experiment/query_backend/query_profile_entry.go
+++ b/pkg/experiment/query_backend/query_profile_entry.go
@@ -28,7 +28,7 @@ type ProfileEntry struct {
 func (e ProfileEntry) RowNumber() int64 { return e.RowNum }
 
 func profileEntryIterator(q *queryContext, groupBy ...string) (iter.Iterator[ProfileEntry], error) {
-	series, err := getSeriesLabels(q.ds.Index(), q.req.matchers, groupBy...)
+	series, err := getSeries(q.ds.Index(), q.req.matchers, groupBy...)
 	if err != nil {
 		return nil, err
 	}
@@ -62,35 +62,34 @@ func profileEntryIterator(q *queryContext, groupBy ...string) (iter.Iterator[Pro
 	return entries, nil
 }
 
-type seriesLabels struct {
+type series struct {
 	fingerprint model.Fingerprint
 	labels      phlaremodel.Labels
 }
 
-func getSeriesLabels(reader phlaredb.IndexReader, matchers []*labels.Matcher, by ...string) (map[uint32]seriesLabels, error) {
+func getSeries(reader phlaredb.IndexReader, matchers []*labels.Matcher, by ...string) (map[uint32]series, error) {
 	postings, err := getPostings(reader, matchers...)
 	if err != nil {
 		return nil, err
 	}
 	chunks := make([]index.ChunkMeta, 1)
-	series := make(map[uint32]seriesLabels)
+	s := make(map[uint32]series)
 	l := make(phlaremodel.Labels, 0, 6)
 	for postings.Next() {
 		fp, err := reader.SeriesBy(postings.At(), &l, &chunks, by...)
 		if err != nil {
 			return nil, err
 		}
-		_, ok := series[chunks[0].SeriesIndex]
+		_, ok := s[chunks[0].SeriesIndex]
 		if ok {
 			continue
 		}
-		series[chunks[0].SeriesIndex] = seriesLabels{
+		s[chunks[0].SeriesIndex] = series{
 			fingerprint: model.Fingerprint(fp),
 			labels:      l.Clone(),
 		}
 	}
-
-	return series, postings.Err()
+	return s, postings.Err()
 }
 
 func getPostings(reader phlaredb.IndexReader, matchers ...*labels.Matcher) (index.Postings, error) {

--- a/pkg/experiment/query_backend/query_series_labels.go
+++ b/pkg/experiment/query_backend/query_series_labels.go
@@ -1,12 +1,18 @@
 package query_backend
 
 import (
+	"errors"
+	"slices"
 	"sync"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
 
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	"github.com/grafana/pyroscope/pkg/experiment/block"
 	phlaremodel "github.com/grafana/pyroscope/pkg/model"
+	"github.com/grafana/pyroscope/pkg/phlaredb"
 )
 
 func init() {
@@ -20,15 +26,9 @@ func init() {
 }
 
 func querySeriesLabels(q *queryContext, query *queryv1.Query) (*queryv1.Report, error) {
-	m, err := getSeriesLabels(q.ds.Index(), q.req.matchers)
+	series, err := getSeriesLabels(q.ds.Index(), q.req.matchers, query.SeriesLabels.LabelNames...)
 	if err != nil {
 		return nil, err
-	}
-	series := make([]*typesv1.Labels, len(m))
-	var i int
-	for _, s := range m {
-		series[i] = &typesv1.Labels{Labels: s.labels}
-		i++
 	}
 	resp := &queryv1.Report{
 		SeriesLabels: &queryv1.SeriesLabelsReport{
@@ -66,4 +66,63 @@ func (a *seriesLabelsAggregator) build() *queryv1.Report {
 			SeriesLabels: a.series.Labels(),
 		},
 	}
+}
+
+func getSeriesLabels(reader phlaredb.IndexReader, matchers []*labels.Matcher, by ...string) ([]*typesv1.Labels, error) {
+	names, err := reader.LabelNames()
+	if err != nil {
+		return nil, err
+	}
+	if len(by) > 0 {
+		names = slices.DeleteFunc(names, func(n string) bool {
+			for j := 0; j < len(by); j++ {
+				if by[j] == n {
+					return false
+				}
+			}
+			return true
+		})
+		if len(names) == 0 {
+			return nil, nil
+		}
+	}
+
+	postings, err := getPostings(reader, matchers...)
+	if err != nil {
+		return nil, err
+	}
+
+	visited := make(map[uint64]struct{})
+	sets := make([]*typesv1.Labels, 0, 32)
+	ls := make(phlaremodel.Labels, len(names))
+	for i := range names {
+		ls[i] = new(typesv1.LabelPair)
+	}
+
+	for postings.Next() {
+		var j int
+		var v string
+		for i := range names {
+			v, err = reader.LabelValueFor(postings.At(), names[i])
+			switch {
+			case err == nil:
+			case errors.Is(err, storage.ErrNotFound):
+			default:
+				return nil, err
+			}
+			if v != "" {
+				ls[j].Name = names[i]
+				ls[j].Value = v
+				j++
+			}
+		}
+		set := ls[:j]
+		h := set.Hash()
+		if _, ok := visited[h]; !ok {
+			visited[h] = struct{}{}
+			sets = append(sets, &typesv1.Labels{Labels: set.Clone()})
+		}
+	}
+
+	return sets, postings.Err()
 }

--- a/pkg/experiment/query_backend/testdata/fixtures/series_labels.json
+++ b/pkg/experiment/query_backend/testdata/fixtures/series_labels.json
@@ -1,0 +1,577 @@
+{
+  "query": {},
+  "series_labels": [
+    {
+      "labels": [
+        {
+          "name": "__name__",
+          "value": "block"
+        },
+        {
+          "name": "__period_type__",
+          "value": "contentions"
+        },
+        {
+          "name": "__period_unit__",
+          "value": "count"
+        },
+        {
+          "name": "__profile_type__",
+          "value": "block:contentions:count:contentions:count"
+        },
+        {
+          "name": "__service_name__",
+          "value": "pyroscope"
+        },
+        {
+          "name": "__type__",
+          "value": "contentions"
+        },
+        {
+          "name": "__unit__",
+          "value": "count"
+        },
+        {
+          "name": "pyroscope_spy",
+          "value": "gospy"
+        },
+        {
+          "name": "service_git_ref",
+          "value": "6389652c7"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        },
+        {
+          "name": "service_repository",
+          "value": "https://github.com/grafana/pyroscope"
+        },
+        {
+          "name": "target",
+          "value": "all"
+        }
+      ]
+    },
+    {
+      "labels": [
+        {
+          "name": "__name__",
+          "value": "block"
+        },
+        {
+          "name": "__period_type__",
+          "value": "contentions"
+        },
+        {
+          "name": "__period_unit__",
+          "value": "count"
+        },
+        {
+          "name": "__profile_type__",
+          "value": "block:delay:nanoseconds:contentions:count"
+        },
+        {
+          "name": "__service_name__",
+          "value": "pyroscope"
+        },
+        {
+          "name": "__type__",
+          "value": "delay"
+        },
+        {
+          "name": "__unit__",
+          "value": "nanoseconds"
+        },
+        {
+          "name": "pyroscope_spy",
+          "value": "gospy"
+        },
+        {
+          "name": "service_git_ref",
+          "value": "6389652c7"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        },
+        {
+          "name": "service_repository",
+          "value": "https://github.com/grafana/pyroscope"
+        },
+        {
+          "name": "target",
+          "value": "all"
+        }
+      ]
+    },
+    {
+      "labels": [
+        {
+          "name": "__name__",
+          "value": "goroutines"
+        },
+        {
+          "name": "__period_type__",
+          "value": "goroutine"
+        },
+        {
+          "name": "__period_unit__",
+          "value": "count"
+        },
+        {
+          "name": "__profile_type__",
+          "value": "goroutines:goroutine:count:goroutine:count"
+        },
+        {
+          "name": "__service_name__",
+          "value": "pyroscope"
+        },
+        {
+          "name": "__type__",
+          "value": "goroutine"
+        },
+        {
+          "name": "__unit__",
+          "value": "count"
+        },
+        {
+          "name": "pyroscope_spy",
+          "value": "gospy"
+        },
+        {
+          "name": "service_git_ref",
+          "value": "6389652c7"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        },
+        {
+          "name": "service_repository",
+          "value": "https://github.com/grafana/pyroscope"
+        },
+        {
+          "name": "target",
+          "value": "all"
+        }
+      ]
+    },
+    {
+      "labels": [
+        {
+          "name": "__name__",
+          "value": "memory"
+        },
+        {
+          "name": "__period_type__",
+          "value": "space"
+        },
+        {
+          "name": "__period_unit__",
+          "value": "bytes"
+        },
+        {
+          "name": "__profile_type__",
+          "value": "memory:alloc_objects:count:space:bytes"
+        },
+        {
+          "name": "__service_name__",
+          "value": "pyroscope"
+        },
+        {
+          "name": "__type__",
+          "value": "alloc_objects"
+        },
+        {
+          "name": "__unit__",
+          "value": "count"
+        },
+        {
+          "name": "pyroscope_spy",
+          "value": "gospy"
+        },
+        {
+          "name": "service_git_ref",
+          "value": "6389652c7"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        },
+        {
+          "name": "service_repository",
+          "value": "https://github.com/grafana/pyroscope"
+        },
+        {
+          "name": "target",
+          "value": "all"
+        }
+      ]
+    },
+    {
+      "labels": [
+        {
+          "name": "__name__",
+          "value": "memory"
+        },
+        {
+          "name": "__period_type__",
+          "value": "space"
+        },
+        {
+          "name": "__period_unit__",
+          "value": "bytes"
+        },
+        {
+          "name": "__profile_type__",
+          "value": "memory:alloc_space:bytes:space:bytes"
+        },
+        {
+          "name": "__service_name__",
+          "value": "pyroscope"
+        },
+        {
+          "name": "__type__",
+          "value": "alloc_space"
+        },
+        {
+          "name": "__unit__",
+          "value": "bytes"
+        },
+        {
+          "name": "pyroscope_spy",
+          "value": "gospy"
+        },
+        {
+          "name": "service_git_ref",
+          "value": "6389652c7"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        },
+        {
+          "name": "service_repository",
+          "value": "https://github.com/grafana/pyroscope"
+        },
+        {
+          "name": "target",
+          "value": "all"
+        }
+      ]
+    },
+    {
+      "labels": [
+        {
+          "name": "__name__",
+          "value": "memory"
+        },
+        {
+          "name": "__period_type__",
+          "value": "space"
+        },
+        {
+          "name": "__period_unit__",
+          "value": "bytes"
+        },
+        {
+          "name": "__profile_type__",
+          "value": "memory:inuse_objects:count:space:bytes"
+        },
+        {
+          "name": "__service_name__",
+          "value": "pyroscope"
+        },
+        {
+          "name": "__type__",
+          "value": "inuse_objects"
+        },
+        {
+          "name": "__unit__",
+          "value": "count"
+        },
+        {
+          "name": "pyroscope_spy",
+          "value": "gospy"
+        },
+        {
+          "name": "service_git_ref",
+          "value": "6389652c7"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        },
+        {
+          "name": "service_repository",
+          "value": "https://github.com/grafana/pyroscope"
+        },
+        {
+          "name": "target",
+          "value": "all"
+        }
+      ]
+    },
+    {
+      "labels": [
+        {
+          "name": "__name__",
+          "value": "memory"
+        },
+        {
+          "name": "__period_type__",
+          "value": "space"
+        },
+        {
+          "name": "__period_unit__",
+          "value": "bytes"
+        },
+        {
+          "name": "__profile_type__",
+          "value": "memory:inuse_space:bytes:space:bytes"
+        },
+        {
+          "name": "__service_name__",
+          "value": "pyroscope"
+        },
+        {
+          "name": "__type__",
+          "value": "inuse_space"
+        },
+        {
+          "name": "__unit__",
+          "value": "bytes"
+        },
+        {
+          "name": "pyroscope_spy",
+          "value": "gospy"
+        },
+        {
+          "name": "service_git_ref",
+          "value": "6389652c7"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        },
+        {
+          "name": "service_repository",
+          "value": "https://github.com/grafana/pyroscope"
+        },
+        {
+          "name": "target",
+          "value": "all"
+        }
+      ]
+    },
+    {
+      "labels": [
+        {
+          "name": "__name__",
+          "value": "mutex"
+        },
+        {
+          "name": "__period_type__",
+          "value": "contentions"
+        },
+        {
+          "name": "__period_unit__",
+          "value": "count"
+        },
+        {
+          "name": "__profile_type__",
+          "value": "mutex:contentions:count:contentions:count"
+        },
+        {
+          "name": "__service_name__",
+          "value": "pyroscope"
+        },
+        {
+          "name": "__type__",
+          "value": "contentions"
+        },
+        {
+          "name": "__unit__",
+          "value": "count"
+        },
+        {
+          "name": "pyroscope_spy",
+          "value": "gospy"
+        },
+        {
+          "name": "service_git_ref",
+          "value": "6389652c7"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        },
+        {
+          "name": "service_repository",
+          "value": "https://github.com/grafana/pyroscope"
+        },
+        {
+          "name": "target",
+          "value": "all"
+        }
+      ]
+    },
+    {
+      "labels": [
+        {
+          "name": "__name__",
+          "value": "mutex"
+        },
+        {
+          "name": "__period_type__",
+          "value": "contentions"
+        },
+        {
+          "name": "__period_unit__",
+          "value": "count"
+        },
+        {
+          "name": "__profile_type__",
+          "value": "mutex:delay:nanoseconds:contentions:count"
+        },
+        {
+          "name": "__service_name__",
+          "value": "pyroscope"
+        },
+        {
+          "name": "__type__",
+          "value": "delay"
+        },
+        {
+          "name": "__unit__",
+          "value": "nanoseconds"
+        },
+        {
+          "name": "pyroscope_spy",
+          "value": "gospy"
+        },
+        {
+          "name": "service_git_ref",
+          "value": "6389652c7"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        },
+        {
+          "name": "service_repository",
+          "value": "https://github.com/grafana/pyroscope"
+        },
+        {
+          "name": "target",
+          "value": "all"
+        }
+      ]
+    },
+    {
+      "labels": [
+        {
+          "name": "__name__",
+          "value": "process_cpu"
+        },
+        {
+          "name": "__period_type__",
+          "value": "cpu"
+        },
+        {
+          "name": "__period_unit__",
+          "value": "nanoseconds"
+        },
+        {
+          "name": "__profile_type__",
+          "value": "process_cpu:cpu:nanoseconds:cpu:nanoseconds"
+        },
+        {
+          "name": "__service_name__",
+          "value": "pyroscope"
+        },
+        {
+          "name": "__type__",
+          "value": "cpu"
+        },
+        {
+          "name": "__unit__",
+          "value": "nanoseconds"
+        },
+        {
+          "name": "pyroscope_spy",
+          "value": "gospy"
+        },
+        {
+          "name": "service_git_ref",
+          "value": "6389652c7"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        },
+        {
+          "name": "service_repository",
+          "value": "https://github.com/grafana/pyroscope"
+        },
+        {
+          "name": "target",
+          "value": "all"
+        }
+      ]
+    },
+    {
+      "labels": [
+        {
+          "name": "__name__",
+          "value": "process_cpu"
+        },
+        {
+          "name": "__period_type__",
+          "value": "cpu"
+        },
+        {
+          "name": "__period_unit__",
+          "value": "nanoseconds"
+        },
+        {
+          "name": "__profile_type__",
+          "value": "process_cpu:samples:count:cpu:nanoseconds"
+        },
+        {
+          "name": "__service_name__",
+          "value": "pyroscope"
+        },
+        {
+          "name": "__type__",
+          "value": "samples"
+        },
+        {
+          "name": "__unit__",
+          "value": "count"
+        },
+        {
+          "name": "pyroscope_spy",
+          "value": "gospy"
+        },
+        {
+          "name": "service_git_ref",
+          "value": "6389652c7"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        },
+        {
+          "name": "service_repository",
+          "value": "https://github.com/grafana/pyroscope"
+        },
+        {
+          "name": "target",
+          "value": "all"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/experiment/query_backend/testdata/fixtures/series_labels_by.json
+++ b/pkg/experiment/query_backend/testdata/fixtures/series_labels_by.json
@@ -1,0 +1,142 @@
+{
+  "query": {
+    "label_names": [
+      "service_name",
+      "__profile_type__"
+    ]
+  },
+  "series_labels": [
+    {
+      "labels": [
+        {
+          "name": "__profile_type__",
+          "value": "block:contentions:count:contentions:count"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        }
+      ]
+    },
+    {
+      "labels": [
+        {
+          "name": "__profile_type__",
+          "value": "block:delay:nanoseconds:contentions:count"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        }
+      ]
+    },
+    {
+      "labels": [
+        {
+          "name": "__profile_type__",
+          "value": "goroutines:goroutine:count:goroutine:count"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        }
+      ]
+    },
+    {
+      "labels": [
+        {
+          "name": "__profile_type__",
+          "value": "memory:alloc_objects:count:space:bytes"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        }
+      ]
+    },
+    {
+      "labels": [
+        {
+          "name": "__profile_type__",
+          "value": "memory:alloc_space:bytes:space:bytes"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        }
+      ]
+    },
+    {
+      "labels": [
+        {
+          "name": "__profile_type__",
+          "value": "memory:inuse_objects:count:space:bytes"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        }
+      ]
+    },
+    {
+      "labels": [
+        {
+          "name": "__profile_type__",
+          "value": "memory:inuse_space:bytes:space:bytes"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        }
+      ]
+    },
+    {
+      "labels": [
+        {
+          "name": "__profile_type__",
+          "value": "mutex:contentions:count:contentions:count"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        }
+      ]
+    },
+    {
+      "labels": [
+        {
+          "name": "__profile_type__",
+          "value": "mutex:delay:nanoseconds:contentions:count"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        }
+      ]
+    },
+    {
+      "labels": [
+        {
+          "name": "__profile_type__",
+          "value": "process_cpu:cpu:nanoseconds:cpu:nanoseconds"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        }
+      ]
+    },
+    {
+      "labels": [
+        {
+          "name": "__profile_type__",
+          "value": "process_cpu:samples:count:cpu:nanoseconds"
+        },
+        {
+          "name": "service_name",
+          "value": "pyroscope"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
If a `SeriesLabels` query hits the dataset index (tenant-wide) we cannot use `SeriesIndex` there as it points the dataset and not specific series within it.