### PR TITLE
fix(v2): segment upload timeout

### DIFF
--- a/pkg/experiment/ingester/client/client.go
+++ b/pkg/experiment/ingester/client/client.go
@@ -63,12 +63,11 @@ func isClientError(err error) bool {
 	switch status.Code(err) {
 	case codes.InvalidArgument,
 		codes.Canceled,
-		codes.DeadlineExceeded,
 		codes.PermissionDenied,
 		codes.Unauthenticated:
 		return true
 	default:
-		return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+		return errors.Is(err, context.Canceled)
 	}
 }
 

--- a/pkg/experiment/ingester/client/client_test.go
+++ b/pkg/experiment/ingester/client/client_test.go
@@ -67,8 +67,9 @@ type segwriterClientSuite struct {
 }
 
 func (s *segwriterClientSuite) SetupTest() {
-	s.listener = bufconn.Listen(256 << 10)
-	s.dialer = func(context.Context, string) (net.Conn, error) { return s.listener.Dial() }
+	listener := bufconn.Listen(256 << 10)
+	s.listener = listener
+	s.dialer = func(context.Context, string) (net.Conn, error) { return listener.Dial() }
 	s.server = grpc.NewServer()
 	s.service = new(segwriterServerMock)
 	segmentwriterv1.RegisterSegmentWriterServiceServer(s.server, s.service)
@@ -93,7 +94,7 @@ func (s *segwriterClientSuite) SetupTest() {
 	s.done = make(chan struct{})
 	go func() {
 		defer close(s.done)
-		s.Require().NoError(s.server.Serve(s.listener))
+		s.Require().NoError(s.server.Serve(listener))
 	}()
 
 	// Wait for the server

--- a/pkg/experiment/ingester/service.go
+++ b/pkg/experiment/ingester/service.go
@@ -79,7 +79,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.Float64Var(&cfg.UploadHedgeRateMax, prefix+".upload-hedge-rate-max", defaultHedgedRequestMaxRate, "Maximum number of hedged requests per second.")
 	f.UintVar(&cfg.UploadHedgeRateBurst, prefix+".upload-hedge-rate-burst", defaultHedgedRequestBurst, "Maximum number of hedged requests in a burst.")
 	f.BoolVar(&cfg.MetadataDLQEnabled, prefix+".metadata-dlq-enabled", true, "Enables dead letter queue (DLQ) for metadata. If the metadata update fails, it will be stored and updated asynchronously.")
-	f.DurationVar(&cfg.MetadataUpdateTimeout, prefix+".metadata-update-timeout", time.Second, "Timeout for metadata update requests.")
+	f.DurationVar(&cfg.MetadataUpdateTimeout, prefix+".metadata-update-timeout", 2*time.Second, "Timeout for metadata update requests.")
 }
 
 type Limits interface {

--- a/pkg/experiment/ingester/service.go
+++ b/pkg/experiment/ingester/service.go
@@ -71,7 +71,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	cfg.LifecyclerConfig.RegisterFlagsWithPrefix(prefix+".", f, util.Logger)
 	f.DurationVar(&cfg.SegmentDuration, prefix+".segment-duration", defaultSegmentDuration, "Timeout when flushing segments to bucket.")
 	f.UintVar(&cfg.FlushConcurrency, prefix+".flush-concurrency", 0, "Number of concurrent flushes. Defaults to the number of CPUs, but not less than 8.")
-	f.DurationVar(&cfg.UploadTimeout, prefix+".upload-timeout", time.Second, "Timeout for upload requests.")
+	f.DurationVar(&cfg.UploadTimeout, prefix+".upload-timeout", 2*time.Second, "Timeout for upload requests, including retries.")
 	f.IntVar(&cfg.UploadMaxRetries, prefix+".upload-max-retries", 3, "Number of times to backoff and retry before failing.")
 	f.DurationVar(&cfg.UploadMinBackoff, prefix+".upload-retry-min-period", 50*time.Millisecond, "Minimum delay when backing off.")
 	f.DurationVar(&cfg.UploadMaxBackoff, prefix+".upload-retry-max-period", defaultSegmentDuration, "Maximum delay when backing off.")


### PR DESCRIPTION
Currently, the segment upload timeout is applied to each individual attempt. In practice, I saw that a configuration with 3 attempts and 1s timeout may take up to 5 seconds, which is not desirable.

This change modifies the behavior so that the timeout covers the entire upload routine – including backoff intervals, delays, and other overhead – making the process more predictable.

If a single attempt takes too long (e.g., due to a slow connection), it may be recovered using a hedged request. Regular retries are intended to recover from transient errors.