### PR TITLE
fix(v2): object download error branch panic

### DIFF
--- a/pkg/objstore/read_only_file.go
+++ b/pkg/objstore/read_only_file.go
@@ -33,39 +33,36 @@ func Download(ctx context.Context, name string, src BucketReader, dir string) (*
 	return f, nil
 }
 
-func download(ctx context.Context, name string, src BucketReader, dir string) (f *ReadOnlyFile, err error) {
+func download(ctx context.Context, name string, src BucketReader, dir string) (*ReadOnlyFile, error) {
 	r, err := src.Get(ctx, name)
 	if err != nil {
 		return nil, err
 	}
-	f = &ReadOnlyFile{
-		size: 0,
+	defer r.Close()
+
+	path := filepath.Join(dir, filepath.Base(name))
+	f := &ReadOnlyFile{
 		name: name,
-		path: filepath.Join(dir, filepath.Base(name)),
+		path: path,
 	}
-	defer func() {
-		if err != nil {
-			_ = f.Close()
-		}
-		_ = r.Close()
-	}()
 	if err = os.MkdirAll(dir, 0755); err != nil {
 		return nil, err
 	}
-	dst, err := os.Create(f.path)
+	dst, err := os.Create(path)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = dst.Close()
-	}()
+	defer dst.Close()
+
 	buf := bufferpool.GetBuffer(32 << 10)
 	defer bufferpool.Put(buf)
 	buf.B = buf.B[:cap(buf.B)]
 	n, err := io.CopyBuffer(dst, r, buf.B)
 	if err != nil {
+		_ = os.RemoveAll(path)
 		return nil, err
 	}
+
 	f.size = n
 	return f, nil
 }

--- a/pkg/objstore/read_only_file_test.go
+++ b/pkg/objstore/read_only_file_test.go
@@ -1,0 +1,25 @@
+package objstore_test
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/pyroscope/pkg/objstore"
+	"github.com/grafana/pyroscope/pkg/test/mocks/mockobjstore"
+)
+
+func TestReadOnlyFileError(t *testing.T) {
+	m := new(mockobjstore.MockBucket)
+	m.EXPECT().Get(mock.Anything, "test").Return(failReader{}, nil).Once()
+	_, err := objstore.Download(context.Background(), "test", m, t.TempDir())
+	require.ErrorIs(t, err, io.ErrNoProgress)
+}
+
+type failReader struct{}
+
+func (failReader) Read([]byte) (int, error) { return 0, io.ErrNoProgress }
+func (failReader) Close() error             { return nil }


### PR DESCRIPTION
An error that occurs during object downloading in compaction workers may result in a panic. The reason is that one of the named return values is closed in a defer statement, but it may be nil if the error path is taken.