### PR TITLE
chore(v2): make boltdb compaction configurable

### DIFF
--- a/pkg/experiment/metastore/fsm/boltdb_test.go
+++ b/pkg/experiment/metastore/fsm/boltdb_test.go
@@ -4,18 +4,19 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/bbolt"
-
-	"github.com/grafana/pyroscope/pkg/util"
 )
 
 func TestBoltDB_open_restore(t *testing.T) {
 	tempDir := t.TempDir()
-	db := newDB(util.Logger, newMetrics(nil), tempDir)
+	buf := bytes.NewBuffer(nil)
+	db := newDB(log.NewLogfmtLogger(buf), newMetrics(nil), Config{DataDir: tempDir})
 	require.NoError(t, db.open(false))
 
 	data := []string{
@@ -41,6 +42,42 @@ func TestBoltDB_open_restore(t *testing.T) {
 	}))
 
 	assert.Equal(t, data, collected)
+	assert.False(t, strings.Contains(buf.String(), "compacting snapshot"))
+}
+
+func TestBoltDB_open_restore_compact(t *testing.T) {
+	tempDir := t.TempDir()
+	buf := bytes.NewBuffer(nil)
+	db := newDB(log.NewLogfmtLogger(buf), newMetrics(nil), Config{
+		DataDir:                  tempDir,
+		SnapshotCompactOnRestore: true,
+	})
+	require.NoError(t, db.open(false))
+
+	data := []string{
+		"k1", "v1",
+		"k2", "v2",
+		"k3", "v3",
+	}
+
+	snapshotSource := filepath.Join(tempDir, "snapshot_source")
+	require.NoError(t, createDB(t, snapshotSource, data).Close())
+	s, err := os.ReadFile(snapshotSource)
+	require.NoError(t, err)
+	require.NoError(t, db.restore(bytes.NewReader(s)))
+
+	collected := make([]string, 0, len(data))
+	require.NoError(t, db.boltdb.View(func(tx *bbolt.Tx) error {
+		b := tx.Bucket([]byte("test"))
+		assert.NotNil(t, b)
+		return b.ForEach(func(k, v []byte) error {
+			collected = append(collected, string(k), string(v))
+			return nil
+		})
+	}))
+
+	assert.Equal(t, data, collected)
+	assert.True(t, strings.Contains(buf.String(), "compacting snapshot"))
 }
 
 func createDB(t *testing.T, path string, pairs []string) *bbolt.DB {


### PR DESCRIPTION
In many cases, BoltDB compaction is unnecessary and provides little benefit. However, it involves creating a full copy of the database, which can be wasteful. I'm adding a configuration option to control whether compaction is performed when restoring the DB from a snapshot (disabled by default).

This change also ensures that the uncompacted DB is used if compaction fails, and fixes a bug where compaction could fail due to leftovers from previous failed attempts.