### PR TITLE
feat(v2): function totals recording rules

### DIFF
--- a/api/settings/v1/recording_rules.proto
+++ b/api/settings/v1/recording_rules.proto
@@ -74,11 +74,34 @@ message RecordingRule {
   repeated string matchers = 4;
   repeated string group_by = 5;
   repeated types.v1.LabelPair external_labels = 6;
+  StacktraceFilter stacktrace_filter = 7;
 
   // The observed generation of this recording rule. This value should be
   // provided when making updates to this record, to avoid conflicting
   // concurrent updates.
-  int64 generation = 7;
+  int64 generation = 8;
+}
+
+message StacktraceFilter {
+  StacktraceFilterType type = 1;
+  StacktraceFilterFunctionName function_name = 2;
+  // StacktraceFilterFunctionNameRegExp functionNameRegExp = 3;
+  // ...
+}
+
+enum StacktraceFilterType {
+  STACKTRACE_FILTER_FUNCTION_NAME = 0;
+  // STACKTRACE_FILTER_FUNCTION_NAME_REGEXP = 1;
+}
+
+enum MetricType {
+  TOTAL = 0;
+  // SELF = 1;
+}
+
+message StacktraceFilterFunctionName {
+  string function_name = 1;
+  MetricType metric_type = 2;
 }
 
 message RecordingRuleStore {


### PR DESCRIPTION
Adding a stacktrace filter field in the recording rules.

This way, we can define filter for function names and extend it in the future.

Examples of use:
```
# total cpu per service
- metric_name: 'pyroscope_metric_cpu_total_nanoseconds'
  matchers: ['{__profile_type__="..."}']
  group_by: ['service_name']
- metric_name: 'pyroscope_metric_ingester_cpu_gc_total_nanoseconds'
  matchers: ['{__profile_type__="..."}']
  group_by: ['service_name']
  stacktrace_filter:
    type: 'function_name'
    expr: 'runtime.gcBgMarkWorker'
    metric_type: total
```