### PR TITLE
fix(v2): register metastore readiness check

### DIFF
--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -722,6 +722,13 @@ func (f *Phlare) readyHandler(sm *services.Manager) http.HandlerFunc {
 			}
 		}
 
+		if f.metastore != nil {
+			if err := f.metastore.CheckReady(r.Context()); err != nil {
+				http.Error(w, "Metastore not ready: "+err.Error(), http.StatusServiceUnavailable)
+				return
+			}
+		}
+
 		util.WriteTextResponse(w, "ready")
 	}
 }

--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -702,12 +702,20 @@ func (f *Phlare) readyHandler(sm *services.Manager) http.HandlerFunc {
 			return
 		}
 
+		if f.metastore != nil {
+			if err := f.metastore.CheckReady(r.Context()); err != nil {
+				http.Error(w, "Metastore not ready: "+err.Error(), http.StatusServiceUnavailable)
+				return
+			}
+		}
+
 		if f.ingester != nil {
 			if err := f.ingester.CheckReady(r.Context()); err != nil {
 				http.Error(w, "Ingester not ready: "+err.Error(), http.StatusServiceUnavailable)
 				return
 			}
 		}
+
 		if f.segmentWriter != nil {
 			if err := f.segmentWriter.CheckReady(r.Context()); err != nil {
 				http.Error(w, "Segment Writer not ready: "+err.Error(), http.StatusServiceUnavailable)
@@ -718,13 +726,6 @@ func (f *Phlare) readyHandler(sm *services.Manager) http.HandlerFunc {
 		if f.frontend != nil {
 			if err := f.frontend.CheckReady(r.Context()); err != nil {
 				http.Error(w, "Query Frontend not ready: "+err.Error(), http.StatusServiceUnavailable)
-				return
-			}
-		}
-
-		if f.metastore != nil {
-			if err := f.metastore.CheckReady(r.Context()); err != nil {
-				http.Error(w, "Metastore not ready: "+err.Error(), http.StatusServiceUnavailable)
 				return
 			}
 		}


### PR DESCRIPTION
One day, we should make our component management more ergonomic. The fact that the server starts serving requests before components are fully initialized — and continues serving them after they're de-initialized — is the root of countless hard-to-diagnose issues. None of our components expect to handle requests after `Stop` is called.

The assumption that clients only interact with instances reporting `/ready` = true is incorrect – and so is the assumption that an instance stops receiving requests immediately after `SIGTERM`.
