### PR TITLE
chore(v2): skip query-frontend initialization if it is not used

### DIFF
--- a/pkg/frontend/read_path/query_frontend/query_frontend.go
+++ b/pkg/frontend/read_path/query_frontend/query_frontend.go
@@ -58,7 +58,6 @@ func (q *QueryFrontend) Query(
 	ctx context.Context,
 	req *queryv1.QueryRequest,
 ) (*queryv1.QueryResponse, error) {
-	// TODO(kolesnikovae):
 	// This method is supposed to be the entry point of the read path
 	// in the future versions. Therefore, validation, overrides, and
 	// rest of the request handling should be moved here.


### PR DESCRIPTION
The change is needed to skip old query-frontend initialization (and thus the dependency on the query scheduler) if it's not used.