### PR TITLE
feat(v2): segment-writer client conn pool warm up

### DIFF
--- a/pkg/experiment/ingester/client/client.go
+++ b/pkg/experiment/ingester/client/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/go-kit/log"
@@ -29,7 +30,10 @@ import (
 
 var errServiceUnavailableMsg = "service is unavailable"
 
-// TODO(kolesnikovae): Make these configurable (advanced category)?
+// TODO(kolesnikovae):
+//  * Replace the ring service discovery and client pool implementations.
+//  * Make CB options configurable.
+
 const (
 	// Circuit breaker defaults.
 	cbMinSuccess     = 5
@@ -139,6 +143,7 @@ type Client struct {
 	logger  log.Logger
 	metrics *metrics
 
+	ring        ring.ReadRing
 	pool        *connpool.Pool
 	distributor *distributor.Distributor
 
@@ -164,6 +169,7 @@ func NewSegmentWriterClient(
 		metrics:     newMetrics(registry),
 		distributor: distributor.NewDistributor(placement, ring),
 		pool:        pool,
+		ring:        ring,
 	}
 	c.subservices, err = services.NewManager(c.pool)
 	if err != nil {
@@ -178,6 +184,20 @@ func NewSegmentWriterClient(
 func (c *Client) Service() services.Service { return c.service }
 
 func (c *Client) starting(ctx context.Context) error {
+	// Warm up connections. The pool does not do this.
+	instances, err := c.ring.GetAllHealthy(ring.Reporting)
+	if err != nil {
+		return fmt.Errorf("get all healthy instances: %w", err)
+	}
+	var wg sync.WaitGroup
+	for _, x := range instances.Instances {
+		wg.Add(1)
+		go func(x ring.InstanceDesc) {
+			defer wg.Done()
+			_, _ = c.pool.GetClientFor(x.Addr)
+		}(x)
+	}
+	wg.Wait()
 	return services.StartManagerAndAwaitHealthy(ctx, c.subservices)
 }
 
@@ -235,8 +255,8 @@ func (c *Client) Push(
 			return nil, status.Error(codes.Unavailable, errServiceUnavailableMsg)
 		}
 		level.Warn(logger).Log("msg", "failed attempt to push data to segment writer", "err", err)
-		if err = ctx.Err(); err != nil {
-			return nil, err
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
 		}
 	}
 
@@ -293,9 +313,9 @@ func newConnPool(
 	)
 
 	// Note that circuit breaker must be created per client conn.
-	factory := connpool.NewConnPoolFactory(func(desc ring.InstanceDesc) []grpc.DialOption {
-		cb := gobreaker.NewCircuitBreaker[any](circuitBreakerConfig)
-		return append(options, grpc.WithUnaryInterceptor(circuitbreaker.UnaryClientInterceptor(cb)))
+	factory := connpool.NewConnPoolFactory(func(ring.InstanceDesc) []grpc.DialOption {
+		cb := circuitbreaker.UnaryClientInterceptor(gobreaker.NewCircuitBreaker[any](circuitBreakerConfig))
+		return append(options, grpc.WithUnaryInterceptor(cb))
 	})
 
 	p := ring_client.NewPool(

--- a/pkg/experiment/ingester/client/connpool/conn_pool_ring.go
+++ b/pkg/experiment/ingester/client/connpool/conn_pool_ring.go
@@ -41,7 +41,7 @@ func NewConnPoolFactory(options func(ring.InstanceDesc) []grpc.DialOption) ring_
 }
 
 func (f *ConnFactory) FromInstance(inst ring.InstanceDesc) (ring_client.PoolClient, error) {
-	conn, err := grpc.Dial(inst.Addr, f.options(inst)...)
+	conn, err := grpc.NewClient(inst.Addr, f.options(inst)...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/experiment/ingester/service.go
+++ b/pkg/experiment/ingester/service.go
@@ -67,8 +67,8 @@ func (cfg *Config) Validate() error {
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	const prefix = "segment-writer"
-	cfg.GRPCClientConfig.RegisterFlagsWithPrefix(prefix, f)
 	cfg.LifecyclerConfig.RegisterFlagsWithPrefix(prefix+".", f, util.Logger)
+	cfg.GRPCClientConfig.RegisterFlagsWithPrefix(prefix+".grpc-client-config", f)
 	f.DurationVar(&cfg.SegmentDuration, prefix+".segment-duration", defaultSegmentDuration, "Timeout when flushing segments to bucket.")
 	f.UintVar(&cfg.FlushConcurrency, prefix+".flush-concurrency", 0, "Number of concurrent flushes. Defaults to the number of CPUs, but not less than 8.")
 	f.DurationVar(&cfg.UploadTimeout, prefix+".upload-timeout", 2*time.Second, "Timeout for upload requests, including retries.")


### PR DESCRIPTION
The change forces the conn pool to actually create connections at initialization.

Also fixes the segment-writer grpc client config: currently, default values are used.
