### PR TITLE
chore(v2): add option to specify raft fsm snapshot directory

### DIFF
--- a/pkg/experiment/metastore/raftnode/snapshot.go
+++ b/pkg/experiment/metastore/raftnode/snapshot.go
@@ -1,0 +1,109 @@
+package raftnode
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/go-kit/log/level"
+)
+
+// importSnapshots moves snapshots from SnapshotsImportDir to SnapshotsDir.
+//
+// When initializing the snapshot store, Raft creates a "snapshots" subdirectory.
+// To maintain consistency, this behavior is replicated here – so "snapshots" should
+// not be included in the configured path.
+//
+// Note: the import process does not guarantee atomicity, as it may involve moving
+// files across different file systems. If an error occurs during the import,
+// both the source and destination directories may be left in an inconsistent state.
+// The function does not attempt to recover from such a state, but it will try to
+// continue copying on the next call.
+func (n *Node) importSnapshots() error {
+	if n.config.SnapshotsImportDir == "" {
+		return nil
+	}
+
+	importDir := filepath.Join(n.config.SnapshotsImportDir, "snapshots")
+	snapshotsDir := filepath.Join(n.config.SnapshotsDir, "snapshots")
+
+	level.Info(n.logger).Log("msg", "importing snapshots")
+	entries, err := fs.ReadDir(os.DirFS(importDir), ".")
+	if err != nil {
+		return fmt.Errorf("failed to read dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		dstDir := filepath.Join(snapshotsDir, entry.Name())
+		srcDir := filepath.Join(importDir, entry.Name())
+		if err = n.copySnapshot(srcDir, dstDir); err != nil {
+			return fmt.Errorf("failed to import snapshot %q: %w", entry.Name(), err)
+		}
+	}
+
+	return nil
+}
+
+func (n *Node) copySnapshot(srcDir, dstDir string) error {
+	entries, err := fs.ReadDir(os.DirFS(srcDir), ".")
+	if err != nil {
+		return fmt.Errorf("failed to read snapshot dir: %w", err)
+	}
+	var hasFiles bool
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		hasFiles = true
+		break
+	}
+	if !hasFiles {
+		return nil
+	}
+
+	level.Info(n.logger).Log("msg", "importing snapshot", "snapshot", srcDir)
+	if err = os.MkdirAll(dstDir, 0755); err != nil {
+		return fmt.Errorf("failed to create snapshot directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(srcDir, entry.Name())
+		dstPath := filepath.Join(dstDir, entry.Name())
+		if err = copyFile(srcPath, dstPath); err != nil {
+			return fmt.Errorf("failed to copy snapshot file %q: %w", entry.Name(), err)
+		}
+		if err = os.Remove(srcPath); err != nil {
+			level.Warn(n.logger).Log("msg", "failed to remove source file after copy", "file", srcPath, "err", err)
+		}
+	}
+
+	return nil
+}
+
+func copyFile(src, dst string) error {
+	sourceFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open source file: %w", err)
+	}
+	defer func() {
+		_ = sourceFile.Close()
+	}()
+	sourceInfo, err := sourceFile.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat source file: %w", err)
+	}
+	destFile, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, sourceInfo.Mode())
+	if err != nil {
+		return fmt.Errorf("failed to create destination file: %w", err)
+	}
+	if _, err = io.Copy(destFile, sourceFile); err != nil {
+		_ = destFile.Close()
+		return fmt.Errorf("failed to copy file contents: %w", err)
+	}
+	return destFile.Close()
+}

--- a/pkg/experiment/metastore/raftnode/snapshot_test.go
+++ b/pkg/experiment/metastore/raftnode/snapshot_test.go
@@ -1,0 +1,50 @@
+package raftnode
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/pyroscope/pkg/test"
+)
+
+func TestCopySnapshots(t *testing.T) {
+	tmp := t.TempDir()
+	snapshotsImportDir := filepath.Join(tmp, "src")
+	snapshotsDir := filepath.Join(tmp, "dst")
+	test.Copy(t, "testdata/snapshots", snapshotsImportDir+"/snapshots")
+
+	buf := bytes.NewBuffer(nil)
+	n := &Node{
+		logger: log.NewLogfmtLogger(buf),
+		config: Config{
+			SnapshotsImportDir: snapshotsImportDir,
+			SnapshotsDir:       snapshotsDir,
+		},
+	}
+
+	require.NoError(t, n.importSnapshots())
+	require.NoError(t, n.importSnapshots())
+
+	actual := bytes.NewBuffer(nil)
+	for _, line := range []string{
+		`level=info msg="importing snapshots"`,
+		`level=info msg="importing snapshot" snapshot=/tmp/src/snapshots/81-206944-1744474737935`,
+		`level=info msg="importing snapshot" snapshot=/tmp/src/snapshots/82-215276-1744546508773`,
+		`level=info msg="importing snapshot" snapshot=/tmp/src/snapshots/83-223473-1744577537873`,
+		`level=info msg="importing snapshots"`,
+	} {
+		_, _ = fmt.Fprintln(actual, line)
+	}
+
+	assert.Equal(t,
+		strings.ReplaceAll(buf.String(), n.config.SnapshotsImportDir, "/tmp/src"),
+		actual.String(),
+	)
+}

--- a/pkg/experiment/metastore/raftnode/testdata/snapshots/81-206944-1744474737935/meta.json
+++ b/pkg/experiment/metastore/raftnode/testdata/snapshots/81-206944-1744474737935/meta.json
@@ -1,0 +1,1 @@
+{"Version":1,"ID":"81-206944-1744474737935","Index":206944,"Term":81,"Peers":"ka5sb2NhbGhvc3Q6OTA5OQ==","Configuration":{"Servers":[{"Suffrage":0,"ID":"localhost:9099","Address":"localhost:9099"}]},"ConfigurationIndex":1,"Size":14125,"CRC":"gwhKlGf252o="}

--- a/pkg/experiment/metastore/raftnode/testdata/snapshots/81-206944-1744474737935/state.bin
+++ b/pkg/experiment/metastore/raftnode/testdata/snapshots/81-206944-1744474737935/state.bin
@@ -1,0 +1,1 @@
+{"Version":1,"ID":"81-206944-1744474737935","Index":206944,"Term":81,"Peers":"ka5sb2NhbGhvc3Q6OTA5OQ==","Configuration":{"Servers":[{"Suffrage":0,"ID":"localhost:9099","Address":"localhost:9099"}]},"ConfigurationIndex":1,"Size":14125,"CRC":"gwhKlGf252o="}

--- a/pkg/experiment/metastore/raftnode/testdata/snapshots/82-215276-1744546508773/meta.json
+++ b/pkg/experiment/metastore/raftnode/testdata/snapshots/82-215276-1744546508773/meta.json
@@ -1,0 +1,1 @@
+{"Version":1,"ID":"82-215276-1744546508773","Index":215276,"Term":82,"Peers":"ka5sb2NhbGhvc3Q6OTA5OQ==","Configuration":{"Servers":[{"Suffrage":0,"ID":"localhost:9099","Address":"localhost:9099"}]},"ConfigurationIndex":1,"Size":11912,"CRC":"3c6ZlpXOmFI="}

--- a/pkg/experiment/metastore/raftnode/testdata/snapshots/82-215276-1744546508773/state.bin
+++ b/pkg/experiment/metastore/raftnode/testdata/snapshots/82-215276-1744546508773/state.bin
@@ -1,0 +1,1 @@
+{"Version":1,"ID":"82-215276-1744546508773","Index":215276,"Term":82,"Peers":"ka5sb2NhbGhvc3Q6OTA5OQ==","Configuration":{"Servers":[{"Suffrage":0,"ID":"localhost:9099","Address":"localhost:9099"}]},"ConfigurationIndex":1,"Size":11912,"CRC":"3c6ZlpXOmFI="}

--- a/pkg/experiment/metastore/raftnode/testdata/snapshots/83-223473-1744577537873/meta.json
+++ b/pkg/experiment/metastore/raftnode/testdata/snapshots/83-223473-1744577537873/meta.json
@@ -1,0 +1,1 @@
+{"Version":1,"ID":"83-223473-1744577537873","Index":223473,"Term":83,"Peers":"ka5sb2NhbGhvc3Q6OTA5OQ==","Configuration":{"Servers":[{"Suffrage":0,"ID":"localhost:9099","Address":"localhost:9099"}]},"ConfigurationIndex":1,"Size":14353,"CRC":"8Eyja9ULd/I="}

--- a/pkg/experiment/metastore/raftnode/testdata/snapshots/83-223473-1744577537873/state.bin
+++ b/pkg/experiment/metastore/raftnode/testdata/snapshots/83-223473-1744577537873/state.bin
@@ -1,0 +1,1 @@
+{"Version":1,"ID":"83-223473-1744577537873","Index":223473,"Term":83,"Peers":"ka5sb2NhbGhvc3Q6OTA5OQ==","Configuration":{"Servers":[{"Suffrage":0,"ID":"localhost:9099","Address":"localhost:9099"}]},"ConfigurationIndex":1,"Size":14353,"CRC":"8Eyja9ULd/I="}


### PR DESCRIPTION
Previously, raft configuration accepted a single directory parameter for all raft-related files. In practice, it's often desirable to separate the WAL and snapshot storage. To facilitate this, two new configuration parameters have been introduced:
 * `snapshots-dir`: specifies the directory where Raft snapshots are stored. Overrides the default location.
 * `snapshots-import-dir`: an optional parameter that simplifies migration of existing snapshots.
