### PR TITLE
chore(helm): extra volume claim templates

### DIFF
--- a/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
@@ -183,6 +183,9 @@ spec:
       selector:
         {{- toYaml $persistence.selector | nindent 8 }}
       {{- end }}
+  {{- with $persistence.extraVolumeClaimTemplates }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
   {{- end }}
 ---
 {{- $pdb := $values.podDisruptionBudget }}


### PR DESCRIPTION
An option to include extra volume claim templates. Might be very helpful, e.g., to place different data (e.g. split by tenant) on different volumes.

The new `extraVolumeClaimTemplates` option is part of the `persistence.` member, in spite of other `extra*`. This is done so to avoid ambiguity.
