### PR TITLE
fix(v2): query frontends compatibility

### DIFF
--- a/pkg/phlare/modules.go
+++ b/pkg/phlare/modules.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/dskit/kv/codec"
 	"github.com/grafana/dskit/kv/memberlist"
 	"github.com/grafana/dskit/middleware"
-	"github.com/grafana/dskit/netutil"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/runtimeconfig"
 	"github.com/grafana/dskit/server"
@@ -35,7 +34,6 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"gopkg.in/yaml.v3"
 
-	"github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect"
 	statusv1 "github.com/grafana/pyroscope/api/gen/proto/go/status/v1"
 	"github.com/grafana/pyroscope/pkg/adhocprofiles"
 	apiversion "github.com/grafana/pyroscope/pkg/api/version"
@@ -43,10 +41,6 @@ import (
 	"github.com/grafana/pyroscope/pkg/distributor"
 	"github.com/grafana/pyroscope/pkg/embedded/grafana"
 	"github.com/grafana/pyroscope/pkg/experiment/query_backend"
-	"github.com/grafana/pyroscope/pkg/frontend"
-	readpath "github.com/grafana/pyroscope/pkg/frontend/read_path"
-	queryfrontend "github.com/grafana/pyroscope/pkg/frontend/read_path/query_frontend"
-	"github.com/grafana/pyroscope/pkg/frontend/vcs"
 	"github.com/grafana/pyroscope/pkg/ingester"
 	objstoreclient "github.com/grafana/pyroscope/pkg/objstore/client"
 	"github.com/grafana/pyroscope/pkg/objstore/providers/filesystem"
@@ -57,7 +51,6 @@ import (
 	"github.com/grafana/pyroscope/pkg/scheduler"
 	"github.com/grafana/pyroscope/pkg/settings"
 	"github.com/grafana/pyroscope/pkg/storegateway"
-	"github.com/grafana/pyroscope/pkg/tenant"
 	"github.com/grafana/pyroscope/pkg/usagestats"
 	"github.com/grafana/pyroscope/pkg/util"
 	"github.com/grafana/pyroscope/pkg/util/build"
@@ -110,91 +103,6 @@ const (
 )
 
 var objectStoreTypeStats = usagestats.NewString("store_object_type")
-
-func (f *Phlare) initQueryFrontend() (services.Service, error) {
-	var err error
-	if f.Cfg.Frontend.Addr, err = f.getFrontendAddress(); err != nil {
-		return nil, fmt.Errorf("failed to get frontend address: %w", err)
-	}
-	if f.Cfg.Frontend.Port == 0 {
-		f.Cfg.Frontend.Port = f.Cfg.Server.HTTPListenPort
-	}
-	if f.Cfg.v2Experiment {
-		return f.initQueryFrontendV2()
-	}
-	frontendSvc, err := frontend.NewFrontend(f.Cfg.Frontend, f.Overrides, log.With(f.logger, "component", "frontend"), f.reg)
-	if err != nil {
-		return nil, err
-	}
-	f.frontend = frontendSvc
-	f.API.RegisterFrontendForQuerierHandler(frontendSvc)
-	f.API.RegisterQuerierServiceHandler(frontendSvc)
-	f.API.RegisterPyroscopeHandlers(frontendSvc)
-	f.API.RegisterVCSServiceHandler(frontendSvc)
-	return frontendSvc, nil
-}
-
-func (f *Phlare) initQueryFrontendV2() (services.Service, error) {
-	vcsService := vcs.New(
-		log.With(f.logger, "component", "vcs-service"),
-		f.reg,
-	)
-
-	newFrontend := queryfrontend.NewQueryFrontend(
-		log.With(f.logger, "component", "query-frontend"),
-		f.Overrides,
-		f.metastoreClient,
-		f.metastoreClient,
-		f.queryBackendClient,
-	)
-
-	// If the new read path is enabled globally by default,
-	// the old query frontend is not used. Tenant-specific overrides
-	// are ignored — all tenants use the new read path.
-	//
-	// If the old read path is still in use, we configure the router
-	// to use both the old and new query frontends.
-
-	var handler querierv1connect.QuerierServiceHandler
-	handler = newFrontend
-	if !f.isV2QueryFrontendOnly() {
-		handler = readpath.NewRouter(
-			log.With(f.logger, "component", "read-path-router"),
-			f.Overrides,
-			f.frontend,
-			newFrontend,
-		)
-	}
-
-	f.API.RegisterVCSServiceHandler(vcsService)
-	f.API.RegisterQuerierServiceHandler(handler)
-	f.API.RegisterPyroscopeHandlers(handler)
-
-	// New query frontend does not have any state.
-	// For simplicity, we return a no-op service.
-	svc := services.NewIdleService(
-		func(context.Context) error { return nil },
-		func(error) error { return nil },
-	)
-
-	return svc, nil
-}
-
-func (f *Phlare) isV2QueryFrontendOnly() bool {
-	c := f.Overrides.ReadPathOverrides(tenant.DefaultTenantID)
-	return c.EnableQueryBackend && c.EnableQueryBackendFrom.IsZero()
-}
-
-func (f *Phlare) getFrontendAddress() (addr string, err error) {
-	addr = f.Cfg.Frontend.Addr
-	if f.Cfg.Frontend.AddrOld != "" {
-		addr = f.Cfg.Frontend.AddrOld
-	}
-	if addr != "" {
-		return addr, nil
-	}
-	return netutil.GetFirstAddressOf(f.Cfg.Frontend.InfNames, f.logger, f.Cfg.Frontend.EnableIPv6)
-}
 
 func (f *Phlare) initRuntimeConfig() (services.Service, error) {
 	if len(f.Cfg.RuntimeConfig.LoadPath) == 0 {

--- a/pkg/phlare/modules_experimental.go
+++ b/pkg/phlare/modules_experimental.go
@@ -1,6 +1,7 @@
 package phlare
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"time"
@@ -8,6 +9,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/middleware"
+	"github.com/grafana/dskit/netutil"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
 	otgrpc "github.com/opentracing-contrib/go-grpc"
@@ -27,10 +29,132 @@ import (
 	"github.com/grafana/pyroscope/pkg/experiment/metrics"
 	querybackend "github.com/grafana/pyroscope/pkg/experiment/query_backend"
 	querybackendclient "github.com/grafana/pyroscope/pkg/experiment/query_backend/client"
+	"github.com/grafana/pyroscope/pkg/frontend"
+	readpath "github.com/grafana/pyroscope/pkg/frontend/read_path"
+	queryfrontend "github.com/grafana/pyroscope/pkg/frontend/read_path/query_frontend"
+	"github.com/grafana/pyroscope/pkg/frontend/vcs"
 	recordingrulesclient "github.com/grafana/pyroscope/pkg/settings/recording/client"
+	"github.com/grafana/pyroscope/pkg/tenant"
 	"github.com/grafana/pyroscope/pkg/util"
 	"github.com/grafana/pyroscope/pkg/util/health"
 )
+
+func (f *Phlare) initQueryFrontend() (services.Service, error) {
+	var err error
+	if f.Cfg.Frontend.Addr, err = f.getFrontendAddress(); err != nil {
+		return nil, fmt.Errorf("failed to get frontend address: %w", err)
+	}
+	if f.Cfg.Frontend.Port == 0 {
+		f.Cfg.Frontend.Port = f.Cfg.Server.HTTPListenPort
+	}
+	if !f.Cfg.v2Experiment {
+		return f.initQueryFrontendV1()
+	}
+	// If the new read path is enabled globally by default,
+	// the old query frontend is not used. Tenant-specific overrides
+	// are ignored — all tenants use the new read path.
+	//
+	// If the old read path is still in use, we configure the router
+	// to use both the old and new query frontends.
+	c := f.Overrides.ReadPathOverrides(tenant.DefaultTenantID)
+	switch {
+	case !c.EnableQueryBackend:
+		return f.initQueryFrontendV1()
+	case c.EnableQueryBackend && c.EnableQueryBackendFrom.IsZero():
+		return f.initQueryFrontendV2()
+	case c.EnableQueryBackend && !c.EnableQueryBackendFrom.IsZero():
+		return f.initQueryFrontendV12()
+	default:
+		return nil, fmt.Errorf("invalid query backend configuration: %v", c)
+	}
+}
+
+func (f *Phlare) initQueryFrontendV1() (services.Service, error) {
+	var err error
+	f.frontend, err = frontend.NewFrontend(f.Cfg.Frontend, f.Overrides, log.With(f.logger, "component", "frontend"), f.reg)
+	if err != nil {
+		return nil, err
+	}
+	f.API.RegisterFrontendForQuerierHandler(f.frontend)
+	f.API.RegisterQuerierServiceHandler(f.frontend)
+	f.API.RegisterPyroscopeHandlers(f.frontend)
+	f.API.RegisterVCSServiceHandler(f.frontend)
+	return f.frontend, nil
+}
+
+func (f *Phlare) initQueryFrontendV2() (services.Service, error) {
+	queryFrontend := queryfrontend.NewQueryFrontend(
+		log.With(f.logger, "component", "query-frontend"),
+		f.Overrides,
+		f.metastoreClient,
+		f.metastoreClient,
+		f.queryBackendClient,
+	)
+
+	vcsService := vcs.New(
+		log.With(f.logger, "component", "vcs-service"),
+		f.reg,
+	)
+
+	f.API.RegisterQuerierServiceHandler(queryFrontend)
+	f.API.RegisterPyroscopeHandlers(queryFrontend)
+	f.API.RegisterVCSServiceHandler(vcsService)
+
+	// New query frontend does not have any state.
+	// For simplicity, we return a no-op service.
+	svc := services.NewIdleService(
+		func(context.Context) error { return nil },
+		func(error) error { return nil },
+	)
+
+	return svc, nil
+}
+
+func (f *Phlare) initQueryFrontendV12() (services.Service, error) {
+	var err error
+	f.frontend, err = frontend.NewFrontend(f.Cfg.Frontend, f.Overrides, log.With(f.logger, "component", "frontend"), f.reg)
+	if err != nil {
+		return nil, err
+	}
+
+	newFrontend := queryfrontend.NewQueryFrontend(
+		log.With(f.logger, "component", "query-frontend"),
+		f.Overrides,
+		f.metastoreClient,
+		f.metastoreClient,
+		f.queryBackendClient,
+	)
+
+	handler := readpath.NewRouter(
+		log.With(f.logger, "component", "read-path-router"),
+		f.Overrides,
+		f.frontend,
+		newFrontend,
+	)
+
+	vcsService := vcs.New(
+		log.With(f.logger, "component", "vcs-service"),
+		f.reg,
+	)
+
+	f.API.RegisterFrontendForQuerierHandler(f.frontend)
+	f.API.RegisterQuerierServiceHandler(handler)
+	f.API.RegisterPyroscopeHandlers(handler)
+	f.API.RegisterVCSServiceHandler(vcsService)
+
+	return f.frontend, nil
+}
+
+func (f *Phlare) getFrontendAddress() (addr string, err error) {
+	addr = f.Cfg.Frontend.Addr
+	if f.Cfg.Frontend.AddrOld != "" {
+		addr = f.Cfg.Frontend.AddrOld
+	}
+	if addr != "" {
+		return addr, nil
+	}
+	return netutil.GetFirstAddressOf(f.Cfg.Frontend.InfNames, f.logger, f.Cfg.Frontend.EnableIPv6)
+}
 
 func (f *Phlare) initSegmentWriterRing() (_ services.Service, err error) {
 	if err = f.Cfg.SegmentWriter.Validate(); err != nil {


### PR DESCRIPTION
The change refactors query-frontend initialization: #4120 and #4135 made it error prone.

Additionally, the change makes it possible to skip the new query-frontend initialization even if experimental modules are enabled, which simplifies migration.