### PR TITLE
feat(lidia): add binary layout support

### DIFF
--- a/lidia/binary_layout.go
+++ b/lidia/binary_layout.go
@@ -1,0 +1,19 @@
+package lidia
+
+// BinaryLayoutInfo represents the layout information of the binary
+type BinaryLayoutInfo struct {
+	Type           uint16
+	ProgramHeaders []ProgramHeaderInfo
+}
+
+// ProgramHeaderInfo represents a program header from the ELF file
+type ProgramHeaderInfo struct {
+	Type        uint32
+	Flags       uint32
+	Offset      uint64
+	VirtualAddr uint64
+	PhysAddr    uint64
+	FileSize    uint64
+	MemSize     uint64
+	Align       uint64
+}

--- a/lidia/constants.go
+++ b/lidia/constants.go
@@ -11,7 +11,7 @@ const (
 	version uint32 = 1
 
 	// Size of the file header in bytes
-	headerSize = 0x80
+	headerSize = 0x98
 
 	// Number of fields in a line table entry
 	lineTableFieldsCount = 2

--- a/lidia/format.go
+++ b/lidia/format.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"hash/crc32"
 	"io"
-	"os"
 )
 
 type stringOffset uint64
@@ -55,6 +54,13 @@ type lineTablesHeader struct {
 	_         uint32
 }
 
+type binaryLayoutHeader struct {
+	size   uint64
+	offset uint64
+	crc    uint32
+	_      uint32
+}
+
 type header struct {
 	// 0x0
 	magic   [4]byte
@@ -68,6 +74,8 @@ type header struct {
 	// 0x60
 	lineTablesHeader lineTablesHeader
 	// 0x80
+	binaryLayoutHeader binaryLayoutHeader
+	// 0x98
 }
 
 func readHeader(file io.Reader) (header, error) {
@@ -97,6 +105,10 @@ func readHeader(file io.Reader) (header, error) {
 	hdr.lineTablesHeader.count = binary.LittleEndian.Uint64(headerBuf[0x68:])
 	hdr.lineTablesHeader.offset = binary.LittleEndian.Uint64(headerBuf[0x70:])
 	hdr.lineTablesHeader.crc = binary.LittleEndian.Uint32(headerBuf[0x78:])
+
+	hdr.binaryLayoutHeader.size = binary.LittleEndian.Uint64(headerBuf[0x80:])
+	hdr.binaryLayoutHeader.offset = binary.LittleEndian.Uint64(headerBuf[0x88:])
+	hdr.binaryLayoutHeader.crc = binary.LittleEndian.Uint32(headerBuf[0x90:])
 
 	return hdr, nil
 }
@@ -131,7 +143,7 @@ func readFields8(entryBuf []byte) rangeEntry {
 	}
 }
 
-func (rc *rangeCollector) write(f *os.File) error {
+func (rc *rangeCollector) write(f io.WriteSeeker) error {
 	buf := bufio.NewWriter(f)
 	hdr := &header{
 		version: version,
@@ -167,6 +179,26 @@ func (rc *rangeCollector) write(f *os.File) error {
 		return err
 	}
 
+	if err := buf.Flush(); err != nil {
+		return err
+	}
+
+	entrySize := 4 // Default for 2-byte fields (2 fields × 2 bytes)
+	if hdr.lineTablesHeader.fieldSize == 4 {
+		entrySize = 8 // For 4-byte fields (2 fields × 4 bytes)
+	}
+	hdr.binaryLayoutHeader.offset = hdr.lineTablesHeader.offset + uint64(len(rc.lb.entries)*entrySize)
+	hdr.binaryLayoutHeader.size = uint64(len(rc.blb.buf))
+
+	if len(rc.blb.buf) > 0 {
+		if _, err := f.Write(rc.blb.buf); err != nil {
+			return err
+		}
+		crc := crc32.New(castagnoli)
+		_, _ = crc.Write(rc.blb.buf)
+		hdr.binaryLayoutHeader.crc = crc.Sum32()
+	}
+
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
 		return err
 	}
@@ -200,6 +232,10 @@ func writeHeader(output io.Writer, hdr *header) error {
 	binary.LittleEndian.PutUint64(headerBuf[0x68:], hdr.lineTablesHeader.count)
 	binary.LittleEndian.PutUint64(headerBuf[0x70:], hdr.lineTablesHeader.offset)
 	binary.LittleEndian.PutUint32(headerBuf[0x78:], hdr.lineTablesHeader.crc)
+
+	binary.LittleEndian.PutUint64(headerBuf[0x80:], hdr.binaryLayoutHeader.size)
+	binary.LittleEndian.PutUint64(headerBuf[0x88:], hdr.binaryLayoutHeader.offset)
+	binary.LittleEndian.PutUint32(headerBuf[0x90:], hdr.binaryLayoutHeader.crc)
 
 	if _, err := output.Write(headerBuf); err != nil {
 		return err

--- a/lidia/lidia_test.go
+++ b/lidia/lidia_test.go
@@ -8,13 +8,13 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/grafana/pyroscope/lidia"
-
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/pyroscope/lidia"
 )
 
 const compressedTestBinaryFile = "testdata/test-binary.zip"
-const decompressedDir = "decompressed" // Will be created in the temp dir
+const decompressedDir = "decompressed"
 
 // TestCreateLidia tests the CreateLidia function with the test binary
 func TestCreateLidia(t *testing.T) {


### PR DESCRIPTION
This PR adds binary layout support to Lidia format needed for symbolization.

Refer to the [POC](https://github.com/grafana/pyroscope/pull/3799) to better understand why is needed.