### PR TITLE
perf(v2): optimize compaction planning

### DIFF
--- a/pkg/experiment/metastore/compaction/compactor/compaction_queue.go
+++ b/pkg/experiment/metastore/compaction/compactor/compaction_queue.go
@@ -385,10 +385,6 @@ type blockIter struct {
 }
 
 func newBlockIter() *blockIter {
-	// Assuming that block IDs (16b ULID) are globally unique.
-	// We could achieve the same with more efficiency by marking visited
-	// batches. However, marking visited blocks seems to be more robust,
-	// and the size of the map is expected to be small.
 	visited := make(map[string]struct{}, 64)
 	visited[zeroBlockEntry.id] = struct{}{}
 	return &blockIter{visited: visited}

--- a/pkg/experiment/metastore/compaction/compactor/compactor.go
+++ b/pkg/experiment/metastore/compaction/compactor/compactor.go
@@ -75,12 +75,7 @@ func (c *Compactor) NewPlan(cmd *raft.Log) compaction.Plan {
 	now := cmd.AppendedAt.UnixNano()
 	before := cmd.AppendedAt.Add(-c.config.CleanupDelay)
 	tombstones := c.tombstones.ListTombstones(before)
-	return &plan{
-		compactor:  c,
-		tombstones: tombstones,
-		blocks:     newBlockIter(),
-		now:        now,
-	}
+	return newPlan(c, tombstones, now)
 }
 
 func (c *Compactor) UpdatePlan(tx *bbolt.Tx, plan *raft_log.CompactionPlanUpdate) error {


### PR DESCRIPTION
It's been observed that the compaction process might be very wasteful in terms of CPU resources. The reason is that the compaction planner inspects the block queues, cancelling the planned compaction job if the conditions are not met. The problem is that we do not skip the queues that we could have already checked.

<img width="1250" alt="image" src="https://github.com/user-attachments/assets/d075ea04-201d-46a6-bbe2-d08d9bb5a807" />