### PR TITLE
chore: Github actions weekly, remove `actions: write` for git tag

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  actions: write
   id-token: write
 
 jobs:


### PR DESCRIPTION
Tested it here works without: https://github.com/grafana/pyroscope/actions/runs/14735759777/job/41361308736

cc @aleks-p 