### PR TITLE
fix(v2): add missing tenant filter for metadata label queries

### DIFF
--- a/pkg/experiment/metastore/index/query.go
+++ b/pkg/experiment/metastore/index/query.go
@@ -252,6 +252,9 @@ func (q *metadataLabelQuerier) collectLabels(s *store.Shard) error {
 		md := q.shards.index.blocks.getOrCreate(s, blocks.At())
 		if q.query.overlapsUnixMilli(md.MinTime, md.MaxTime) {
 			for _, ds := range md.Datasets {
+				if _, ok := q.query.tenantMap[s.Lookup(ds.Tenant)]; !ok {
+					continue
+				}
 				if q.query.overlapsUnixMilli(ds.MinTime, ds.MaxTime) {
 					matcher.Matches(ds.Labels)
 				}

--- a/pkg/experiment/metastore/index/query_test.go
+++ b/pkg/experiment/metastore/index/query_test.go
@@ -240,6 +240,21 @@ func TestIndex_Query(t *testing.T) {
 				{Name: model.LabelNameServiceName, Value: "dataset-a"},
 			}}}, labels)
 		})
+
+		t.Run("LabelsTenantFilter", func(t *testing.T) {
+			labels, err := index.QueryMetadataLabels(tx, MetadataQuery{
+				Expr:      "{}",
+				StartTime: time.UnixMilli(minT),
+				EndTime:   time.UnixMilli(maxT),
+				Tenant:    []string{"tenant-b"},
+				Labels: []string{
+					model.LabelNameProfileType,
+					model.LabelNameServiceName,
+				},
+			})
+			require.NoError(t, err)
+			require.Empty(t, labels)
+		})
 	}
 
 	idx := NewIndex(util.Logger, NewStore(), DefaultConfig)


### PR DESCRIPTION
Fixes a rare case in v2 where datasets in L0 blocks are not correctly filtered by tenant.

This code path is only used in the `Series` endpoint, and only when requesting these 2 sets of labels AND no query selector is provided:

Set 1:
- `__profile_type__` 
- `service_name`

Set 2:
- `__name__` 
- `__profile_type__` 
- `__type__` 
- `pyroscope_app`
- `service_name`
