### PR TITLE
Revert "feat: add __unsymbolized__ label on ingest path (#4147)"

### DIFF
--- a/pkg/experiment/block/metadata/metadata_labels.go
+++ b/pkg/experiment/block/metadata/metadata_labels.go
@@ -18,7 +18,6 @@ import (
 const (
 	LabelNameTenantDataset     = "__tenant_dataset__"
 	LabelValueDatasetTSDBIndex = "dataset_tsdb_index"
-	LabelNameUnsymbolized      = "__unsymbolized__"
 )
 
 type LabelBuilder struct {

--- a/pkg/experiment/ingester/memdb/head.go
+++ b/pkg/experiment/ingester/memdb/head.go
@@ -21,11 +21,10 @@ import (
 )
 
 type FlushedHead struct {
-	Index                   []byte
-	Profiles                []byte
-	Symbols                 []byte
-	HasUnsymbolizedProfiles bool
-	Meta                    struct {
+	Index    []byte
+	Profiles []byte
+	Symbols  []byte
+	Meta     struct {
 		ProfileTypeNames []string
 		MinTimeNanos     int64
 		MaxTimeNanos     int64
@@ -154,8 +153,6 @@ func (h *Head) flush(ctx context.Context) (*FlushedHead, error) {
 		return res, nil
 	}
 
-	res.HasUnsymbolizedProfiles = HasUnsymbolizedProfiles(h.symbols.Symbols())
-
 	symbolsBuffer := bytes.NewBuffer(nil)
 	if err := symdb.WritePartition(h.symbols, symbolsBuffer); err != nil {
 		return nil, err
@@ -175,16 +172,4 @@ func (h *Head) flush(ctx context.Context) (*FlushedHead, error) {
 		return nil, fmt.Errorf("failed to write profiles parquet: %w", err)
 	}
 	return res, nil
-}
-
-// TODO: move into the symbolizer package when available
-func HasUnsymbolizedProfiles(symbols *symdb.Symbols) bool {
-	locations := symbols.Locations
-	mappings := symbols.Mappings
-	for _, loc := range locations {
-		if !mappings[loc.MappingId].HasFunctions {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
This reverts commit b19fa15fa6312520623e9448175ef14683fb9346 from #4147 . Once deployed to dev, see a fair bit of panics, can you take another look. The diff looks weird, maybe a rebase gone wrong?


```
goroutine 83546 [running]:
github.com/grafana/pyroscope/pkg/util.PanicError({0x2954940, 0xc0ee2b0288})
        /home/runner/work/pyroscope/pyroscope/pkg/util/recovery.go:46 +0x4d
github.com/grafana/pyroscope/pkg/util.init.WithRecoveryHandler.func3.1({0x43a2e8?, 0x1?}, {0x2954940?, 0xc0ee2b0288?})
        /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/options.go:33 +0x27
github.com/grpc-ecosystem/go-grpc-middleware/recovery.recoverFrom({0x3908970?, 0xc0edfdb950?}, {0x2954940?, 0xc0ee2b0288?}, 0xc02a7ae540?)
        /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/interceptors.go:61 +0x30
github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1.1()
        /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/interceptors.go:29 +0x75
panic({0x2954940?, 0xc0ee2b0288?})
        /opt/hostedtoolcache/go/1.23.8/x64/src/runtime/panic.go:791 +0x132
github.com/grafana/pyroscope/pkg/pprof.(*lookupTable).lookup(...)
        /home/runner/work/pyroscope/pyroscope/pkg/pprof/pprof.go:797
github.com/grafana/pyroscope/pkg/pprof.(*SampleExporter).ExportSamples(0xc0edffa090, 0xc02a7ae850, {0xc0eac68fa8, 0x97, 0x1eb})
        /home/runner/work/pyroscope/pyroscope/pkg/pprof/pprof.go:858 +0x14e8
github.com/grafana/pyroscope/pkg/experiment/ingester.(*sampleAppender).VisitSampleSeries(0xc0ee0ff680, {0xc0edfa9200, 0x11, 0x20}, {0xc0eac68fa8?, 0x74?, 0x25f?})
        /home/runner/work/pyroscope/pyroscope/pkg/experiment/ingester/segment.go:539 +0x251
github.com/grafana/pyroscope/pkg/model/pprof_split.VisitSampleSeries(0xc0ee098000, {0xc0ec3f4d00, 0x10, 0x10}, {0x511cf00, 0x5, 0x3?}, {0x38fe5f0, 0xc0ee0ff680})
        /home/runner/work/pyroscope/pyroscope/pkg/model/pprof_split/pprof_split.go:81 +0x694
github.com/grafana/pyroscope/pkg/experiment/ingester.(*segment).ingest(0xc0e77dbec0, {0xc0edff0922, 0x2}, 0xc0ee098000, {0x58, 0xad, 0x91, 0xc8, 0x66, 0xf2, ...}, ...)
        /home/runner/work/pyroscope/pyroscope/pkg/experiment/ingester/segment.go:512 +0x30e
github.com/grafana/pyroscope/pkg/experiment/ingester.(*SegmentWriterService).Push.func2({0x38e5d00?, 0xc0e77dbec0?})
        /home/runner/work/pyroscope/pyroscope/pkg/experiment/ingester/service.go:213 +0x6b
github.com/grafana/pyroscope/pkg/experiment/ingester.(*shard).ingest(0xc0013dacc0, 0xc00ed20f68)
        /home/runner/work/pyroscope/pyroscope/pkg/experiment/ingester/segment.go:75 +0xcd
github.com/grafana/pyroscope/pkg/experiment/ingester.(*segmentsWriter).ingest(0xc000bcaf08, 0x8, 0xc00ed20f68)
        /home/runner/work/pyroscope/pyroscope/pkg/experiment/ingester/segment.go:148 +0x19c
github.com/grafana/pyroscope/pkg/experiment/ingester.(*SegmentWriterService).Push(0xc000bcaa08, {0x3908970, 0xc0edfdb950}, 0xc0e6b3fea0)
        /home/runner/work/pyroscope/pyroscope/pkg/experiment/ingester/service.go:212 +0x418
github.com/grafana/pyroscope/api/gen/proto/go/segmentwriter/v1._SegmentWriterService_Push_Handler.func1({0x3908970?, 0xc0edfdb950?}, {0x2a90c00?, 0xc0e6b3fea0?})
        /home/runner/work/pyroscope/pyroscope/api/gen/proto/go/segmentwriter/v1/push_vtproto.pb.go:252 +0xcb
github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1({0x3908970?, 0xc0edfdb950?}, {0x2a90c00?, 0xc0e6b3fea0?}, 0xd99a62?, 0xc00ed21138?)
        /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/interceptors.go:33 +0x9e
google.golang.org/grpc.getChainUnaryHandler.func1({0x3908970, 0xc0edfdb950}, {0x2a90c00, 0xc0e6b3fea0})
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1212 +0xb2
github.com/grafana/dskit/middleware.UnaryServerInstrumentInterceptor.func1({0x3908970, 0xc0edfdb950}, {0x2a90c00, 0xc0e6b3fea0}, 0xc0eab7fca0, 0xc0edfd7780)
        /home/runner/go/pkg/mod/github.com/grafana/dskit@v0.0.0-20231221015914-de83901bf4d6/middleware/grpc_instrumentation.go:33 +0xa4
google.golang.org/grpc.getChainUnaryHandler.func1({0x3908970, 0xc0edfdb950}, {0x2a90c00, 0xc0e6b3fea0})
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1212 +0xb2
github.com/grafana/dskit/server.newServer.HTTPGRPCTracingInterceptor.func3({0x3908970?, 0xc0edfdb950?}, {0x2a90c00?, 0xc0e6b3fea0?}, 0xc0eab7fca0?, 0xc0edfc84b0?)
        /home/runner/go/pkg/mod/github.com/grafana/dskit@v0.0.0-20231221015914-de83901bf4d6/middleware/http_tracing.go:75 +0x953
google.golang.org/grpc.getChainUnaryHandler.func1({0x3908970, 0xc0edfdb950}, {0x2a90c00, 0xc0e6b3fea0})
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1212 +0xb2
github.com/opentracing-contrib/go-grpc.OpenTracingServerInterceptor.func1({0x3908970, 0xc0edfdb800}, {0x2a90c00, 0xc0e6b3fea0}, 0xc0eab7fca0, 0xc0edfd75c0)
        /home/runner/go/pkg/mod/github.com/opentracing-contrib/go-grpc@v0.0.0-20210225150812-73cb765af46e/server.go:57 +0x3c7
google.golang.org/grpc.getChainUnaryHandler.func1({0x3908970, 0xc0edfdb800}, {0x2a90c00, 0xc0e6b3fea0})
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1212 +0xb2
github.com/grafana/dskit/middleware.GRPCServerLog.UnaryServerInterceptor({{0x38e30c0?, 0xc0009ba0e0?}, 0x80?, 0x75?}, {0x3908970, 0xc0edfdb800}, {0x2a90c00, 0xc0e6b3fea0}, 0xc0eab7fca0, 0xc0edfd7580)
        /home/runner/go/pkg/mod/github.com/grafana/dskit@v0.0.0-20231221015914-de83901bf4d6/middleware/grpc_logging.go:49 +0xaf
google.golang.org/grpc.NewServer.chainUnaryServerInterceptors.chainUnaryInterceptors.func1({0x3908970, 0xc0edfdb800}, {0x2a90c00, 0xc0e6b3fea0}, 0xc0eab7fca0, 0x80?)
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1203 +0x85
github.com/grafana/pyroscope/api/gen/proto/go/segmentwriter/v1._SegmentWriterService_Push_Handler({0x29e1be0, 0xc000bcaa08}, {0x3908970, 0xc0edfdb800}, 0xc0ec3f4c80, 0xc0009bae40)
        /home/runner/work/pyroscope/pyroscope/api/gen/proto/go/segmentwriter/v1/push_vtproto.pb.go:254 +0x143
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0005f5600, {0x3908970, 0xc091561290}, 0xc091555c80, 0xc000be20c0, 0x51054f0, 0x0)
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1400 +0x103b
google.golang.org/grpc.(*Server).handleStream(0xc0005f5600, {0x390b488, 0xc000539ba0}, 0xc091555c80)
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1810 +0xbaa
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1030 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 1458
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1041 +0x125
```

```
goroutine 84926 [running]:
github.com/grafana/pyroscope/pkg/util.PanicError({0x24e6c80, 0xc0edbfff50})
        /home/runner/work/pyroscope/pyroscope/pkg/util/recovery.go:46 +0x4d
github.com/grafana/pyroscope/pkg/util.init.WithRecoveryHandler.func3.1({0x43a2e8?, 0x0?}, {0x24e6c80?, 0xc0edbfff50?})
        /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/options.go:33 +0x27
github.com/grpc-ecosystem/go-grpc-middleware/recovery.recoverFrom({0x3908970?, 0xc0eddd92f0?}, {0x24e6c80?, 0xc0edbfff50?}, 0xc0010ee0f0?)
        /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/interceptors.go:61 +0x30
github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1.1()
        /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/interceptors.go:29 +0x75
panic({0x24e6c80?, 0xc0edbfff50?})
        /opt/hostedtoolcache/go/1.23.8/x64/src/runtime/panic.go:791 +0x132
github.com/grafana/pyroscope/pkg/phlaredb/symdb.idConversionTable.rewriteUint64(0x0?, 0xc0eaa212c0)
        /home/runner/work/pyroscope/pyroscope/pkg/phlaredb/symdb/dedup_slice.go:182 +0x99
github.com/grafana/pyroscope/pkg/phlaredb/symdb.(*PartitionWriter).convertSamples(0xc0edd9f8c0, 0xc0edf38690, {0xc0edd9ac00, 0xd, 0x18?}, {0x0, 0x0, 0xc0010ee580?})
        /home/runner/work/pyroscope/pyroscope/pkg/phlaredb/symdb/dedup_slice.go:137 +0x7cb
github.com/grafana/pyroscope/pkg/phlaredb/symdb.(*PartitionWriter).WriteProfileSymbols(0xc0edd9f8c0, 0xc0edde0480)
        /home/runner/work/pyroscope/pyroscope/pkg/phlaredb/symdb/dedup_slice.go:87 +0x545
github.com/grafana/pyroscope/pkg/experiment/ingester/memdb.(*Head).Ingest(0xc0eddeac80, 0xc0edde0480, {0x69, 0x69, 0x39, 0x8f, 0x8c, 0xf3, 0x41, 0x56, ...}, ...)
        /home/runner/work/pyroscope/pyroscope/pkg/experiment/ingester/memdb/head.go:79 +0x5bf
github.com/grafana/pyroscope/pkg/experiment/ingester.(*sampleAppender).VisitSampleSeries(0xc0eddeacd0, {0xc0edde06c0, 0x13, 0x24}, {0xc0edd9ac60?, 0xc?, 0x10?})
        /home/runner/work/pyroscope/pyroscope/pkg/experiment/ingester/segment.go:540 +0x29f
github.com/grafana/pyroscope/pkg/model/pprof_split.VisitSampleSeries(0xc0edde0480, {0xc0eddb6400, 0x12, 0x20}, {0x511cf00, 0x5, 0x3?}, {0x38fe5f0, 0xc0eddeacd0})
        /home/runner/work/pyroscope/pyroscope/pkg/model/pprof_split/pprof_split.go:81 +0x694
github.com/grafana/pyroscope/pkg/experiment/ingester.(*segment).ingest(0xc0e5a54cc0, {0xc0edddc16a, 0x2}, 0xc0edde0480, {0x69, 0x69, 0x39, 0x8f, 0x8c, 0xf3, ...}, ...)
        /home/runner/work/pyroscope/pyroscope/pkg/experiment/ingester/segment.go:512 +0x30e
github.com/grafana/pyroscope/pkg/experiment/ingester.(*SegmentWriterService).Push.func2({0x38e5d00?, 0xc0e5a54cc0?})
        /home/runner/work/pyroscope/pyroscope/pkg/experiment/ingester/service.go:213 +0x6b
github.com/grafana/pyroscope/pkg/experiment/ingester.(*shard).ingest(0xc002045ce0, 0xc01cfb0f68)
        /home/runner/work/pyroscope/pyroscope/pkg/experiment/ingester/segment.go:75 +0xcd
github.com/grafana/pyroscope/pkg/experiment/ingester.(*segmentsWriter).ingest(0xc000bcaf08, 0x3, 0xc01cfb0f68)
        /home/runner/work/pyroscope/pyroscope/pkg/experiment/ingester/segment.go:148 +0x19c
github.com/grafana/pyroscope/pkg/experiment/ingester.(*SegmentWriterService).Push(0xc000bcaa08, {0x3908970, 0xc0eddd92f0}, 0xc0edbf8fa0)
        /home/runner/work/pyroscope/pyroscope/pkg/experiment/ingester/service.go:212 +0x418
github.com/grafana/pyroscope/api/gen/proto/go/segmentwriter/v1._SegmentWriterService_Push_Handler.func1({0x3908970?, 0xc0eddd92f0?}, {0x2a90c00?, 0xc0edbf8fa0?})
        /home/runner/work/pyroscope/pyroscope/api/gen/proto/go/segmentwriter/v1/push_vtproto.pb.go:252 +0xcb
github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1({0x3908970?, 0xc0eddd92f0?}, {0x2a90c00?, 0xc0edbf8fa0?}, 0xd99a62?, 0xc01cfb1138?)
        /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/interceptors.go:33 +0x9e
google.golang.org/grpc.getChainUnaryHandler.func1({0x3908970, 0xc0eddd92f0}, {0x2a90c00, 0xc0edbf8fa0})
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1212 +0xb2
github.com/grafana/dskit/middleware.UnaryServerInstrumentInterceptor.func1({0x3908970, 0xc0eddd92f0}, {0x2a90c00, 0xc0edbf8fa0}, 0xc0edbf58e0, 0xc0eddadcc0)
        /home/runner/go/pkg/mod/github.com/grafana/dskit@v0.0.0-20231221015914-de83901bf4d6/middleware/grpc_instrumentation.go:33 +0xa4
google.golang.org/grpc.getChainUnaryHandler.func1({0x3908970, 0xc0eddd92f0}, {0x2a90c00, 0xc0edbf8fa0})
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1212 +0xb2
github.com/grafana/dskit/server.newServer.HTTPGRPCTracingInterceptor.func3({0x3908970?, 0xc0eddd92f0?}, {0x2a90c00?, 0xc0edbf8fa0?}, 0xc0edbf58e0?, 0xc0edd86e58?)
        /home/runner/go/pkg/mod/github.com/grafana/dskit@v0.0.0-20231221015914-de83901bf4d6/middleware/http_tracing.go:75 +0x953
google.golang.org/grpc.getChainUnaryHandler.func1({0x3908970, 0xc0eddd92f0}, {0x2a90c00, 0xc0edbf8fa0})
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1212 +0xb2
github.com/opentracing-contrib/go-grpc.OpenTracingServerInterceptor.func1({0x3908970, 0xc0eddd91a0}, {0x2a90c00, 0xc0edbf8fa0}, 0xc0edbf58e0, 0xc0eddadb00)
        /home/runner/go/pkg/mod/github.com/opentracing-contrib/go-grpc@v0.0.0-20210225150812-73cb765af46e/server.go:57 +0x3c7
google.golang.org/grpc.getChainUnaryHandler.func1({0x3908970, 0xc0eddd91a0}, {0x2a90c00, 0xc0edbf8fa0})
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1212 +0xb2
github.com/grafana/dskit/middleware.GRPCServerLog.UnaryServerInterceptor({{0x38e30c0?, 0xc0009ba0e0?}, 0xc0?, 0xda?}, {0x3908970, 0xc0eddd91a0}, {0x2a90c00, 0xc0edbf8fa0}, 0xc0edbf58e0, 0xc0eddadac0)
        /home/runner/go/pkg/mod/github.com/grafana/dskit@v0.0.0-20231221015914-de83901bf4d6/middleware/grpc_logging.go:49 +0xaf
google.golang.org/grpc.NewServer.chainUnaryServerInterceptors.chainUnaryInterceptors.func1({0x3908970, 0xc0eddd91a0}, {0x2a90c00, 0xc0edbf8fa0}, 0xc0edbf58e0, 0x80?)
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1203 +0x85
github.com/grafana/pyroscope/api/gen/proto/go/segmentwriter/v1._SegmentWriterService_Push_Handler({0x29e1be0, 0xc000bcaa08}, {0x3908970, 0xc0eddd91a0}, 0xc0edd9ab00, 0xc0009bae40)
        /home/runner/work/pyroscope/pyroscope/api/gen/proto/go/segmentwriter/v1/push_vtproto.pb.go:254 +0x143
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0005f5600, {0x3908970, 0xc0cfc33ef0}, 0xc0bd242a20, 0xc000be20c0, 0x51054f0, 0x0)
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1400 +0x103b
google.golang.org/grpc.(*Server).handleStream(0xc0005f5600, {0x390b488, 0xc0044336c0}, 0xc0bd242a20)
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1810 +0xbaa
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1030 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 1701
        /home/runner/go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1041 +0x125
```