### PR TITLE
chore: redirect stderr of  git commands with gh token to /dev/null fo…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
         run: echo "PYROSCOPE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Update homebrew formulas
         run: |
-          git config --global url."https://x-access-token:$(echo "${HOMEBREW_GITHUB_TOKEN}" | xargs)@github.com/pyroscope-io/homebrew-brew".insteadOf "https://github.com/pyroscope-io/homebrew-brew"
+          git config --global url."https://x-access-token:$(echo "${HOMEBREW_GITHUB_TOKEN}" | xargs)@github.com/pyroscope-io/homebrew-brew".insteadOf "https://github.com/pyroscope-io/homebrew-brew" 2> /dev/null
           git config --global user.email "dmitry+bot@pyroscope.io"
           git config --global user.name "Pyroscope Bot <dmitry+bot@pyroscope.io>"
           git clone https://github.com/pyroscope-io/homebrew-brew ../homebrew-brew

--- a/.github/workflows_disabled/update-contributors.yml
+++ b/.github/workflows_disabled/update-contributors.yml
@@ -26,7 +26,7 @@ jobs:
               git add README.md
               git commit -m 'docs: updates the list of contributors in README'
               gh auth status
-              git push --force https://x-access-token:${{ secrets.BOT_GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:main
+              git push --force https://x-access-token:${{ secrets.BOT_GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:main 2> /dev/null
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/Makefile.examples
+++ b/Makefile.examples
@@ -12,7 +12,7 @@ tools/update_examples_pr:
 	git checkout -b gh_bot_examples_update
 	git add .
 	git commit -m "chore(examples): update examples"
-	git push -f https://x-access-token:$(GITHUB_TOKEN)@github.com/$(GITHUB_REPOSITORY).git gh_bot_examples_update
+	git push -f https://x-access-token:$(GITHUB_TOKEN)@github.com/$(GITHUB_REPOSITORY).git gh_bot_examples_update 2> /dev/null
 	gh pr create --head gh_bot_examples_update --title "chore(examples): update examples" --body "make tools/update_examples" --repo $(GITHUB_REPOSITORY) || \
 	   gh pr edit gh_bot_examples_update --title "chore(examples): update examples" --body "make tools/update_examples" --repo $(GITHUB_REPOSITORY)
 


### PR DESCRIPTION
…r consistency

to be fair I think this is not needed, but I think we better be consistent, either redirect everywhere or do not redirect everywhere