### PR TITLE
feat: add __unsymbolized__ label on ingest path

### DIFF
--- a/pkg/experiment/block/metadata/metadata_labels.go
+++ b/pkg/experiment/block/metadata/metadata_labels.go
@@ -18,6 +18,7 @@ import (
 const (
 	LabelNameTenantDataset     = "__tenant_dataset__"
 	LabelValueDatasetTSDBIndex = "dataset_tsdb_index"
+	LabelNameUnsymbolized      = "__unsymbolized__"
 )
 
 type LabelBuilder struct {

--- a/pkg/experiment/ingester/memdb/head.go
+++ b/pkg/experiment/ingester/memdb/head.go
@@ -21,11 +21,11 @@ import (
 )
 
 type FlushedHead struct {
-	Index                   []byte
-	Profiles                []byte
-	Symbols                 []byte
-	HasUnsymbolizedProfiles bool
-	Meta                    struct {
+	Index        []byte
+	Profiles     []byte
+	Symbols      []byte
+	Unsymbolized bool
+	Meta         struct {
 		ProfileTypeNames []string
 		MinTimeNanos     int64
 		MaxTimeNanos     int64
@@ -154,7 +154,7 @@ func (h *Head) flush(ctx context.Context) (*FlushedHead, error) {
 		return res, nil
 	}
 
-	res.HasUnsymbolizedProfiles = HasUnsymbolizedProfiles(h.symbols.Symbols())
+	res.Unsymbolized = HasUnsymbolizedProfiles(h.symbols.Symbols())
 
 	symbolsBuffer := bytes.NewBuffer(nil)
 	if err := symdb.WritePartition(h.symbols, symbolsBuffer); err != nil {

--- a/pkg/experiment/ingester/memdb/head_test.go
+++ b/pkg/experiment/ingester/memdb/head_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/pyroscope/pkg/og/convert/pprof/bench"
 	"github.com/grafana/pyroscope/pkg/phlaredb"
 	testutil2 "github.com/grafana/pyroscope/pkg/phlaredb/block/testutil"
+	"github.com/grafana/pyroscope/pkg/phlaredb/symdb"
 	"github.com/grafana/pyroscope/pkg/pprof"
 	"github.com/grafana/pyroscope/pkg/pprof/testhelper"
 )
@@ -672,6 +673,88 @@ func Test_HeadFlush_DuplicateLabels(t *testing.T) {
 		&typesv1.LabelPair{Name: "pod", Value: "not-my-pod"},
 	)
 }
+
+// TODO: move into the symbolizer package when available
+func TestUnsymbolized(t *testing.T) {
+	testCases := []struct {
+		name               string
+		profile            *profilev1.Profile
+		expectUnsymbolized bool
+	}{
+		{
+			name: "fully symbolized profile",
+			profile: &profilev1.Profile{
+				StringTable: []string{"", "a"},
+				Function: []*profilev1.Function{
+					{Id: 4, Name: 1},
+				},
+				Mapping: []*profilev1.Mapping{
+					{Id: 239, HasFunctions: true},
+				},
+				Location: []*profilev1.Location{
+					{Id: 5, MappingId: 239, Line: []*profilev1.Line{{FunctionId: 4, Line: 1}}},
+				},
+				Sample: []*profilev1.Sample{
+					{LocationId: []uint64{5}, Value: []int64{1}},
+				},
+			},
+			expectUnsymbolized: false,
+		},
+		{
+			name: "mapping without functions",
+			profile: &profilev1.Profile{
+				StringTable: []string{"", "a"},
+				Function: []*profilev1.Function{
+					{Id: 4, Name: 1},
+				},
+				Mapping: []*profilev1.Mapping{
+					{Id: 239, HasFunctions: false},
+				},
+				Location: []*profilev1.Location{
+					{Id: 5, MappingId: 239, Line: []*profilev1.Line{{FunctionId: 4, Line: 1}}},
+				},
+				Sample: []*profilev1.Sample{
+					{LocationId: []uint64{5}, Value: []int64{1}},
+				},
+			},
+			expectUnsymbolized: true,
+		},
+		{
+			name: "multiple locations with mixed symbolization",
+			profile: &profilev1.Profile{
+				StringTable: []string{"", "a", "b"},
+				Function: []*profilev1.Function{
+					{Id: 4, Name: 1},
+					{Id: 5, Name: 2},
+				},
+				Mapping: []*profilev1.Mapping{
+					{Id: 239, HasFunctions: true},
+					{Id: 240, HasFunctions: false},
+				},
+				Location: []*profilev1.Location{
+					{Id: 5, MappingId: 239, Line: []*profilev1.Line{{FunctionId: 4, Line: 1}}},
+					{Id: 6, MappingId: 240, Line: nil},
+				},
+				Sample: []*profilev1.Sample{
+					{LocationId: []uint64{5, 6}, Value: []int64{1}},
+				},
+			},
+			expectUnsymbolized: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			symbols := symdb.NewPartitionWriter(0, &symdb.Config{
+				Version: symdb.FormatV3,
+			})
+			symbols.WriteProfileSymbols(tc.profile)
+			unsymbolized := HasUnsymbolizedProfiles(symbols.Symbols())
+			assert.Equal(t, tc.expectUnsymbolized, unsymbolized)
+		})
+	}
+}
+
 func BenchmarkHeadIngestProfiles(t *testing.B) {
 	var (
 		profilePaths = []string{

--- a/pkg/experiment/ingester/segment.go
+++ b/pkg/experiment/ingester/segment.go
@@ -116,7 +116,7 @@ func (sh *shard) flushSegment(ctx context.Context, wg *sync.WaitGroup) {
 		if s.debuginfo.movedHeads > 0 {
 			_ = level.Debug(s.logger).Log("msg",
 				"writing segment block done",
-				"heads-count", len(s.datasets),
+				"heads-count", len(s.heads),
 				"heads-moved-count", s.debuginfo.movedHeads,
 				"inflight-duration", s.debuginfo.waitInflight,
 				"flush-heads-duration", s.debuginfo.flushHeadsDuration,
@@ -203,7 +203,7 @@ func (sw *segmentsWriter) newSegment(sh *shard, sk shardKey, sl log.Logger) *seg
 	s := &segment{
 		logger:   log.With(sl, "segment-id", id.String()),
 		ulid:     id,
-		datasets: make(map[datasetKey]*dataset),
+		heads:    make(map[datasetKey]dataset),
 		sw:       sw,
 		sh:       sh,
 		shard:    sk,
@@ -216,7 +216,7 @@ func (sw *segmentsWriter) newSegment(sh *shard, sk shardKey, sl log.Logger) *seg
 func (s *segment) flush(ctx context.Context) (err error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "segment.flush", opentracing.Tags{
 		"block_id": s.ulid.String(),
-		"datasets": len(s.datasets),
+		"datasets": len(s.heads),
 		"shard":    s.shard,
 	})
 	defer span.Finish()
@@ -352,8 +352,8 @@ func concatSegmentHead(f *headFlush, w *writerOffset, s *metadata.StringTable) *
 }
 
 func (s *segment) flushHeads(ctx context.Context) flushStream {
-	heads := maps.Values(s.datasets)
-	slices.SortFunc(heads, func(a, b *dataset) int {
+	heads := maps.Values(s.heads)
+	slices.SortFunc(heads, func(a, b dataset) int {
 		return a.key.compare(b.key)
 	})
 
@@ -368,15 +368,15 @@ func (s *segment) flushHeads(ctx context.Context) flushStream {
 			defer close(f.done)
 			flushed, err := s.flushHead(ctx, f.head)
 			if err != nil {
-				level.Error(s.logger).Log("msg", "failed to flush dataset", "err", err)
+				level.Error(s.logger).Log("msg", "failed to flush head", "err", err)
 				return
 			}
 			if flushed == nil {
-				level.Debug(s.logger).Log("msg", "skipping nil dataset")
+				level.Debug(s.logger).Log("msg", "skipping nil head")
 				return
 			}
 			if flushed.Meta.NumSamples == 0 {
-				level.Debug(s.logger).Log("msg", "skipping empty dataset")
+				level.Debug(s.logger).Log("msg", "skipping empty head")
 				return
 			}
 			f.flushed = flushed
@@ -407,7 +407,7 @@ func (s *flushStream) Next() bool {
 	return false
 }
 
-func (s *segment) flushHead(ctx context.Context, e *dataset) (*memdb.FlushedHead, error) {
+func (s *segment) flushHead(ctx context.Context, e dataset) (*memdb.FlushedHead, error) {
 	th := time.Now()
 	flushed, err := e.head.Flush(ctx)
 	if err != nil {
@@ -447,7 +447,7 @@ type dataset struct {
 }
 
 type headFlush struct {
-	head    *dataset
+	head    dataset
 	flushed *memdb.FlushedHead
 	// protects head
 	done chan struct{}
@@ -459,8 +459,8 @@ type segment struct {
 	sshard           string
 	inFlightProfiles sync.WaitGroup
 
-	mu       sync.RWMutex
-	datasets map[datasetKey]*dataset
+	headsLock sync.RWMutex
+	heads     map[datasetKey]dataset
 
 	logger log.Logger
 	sw     *segmentsWriter
@@ -511,7 +511,7 @@ func (s *segment) ingest(tenantID string, p *profilev1.Profile, id uuid.UUID, la
 	rules := s.sw.limits.IngestionRelabelingRules(tenantID)
 	usage := s.sw.limits.DistributorUsageGroups(tenantID).GetUsageGroups(tenantID, labels)
 	appender := &sampleAppender{
-		dataset:     s.headForIngest(k),
+		head:        s.headForIngest(k),
 		profile:     p,
 		id:          id,
 		annotations: annotations,
@@ -525,7 +525,7 @@ func (s *segment) ingest(tenantID string, p *profilev1.Profile, id uuid.UUID, la
 
 type sampleAppender struct {
 	id          uuid.UUID
-	dataset     *dataset
+	head        *memdb.Head
 	profile     *profilev1.Profile
 	exporter    *pprofmodel.SampleExporter
 	annotations []*typesv1.ProfileAnnotation
@@ -535,7 +535,7 @@ type sampleAppender struct {
 }
 
 func (v *sampleAppender) VisitProfile(labels []*typesv1.LabelPair) {
-	v.dataset.head.Ingest(v.profile, v.id, labels, v.annotations)
+	v.head.Ingest(v.profile, v.id, labels, v.annotations)
 }
 
 func (v *sampleAppender) VisitSampleSeries(labels []*typesv1.LabelPair, samples []*profilev1.Sample) {
@@ -544,7 +544,7 @@ func (v *sampleAppender) VisitSampleSeries(labels []*typesv1.LabelPair, samples 
 	}
 	var n profilev1.Profile
 	v.exporter.ExportSamples(&n, samples)
-	v.dataset.head.Ingest(&n, v.id, labels, v.annotations)
+	v.head.Ingest(&n, v.id, labels, v.annotations)
 }
 
 func (v *sampleAppender) Discarded(profiles, bytes int) {
@@ -552,28 +552,29 @@ func (v *sampleAppender) Discarded(profiles, bytes int) {
 	v.discardedBytes += bytes
 }
 
-func (s *segment) headForIngest(k datasetKey) *dataset {
-	s.mu.RLock()
-	ds, ok := s.datasets[k]
-	s.mu.RUnlock()
+func (s *segment) headForIngest(k datasetKey) *memdb.Head {
+	s.headsLock.RLock()
+	h, ok := s.heads[k]
+	s.headsLock.RUnlock()
 	if ok {
-		return ds
+		return h.head
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if ds, ok = s.datasets[k]; ok {
-		return ds
+	s.headsLock.Lock()
+	defer s.headsLock.Unlock()
+	h, ok = s.heads[k]
+	if ok {
+		return h.head
 	}
 
-	h := memdb.NewHead(s.sw.headMetrics)
-	ds = &dataset{
+	nh := memdb.NewHead(s.sw.headMetrics)
+
+	s.heads[k] = dataset{
 		key:  k,
-		head: h,
+		head: nh,
 	}
 
-	s.datasets[k] = ds
-	return ds
+	return nh
 }
 
 func (sw *segmentsWriter) uploadBlock(ctx context.Context, blockData []byte, meta *metastorev1.BlockMeta, s *segment) error {

--- a/pkg/experiment/ingester/segment.go
+++ b/pkg/experiment/ingester/segment.go
@@ -340,7 +340,7 @@ func concatSegmentHead(f *headFlush, w *writerOffset, s *metadata.StringTable) *
 		lb.WithLabelSet(model.LabelNameServiceName, f.head.key.service, model.LabelNameProfileType, profileType)
 	}
 
-	if f.flushed.HasUnsymbolizedProfiles {
+	if f.flushed.Unsymbolized {
 		lb.WithLabelSet(model.LabelNameServiceName, f.head.key.service, metadata.LabelNameUnsymbolized, "true")
 	}
 

--- a/pkg/experiment/ingester/segment_test.go
+++ b/pkg/experiment/ingester/segment_test.go
@@ -472,11 +472,26 @@ func TestUnsymbolizedLabelIsSet(t *testing.T) {
 	}
 	p.Location = append(p.Location, loc)
 
-	sample := &profilev1.Sample{
+	keyIdx := int64(len(p.StringTable))
+	p.StringTable = append(p.StringTable, "foo")
+	valIdx := int64(len(p.StringTable))
+	p.StringTable = append(p.StringTable, "bar")
+
+	sample1 := &profilev1.Sample{
 		LocationId: []uint64{1},
 		Value:      []int64{1},
+		Label: []*profilev1.Label{
+			{Key: keyIdx, Str: valIdx},
+		},
 	}
-	p.Sample = append(p.Sample, sample)
+	p.Sample = append(p.Sample, sample1)
+
+	sample2 := &profilev1.Sample{
+		LocationId: []uint64{1},
+		Value:      []int64{2},
+		Label:      nil,
+	}
+	p.Sample = append(p.Sample, sample2)
 
 	chunk := inputChunk{
 		{shard: 1, tenant: "t1", profile: p},

--- a/pkg/experiment/ingester/segment_test.go
+++ b/pkg/experiment/ingester/segment_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/pyroscope/pkg/experiment/block/metadata"
+
 	gprofile "github.com/google/pprof/profile"
 	"github.com/grafana/dskit/flagext"
 	model2 "github.com/prometheus/common/model"
@@ -443,6 +445,46 @@ func TestDLQRecovery(t *testing.T) {
 	clients := sw.createBlocksFromMetas([]*metastorev1.BlockMeta{block})
 	inputs := groupInputs(t, chunk)
 	sw.queryInputs(clients, inputs)
+}
+
+func TestUnsymbolizedLabelIsSet(t *testing.T) {
+	sw := newTestSegmentWriter(t, defaultTestConfig())
+	defer sw.stop()
+	blocks := make(chan *metastorev1.BlockMeta, 1)
+
+	sw.client.On("AddBlock", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			blocks <- args.Get(1).(*metastorev1.AddBlockRequest).Block
+		}).Return(new(metastorev1.AddBlockResponse), nil)
+
+	p := pprofth.NewProfileBuilder(time.Now().UnixNano()).
+		CPUProfile().
+		WithLabels(model.LabelNameServiceName, "svc1")
+
+	p.Mapping = []*profilev1.Mapping{
+		{Id: 1, HasFunctions: false},
+	}
+
+	loc := &profilev1.Location{
+		Id:        1,
+		MappingId: 1,
+		Line:      nil,
+	}
+	p.Location = append(p.Location, loc)
+
+	sample := &profilev1.Sample{
+		LocationId: []uint64{1},
+		Value:      []int64{1},
+	}
+	p.Sample = append(p.Sample, sample)
+
+	chunk := inputChunk{
+		{shard: 1, tenant: "t1", profile: p},
+	}
+	_ = sw.ingestChunk(t, chunk, false)
+	block := <-blocks
+
+	require.True(t, hasUnsymbolizedLabel(t, block))
 }
 
 type sw struct {
@@ -926,4 +968,24 @@ func isSegmentPath(p string) bool {
 		fs[0] == block.DirNameSegment &&
 		fs[2] == block.DirNameAnonTenant &&
 		fs[4] == block.FileNameDataObject
+}
+
+func hasUnsymbolizedLabel(t *testing.T, block *metastorev1.BlockMeta) bool {
+	t.Helper()
+	for _, ds := range block.Datasets {
+		i := 0
+		for i < len(ds.Labels) {
+			n := int(ds.Labels[i])
+			i++
+			for j := 0; j < n; j++ {
+				keyIdx := ds.Labels[i]
+				valIdx := ds.Labels[i+1]
+				i += 2
+				if block.StringTable[keyIdx] == metadata.LabelNameUnsymbolized && block.StringTable[valIdx] == "true" {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This PR adds the __has_native_unsymbolized_profiles__ label on the ingest path.

Original [PR](https://github.com/grafana/pyroscope/pull/4147) that made us discover the panics.