### PR TITLE
chore(examples): maybe fix examples cron

### DIFF
--- a/.github/workflows/update-examples-cron.yml
+++ b/.github/workflows/update-examples-cron.yml
@@ -22,7 +22,7 @@ jobs:
           repo_secrets: |
             GITHUB_APP_ID=pyroscope-development-app:app-id
             GITHUB_APP_INSTALLATION_ID=pyroscope-development-app:app-installation-id
-            GITHUB_APP_PRIVATE_KEY=pyroscope-development-app:app-private-key
+            GITHUB_APP_PRIVATE_KEY=pyroscope-development-app:private-key
 
       - name: Generate token
         id: generate_token


### PR DESCRIPTION
https://github.com/grafana/deployment_tools/blob/9427f38d416d5a1c992cff4dd31eb64cfa80a5cf/docs/interacting-with-github-api.md?plain=1#L81

it is likely called private-key instead of app-private-key