### PR TITLE
Update helm release workflow

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - "release-[0-9]+.[0-9]+"
-      - 20250506_helm-release-workflow
 
 jobs:
   call-update-helm-repo:

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -19,4 +19,4 @@ jobs:
       cr_configfile: operations/pyroscope/helm/cr.yaml
       ct_configfile: operations/pyroscope/helm/ct.yaml
     secrets:
-      vault_repo_secret_name: pyroscope-development-app
+      vault_repo_secret_name: grafana-pyroscope-releases

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - "release-[0-9]+.[0-9]+"
+      - 20250506_helm-release-workflow
 
 jobs:
   call-update-helm-repo:
@@ -18,4 +19,4 @@ jobs:
       cr_configfile: operations/pyroscope/helm/cr.yaml
       ct_configfile: operations/pyroscope/helm/ct.yaml
     secrets:
-      vault_repo_secret_name: grafana-pyroscope-bot
+      vault_repo_secret_name: pyroscope-development-app


### PR DESCRIPTION
We were using a GitHub app without permission for that action, this is using the https://github.com/apps/grafana-pyroscope-releases app, as we used before. The secret is now available in vault.

cc @korniltsev 