### PR TITLE
pyroscope(v2): query-backend tenant isolation check

### DIFF
--- a/pkg/experiment/query_backend/block_reader.go
+++ b/pkg/experiment/query_backend/block_reader.go
@@ -88,7 +88,7 @@ func (b *BlockReader) Invoke(
 	for _, md := range req.QueryPlan.Root.Blocks {
 		md.Datasets, err = filterNotOwnedDatasets(md, tenantMap)
 		if err != nil {
-			b.metrics.tenantIsolationViolationAttempt.Inc()
+			b.metrics.datasetTenantIsolationFailure.Inc()
 			traceId, _ := tracing.ExtractTraceID(ctx)
 			level.Error(b.log).Log("msg", "trying to query datasets of other tenants", "valid-tenant", strings.Join(req.Tenant, ","), "block", md.Id, "err", err, "traceId", traceId)
 		}

--- a/pkg/experiment/query_backend/block_reader_test.go
+++ b/pkg/experiment/query_backend/block_reader_test.go
@@ -269,5 +269,5 @@ func (s *testSuite) Test_QueryTree_All_Tenant_Isolation() {
 		Tenant: []string{queryTenant},
 	})
 
-	s.Require().Error(err)
+	s.Require().ErrorContains(err, "querying other tenants' dataset")
 }

--- a/pkg/experiment/query_backend/metrics.go
+++ b/pkg/experiment/query_backend/metrics.go
@@ -3,20 +3,20 @@ package query_backend
 import "github.com/prometheus/client_golang/prometheus"
 
 type metrics struct {
-	mismatchingTenantDataset *prometheus.CounterVec
+	tenantIsolationViolationAttempt prometheus.Counter
 }
 
 func newMetrics(reg prometheus.Registerer) *metrics {
 	m := &metrics{
-		mismatchingTenantDataset: prometheus.NewCounterVec(
+		tenantIsolationViolationAttempt: prometheus.NewCounter(
 			prometheus.CounterOpts{
 				Namespace: "pyroscope",
 				Subsystem: "query_backend",
-				Name:      "invalid_tenant_query_total",
-			}, []string{"tenant"}),
+				Name:      "tenant_isolation_violation_query_attempt_total",
+			}),
 	}
 	if reg != nil {
-		reg.MustRegister(m.mismatchingTenantDataset)
+		reg.MustRegister(m.tenantIsolationViolationAttempt)
 	}
 	return m
 }

--- a/pkg/experiment/query_backend/metrics.go
+++ b/pkg/experiment/query_backend/metrics.go
@@ -3,20 +3,20 @@ package query_backend
 import "github.com/prometheus/client_golang/prometheus"
 
 type metrics struct {
-	tenantIsolationViolationAttempt prometheus.Counter
+	datasetTenantIsolationFailure prometheus.Counter
 }
 
 func newMetrics(reg prometheus.Registerer) *metrics {
 	m := &metrics{
-		tenantIsolationViolationAttempt: prometheus.NewCounter(
+		datasetTenantIsolationFailure: prometheus.NewCounter(
 			prometheus.CounterOpts{
 				Namespace: "pyroscope",
 				Subsystem: "query_backend",
-				Name:      "tenant_isolation_violation_query_attempt_total",
+				Name:      "dataset_tenant_isolation_failure_total",
 			}),
 	}
 	if reg != nil {
-		reg.MustRegister(m.tenantIsolationViolationAttempt)
+		reg.MustRegister(m.datasetTenantIsolationFailure)
 	}
 	return m
 }

--- a/pkg/experiment/query_backend/metrics.go
+++ b/pkg/experiment/query_backend/metrics.go
@@ -1,0 +1,22 @@
+package query_backend
+
+import "github.com/prometheus/client_golang/prometheus"
+
+type metrics struct {
+	mismatchingTenantDataset *prometheus.CounterVec
+}
+
+func newMetrics(reg prometheus.Registerer) *metrics {
+	m := &metrics{
+		mismatchingTenantDataset: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "pyroscope",
+				Subsystem: "query_backend",
+				Name:      "invalid_tenant_query_total",
+			}, []string{"tenant"}),
+	}
+	if reg != nil {
+		reg.MustRegister(m.mismatchingTenantDataset)
+	}
+	return m
+}

--- a/pkg/phlare/modules_experimental.go
+++ b/pkg/phlare/modules_experimental.go
@@ -329,7 +329,7 @@ func (f *Phlare) initQueryBackend() (services.Service, error) {
 		logger,
 		f.reg,
 		f.queryBackendClient,
-		querybackend.NewBlockReader(f.logger, f.storageBucket),
+		querybackend.NewBlockReader(f.logger, f.storageBucket, f.reg),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -593,10 +593,6 @@ func (f *Phlare) Run() error {
 					"service_git_ref":    serviceGitRef(),
 					"service_repository": "https://github.com/grafana/pyroscope",
 				},
-<<<<<<< Updated upstream
-=======
-				TenantID: "pyroscope-tenant",
->>>>>>> Stashed changes
 				ProfileTypes: []pyroscope.ProfileType{
 					pyroscope.ProfileCPU,
 					pyroscope.ProfileAllocObjects,

--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -593,6 +593,10 @@ func (f *Phlare) Run() error {
 					"service_git_ref":    serviceGitRef(),
 					"service_repository": "https://github.com/grafana/pyroscope",
 				},
+<<<<<<< Updated upstream
+=======
+				TenantID: "pyroscope-tenant",
+>>>>>>> Stashed changes
 				ProfileTypes: []pyroscope.ProfileType{
 					pyroscope.ProfileCPU,
 					pyroscope.ProfileAllocObjects,


### PR DESCRIPTION
Validating the read block request so we ensure no foreign dataset is read