### PR TITLE
[profile-cli.md] Update link to recent profilecli release

### DIFF
--- a/docs/sources/view-and-analyze-profile-data/profile-cli.md
+++ b/docs/sources/view-and-analyze-profile-data/profile-cli.md
@@ -41,7 +41,7 @@ For example, for Linux with the AMD64 architecture:
 1. Download and extract the package (archive).
 
     ```bash
-    curl -fL https://github.com/grafana/pyroscope/releases/download/v1.1.5/profilecli_1.1.5_linux_amd64.tar.gz | tar xvz
+    curl -fL https://github.com/grafana/pyroscope/releases/download/v1.13.2/profilecli_1.13.2_linux_amd64.tar.gz | tar xvz
     ```
 
 1. Make `profilecli` executable:


### PR DESCRIPTION
The documentation for Linux propose to download version **1.1.5** of profilecli.
But version 1.1.5 does not support the `profile` subcommand. So I propose to update the link to a more recent version.