### PR TITLE
chore: update Java OTEL agent version in tracing example

### DIFF
--- a/examples/tracing/java/Dockerfile
+++ b/examples/tracing/java/Dockerfile
@@ -41,7 +41,7 @@ COPY --from=builder /opt/app/build/libs/rideshare-1.0-SNAPSHOT.jar /opt/app/buil
 
 WORKDIR /opt/app
 
-ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.17.0/opentelemetry-javaagent.jar opentelemetry-javaagent.jar
+ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.15.0/opentelemetry-javaagent.jar opentelemetry-javaagent.jar
 ADD https://github.com/grafana/pyroscope-java/releases/download/v2.1.2/pyroscope.jar pyroscope.jar
 ADD https://github.com/grafana/otel-profiling-java/releases/download/v1.0.4/pyroscope-otel.jar pyroscope-otel.jar
 

--- a/examples/tracing/java/docker-compose.yml
+++ b/examples/tracing/java/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       OTLP_INSECURE: 1
       OTEL_TRACES_EXPORTER: otlp
       OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4317
+      OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_SERVICE_NAME: rideshare.java.push.app
       OTEL_METRICS_EXPORTER: none
       OTEL_TRACES_SAMPLER: always_on

--- a/examples/tracing/java/docker-compose.yml
+++ b/examples/tracing/java/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   pyroscope:
-    image: grafana/pyroscope:1.13.3
+    image: grafana/pyroscope:1.13.4
     ports:
     - "4040:4040"
 

--- a/examples/tracing/java/docker-compose.yml
+++ b/examples/tracing/java/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   pyroscope:
-    image: korniltsev/pyroscope:update-java-examples-0d5533778 # remove after next release
+    image: grafana/pyroscope:1.13.3
     ports:
     - "4040:4040"
 


### PR DESCRIPTION
Update the OTEL Java agent to the latest version. This is a major version upgrade, but it only required a small change to keep tracing happy.