### PR TITLE
fix(v2): make the metastore index search more broad

### DIFF
--- a/cmd/profilecli/canary_exporter.go
+++ b/cmd/profilecli/canary_exporter.go
@@ -166,7 +166,7 @@ func newCanaryExporter(params *canaryExporterParams) *canaryExporter {
 		ce.queryProbes = append(ce.queryProbes, &queryProbe{"query-series", ce.testSeries})
 		ce.queryProbes = append(ce.queryProbes, &queryProbe{"query-label-names", ce.testLabelNames})
 		ce.queryProbes = append(ce.queryProbes, &queryProbe{"query-label-values", ce.testLabelValues})
-		ce.queryProbes = append(ce.queryProbes, &queryProbe{"query-select-select-series", ce.testSelectSeries})
+		ce.queryProbes = append(ce.queryProbes, &queryProbe{"query-select-series", ce.testSelectSeries})
 		ce.queryProbes = append(ce.queryProbes, &queryProbe{"query-select-merge-stacktraces", ce.testSelectMergeStacktraces})
 		ce.queryProbes = append(ce.queryProbes, &queryProbe{"query-select-merge-span-profile", ce.testSelectMergeSpanProfile})
 		ce.queryProbes = append(ce.queryProbes, &queryProbe{"query-get-profile-stats", ce.testGetProfileStats})

--- a/pkg/experiment/metastore/index/query.go
+++ b/pkg/experiment/metastore/index/query.go
@@ -85,7 +85,15 @@ func (q *metadataQuery) buildTenantMap(tenants []string) {
 }
 
 func (q *metadataQuery) overlaps(start, end time.Time) bool {
-	return start.Before(q.endTime) && !end.Before(q.startTime)
+	if q.startTime.After(end) {
+		return false
+	}
+
+	if q.endTime.Before(start) {
+		return false
+	}
+
+	return true
 }
 
 func (q *metadataQuery) overlapsUnixMilli(start, end int64) bool {

--- a/pkg/experiment/metastore/index/query_test.go
+++ b/pkg/experiment/metastore/index/query_test.go
@@ -33,8 +33,8 @@ func TestIndex_Query(t *testing.T) {
 		MaxTime:   maxT,
 		CreatedBy: 1,
 		Datasets: []*metastorev1.Dataset{
-			{Tenant: 2, Name: 3, MinTime: minT, MaxTime: minT, Labels: []int32{2, 4, 3, 5, 6}},
-			{Tenant: 7, Name: 8, MinTime: maxT, MaxTime: maxT, Labels: []int32{2, 4, 8, 5, 9}},
+			{Tenant: 2, Name: 3, MinTime: minT, MaxTime: maxT, Labels: []int32{2, 4, 3, 5, 6}},
+			{Tenant: 7, Name: 8, MinTime: minT, MaxTime: maxT, Labels: []int32{2, 4, 8, 5, 9}},
 		},
 		StringTable: []string{
 			"", "ingester",
@@ -51,7 +51,7 @@ func TestIndex_Query(t *testing.T) {
 		MaxTime:   maxT,
 		CreatedBy: 2,
 		Datasets: []*metastorev1.Dataset{
-			{Tenant: 1, Name: 3, MinTime: minT, MaxTime: minT, Labels: []int32{2, 4, 3, 5, 6}},
+			{Tenant: 1, Name: 3, MinTime: minT, MaxTime: maxT, Labels: []int32{2, 4, 3, 5, 6}},
 		},
 		StringTable: []string{
 			"", "tenant-a", "ingester", "dataset-a", "service_name", "__profile_type__", "1",
@@ -66,7 +66,7 @@ func TestIndex_Query(t *testing.T) {
 		MaxTime:   maxT,
 		CreatedBy: 2,
 		Datasets: []*metastorev1.Dataset{
-			{Tenant: 1, Name: 3, MinTime: minT, MaxTime: minT, Labels: []int32{2, 4, 3, 5, 6}},
+			{Tenant: 1, Name: 3, MinTime: minT, MaxTime: maxT, Labels: []int32{2, 4, 3, 5, 6}},
 		},
 		StringTable: []string{
 			"", "tenant-a", "ingester", "dataset-a", "service_name", "__profile_type__", "1",
@@ -114,7 +114,7 @@ func TestIndex_Query(t *testing.T) {
 					MinTime:     minT,
 					MaxTime:     maxT,
 					CreatedBy:   1,
-					Datasets:    []*metastorev1.Dataset{{Tenant: 2, Name: 3, MinTime: minT, MaxTime: minT}},
+					Datasets:    []*metastorev1.Dataset{{Tenant: 2, Name: 3, MinTime: minT, MaxTime: maxT}},
 					StringTable: []string{"", "ingester", "tenant-a", "dataset-a"},
 				},
 				{
@@ -124,7 +124,7 @@ func TestIndex_Query(t *testing.T) {
 					MinTime:     minT,
 					MaxTime:     maxT,
 					CreatedBy:   2,
-					Datasets:    []*metastorev1.Dataset{{Tenant: 1, Name: 3, MinTime: minT, MaxTime: minT}},
+					Datasets:    []*metastorev1.Dataset{{Tenant: 1, Name: 3, MinTime: minT, MaxTime: maxT}},
 					StringTable: []string{"", "tenant-a", "ingester", "dataset-a"},
 				},
 				{
@@ -134,7 +134,7 @@ func TestIndex_Query(t *testing.T) {
 					MinTime:     minT,
 					MaxTime:     maxT,
 					CreatedBy:   2,
-					Datasets:    []*metastorev1.Dataset{{Tenant: 1, Name: 3, MinTime: minT, MaxTime: minT}},
+					Datasets:    []*metastorev1.Dataset{{Tenant: 1, Name: 3, MinTime: minT, MaxTime: maxT}},
 					StringTable: []string{"", "tenant-a", "ingester", "dataset-a"},
 				},
 			}
@@ -157,7 +157,7 @@ func TestIndex_Query(t *testing.T) {
 					MinTime:     minT,
 					MaxTime:     maxT,
 					CreatedBy:   1,
-					Datasets:    []*metastorev1.Dataset{{Tenant: 2, Name: 3, MinTime: maxT, MaxTime: maxT}},
+					Datasets:    []*metastorev1.Dataset{{Tenant: 2, Name: 3, MinTime: minT, MaxTime: maxT}},
 					StringTable: []string{"", "ingester", "tenant-b", "dataset-b"},
 				},
 			}
@@ -195,7 +195,7 @@ func TestIndex_Query(t *testing.T) {
 						Tenant:  2,
 						Name:    3,
 						MinTime: minT,
-						MaxTime: minT,
+						MaxTime: maxT,
 						Labels:  []int32{1, 4, 3},
 					}},
 					StringTable: []string{"", "ingester", "tenant-a", "dataset-a", "service_name"},
@@ -211,7 +211,7 @@ func TestIndex_Query(t *testing.T) {
 						Tenant:  1,
 						Name:    3,
 						MinTime: minT,
-						MaxTime: minT,
+						MaxTime: maxT,
 						Labels:  []int32{1, 4, 3},
 					}},
 					StringTable: []string{"", "tenant-a", "ingester", "dataset-a", "service_name"},
@@ -227,7 +227,7 @@ func TestIndex_Query(t *testing.T) {
 						Tenant:  1,
 						Name:    3,
 						MinTime: minT,
-						MaxTime: minT,
+						MaxTime: maxT,
 						Labels:  []int32{1, 4, 3},
 					}},
 					StringTable: []string{"", "tenant-a", "ingester", "dataset-a", "service_name"},
@@ -248,8 +248,8 @@ func TestIndex_Query(t *testing.T) {
 		t.Run("TimeRangeFilter", func(t *testing.T) {
 			found, err := index.QueryMetadata(tx, MetadataQuery{
 				Expr:      `{service_name=~"dataset-b"}`,
-				StartTime: time.UnixMilli(minT),
-				EndTime:   time.UnixMilli(maxT - 1),
+				StartTime: time.UnixMilli(minT - 3),
+				EndTime:   time.UnixMilli(minT - 1), // dataset-b starts at minT
 				Tenant:    []string{"tenant-b"},
 			})
 			require.NoError(t, err)

--- a/pkg/experiment/metastore/index/query_test.go
+++ b/pkg/experiment/metastore/index/query_test.go
@@ -249,7 +249,7 @@ func TestIndex_Query(t *testing.T) {
 			found, err := index.QueryMetadata(tx, MetadataQuery{
 				Expr:      `{service_name=~"dataset-b"}`,
 				StartTime: time.UnixMilli(minT),
-				EndTime:   time.UnixMilli(maxT),
+				EndTime:   time.UnixMilli(maxT - 1),
 				Tenant:    []string{"tenant-b"},
 			})
 			require.NoError(t, err)
@@ -287,7 +287,11 @@ func TestIndex_Query(t *testing.T) {
 				},
 			})
 			require.NoError(t, err)
-			require.Empty(t, labels)
+			require.NotEmpty(t, labels)
+			assert.Equal(t, []*typesv1.Labels{{Labels: []*typesv1.LabelPair{
+				{Name: model.LabelNameProfileType, Value: "4"},
+				{Name: model.LabelNameServiceName, Value: "dataset-b"},
+			}}}, labels)
 		})
 	}
 

--- a/pkg/experiment/metastore/index/store/index_store.go
+++ b/pkg/experiment/metastore/index/store/index_store.go
@@ -293,7 +293,8 @@ func (s *Shard) Overlaps(start, end time.Time) bool {
 	if s.MinTime == 0 || s.MaxTime == 0 {
 		return true
 	}
-	return start.Before(time.UnixMilli(s.MaxTime)) && !end.Before(time.UnixMilli(s.MinTime))
+	// adjust by 1ms to make the check inclusive for start==s.MaxTime or end==s.MinTime
+	return start.Before(time.UnixMilli(s.MaxTime+1)) && !end.Before(time.UnixMilli(s.MinTime-1))
 }
 
 type stringIterator struct {

--- a/pkg/experiment/metastore/index/store/index_store.go
+++ b/pkg/experiment/metastore/index/store/index_store.go
@@ -293,8 +293,16 @@ func (s *Shard) Overlaps(start, end time.Time) bool {
 	if s.MinTime == 0 || s.MaxTime == 0 {
 		return true
 	}
-	// adjust by 1ms to make the check inclusive for start==s.MaxTime or end==s.MinTime
-	return start.Before(time.UnixMilli(s.MaxTime+1)) && !end.Before(time.UnixMilli(s.MinTime-1))
+
+	if start.After(time.UnixMilli(s.MaxTime)) {
+		return false
+	}
+
+	if end.Before(time.UnixMilli(s.MinTime)) {
+		return false
+	}
+
+	return true
 }
 
 type stringIterator struct {

--- a/pkg/experiment/metastore/index/store/index_store_test.go
+++ b/pkg/experiment/metastore/index/store/index_store_test.go
@@ -1,0 +1,153 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	"github.com/grafana/pyroscope/pkg/experiment/block/metadata"
+	"github.com/grafana/pyroscope/pkg/test"
+)
+
+func TestShard_Overlaps(t *testing.T) {
+	db := test.BoltDB(t)
+
+	store := NewIndexStore()
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		return store.CreateBuckets(tx)
+	}))
+
+	partitionKey := NewPartitionKey(test.Time("2024-09-11T06:00:00.000Z"), 6*time.Hour)
+	tenant := "test-tenant"
+	shardID := uint32(1)
+
+	blockMinTime := test.UnixMilli("2024-09-11T07:00:00.000Z")
+	blockMaxTime := test.UnixMilli("2024-09-11T09:00:00.000Z")
+
+	blockMeta := &metastorev1.BlockMeta{
+		FormatVersion: 1,
+		Id:            "test-block-123",
+		Tenant:        1, // Index 1 in StringTable ("test-tenant")
+		Shard:         shardID,
+		MinTime:       blockMinTime,
+		MaxTime:       blockMaxTime,
+		Datasets: []*metastorev1.Dataset{
+			{
+				Tenant:  1, // Index 1 in StringTable ("test-tenant")
+				Name:    3, // Index 3 in StringTable ("test-dataset")
+				MinTime: blockMinTime,
+				MaxTime: blockMaxTime,
+				// Labels format: [count, name_idx, value_idx, name_idx, value_idx, ...]
+				// 2 labels: service_name="service", __profile_type__="cpu"
+				Labels: []int32{2, 3, 5, 4, 6},
+			},
+		},
+		StringTable: []string{
+			"",                 // Index 0
+			"test-tenant",      // Index 1
+			"test-dataset",     // Index 2
+			"service_name",     // Index 3
+			"__profile_type__", // Index 4
+			"service",          // Index 5
+			"cpu",              // Index 6
+		},
+	}
+
+	// store a block
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		shard := &Shard{
+			Partition:   partitionKey,
+			Tenant:      tenant,
+			Shard:       shardID,
+			StringTable: metadata.NewStringTable(),
+		}
+
+		return shard.Store(tx, blockMeta)
+	}))
+
+	require.NoError(t, db.View(func(tx *bbolt.Tx) error {
+		shard, err := store.LoadShard(tx, partitionKey, tenant, shardID)
+		require.NoError(t, err)
+		require.NotNil(t, shard)
+
+		assert.Equal(t, blockMinTime, shard.MinTime)
+		assert.Equal(t, blockMaxTime, shard.MaxTime)
+
+		testCases := []struct {
+			name      string
+			startTime time.Time
+			endTime   time.Time
+			expected  bool
+		}{
+			{
+				name:      "complete overlap - query contains block range",
+				startTime: test.Time("2024-09-11T06:30:00.000Z"),
+				endTime:   test.Time("2024-09-11T10:00:00.000Z"),
+				expected:  true,
+			},
+			{
+				name:      "block contains query range",
+				startTime: test.Time("2024-09-11T07:30:00.000Z"),
+				endTime:   test.Time("2024-09-11T08:30:00.000Z"),
+				expected:  true,
+			},
+			{
+				name:      "partial overlap - start before block, end within block",
+				startTime: test.Time("2024-09-11T06:30:00.000Z"),
+				endTime:   test.Time("2024-09-11T08:00:00.000Z"),
+				expected:  true,
+			},
+			{
+				name:      "partial overlap - start within block, end after block",
+				startTime: test.Time("2024-09-11T08:00:00.000Z"),
+				endTime:   test.Time("2024-09-11T10:00:00.000Z"),
+				expected:  true,
+			},
+			{
+				name:      "edge case - query ends exactly at block start",
+				startTime: test.Time("2024-09-11T06:00:00.000Z"),
+				endTime:   test.Time("2024-09-11T07:00:00.000Z"),
+				expected:  true, // Inclusive boundary check
+			},
+			{
+				name:      "edge case - query starts exactly at block end",
+				startTime: test.Time("2024-09-11T09:00:00.000Z"),
+				endTime:   test.Time("2024-09-11T10:00:00.000Z"),
+				expected:  true, // Inclusive boundary check
+			},
+			{
+				name:      "no overlap - query before block",
+				startTime: test.Time("2024-09-11T05:00:00.000Z"),
+				endTime:   test.Time("2024-09-11T06:59:58.999Z"),
+				expected:  false,
+			},
+			{
+				name:      "no overlap - query after block",
+				startTime: test.Time("2024-09-11T09:00:00.001Z"),
+				endTime:   test.Time("2024-09-11T11:00:00.000Z"),
+				expected:  false,
+			},
+			{
+				name:      "exact match - same start and end times",
+				startTime: test.Time("2024-09-11T07:00:00.000Z"),
+				endTime:   test.Time("2024-09-11T09:00:00.000Z"),
+				expected:  true,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				result := shard.Overlaps(tc.startTime, tc.endTime)
+				assert.Equal(t, tc.expected, result,
+					"Overlaps(%v, %v) = %v, expected %v",
+					tc.startTime, tc.endTime, result, tc.expected)
+			})
+		}
+
+		return nil
+	}))
+}


### PR DESCRIPTION
Currently when the metastore is asked for blocks within a time range, the range check is exclusive (for the most part). Shards and blocks that start / end exactly at the query boundaries are skipped. The impact is more noticeable in low-ingest-throughput environments.

This PR changes this behavior so that the metastore will return all shards and blocks at the query boundaries. The data within the blocks is still expected to be filtered by each read endpoint individually.

Additionally, `QuerierService.SelectSeries` in v1 adjusts the query start by the step. I've applied the same logic in v2 for consistency.