### PR TITLE
examples: Bump deps to fix dependency incompatibility

### DIFF
--- a/examples/language-sdk-instrumentation/python/rideshare/flask/Dockerfile
+++ b/examples/language-sdk-instrumentation/python/rideshare/flask/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9
 
-RUN pip3 install flask pyroscope-io==0.8.11 pyroscope-otel==0.4.0
+RUN pip3 install flask pyroscope-io==0.8.11 pyroscope-otel==0.4.1
 RUN pip3 install opentelemetry-api opentelemetry-sdk opentelemetry-instrumentation-flask opentelemetry-exporter-otlp-proto-grpc
 
 ENV FLASK_ENV=development


### PR DESCRIPTION
Small bugfix for the tutorial [linked from the docs](https://grafana.com/docs/pyroscope/latest/get-started/ride-share-tutorial/)

Currently, running `docker compose up -d`, I get the following error:

```
   > [us-east 2/4] RUN pip3 install flask pyroscope-io==0.8.11 pyroscope-otel==0.4.0:                                                                                             
  2.342 Collecting flask                                                                                                                                                          
  2.391   Downloading flask-3.1.1-py3-none-any.whl (103 kB)                                                                                                                       
  2.414      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 103.3/103.3 kB 4.7 MB/s eta 0:00:00
  2.486 Collecting pyroscope-io==0.8.11
  2.494   Downloading pyroscope_io-0.8.11-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (2.7 MB)
  2.625      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.7/2.7 MB 21.0 MB/s eta 0:00:00
  2.711 Collecting pyroscope-otel==0.4.0
  2.719   Downloading pyroscope_otel-0.4.0-py3-none-any.whl (10 kB)
  2.998 Collecting cffi>=1.6.0
  3.005   Downloading cffi-1.17.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (445 kB)
  3.029      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 445.2/445.2 kB 20.9 MB/s eta 0:00:00
  3.085 Collecting opentelemetry-sdk<2.0.0,>=1.27.0
  3.092   Downloading opentelemetry_sdk-1.33.1-py3-none-any.whl (118 kB)
  3.101      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 119.0/119.0 kB 17.3 MB/s eta 0:00:00
  3.105 INFO: pip is looking at multiple versions of pyroscope-io to determine which version is compatible with other requirements. This could take a while.
  3.106 ERROR: Cannot install pyroscope-io==0.8.11 and pyroscope-otel==0.4.0 because these package versions have conflicting dependencies.
  3.106 
  3.106 The conflict is caused by:
  3.106     The user requested pyroscope-io==0.8.11
  3.106     pyroscope-otel 0.4.0 depends on pyroscope-io==0.8.8
  3.106 
  3.106 To fix this you could try to:
  3.106 1. loosen the range of package versions you've specified
  3.106 2. remove package versions to allow pip attempt to solve the dependency conflict
  3.106 
  3.107 ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
  3.233 
  3.233 [notice] A new release of pip is available: 23.0.1 -> 25.1.1
  3.233 [notice] To update, run: pip install --upgrade pip
  ------
  failed to solve: process "/bin/sh -c pip3 install flask pyroscope-io==0.8.11 pyroscope-otel==0.4.0" did not complete successfully: exit code: 1
```

The problem is that `pyroscope-otel` has since moved to `0.4.1`. And the dependency for `0.4.0` was too tightly constrained. See https://github.com/grafana/otel-profiling-python/commit/990662d416943e992ab70036b35b27488c98336a

The next automated update to the examples would have fixed this issue, but getting there sooner, I hope ;)