### PR TITLE
fix: [v2] Read parquet footer correctly, when bigger than estimated

### DIFF
--- a/pkg/experiment/block/section_profiles.go
+++ b/pkg/experiment/block/section_profiles.go
@@ -33,7 +33,6 @@ func openProfileTable(_ context.Context, s *Dataset) (err error) {
 			s.inMemoryBucket(buf), s.obj.path, offset, size,
 			0, // Do not prefetch the footer.
 			parquet.SkipBloomFilters(true),
-			parquet.SkipPageIndex(true),
 			parquet.FileReadMode(parquet.ReadModeSync),
 			parquet.ReadBufferSize(4<<10))
 	} else {
@@ -41,7 +40,6 @@ func openProfileTable(_ context.Context, s *Dataset) (err error) {
 			s.obj.storage, s.obj.path, offset, size,
 			estimateFooterSize(size),
 			parquet.SkipBloomFilters(true),
-			parquet.SkipPageIndex(true),
 			parquet.FileReadMode(parquet.ReadModeAsync),
 			parquet.ReadBufferSize(estimateReadBufferSize(size)))
 	}

--- a/pkg/experiment/block/section_profiles.go
+++ b/pkg/experiment/block/section_profiles.go
@@ -127,8 +127,18 @@ func footerSize(buf []byte) int64 {
 }
 
 func (f *ParquetFile) fetchFooter(ctx context.Context, buf *bufferpool.Buffer, estimatedSize int64) error {
+	if f.size < 8 {
+		return fmt.Errorf("file size is too small to contain a footer")
+	}
+
+	// Ensure the footer is at least 8 bytes.
 	if estimatedSize < 8 {
 		estimatedSize = 8
+	}
+
+	// Ensure the footer is not bigger than the file.
+	if estimatedSize > f.size {
+		estimatedSize = f.size
 	}
 
 	// Fetch the footer of estimated size at the estimated offset.

--- a/pkg/experiment/block/section_profiles.go
+++ b/pkg/experiment/block/section_profiles.go
@@ -135,7 +135,11 @@ func (f *ParquetFile) fetchFooter(ctx context.Context, buf *bufferpool.Buffer, e
 		// The footer has been fetched.
 		return nil
 	}
-	// Fetch footer to buf for sure.
+
+	// reset buffer
+	buf.B = buf.B[:0]
+
+	// Fetch exact footer to buf for sure.
 	return objstore.ReadRange(ctx, buf, f.path, f.storage, f.off+f.size-s, s)
 }
 

--- a/pkg/experiment/block/section_profiles_test.go
+++ b/pkg/experiment/block/section_profiles_test.go
@@ -1,0 +1,100 @@
+package block
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/parquet-go/parquet-go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/pyroscope/pkg/objstore/testutil"
+)
+
+func createParquetFile[T any](t testing.TB, f io.Writer, rows []T, rowGroups int) {
+	perRG := len(rows) / rowGroups
+
+	w := parquet.NewGenericWriter[T](f)
+	for i := 0; i < (rowGroups - 1); i++ {
+		_, err := w.Write(rows[0:perRG])
+		require.NoError(t, err)
+		require.NoError(t, w.Flush())
+		rows = rows[perRG:]
+	}
+
+	_, err := w.Write(rows)
+	require.NoError(t, err)
+	require.NoError(t, w.Flush())
+
+	require.NoError(t, w.Close())
+}
+
+func createParquetTestFile(t testing.TB, f io.Writer, count int) {
+	type T struct{ A int }
+
+	rows := []T{}
+	for i := 0; i < count; i++ {
+		rows = append(rows, T{i})
+	}
+
+	createParquetFile(t, f, rows, 4)
+}
+
+func validateColumnIndex(t *testing.T, pf *parquet.File, count int) {
+	rgs := pf.RowGroups()
+	require.Equal(t, 4, len(rgs))
+
+	// check last row groups column index
+	ci, err := rgs[3].ColumnChunks()[0].ColumnIndex()
+	require.NoError(t, err)
+
+	pages := ci.NumPages()
+	require.Equal(t, int64(count-1), ci.MaxValue(pages-1).Int64())
+}
+
+func Test_openParquetFile(t *testing.T) {
+	path := "test.parquet"
+	ctx := context.Background()
+	bucket, _ := testutil.NewFilesystemBucket(t, ctx, "testdata")
+
+	buf := bytes.NewBuffer(nil)
+	count := 100
+	createParquetTestFile(t, buf, count)
+
+	actualFooterSize := footerSize(buf.Bytes())
+
+	err := bucket.Upload(ctx, path, bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+
+	opts := []parquet.FileOption{
+		parquet.SkipBloomFilters(true),
+	}
+
+	t.Run("withFooterSizeSmallerThanEstimate", func(t *testing.T) {
+		pf, err := openParquetFile(bucket, path, 0, int64(buf.Len()), actualFooterSize*2, opts...)
+		require.NoError(t, err)
+
+		validateColumnIndex(t, pf.File, count)
+	})
+
+	t.Run("withFooterSizeExactEstimate", func(t *testing.T) {
+		pf, err := openParquetFile(bucket, path, 0, int64(buf.Len()), actualFooterSize, opts...)
+		require.NoError(t, err)
+
+		validateColumnIndex(t, pf.File, count)
+	})
+	t.Run("withFooterSizeSmallerEstimate", func(t *testing.T) {
+		pf, err := openParquetFile(bucket, path, 0, int64(buf.Len()), 200, opts...)
+		require.NoError(t, err)
+
+		validateColumnIndex(t, pf.File, count)
+	})
+	t.Run("withFooterSizeVerySmall", func(t *testing.T) {
+		pf, err := openParquetFile(bucket, path, 0, int64(buf.Len()), 1, opts...)
+		require.NoError(t, err)
+
+		validateColumnIndex(t, pf.File, count)
+	})
+
+}


### PR DESCRIPTION
This bug explains how the column index was "corrupted": Bigger parquet footer, would not fit the estimatedSize and the code to fetch the longer footerSize was broken.

I have additionally added some test coverage for this.

I am also proposing to revert the skipping of the page index (from #4036), it will be easier catching bugs like this and it also will avoid downloading the footer twice, as we free it after open: 

https://github.com/grafana/pyroscope/blob/9d8285c4a3126742f40ede91a5d0be0dfe20ace2/pkg/experiment/block/section_profiles.go#L95-L105