### PR TITLE
feat: dynamically named usage groups

### DIFF
--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -599,7 +599,7 @@ func Test_IngestLimits(t *testing.T) {
 					"group-2": "{service_name=\"svc2\"}",
 				})
 				require.NoError(t, err)
-				l.DistributorUsageGroups = &usageGroupCfg
+				l.DistributorUsageGroups = usageGroupCfg
 				tenantLimits["user-1"] = l
 			}),
 			verifyExpectations: func(err error, req *distributormodel.PushRequest, res *connect.Response[pushv1.PushResponse]) {
@@ -655,7 +655,7 @@ func Test_IngestLimits(t *testing.T) {
 					"group-1": "{service_name=\"svc\"}",
 				})
 				require.NoError(t, err)
-				l.DistributorUsageGroups = &usageGroupCfg
+				l.DistributorUsageGroups = usageGroupCfg
 				tenantLimits["user-1"] = l
 			}),
 			verifyExpectations: func(err error, req *distributormodel.PushRequest, res *connect.Response[pushv1.PushResponse]) {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -698,11 +698,13 @@ func Test_SampleLabels(t *testing.T) {
 		expectBytesDropped    float64
 		expectProfilesDropped float64
 	}
+	const dummyTenantID = "tenant1"
 
 	testCases := []testCase{
 		{
 			description: "no series labels, no sample labels",
 			pushReq: &distributormodel.PushRequest{
+				TenantID: dummyTenantID,
 				Series: []*distributormodel.ProfileSeries{
 					{
 						Samples: []*distributormodel.ProfileSample{
@@ -734,6 +736,7 @@ func Test_SampleLabels(t *testing.T) {
 		{
 			description: "has series labels, no sample labels",
 			pushReq: &distributormodel.PushRequest{
+				TenantID: dummyTenantID,
 				Series: []*distributormodel.ProfileSeries{
 					{
 						Labels: []*typesv1.LabelPair{
@@ -771,6 +774,7 @@ func Test_SampleLabels(t *testing.T) {
 		{
 			description: "no series labels, all samples have identical label set",
 			pushReq: &distributormodel.PushRequest{
+				TenantID: dummyTenantID,
 				Series: []*distributormodel.ProfileSeries{
 					{
 						Samples: []*distributormodel.ProfileSample{
@@ -811,6 +815,7 @@ func Test_SampleLabels(t *testing.T) {
 		{
 			description: "has series labels, all samples have identical label set",
 			pushReq: &distributormodel.PushRequest{
+				TenantID: dummyTenantID,
 				Series: []*distributormodel.ProfileSeries{
 					{
 						Labels: []*typesv1.LabelPair{
@@ -855,6 +860,7 @@ func Test_SampleLabels(t *testing.T) {
 		{
 			description: "has series labels, and the only sample label name overlaps with series label, creating overlapping groups",
 			pushReq: &distributormodel.PushRequest{
+				TenantID: dummyTenantID,
 				Series: []*distributormodel.ProfileSeries{
 					{
 						Labels: []*typesv1.LabelPair{
@@ -905,6 +911,7 @@ func Test_SampleLabels(t *testing.T) {
 		{
 			description: "has series labels, samples have distinct label sets",
 			pushReq: &distributormodel.PushRequest{
+				TenantID: dummyTenantID,
 				Series: []*distributormodel.ProfileSeries{
 					{
 						Labels: []*typesv1.LabelPair{
@@ -975,6 +982,7 @@ func Test_SampleLabels(t *testing.T) {
 			description:  "has series labels that should be renamed to no longer include godeltaprof",
 			relabelRules: defaultRelabelConfigs,
 			pushReq: &distributormodel.PushRequest{
+				TenantID: dummyTenantID,
 				Series: []*distributormodel.ProfileSeries{
 					{
 						Labels: []*typesv1.LabelPair{
@@ -1021,6 +1029,7 @@ func Test_SampleLabels(t *testing.T) {
 				{Action: relabel.Drop, SourceLabels: []model.LabelName{"__name__", "span_name"}, Separator: "/", Regex: relabel.MustNewRegexp("unwanted/randomness")},
 			},
 			pushReq: &distributormodel.PushRequest{
+				TenantID: dummyTenantID,
 				Series: []*distributormodel.ProfileSeries{
 					{
 						Labels: []*typesv1.LabelPair{
@@ -1073,6 +1082,7 @@ func Test_SampleLabels(t *testing.T) {
 				{Action: relabel.Drop, Regex: relabel.MustNewRegexp(".*")},
 			},
 			pushReq: &distributormodel.PushRequest{
+				TenantID: dummyTenantID,
 				Series: []*distributormodel.ProfileSeries{
 					{
 						Labels: []*typesv1.LabelPair{
@@ -1108,6 +1118,7 @@ func Test_SampleLabels(t *testing.T) {
 				{Action: relabel.Replace, Regex: relabel.MustNewRegexp(".*"), Replacement: "", TargetLabel: "span_name"},
 			},
 			pushReq: &distributormodel.PushRequest{
+				TenantID: dummyTenantID,
 				Series: []*distributormodel.ProfileSeries{
 					{
 						Labels: []*typesv1.LabelPair{
@@ -1155,6 +1166,7 @@ func Test_SampleLabels(t *testing.T) {
 		{
 			description: "ensure only samples of same stacktraces get grouped",
 			pushReq: &distributormodel.PushRequest{
+				TenantID: dummyTenantID,
 				Series: []*distributormodel.ProfileSeries{
 					{
 						Labels: []*typesv1.LabelPair{
@@ -1266,10 +1278,23 @@ func Test_SampleLabels(t *testing.T) {
 		// reporting. Neither are validated by the tests, nor do they influence
 		// test behavior in any way.
 		ug := &validation.UsageGroupConfig{}
-		const dummyTenantID = "tenant1"
 
 		t.Run(tc.description, func(t *testing.T) {
-			series, actualBytesDropped, actualProfilesDropped := extractSampleSeries(tc.pushReq, dummyTenantID, ug, tc.relabelRules)
+			overrides := validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+				l := validation.MockDefaultLimits()
+				l.IngestionRelabelingRules = tc.relabelRules
+				tenantLimits[dummyTenantID] = l
+			})
+			d, err := New(Config{
+				DistributorRing: ringConfig,
+			}, testhelper.NewMockRing([]ring.InstanceDesc{
+				{Addr: "foo"},
+			}, 3), &poolFactory{func(addr string) (client.PoolClient, error) {
+				return newFakeIngester(t, false), nil
+			}}, overrides, nil, log.NewLogfmtLogger(os.Stdout), nil)
+			require.NoError(t, err)
+
+			series, actualBytesDropped, actualProfilesDropped := d.extractSampleSeries(tc.pushReq, ug)
 			assert.Equal(t, tc.expectBytesDropped, actualBytesDropped)
 			assert.Equal(t, tc.expectProfilesDropped, actualProfilesDropped)
 			require.Len(t, series, len(tc.series))

--- a/pkg/experiment/ingester/segment_test.go
+++ b/pkg/experiment/ingester/segment_test.go
@@ -131,7 +131,7 @@ func TestIngestWait(t *testing.T) {
 	t1 := time.Now()
 	awaiter := sw.ingest(0, func(head segmentIngest) {
 		p := cpuProfile(42, 480, "svc1", "foo", "bar")
-		head.ingest("t1", p.Profile, p.UUID, p.Labels, p.Annotations)
+		head.ingest(context.Background(), "t1", p.Profile, p.UUID, p.Labels, p.Annotations)
 	})
 	err := awaiter.waitFlushed(context.Background())
 	require.NoError(t, err)
@@ -200,7 +200,7 @@ func TestBusyIngestLoop(t *testing.T) {
 					ts := workerno*1000000000 + len(profiles)
 					awaiter := sw.ingest(1, func(head segmentIngest) {
 						p := cpuProfile(42, ts, "svc1", "foo", "bar")
-						head.ingest("t1", p.CloneVT(), p.UUID, p.Labels, p.Annotations)
+						head.ingest(context.Background(), "t1", p.CloneVT(), p.UUID, p.Labels, p.Annotations)
 						profiles = append(profiles, p)
 					})
 					awaiters = append(awaiters, awaiter)
@@ -250,7 +250,7 @@ func TestDLQFail(t *testing.T) {
 	ing := func(head segmentIngest) {
 		ts += 420
 		p := cpuProfile(42, ts, "svc1", "foo", "bar")
-		head.ingest("t1", p.Profile, p.UUID, p.Labels, p.Annotations)
+		head.ingest(context.Background(), "t1", p.Profile, p.UUID, p.Labels, p.Annotations)
 	}
 
 	awaiter1 := res.ingest(0, ing)
@@ -298,7 +298,7 @@ func TestDatasetMinMaxTime(t *testing.T) {
 	}
 	_ = res.ingest(1, func(head segmentIngest) {
 		for _, p := range data {
-			head.ingest(p.tenant, p.profile.Profile, p.profile.UUID, p.profile.Labels, p.profile.Annotations)
+			head.ingest(context.Background(), p.tenant, p.profile.Profile, p.profile.UUID, p.profile.Labels, p.profile.Annotations)
 		}
 	})
 	defer res.stop()
@@ -727,7 +727,7 @@ func (sw *sw) ingestChunk(t *testing.T, chunk inputChunk, expectAwaitError bool)
 			defer wg.Done()
 			awaiter := sw.ingest(shardKey(it.shard), func(head segmentIngest) {
 				p := it.profile.CloneVT() // important to not rewrite original profile
-				head.ingest(it.tenant, p, it.profile.UUID, it.profile.Labels, it.profile.Annotations)
+				head.ingest(context.Background(), it.tenant, p, it.profile.UUID, it.profile.Labels, it.profile.Annotations)
 			})
 			err := awaiter.waitFlushed(context.Background())
 			if expectAwaitError {

--- a/pkg/experiment/ingester/service.go
+++ b/pkg/experiment/ingester/service.go
@@ -210,7 +210,7 @@ func (i *SegmentWriterService) Push(ctx context.Context, req *segmentwriterv1.Pu
 	}
 
 	wait := i.segmentWriter.ingest(shardKey(req.Shard), func(segment segmentIngest) {
-		segment.ingest(req.TenantId, p.Profile, id, req.Labels, req.Annotations)
+		segment.ingest(ctx, req.TenantId, p.Profile, id, req.Labels, req.Annotations)
 	})
 
 	flushStarted := time.Now()

--- a/pkg/validation/usage_groups.go
+++ b/pkg/validation/usage_groups.go
@@ -62,8 +62,8 @@ type templatePart struct {
 // usageGroupEntry represents a single usage group configuration
 type usageGroupEntry struct {
 	matchers []*labels.Matcher
-	// For static names, template is nil and staticName is used
-	staticName string
+	// For static names, template is nil and name is used
+	name string
 	// For dynamic names, template contains the parsed template parts
 	template []templatePart
 }
@@ -103,20 +103,18 @@ func (e *UsageGroupEvaluator) GetMatch(tenantID string, c *UsageGroupConfig, lbl
 					level.Warn(e.logger).Log(
 						"msg", "failed to expand usage group template, skipping usage group",
 						"err", err,
-						"labels", lbls,
-						"usage_group", entry.staticName)
+						"usage_group", entry.name)
 					continue
 				}
 				if dynamicName == "" {
 					level.Warn(e.logger).Log(
 						"msg", "usage group template expanded to empty string, skipping usage group",
-						"labels", lbls,
-						"usage_group", entry.staticName)
+						"usage_group", entry.name)
 					continue
 				}
 				match.names = append(match.names, dynamicName)
 			} else {
-				match.names = append(match.names, entry.staticName)
+				match.names = append(match.names, entry.name)
 			}
 		}
 	}
@@ -230,6 +228,7 @@ func parseUsageGroupEntries(m map[string]string) ([]usageGroupEntry, map[string]
 
 		entry := usageGroupEntry{
 			matchers: matchers,
+			name:     name,
 		}
 
 		if strings.Contains(name, dynamicLabelNamePrefix) {
@@ -238,8 +237,6 @@ func parseUsageGroupEntries(m map[string]string) ([]usageGroupEntry, map[string]
 				return nil, nil, fmt.Errorf("failed to parse template for usage group %q: %w", name, err)
 			}
 			entry.template = template
-		} else {
-			entry.staticName = name
 		}
 
 		entries = append(entries, entry)

--- a/pkg/validation/usage_groups.go
+++ b/pkg/validation/usage_groups.go
@@ -74,10 +74,7 @@ type UsageGroupConfig struct {
 	parsedEntries []usageGroupEntry
 }
 
-var (
-	dynamicLabelNamePrefix       = "${labels."
-	dynamicLabelNamePrefixLength = len(dynamicLabelNamePrefix)
-)
+const dynamicLabelNamePrefix = "${labels."
 
 type UsageGroupEvaluator struct {
 	logger log.Logger

--- a/pkg/validation/usage_groups.go
+++ b/pkg/validation/usage_groups.go
@@ -322,6 +322,9 @@ func (c *UsageGroupConfig) expandTemplate(template []templatePart, lbls phlaremo
 			if !found {
 				return "", fmt.Errorf("label %q not found", part.value)
 			}
+			if value.Value == "" {
+				return "", fmt.Errorf("label %q is empty", part.value)
+			}
 			result.WriteString(value.Value)
 		}
 	}

--- a/pkg/validation/usage_groups_bench_test.go
+++ b/pkg/validation/usage_groups_bench_test.go
@@ -1,0 +1,94 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/pyroscope/pkg/model"
+)
+
+func BenchmarkUsageGroups_Regular(b *testing.B) {
+	config, err := NewUsageGroupConfig(map[string]string{
+		"app/frontend":  `{service_name=~"(.*)"}`,
+		"app/backend":   `{team=~"(.*)"}`,
+		"app/database":  `{environment=~"(.*)"}`,
+		"team/platform": `{service_name=~"(.*)", team=~"(.*)"}`,
+		"team/product":  `{service_name=~"(.*)", team=~"(.*)", environment=~"(.*)"}`,
+	})
+	require.NoError(b, err)
+
+	l := model.Labels{
+		{Name: "service_name", Value: "frontend"},
+		{Name: "team", Value: "platform"},
+		{Name: "environment", Value: "production"},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = config.GetUsageGroups("tenant1", l)
+	}
+}
+
+func BenchmarkUsageGroups_Dynamic(b *testing.B) {
+	config, err := NewUsageGroupConfig(map[string]string{
+		"app/$1":           `{service_name=~"(.*)"}`,
+		"team/$1":          `{team=~"(.*)"}`,
+		"env/$1":           `{environment=~"(.*)"}`,
+		"$1/$2":            `{service_name=~"(.*)", team=~"(.*)"}`,
+		"complex/$1-$2-$3": `{service_name=~"(.*)", team=~"(.*)", environment=~"(.*)"}`,
+	})
+	require.NoError(b, err)
+
+	l := model.Labels{
+		{Name: "service_name", Value: "frontend"},
+		{Name: "team", Value: "platform"},
+		{Name: "environment", Value: "production"},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = config.GetUsageGroups("tenant1", l)
+	}
+}
+
+func BenchmarkUsageGroups_ComplexRegex(b *testing.B) {
+	config, err := NewUsageGroupConfig(map[string]string{
+		// Simple regex
+		"simple/$1": `{service_name=~"(.*)"}`,
+		// More complex regex with character classes
+		"complex/$1/$2": `{service_name=~"([a-zA-Z]+)-([0-9]+)"}`,
+		// Very complex regex
+		"very-complex/$1/$2/$3": `{service_name=~"([a-zA-Z]+)-([0-9]+)\\.([a-z]{2,4})"}`,
+	})
+	require.NoError(b, err)
+
+	l := model.Labels{
+		{Name: "service_name", Value: "frontend-123.prod"},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = config.GetUsageGroups("tenant1", l)
+	}
+}
+
+func BenchmarkUsageGroups_DynamicParallel(b *testing.B) {
+	config, err := NewUsageGroupConfig(map[string]string{
+		"app/$1":  `{service_name=~"(.*)"}`,
+		"team/$1": `{team=~"(.*)"}`,
+	})
+	require.NoError(b, err)
+
+	l := model.Labels{
+		{Name: "service_name", Value: "frontend"},
+		{Name: "team", Value: "platform"},
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = config.GetUsageGroups("tenant1", l)
+		}
+	})
+}

--- a/pkg/validation/usage_groups_bench_test.go
+++ b/pkg/validation/usage_groups_bench_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/pyroscope/pkg/model"
+	"github.com/grafana/pyroscope/pkg/util"
 )
 
 func BenchmarkUsageGroups_Regular(b *testing.B) {
@@ -23,10 +24,11 @@ func BenchmarkUsageGroups_Regular(b *testing.B) {
 		{Name: "team", Value: "platform"},
 		{Name: "environment", Value: "production"},
 	}
+	evaluator := NewUsageGroupEvaluator(util.Logger)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = config.GetUsageGroups("tenant1", l)
+		_ = evaluator.GetMatch("tenant1", config, l)
 	}
 }
 
@@ -45,18 +47,17 @@ func BenchmarkUsageGroups_Dynamic(b *testing.B) {
 		{Name: "team", Value: "platform"},
 		{Name: "environment", Value: "production"},
 	}
+	evaluator := NewUsageGroupEvaluator(util.Logger)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = config.GetUsageGroups("tenant1", l)
+		_ = evaluator.GetMatch("tenant1", config, l)
 	}
 }
 
 func BenchmarkUsageGroups_ComplexRegex(b *testing.B) {
 	config, err := NewUsageGroupConfig(map[string]string{
-		// More complex regex with character classes
-		"complex/${labels.service_name}": `{service_name=~"[a-zA-Z]+-[0-9]+"}`,
-		// Very complex regex
+		"complex/${labels.service_name}":      `{service_name=~"[a-zA-Z]+-[0-9]+"}`,
 		"very-complex/${labels.service_name}": `{service_name=~"[a-zA-Z]+-[0-9]+\\.[a-z]{2,4}"}`,
 	})
 	require.NoError(b, err)
@@ -64,9 +65,10 @@ func BenchmarkUsageGroups_ComplexRegex(b *testing.B) {
 	l := model.Labels{
 		{Name: "service_name", Value: "frontend-123.prod"},
 	}
+	evaluator := NewUsageGroupEvaluator(util.Logger)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = config.GetUsageGroups("tenant1", l)
+		_ = evaluator.GetMatch("tenant1", config, l)
 	}
 }

--- a/pkg/validation/usage_groups_bench_test.go
+++ b/pkg/validation/usage_groups_bench_test.go
@@ -54,8 +54,6 @@ func BenchmarkUsageGroups_Dynamic(b *testing.B) {
 
 func BenchmarkUsageGroups_ComplexRegex(b *testing.B) {
 	config, err := NewUsageGroupConfig(map[string]string{
-		// Simple regex
-		"simple/${labels.service_name}": `{service_name=~".*"}`,
 		// More complex regex with character classes
 		"complex/${labels.service_name}": `{service_name=~"[a-zA-Z]+-[0-9]+"}`,
 		// Very complex regex
@@ -71,24 +69,4 @@ func BenchmarkUsageGroups_ComplexRegex(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = config.GetUsageGroups("tenant1", l)
 	}
-}
-
-func BenchmarkUsageGroups_DynamicParallel(b *testing.B) {
-	config, err := NewUsageGroupConfig(map[string]string{
-		"app/${labels.service_name}": `{service_name=~".*"}`,
-		"team/${labels.team}":        `{team=~".*"}`,
-	})
-	require.NoError(b, err)
-
-	l := model.Labels{
-		{Name: "service_name", Value: "frontend"},
-		{Name: "team", Value: "platform"},
-	}
-
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			_ = config.GetUsageGroups("tenant1", l)
-		}
-	})
 }

--- a/pkg/validation/usage_groups_bench_test.go
+++ b/pkg/validation/usage_groups_bench_test.go
@@ -32,11 +32,11 @@ func BenchmarkUsageGroups_Regular(b *testing.B) {
 
 func BenchmarkUsageGroups_Dynamic(b *testing.B) {
 	config, err := NewUsageGroupConfig(map[string]string{
-		"app/$1":           `{service_name=~"(.*)"}`,
-		"team/$1":          `{team=~"(.*)"}`,
-		"env/$1":           `{environment=~"(.*)"}`,
-		"$1/$2":            `{service_name=~"(.*)", team=~"(.*)"}`,
-		"complex/$1-$2-$3": `{service_name=~"(.*)", team=~"(.*)", environment=~"(.*)"}`,
+		"app/${labels.service_name}":                                          `{service_name=~".*"}`,
+		"team/${labels.team}":                                                 `{team=~".*"}`,
+		"env/${labels.environment}":                                           `{environment=~".*"}`,
+		"${labels.service_name}/${labels.team}":                               `{service_name=~".*", team=~".*"}`,
+		"complex/${labels.service_name}-${labels.team}-${labels.environment}": `{service_name=~".*", team=~".*", environment=~".*"}`,
 	})
 	require.NoError(b, err)
 
@@ -55,11 +55,11 @@ func BenchmarkUsageGroups_Dynamic(b *testing.B) {
 func BenchmarkUsageGroups_ComplexRegex(b *testing.B) {
 	config, err := NewUsageGroupConfig(map[string]string{
 		// Simple regex
-		"simple/$1": `{service_name=~"(.*)"}`,
+		"simple/${labels.service_name}": `{service_name=~".*"}`,
 		// More complex regex with character classes
-		"complex/$1/$2": `{service_name=~"([a-zA-Z]+)-([0-9]+)"}`,
+		"complex/${labels.service_name}": `{service_name=~"[a-zA-Z]+-[0-9]+"}`,
 		// Very complex regex
-		"very-complex/$1/$2/$3": `{service_name=~"([a-zA-Z]+)-([0-9]+)\\.([a-z]{2,4})"}`,
+		"very-complex/${labels.service_name}": `{service_name=~"[a-zA-Z]+-[0-9]+\\.[a-z]{2,4}"}`,
 	})
 	require.NoError(b, err)
 
@@ -75,8 +75,8 @@ func BenchmarkUsageGroups_ComplexRegex(b *testing.B) {
 
 func BenchmarkUsageGroups_DynamicParallel(b *testing.B) {
 	config, err := NewUsageGroupConfig(map[string]string{
-		"app/$1":  `{service_name=~"(.*)"}`,
-		"team/$1": `{team=~"(.*)"}`,
+		"app/${labels.service_name}": `{service_name=~".*"}`,
+		"team/${labels.team}":        `{team=~".*"}`,
 	})
 	require.NoError(b, err)
 

--- a/pkg/validation/usage_groups_test.go
+++ b/pkg/validation/usage_groups_test.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	phlaremodel "github.com/grafana/pyroscope/pkg/model"
+	"github.com/grafana/pyroscope/pkg/util"
 )
 
 func TestUsageGroupConfig_GetUsageGroups(t *testing.T) {
@@ -133,7 +134,8 @@ func TestUsageGroupConfig_GetUsageGroups(t *testing.T) {
 			config, err := NewUsageGroupConfig(tt.Config)
 			require.NoError(t, err)
 
-			got := config.GetUsageGroups(tt.TenantID, tt.Labels)
+			evaluator := NewUsageGroupEvaluator(util.Logger)
+			got := evaluator.GetMatch(tt.TenantID, config, tt.Labels)
 
 			slices.Sort(got.names)
 			slices.Sort(tt.Want.names)

--- a/pkg/validation/usage_groups_test.go
+++ b/pkg/validation/usage_groups_test.go
@@ -19,14 +19,14 @@ func TestUsageGroupConfig_GetUsageGroups(t *testing.T) {
 	tests := []struct {
 		Name     string
 		TenantID string
-		Config   UsageGroupConfig
+		Config   *UsageGroupConfig
 		Labels   phlaremodel.Labels
 		Want     UsageGroupMatch
 	}{
 		{
 			Name:     "single_usage_group_match",
 			TenantID: "tenant1",
-			Config: UsageGroupConfig{
+			Config: &UsageGroupConfig{
 				config: map[string][]*labels.Matcher{
 					"app/foo": testMustParseMatcher(t, `{service_name="foo"}`),
 				},
@@ -42,7 +42,7 @@ func TestUsageGroupConfig_GetUsageGroups(t *testing.T) {
 		{
 			Name:     "multiple_usage_group_matches",
 			TenantID: "tenant1",
-			Config: UsageGroupConfig{
+			Config: &UsageGroupConfig{
 				config: map[string][]*labels.Matcher{
 					"app/foo":  testMustParseMatcher(t, `{service_name="foo"}`),
 					"app/foo2": testMustParseMatcher(t, `{service_name="foo", namespace=~"bar.*"}`),
@@ -63,7 +63,7 @@ func TestUsageGroupConfig_GetUsageGroups(t *testing.T) {
 		{
 			Name:     "no_usage_group_matches",
 			TenantID: "tenant1",
-			Config: UsageGroupConfig{
+			Config: &UsageGroupConfig{
 				config: map[string][]*labels.Matcher{
 					"app/foo": testMustParseMatcher(t, `{service_name="notfound"}`),
 				},
@@ -78,7 +78,7 @@ func TestUsageGroupConfig_GetUsageGroups(t *testing.T) {
 		{
 			Name:     "wildcard_matcher",
 			TenantID: "tenant1",
-			Config: UsageGroupConfig{
+			Config: &UsageGroupConfig{
 				config: map[string][]*labels.Matcher{
 					"app/foo": testMustParseMatcher(t, `{}`),
 				},
@@ -94,7 +94,7 @@ func TestUsageGroupConfig_GetUsageGroups(t *testing.T) {
 		{
 			Name:     "no_labels",
 			TenantID: "tenant1",
-			Config: UsageGroupConfig{
+			Config: &UsageGroupConfig{
 				config: map[string][]*labels.Matcher{
 					"app/foo": testMustParseMatcher(t, `{service_name="foo"}`),
 				},
@@ -107,7 +107,7 @@ func TestUsageGroupConfig_GetUsageGroups(t *testing.T) {
 		{
 			Name:     "disjoint_labels_do_not_match",
 			TenantID: "tenant1",
-			Config: UsageGroupConfig{
+			Config: &UsageGroupConfig{
 				config: map[string][]*labels.Matcher{
 					"app/foo": testMustParseMatcher(t, `{namespace="foo", container="bar"}`),
 				},
@@ -122,7 +122,7 @@ func TestUsageGroupConfig_GetUsageGroups(t *testing.T) {
 		{
 			Name:     "dynamic_usage_group_names",
 			TenantID: "tenant1",
-			Config: UsageGroupConfig{
+			Config: &UsageGroupConfig{
 				config: map[string][]*labels.Matcher{
 					"app/$1": testMustParseMatcher(t, `{service_name=~"(.*)"}`),
 				},
@@ -140,7 +140,7 @@ func TestUsageGroupConfig_GetUsageGroups(t *testing.T) {
 		{
 			Name:     "dynamic_usage_group_names_multiple_capture_groups",
 			TenantID: "tenant1",
-			Config: UsageGroupConfig{
+			Config: &UsageGroupConfig{
 				config: map[string][]*labels.Matcher{
 					"$1/$2": testMustParseMatcher(t, `{namespace=~"(.*)", container=~"(.*)"}`),
 				},
@@ -327,7 +327,7 @@ func TestNewUsageGroupConfig(t *testing.T) {
 	tests := []struct {
 		Name      string
 		ConfigMap map[string]string
-		Want      UsageGroupConfig
+		Want      *UsageGroupConfig
 		WantErr   string
 	}{
 		{
@@ -335,7 +335,7 @@ func TestNewUsageGroupConfig(t *testing.T) {
 			ConfigMap: map[string]string{
 				"app/foo": `{service_name="foo"}`,
 			},
-			Want: UsageGroupConfig{
+			Want: &UsageGroupConfig{
 				config: map[string][]*labels.Matcher{
 					"app/foo": testMustParseMatcher(t, `{service_name="foo"}`),
 				},
@@ -347,7 +347,7 @@ func TestNewUsageGroupConfig(t *testing.T) {
 				"app/foo":  `{service_name="foo"}`,
 				"app/foo2": `{service_name="foo", namespace=~"bar.*"}`,
 			},
-			Want: UsageGroupConfig{
+			Want: &UsageGroupConfig{
 				config: map[string][]*labels.Matcher{
 					"app/foo":  testMustParseMatcher(t, `{service_name="foo"}`),
 					"app/foo2": testMustParseMatcher(t, `{service_name="foo", namespace=~"bar.*"}`),
@@ -357,7 +357,7 @@ func TestNewUsageGroupConfig(t *testing.T) {
 		{
 			Name:      "no_usage_groups",
 			ConfigMap: map[string]string{},
-			Want: UsageGroupConfig{
+			Want: &UsageGroupConfig{
 				config: map[string][]*labels.Matcher{},
 			},
 		},
@@ -366,7 +366,7 @@ func TestNewUsageGroupConfig(t *testing.T) {
 			ConfigMap: map[string]string{
 				"app/foo": `{}`,
 			},
-			Want: UsageGroupConfig{
+			Want: &UsageGroupConfig{
 				config: map[string][]*labels.Matcher{
 					"app/foo": testMustParseMatcher(t, `{}`),
 				},
@@ -409,7 +409,7 @@ func TestNewUsageGroupConfig(t *testing.T) {
 			ConfigMap: map[string]string{
 				"   app/foo   ": `{service_name="foo"}`,
 			},
-			Want: UsageGroupConfig{
+			Want: &UsageGroupConfig{
 				config: map[string][]*labels.Matcher{
 					"app/foo": testMustParseMatcher(t, `{service_name="foo"}`),
 				},
@@ -452,7 +452,7 @@ func TestUsageGroupConfig_UnmarshalYAML(t *testing.T) {
 	tests := []struct {
 		Name    string
 		YAML    string
-		Want    UsageGroupConfig
+		Want    *UsageGroupConfig
 		WantErr string
 	}{
 		{
@@ -460,7 +460,7 @@ func TestUsageGroupConfig_UnmarshalYAML(t *testing.T) {
 			YAML: `
 usage_groups:
   app/foo: '{service_name="foo"}'`,
-			Want: UsageGroupConfig{
+			Want: &UsageGroupConfig{
 				config: map[string][]*labels.Matcher{
 					"app/foo": testMustParseMatcher(t, `{service_name="foo"}`),
 				},
@@ -472,7 +472,7 @@ usage_groups:
 usage_groups:
   app/foo: '{service_name="foo"}'
   app/foo2: '{service_name="foo", namespace=~"bar.*"}'`,
-			Want: UsageGroupConfig{
+			Want: &UsageGroupConfig{
 				config: map[string][]*labels.Matcher{
 					"app/foo":  testMustParseMatcher(t, `{service_name="foo"}`),
 					"app/foo2": testMustParseMatcher(t, `{service_name="foo", namespace=~"bar.*"}`),
@@ -483,7 +483,7 @@ usage_groups:
 			Name: "empty_usage_groups",
 			YAML: `
 usage_groups: {}`,
-			Want: UsageGroupConfig{
+			Want: &UsageGroupConfig{
 				config: map[string][]*labels.Matcher{},
 			},
 		},
@@ -504,7 +504,7 @@ usage_groups:
 			YAML: `
 some_other_config:
   foo: bar`,
-			Want: UsageGroupConfig{},
+			Want: &UsageGroupConfig{},
 		},
 	}
 
@@ -530,7 +530,7 @@ func TestUsageGroupConfig_UnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		Name    string
 		JSON    string
-		Want    UsageGroupConfig
+		Want    *UsageGroupConfig
 		WantErr string
 	}{
 		{
@@ -540,7 +540,7 @@ func TestUsageGroupConfig_UnmarshalJSON(t *testing.T) {
 					"app/foo": "{service_name=\"foo\"}"
 				}
 			}`,
-			Want: UsageGroupConfig{
+			Want: &UsageGroupConfig{
 				config: map[string][]*labels.Matcher{
 					"app/foo": testMustParseMatcher(t, `{service_name="foo"}`),
 				},
@@ -554,7 +554,7 @@ func TestUsageGroupConfig_UnmarshalJSON(t *testing.T) {
 					"app/foo2": "{service_name=\"foo\", namespace=~\"bar.*\"}"
 				}
 			}`,
-			Want: UsageGroupConfig{
+			Want: &UsageGroupConfig{
 				config: map[string][]*labels.Matcher{
 					"app/foo":  testMustParseMatcher(t, `{service_name="foo"}`),
 					"app/foo2": testMustParseMatcher(t, `{service_name="foo", namespace=~"bar.*"}`),
@@ -564,7 +564,7 @@ func TestUsageGroupConfig_UnmarshalJSON(t *testing.T) {
 		{
 			Name: "empty_usage_groups",
 			JSON: `{"usage_groups": {}}`,
-			Want: UsageGroupConfig{
+			Want: &UsageGroupConfig{
 				config: map[string][]*labels.Matcher{},
 			},
 		},
@@ -581,7 +581,7 @@ func TestUsageGroupConfig_UnmarshalJSON(t *testing.T) {
 		{
 			Name: "missing_usage_groups_key_in_config",
 			JSON: `{"some_other_key": {"foo": "bar"}}`,
-			Want: UsageGroupConfig{},
+			Want: &UsageGroupConfig{},
 		},
 	}
 

--- a/pkg/validation/usage_groups_test.go
+++ b/pkg/validation/usage_groups_test.go
@@ -127,6 +127,34 @@ func TestUsageGroupConfig_GetUsageGroups(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:     "dynamic_usage_group_names_missing_label",
+			TenantID: "tenant1",
+			Config: map[string]string{
+				"app/${labels.service_name}/${labels.env}": `{service_name=~"(.*)"}`,
+			},
+			Labels: phlaremodel.Labels{
+				{Name: "service_name", Value: "foo"},
+			},
+			Want: UsageGroupMatch{
+				tenantID: "tenant1",
+				names:    []string{},
+			},
+		},
+		{
+			Name:     "dynamic_usage_group_names_empty_label",
+			TenantID: "tenant1",
+			Config: map[string]string{
+				"app/${labels.service_name}": `{service_name=~"(.*)"}`,
+			},
+			Labels: phlaremodel.Labels{
+				{Name: "service_name", Value: ""},
+			},
+			Want: UsageGroupMatch{
+				tenantID: "tenant1",
+				names:    []string{},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/validation/usage_groups_test.go
+++ b/pkg/validation/usage_groups_test.go
@@ -119,6 +119,43 @@ func TestUsageGroupConfig_GetUsageGroups(t *testing.T) {
 				tenantID: "tenant1",
 			},
 		},
+		{
+			Name:     "dynamic_usage_group_names",
+			TenantID: "tenant1",
+			Config: UsageGroupConfig{
+				config: map[string][]*labels.Matcher{
+					"app/$1": testMustParseMatcher(t, `{service_name=~"(.*)"}`),
+				},
+			},
+			Labels: phlaremodel.Labels{
+				{Name: "service_name", Value: "foo"},
+			},
+			Want: UsageGroupMatch{
+				tenantID: "tenant1",
+				names: []string{
+					"app/foo",
+				},
+			},
+		},
+		{
+			Name:     "dynamic_usage_group_names_multiple_capture_groups",
+			TenantID: "tenant1",
+			Config: UsageGroupConfig{
+				config: map[string][]*labels.Matcher{
+					"$1/$2": testMustParseMatcher(t, `{namespace=~"(.*)", container=~"(.*)"}`),
+				},
+			},
+			Labels: phlaremodel.Labels{
+				{Name: "namespace", Value: "dev"},
+				{Name: "container", Value: "distributor"},
+			},
+			Want: UsageGroupMatch{
+				tenantID: "tenant1",
+				names: []string{
+					"dev/distributor",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Adds a special meaning to usage groups with placeholders (`${labels.label_name}`) in their names. When encountered AND there is a match with the provided selector, we replace placeholders with the actual label values.

This allows for a simpler and more powerful configuration of usage groups where this:

```
    distributor_usage_groups:
      cart-service: '{service_name="cart-service"}'
      user-service: '{service_name="user-service"}'
      order-service: '{service_name="order-service"}'
```

can be replaced with:

```
    distributor_usage_groups:
      '${labels.service_name}': '{}'
```

Benchmark results:

```
go test -bench=BenchmarkUsageGroups -benchmem ./pkg/validation
goos: darwin
goarch: arm64
pkg: github.com/grafana/pyroscope/pkg/validation
cpu: Apple M2 Pro
BenchmarkUsageGroups_Regular-10            	12253587	        93.08 ns/op	      80 B/op	       1 allocs/op
BenchmarkUsageGroups_Dynamic-10            	 4551181	       265.0 ns/op	     200 B/op	       6 allocs/op
```

Notes:
- Both styles of usage groups can co-exist (though if there is overlap, attribution would count towards all groups)