### PR TITLE
fix(v2): compaction queue corruption

### DIFF
--- a/pkg/experiment/metastore/compaction/compactor/compaction_queue.go
+++ b/pkg/experiment/metastore/compaction/compactor/compaction_queue.go
@@ -185,14 +185,8 @@ func (q *blockQueue) removeStaged(s *stagedBlocks) {
 		q.registerer.Unregister(s.collector)
 	}
 	delete(q.staged, s.key)
-	if s.heapIndex < 0 {
-		// We usually end up here since s has already been evicted
-		// from the priority queue via Pop due to its age.
-		return
-	}
-	if s.heapIndex >= q.updates.Len() {
-		// Should not be possible.
-		return
+	if s.heapIndex < 0 || s.heapIndex >= q.updates.Len() {
+		panic("bug: attempt to delete compaction queue with an invalid priority index")
 	}
 	heap.Remove(q.updates, s.heapIndex)
 }
@@ -209,21 +203,25 @@ func (s *stagedBlocks) push(block blockEntry) bool {
 	}
 	s.batch.size++
 	s.stats.blocks.Add(1)
-	if !s.queue.config.exceedsMaxSize(s.batch) &&
-		!s.queue.config.exceedsMaxAge(s.batch, s.updatedAt) {
-		// The batch is still valid.
-		return true
+	if s.queue.config.exceedsMaxSize(s.batch) ||
+		s.queue.config.exceedsMaxAge(s.batch, s.updatedAt) {
+		s.flush()
 	}
-	return s.flush()
+	return true
 }
 
-func (s *stagedBlocks) flush() (flushed bool) {
+func (s *stagedBlocks) flush() {
+	var flushed bool
 	s.batch.flush.Do(func() {
-		s.queue.pushBatch(s.batch)
+		if !s.queue.pushBatch(s.batch) {
+			panic("bug: attempt to detach the compaction queue head")
+		}
 		flushed = true
 	})
+	if !flushed {
+		panic("bug: attempt to flush a compaction queue batch twice")
+	}
 	s.resetBatch()
-	return flushed
 }
 
 func (s *stagedBlocks) resetBatch() {
@@ -248,21 +246,54 @@ func (s *stagedBlocks) delete(block string) blockEntry {
 	ref.batch.size--
 	s.stats.blocks.Add(-1)
 	if ref.batch.size == 0 {
-		s.queue.removeBatch(ref.batch)
+		if ref.batch != s.batch {
+			// We should never ever try to delete the staging batch from the
+			// queue: it has not been flushed and added to the queue yet.
+			//
+			// NOTE(kolesnikovae):
+			//  It caused a problem because removeBatch mistakenly interpreted
+			//  the batch as a head (s.batch.prev == nil), and detached it,
+			//  replacing a valid head with s.batch.next, which is always nil
+			//  at this point; it made the queue look empty for the reader,
+			//  because the queue is read from the head.
+			//
+			//  The only way we may end up here if blocks are removed from the
+			//  staging batch. Typically, blocks are not supposed to be removed
+			//  from there before they left the queue (i.e., flushed to the
+			//  global queue).
+			//
+			//  In practice, the compactor is distributed and has multiple
+			//  replicas: the leader instance could have already decided to
+			//  flush the blocks, and now they should be removed from all
+			//  instances. Due to a bug in time-based flushing (when it stops
+			//  working), it was possible that after the leader restarts and
+			//  recovers time-based flushing locally, it would desire to flush
+			//  the oldest batch. Consequently, the follower instances, where
+			//  the batch is still in staging, would need to do the same.
+			if !s.queue.removeBatch(ref.batch) {
+				panic("bug: attempt to remove a batch that is not in the compaction queue")
+			}
+		}
 	}
 	delete(s.refs, block)
 	if len(s.refs) == 0 {
+		// This is the last block with the given compaction key, so we want to
+		// remove the staging structure. It's fine to delete it from the queue
+		// at any point: we guarantee that it does not reference any blocks in
+		// the queue, and we do not need to flush it anymore.
 		s.queue.removeStaged(s)
 	}
 	return e
 }
 
-func (q *blockQueue) pushBatch(b *batch) {
+func (q *blockQueue) pushBatch(b *batch) bool {
 	if q.tail != nil {
 		q.tail.nextG = b
 		b.prevG = q.tail
-	} else {
+	} else if q.head == nil {
 		q.head = b
+	} else {
+		return false
 	}
 	q.tail = b
 
@@ -272,25 +303,33 @@ func (q *blockQueue) pushBatch(b *batch) {
 	if b.staged.tail != nil {
 		b.staged.tail.next = b
 		b.prev = b.staged.tail
-	} else {
+	} else if b.staged.head == nil {
 		b.staged.head = b
+	} else {
+		return false
 	}
 	b.staged.tail = b
+
 	b.staged.stats.batches.Add(1)
+	return true
 }
 
-func (q *blockQueue) removeBatch(b *batch) {
+func (q *blockQueue) removeBatch(b *batch) bool {
 	if b.prevG != nil {
 		b.prevG.nextG = b.nextG
-	} else {
+	} else if b == q.head {
 		// This is the head.
-		q.head = b.nextG
+		q.head = q.head.nextG
+	} else {
+		return false
 	}
 	if b.nextG != nil {
 		b.nextG.prevG = b.prevG
-	} else {
+	} else if b == q.tail {
 		// This is the tail.
-		q.tail = b.prevG
+		q.tail = q.tail.prevG
+	} else {
+		return false
 	}
 	b.nextG = nil
 	b.prevG = nil
@@ -300,32 +339,48 @@ func (q *blockQueue) removeBatch(b *batch) {
 
 	if b.prev != nil {
 		b.prev.next = b.next
-	} else {
+	} else if b == b.staged.head {
 		// This is the head.
-		b.staged.head = b.next
+		b.staged.head = b.staged.head.next
+	} else {
+		return false
 	}
 	if b.next != nil {
 		b.next.prev = b.prev
-	} else {
+	} else if b == b.staged.tail {
 		// This is the tail.
-		b.staged.tail = b.next
+		b.staged.tail = b.staged.tail.prev
+	} else {
+		return false
 	}
 	b.next = nil
 	b.prev = nil
+
 	b.staged.stats.batches.Add(-1)
+	return true
 }
 
 func (q *blockQueue) flushOldest(now int64) {
 	if q.updates.Len() == 0 {
-		// Should not be possible.
-		return
+		panic("bug: compaction queue has empty priority queue")
 	}
+	// Peek the oldest staging batch in the priority queue (min-heap).
 	oldest := (*q.updates)[0]
 	if !q.config.exceedsMaxAge(oldest.batch, now) {
 		return
 	}
-	heap.Pop(q.updates)
-	oldest.flush()
+	// It's possible that the staging batch is empty: it's only removed
+	// from the queue when the last block with the given compaction key is
+	// removed, including ones flushed to the global queue. Therefore, we
+	// should not pop it from the queue, but update its index in the heap.
+	// Otherwise, if the staging batch has not been removed from the queue
+	// yet i.e., references some blocks in the compaction queue (it's rare
+	// but not impossible), time-based flush will stop working for it.
+	if oldest.batch.size > 0 {
+		oldest.flush()
+	}
+	oldest.updatedAt = now
+	heap.Fix(q.updates, oldest.heapIndex)
 }
 
 type priorityBlockQueue []*stagedBlocks

--- a/pkg/experiment/metastore/compaction/compactor/compaction_queue_test.go
+++ b/pkg/experiment/metastore/compaction/compactor/compaction_queue_test.go
@@ -90,14 +90,14 @@ func TestBlockQueue_Linking(t *testing.T) {
 
 	q.stagedBlocks(key).push(testBlockEntry(1))
 	q.stagedBlocks(key).push(testBlockEntry(2))
-	require.NotNil(t, q.head)
-	assert.Equal(t, q.head, q.tail)
+	head, tail := q.head, q.tail
+	require.NotNil(t, head)
+	assert.Equal(t, head, tail)
 
 	q.stagedBlocks(key).push(testBlockEntry(3))
 	assert.NotNil(t, q.tail)
-	assert.Nil(t, q.tail.prevG)
-	assert.NotNil(t, q.head)
-	assert.Nil(t, q.head.nextG)
+	assert.Equal(t, head, q.head)
+	assert.Equal(t, tail, q.tail)
 	assert.Equal(t, []blockEntry{testBlockEntry(1), testBlockEntry(2)}, q.head.blocks)
 	assert.Equal(t, q.tail.blocks, q.head.blocks)
 
@@ -110,13 +110,42 @@ func TestBlockQueue_Linking(t *testing.T) {
 	assert.NotNil(t, q.tail.prevG.prevG)
 	assert.NotNil(t, q.head.nextG.nextG)
 
-	remove(q, key, "3", "2")
-	remove(q, key, "4", "1")
-	remove(q, key, "6")
-	remove(q, key, "5")
+	t.Run("iterator does not affect the queue", func(t *testing.T) {
+		expected := []string{"1", "2", "3", "4", "5", "6"}
+		for i := 0; i < 3; i++ {
+			collected := make([]string, 0, len(expected))
+			iter := newBlockIter()
+			iter.setBatch(q.head)
+			for {
+				b, ok := iter.peek()
+				if !ok {
+					assert.Equal(t, expected, collected)
+					break
+				}
+				collected = append(collected, b)
+				iter.advance()
+			}
+		}
+	})
 
-	assert.Nil(t, q.head)
-	assert.Nil(t, q.tail)
+	t.Run("remove staging batch from the queue", func(t *testing.T) {
+		q.stagedBlocks(key).push(testBlockEntry(7))
+		// Block 7 is still staged: test that it can be
+		// removed without affecting the queue.
+		head, tail = q.head, q.tail
+		remove(q, key, "7")
+		assert.Equal(t, head, q.head)
+		assert.Equal(t, tail, q.tail)
+	})
+
+	t.Run("empty queue", func(t *testing.T) {
+		remove(q, key, "3", "2")
+		remove(q, key, "4", "1")
+		remove(q, key, "6")
+		remove(q, key, "5")
+		assert.Nil(t, q.head)
+		assert.Nil(t, q.tail)
+	})
 }
 
 func TestBlockQueue_EmptyQueue(t *testing.T) {
@@ -173,15 +202,18 @@ func TestBlockQueue_FlushByAge(t *testing.T) {
 	}
 
 	c := newCompactionQueue(s, nil)
-	for _, e := range []compaction.BlockEntry{
+	blocks := []compaction.BlockEntry{
 		{Tenant: "A", Shard: 1, Level: 1, Index: 1, AppendedAt: 5, ID: "1"},
 		{Tenant: "A", Shard: 1, Level: 1, Index: 2, AppendedAt: 15, ID: "2"},
 		{Tenant: "A", Shard: 0, Level: 1, Index: 3, AppendedAt: 30, ID: "3"},
-	} {
+		{Tenant: "A", Shard: 0, Level: 1, Index: 4, AppendedAt: 35, ID: "4"},
+		{Tenant: "B", Shard: 0, Level: 1, Index: 5, AppendedAt: 40, ID: "5"},
+	}
+	for _, e := range blocks {
 		c.push(e)
 	}
 
-	batches := make([]blockEntry, 0, 3)
+	batches := make([]blockEntry, 0, len(blocks))
 	q := c.blockQueue(1)
 	iter := newBatchIter(q)
 	for {
@@ -192,13 +224,33 @@ func TestBlockQueue_FlushByAge(t *testing.T) {
 		batches = append(batches, b.blocks...)
 	}
 
-	expected := []blockEntry{{"1", 1}, {"2", 2}}
-	// "3" remains staged as we need another push to evict it.
+	expected := []blockEntry{{"1", 1}, {"2", 2}, {"3", 3}, {"4", 4}}
+	// "5" remains staged as we need another push to evict it.
 	assert.Equal(t, expected, batches)
 
-	staged := q.stagedBlocks(compactionKey{tenant: "A", shard: 1, level: 1})
+	// We have 3 compaction queues (staging batches):
+	// A/1/1, A/0/1, B/0/1.
+	assert.Equal(t, 3, q.updates.Len())
+
+	staged := q.stagedBlocks(compactionKey{tenant: "B", shard: 0, level: 1})
+	staged.delete("5")
+	// B/0/1 compaction queue is removed.
+	assert.Equal(t, 2, q.updates.Len())
+
+	staged = q.stagedBlocks(compactionKey{tenant: "A", shard: 0, level: 1})
+	staged.delete("4")
+	// A/0/1 is still here.
+	assert.Equal(t, 2, q.updates.Len())
+	staged.delete("3")
+	// A/0/1 compaction queue is removed.
+	assert.Equal(t, 1, q.updates.Len())
+
+	// A/1/1 compaction queue is removed.
+	staged = q.stagedBlocks(compactionKey{tenant: "A", shard: 1, level: 1})
 	assert.NotEmpty(t, staged.delete("1"))
+	assert.Equal(t, 1, q.updates.Len())
 	assert.NotEmpty(t, staged.delete("2"))
+	assert.Equal(t, 0, staged.queue.updates.Len())
 }
 
 func TestBlockQueue_BatchIterator(t *testing.T) {

--- a/pkg/experiment/metastore/compaction/compactor/plan_test.go
+++ b/pkg/experiment/metastore/compaction/compactor/plan_test.go
@@ -384,7 +384,7 @@ func TestPlan_remove_staged_batch_corrupts_queue(t *testing.T) {
 	require.NotNil(t, p1.nextJob())
 	require.Nil(t, p1.nextJob())
 
-	// Add and blocks before they got to the compaction
+	// Add and remove blocks before they got to the compaction
 	// queue, triggering removal of the staged batch.
 	for i := 10; i < 12; i++ {
 		e := compaction.BlockEntry{


### PR DESCRIPTION
This fixes an issue where compaction could stop completely.

Comments should provide exhaustive context:

1. We had a bug in time-based compaction. Specifically, we stopped tracking updates for a given compaction key. This is a rare but possible scenario that occurs when the oldest batch in a tenant-shard-level queue is removed from the priority queue used to track updates, while the queue itself is not removed. Batches added after this point won't be tracked. It was assumed that all batches would be processed by the time the oldest one is flushed, but this is not guaranteed in practice.

2. It can also happen that a compactor removes blocks from the staging batch, which was not expected. This is possible because the leader may decide to flush blocks that are still staged from the follower's perspective – for example, if time-based compaction has stopped on that follower.

3. When we remove blocks from a batch, we remove the batch from the queues once its size is reduced to zero.

4. There was a bug where attempting to remove a batch without a link to a previous batch (i.e., it appears to be the head) would replace the head with a link to the batch after the one being deleted.

Therefore, if we try to remove the staging batch from the queue, we end up replacing the head with nil.

---

Fortunately, this doesn't cause data-level inconsistency – it only renders the system inoperable. I've made some checks more offensive – it's better to fail fast than risk entering an infinite loop or blocking processing entirely.