### PR TITLE
fix(v2): race in compaction scheduler metrics collector

### DIFF
--- a/pkg/experiment/metastore/compaction/scheduler/metrics_test.go
+++ b/pkg/experiment/metastore/compaction/scheduler/metrics_test.go
@@ -3,16 +3,22 @@ package scheduler
 import (
 	"bytes"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/grafana/dskit/multierror"
+	"github.com/hashicorp/raft"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
 
 	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
 	"github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1/raft_log"
+	"github.com/grafana/pyroscope/pkg/experiment/metastore/compaction/scheduler/store"
+	"github.com/grafana/pyroscope/pkg/test"
 )
 
 func TestCollectorRegistration(t *testing.T) {
@@ -54,4 +60,54 @@ func TestCollectorCollect(t *testing.T) {
 	buf, err := os.ReadFile("testdata/metrics.txt")
 	require.NoError(t, err)
 	assert.NoError(t, testutil.GatherAndCompare(reg, bytes.NewReader(buf)))
+}
+
+func TestCollectorCollectRace(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	config := Config{
+		MaxFailures:   5,
+		LeaseDuration: 15 * time.Second,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	db := test.BoltDB(t)
+	go func() {
+		defer wg.Done()
+		s := store.NewJobStore()
+		sc := NewScheduler(config, s, reg)
+		for i := 0; i < 100; i++ {
+			require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+				var merr multierror.MultiError
+				merr.Add(s.CreateBuckets(tx))
+				merr.Add(sc.UpdateSchedule(tx, &raft_log.CompactionPlanUpdate{
+					NewJobs: []*raft_log.NewCompactionJob{{
+						State: &raft_log.CompactionJobState{Name: "a", CompactionLevel: 0, Token: 1},
+						Plan:  &raft_log.CompactionJobPlan{Name: "a", CompactionLevel: 0},
+					}},
+				}))
+				assigned, err := sc.NewSchedule(tx, &raft.Log{}).AssignJob()
+				require.NoError(t, err)
+				require.NotNil(t, assigned)
+				require.Equal(t, "a", assigned.State.Name)
+				merr.Add(sc.UpdateSchedule(tx, &raft_log.CompactionPlanUpdate{
+					CompletedJobs: []*raft_log.CompletedCompactionJob{
+						{State: &raft_log.CompactionJobState{Name: "a", CompactionLevel: 0, Token: 1}},
+					},
+				}))
+				return merr.Err()
+			}))
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			_, err := testutil.GatherAndCount(reg)
+			require.NoError(t, err)
+		}
+	}()
+
+	wg.Wait()
 }

--- a/pkg/experiment/metastore/compaction/scheduler/scheduler.go
+++ b/pkg/experiment/metastore/compaction/scheduler/scheduler.go
@@ -57,8 +57,8 @@ func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 type Scheduler struct {
 	config Config
 	store  JobStore
-	// Although the job queue is only accessed for writes
-	// synchronously, the mutex is needed to collect stats.
+	// Although the job queue is only accessed synchronously,
+	// the mutex is needed to collect stats.
 	mu    sync.Mutex
 	queue *schedulerQueue
 }


### PR DESCRIPTION
There's a race condition when the stats collector accesses the queue levels slice – we can actually modify it without holding the mutex, which was introduced specifically for metrics. Since all methods are called synchronously in the context of raft command execution, this does not affect the behavior of the compaction scheduler.

It was partially fixed in #4194 for schedule updates, but the race is also possible on schedule planning. It's difficult to hit this in the real life because the level slice is bound and quickly reaches its cap when the state is restored, and the number of levels does not change after that.