### PR TITLE
fix: Use tempdir for test instead ./testdata

### DIFF
--- a/pkg/experiment/block/section_profiles_test.go
+++ b/pkg/experiment/block/section_profiles_test.go
@@ -56,7 +56,7 @@ func validateColumnIndex(t *testing.T, pf *parquet.File, count int) {
 func Test_openParquetFile(t *testing.T) {
 	path := "test.parquet"
 	ctx := context.Background()
-	bucket, _ := testutil.NewFilesystemBucket(t, ctx, "testdata")
+	bucket, _ := testutil.NewFilesystemBucket(t, ctx, t.TempDir())
 
 	buf := bytes.NewBuffer(nil)
 	count := 100


### PR DESCRIPTION
This particular test creates the requires parquet files itself.
