### PR TITLE
feat: fine grained sampling

### DIFF
--- a/pkg/distributor/sampling/config.go
+++ b/pkg/distributor/sampling/config.go
@@ -1,0 +1,10 @@
+package sampling
+
+type Config struct {
+	// UsageGroups controls sampling for pre-configured usage groups.
+	UsageGroups map[string]UsageGroupSampling `yaml:"usage_groups" json:"usage_groups"`
+}
+
+type UsageGroupSampling struct {
+	Probability float64 `yaml:"probability" json:"probability"`
+}

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/pyroscope/pkg/distributor/ingest_limits"
+	"github.com/grafana/pyroscope/pkg/distributor/sampling"
 	writepath "github.com/grafana/pyroscope/pkg/distributor/write_path"
 	"github.com/grafana/pyroscope/pkg/experiment/distributor/placement/adaptive_placement"
 	readpath "github.com/grafana/pyroscope/pkg/frontend/read_path"
@@ -35,6 +36,7 @@ type Limits struct {
 	IngestionRateMB        float64               `yaml:"ingestion_rate_mb" json:"ingestion_rate_mb"`
 	IngestionBurstSizeMB   float64               `yaml:"ingestion_burst_size_mb" json:"ingestion_burst_size_mb"`
 	IngestionLimit         *ingest_limits.Config `yaml:"ingestion_limit" json:"ingestion_limit" category:"advanced" doc:"hidden"`
+	Sampling               *sampling.Config      `yaml:"sampling" json:"sampling" category:"advanced" doc:"hidden"`
 	MaxLabelNameLength     int                   `yaml:"max_label_name_length" json:"max_label_name_length"`
 	MaxLabelValueLength    int                   `yaml:"max_label_value_length" json:"max_label_value_length"`
 	MaxLabelNamesPerSeries int                   `yaml:"max_label_names_per_series" json:"max_label_names_per_series"`
@@ -285,6 +287,10 @@ func (o *Overrides) IngestionBurstSizeBytes(tenantID string) int {
 
 func (o *Overrides) IngestionLimit(tenantID string) *ingest_limits.Config {
 	return o.getOverridesForTenant(tenantID).IngestionLimit
+}
+
+func (o *Overrides) SamplingProbability(tenantID string) *sampling.Config {
+	return o.getOverridesForTenant(tenantID).Sampling
 }
 
 // IngestionTenantShardSize returns the ingesters shard size for a given user.

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -57,8 +57,8 @@ const (
 	QueryMissingTimeRange Reason = "missing_time_range"
 	QueryInvalidTimeRange Reason = "invalid_time_range"
 
-	// IngestLimitReached is a reason for discarding a request when an ingestion limit has been reached.
-	IngestLimitReached Reason = "ingest_limit_reached"
+	IngestLimitReached     Reason = "ingest_limit_reached"
+	SkippedBySamplingRules Reason = "dropped_by_sampling_rules"
 
 	// Those profiles were dropped because of relabeling rules
 	DroppedByRelabelRules Reason = "dropped_by_relabel_rules"


### PR DESCRIPTION
Adds support for distributors to drop requests based on probabilistic sampling rules. 

The feature is tied to usage groups. Operators need to define usage groups first using the `distributor_usage_groups` tenant override and then add sampling rules via the `distributor_sampling` override. The sampling rules should target existing usage groups and provide a probability (0.0 means no profiles get through, 1.0 means all profiles are allowed).

The feature can make use of dynamically named usage groups (#4210). A valid example would be:

```
  anonymous: # tenant id
    distributor_usage_groups:
      service/${labels.service_name}: "{}"
    distributor_sampling:
      usage_groups:
        service/${labels.service_name}:
          probability: 0.5
        service/my-special-service:
          probability: 1.0
```

In this example, we drop 50% of all profiles but retain 100% of the profiles for a specific service.