### PR TITLE
chore: Use in-memory connection for scheduler tests

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -97,6 +97,10 @@ type Config struct {
 	QuerierForgetDelay      time.Duration             `yaml:"querier_forget_delay" category:"experimental"`
 	GRPCClientConfig        grpcclient.Config         `yaml:"grpc_client_config" doc:"description=This configures the gRPC client used to report errors back to the query-frontend."`
 	ServiceDiscovery        schedulerdiscovery.Config `yaml:",inline"`
+
+	// Dial options used to initiate outgoing gRPC connections.
+	// Intended to be used by tests to use in-memory network connections.
+	DialOpts []grpc.DialOption `yaml:"-"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
@@ -536,6 +540,7 @@ func (s *Scheduler) forwardErrorToFrontend(ctx context.Context, req *schedulerRe
 		return
 	}
 
+	opts = append(opts, s.cfg.DialOpts...)
 	conn, err := grpc.DialContext(ctx, req.frontendAddress, opts...)
 	if err != nil {
 		level.Warn(s.log).Log("msg", "failed to create gRPC connection to frontend to report error", "frontend", req.frontendAddress, "err", err, "requestErr", requestErr)


### PR DESCRIPTION
... to avoid test flake from network dependency.

Partial fix for https://github.com/grafana/pyroscope/issues/3923
See https://github.com/grafana/pyroscope/pull/4213 for prior work.
