### PR TITLE
chore: Refactor API handler registration

### DIFF
--- a/pkg/api/api_experimental.go
+++ b/pkg/api/api_experimental.go
@@ -18,7 +18,7 @@ func (a *API) RegisterSegmentWriter(svc *segmentwriter.SegmentWriterService) {
 
 // RegisterSegmentWriterRing registers the ring UI page associated with the distributor for writes.
 func (a *API) RegisterSegmentWriterRing(r http.Handler) {
-	a.RegisterRoute("/ring-segment-writer", r, false, true, "GET", "POST")
+	a.RegisterRoute("/ring-segment-writer", r, a.registerOptionsRingPage()...)
 	a.indexPage.AddLinks(defaultWeight, "Segment Writer", []IndexPageLink{
 		{Desc: "Ring status", Path: "/ring-segment-writer"},
 	})
@@ -29,8 +29,8 @@ func (a *API) RegisterQueryBackend(svc *querybackend.QueryBackend) {
 }
 
 func (a *API) RegisterMetastoreAdmin(adm *metastoreadmin.Admin) {
-	a.RegisterRoute("/metastore-nodes", adm.NodeListHandler(), false, true, "GET", "POST")
-	a.RegisterRoute("/metastore-client-test", adm.ClientTestHandler(), false, true, "GET", "POST")
+	a.RegisterRoute("/metastore-nodes", adm.NodeListHandler(), a.registerOptionsRingPage()...)
+	a.RegisterRoute("/metastore-client-test", adm.ClientTestHandler(), a.registerOptionsRingPage()...)
 	a.indexPage.AddLinks(defaultWeight, "Metastore", []IndexPageLink{
 		{Desc: "Nodes", Path: "/metastore-nodes"},
 		{Desc: "Client Test", Path: "/metastore-client-test"},

--- a/pkg/api/connect_options.go
+++ b/pkg/api/connect_options.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"connectrpc.com/connect"
+
+	connectapi "github.com/grafana/pyroscope/pkg/api/connect"
+	"github.com/grafana/pyroscope/pkg/util"
+)
+
+func connectInterceptorRecovery() connect.HandlerOption {
+	return connect.WithInterceptors(util.RecoveryInterceptor)
+}
+
+func (a *API) connectInterceptorAuth() connect.HandlerOption {
+	return a.cfg.GrpcAuthMiddleware
+}
+
+func (a *API) connectInterceptorLog() connect.HandlerOption {
+	return connect.WithInterceptors(util.NewLogInterceptor(a.logger))
+}
+
+func (a *API) connectOptionsRecovery() []connect.HandlerOption {
+	return append(connectapi.DefaultHandlerOptions(), connectInterceptorRecovery())
+}
+
+func (a *API) connectOptionsAuthRecovery() []connect.HandlerOption {
+	return append(connectapi.DefaultHandlerOptions(), a.connectInterceptorAuth(), connectInterceptorRecovery())
+}
+
+func (a *API) connectOptionsAuthLogRecovery() []connect.HandlerOption {
+	return append(connectapi.DefaultHandlerOptions(), a.connectInterceptorAuth(), a.connectInterceptorLog(), connectInterceptorRecovery())
+}

--- a/pkg/api/register_options.go
+++ b/pkg/api/register_options.go
@@ -1,0 +1,125 @@
+package api
+
+import (
+	"strings"
+
+	"github.com/grafana/dskit/middleware"
+
+	"github.com/grafana/pyroscope/pkg/util/gziphandler"
+)
+
+type registerMiddleware struct {
+	middleware.Interface
+	name string
+}
+
+type registerParams struct {
+	methods     []string
+	middlewares []registerMiddleware
+	isPrefix    bool
+}
+
+func (r *registerParams) logFields(path string) []interface{} {
+	gzip := false
+	auth := false
+	for _, m := range r.middlewares {
+		if m.name == "gzip" {
+			gzip = true
+		}
+		if m.name == "auth" {
+			auth = true
+		}
+	}
+	methods := strings.Join(r.methods, ",")
+	if len(r.methods) == 0 {
+		methods = "all"
+	}
+
+	pathField := "path"
+	if r.isPrefix {
+		pathField = "prefix"
+	}
+
+	return []interface{}{
+		"methods", methods,
+		pathField, path,
+		"auth", auth,
+		"gzip", gzip,
+	}
+}
+
+type RegisterOption func(*registerParams)
+
+func applyRegisterOptions(opts ...RegisterOption) *registerParams {
+	result := &registerParams{}
+	for _, opt := range opts {
+		opt(result)
+	}
+	return result
+}
+
+func WithMethod(method string) RegisterOption {
+	return func(r *registerParams) {
+		r.methods = append(r.methods, method)
+	}
+}
+
+func WithPrefix() RegisterOption {
+	return func(r *registerParams) {
+		r.isPrefix = true
+	}
+}
+
+func (a *API) WithAuthMiddleware() RegisterOption {
+	return func(r *registerParams) {
+		r.middlewares = append(r.middlewares, registerMiddleware{a.httpAuthMiddleware, "auth"})
+	}
+}
+
+func WithGzipMiddleware() RegisterOption {
+	return func(r *registerParams) {
+		r.middlewares = append(r.middlewares, registerMiddleware{middleware.Func(gziphandler.GzipHandler), "gzip"})
+	}
+}
+
+func (a *API) registerOptionsTenantPath() []RegisterOption {
+	return []RegisterOption{
+		a.WithAuthMiddleware(),
+		WithGzipMiddleware(),
+		WithMethod("GET"),
+	}
+}
+
+func (a *API) registerOptionsReadPath() []RegisterOption {
+	return a.registerOptionsTenantPath()
+}
+
+func (a *API) registerOptionsWritePath() []RegisterOption {
+	return []RegisterOption{
+		a.WithAuthMiddleware(),
+		WithGzipMiddleware(),
+		WithMethod("POST"),
+	}
+}
+
+func (a *API) registerOptionsPublicAccess() []RegisterOption {
+	return []RegisterOption{
+		WithGzipMiddleware(),
+		WithMethod("GET"),
+	}
+}
+
+func (a *API) registerOptionsPrefixPublicAccess() []RegisterOption {
+	return []RegisterOption{
+		WithGzipMiddleware(),
+		WithMethod("GET"),
+		WithPrefix(),
+	}
+}
+
+func (a *API) registerOptionsRingPage() []RegisterOption {
+	return append(
+		a.registerOptionsPublicAccess(),
+		WithMethod("POST"),
+	)
+}

--- a/pkg/api/register_options.go
+++ b/pkg/api/register_options.go
@@ -118,8 +118,9 @@ func (a *API) registerOptionsPrefixPublicAccess() []RegisterOption {
 }
 
 func (a *API) registerOptionsRingPage() []RegisterOption {
-	return append(
-		a.registerOptionsPublicAccess(),
+	return []RegisterOption{
+		WithGzipMiddleware(),
+		WithMethod("GET"),
 		WithMethod("POST"),
-	)
+	}
 }

--- a/pkg/phlare/phlare.go
+++ b/pkg/phlare/phlare.go
@@ -580,8 +580,7 @@ func (f *Phlare) Run() error {
 	}
 	f.serviceManager = sm
 
-	f.API.RegisterRoute("/ready", f.readyHandler(sm), false, false, "GET")
-
+	f.API.RegisterReadyHandler(f.readyHandler(sm))
 	RegisterHealthServer(f.Server.HTTP, grpcutil.WithManager(sm))
 	healthy := func() {
 		level.Info(f.logger).Log("msg", "Pyroscope started", "version", version.Info())


### PR DESCRIPTION
This change refactors how the API handlers are registered. I am doing
this as I am plannig to add an artificial delay middleware to both push
and /ingest endpoints.

Comparing the registration logs ideally there should have been no
mistake:

```
diff before-log.txt after-log.txt
19d18
< level=debug msg="api: registering route" methods=GET,POST,PUT,DELETE,HEAD,OPTIONS prefix=/api auth=false gzip=true
22a22
> level=debug msg="api: registering route" methods=all prefix=/api auth=false gzip=true
```
