### PR TITLE
fix: skip already-symbolized locations to preserve existing symbols

### DIFF
--- a/pkg/experiment/symbolizer/symbolizer.go
+++ b/pkg/experiment/symbolizer/symbolizer.go
@@ -139,6 +139,11 @@ func (s *Symbolizer) groupLocationsByMapping(profile *googlev1.Profile, mappings
 			continue
 		}
 
+		// Skip locations that already have symbols
+		if len(loc.Line) > 0 {
+			continue
+		}
+
 		locsByMapping[loc.MappingId] = append(locsByMapping[loc.MappingId], loc)
 	}
 


### PR DESCRIPTION
### Problem
  The symbolizer was incorrectly overwriting already-symbolized locations when processing profiles with `HasFunctions=false` mappings, even though individual locations already contained valid symbol information.

  This mainly affected OTEL eBPF profiles where:
  - Profiler successfully symbolizes some locations during collection but sets `HasFunctions=false` at mapping level
  - Symbolizer overwrites existing symbols
 
While we plan to fix this upstream (OTEL profiler should set `HasFunctions=true` when locations have symbols), this defensive check ensures robustness against:
  - Legacy profiles with inconsistent metadata
  - Other profilers with similar issues
  - Future data consistency problems

 ### Solution

  Skip already-symbolized locations in `groupLocationsByMapping()` before creating symbolization requests