### PR TITLE
Use `GetMappingIndex()` to access the mapping index of OTLP locations

### DIFF
--- a/pkg/ingester/otlp/convert.go
+++ b/pkg/ingester/otlp/convert.go
@@ -237,10 +237,7 @@ func (p *profileBuilder) convertLocationBack(ol *otelProfile.Location, dictionar
 	if i, ok := p.locationMap[ol]; ok {
 		return i, nil
 	}
-	if ol.MappingIndex == nil {
-		return 0, fmt.Errorf("invalid location address=%x: mapping index is required", ol.Address)
-	}
-	lmi := *ol.MappingIndex
+	lmi := ol.GetMappingIndex()
 	om, err := at(dictionary.MappingTable, lmi)
 	if err != nil {
 		return 0, fmt.Errorf("could not access mapping: %w", err)


### PR DESCRIPTION
I got some `mapping index is required` errors while exporting valid profiles to Pyroscope. For those profiles I don't have mapping information, thus I'm setting `location.mapping_index = 0` for each location. This is a fully described behavior in the [spec](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/profiles/v1development/profiles.proto#L456), as `mapping_table[0]` must always be some sort of null mapping.

Since `location.mapping_index` [was marked](https://github.com/open-telemetry/opentelemetry-proto/blob/b6ec07ea76b29f149667ff3e4f5f43988fd4a24a/opentelemetry/proto/profiles/v1development/profiles.proto#L437) `optional`, it becomes a `*int32` rather than an `int32` in [opentelemetry-proto-go](https://github.com/open-telemetry/opentelemetry-proto-go/blob/main/otlp/profiles/v1development/profiles.pb.go#L1111). This is not the case anymore after open-telemetry/opentelemetry-proto#659, so this change is going to be required for Pyroscope after the next release of opentelemetry-proto. 

The problem I experienced comes from the fact that Protobuf does not serialize fields set to their default value, thus all my locations have `location.mapping_index == nil`. I'm proposing to introduce this change now because it's not a big one, and I feel like Pyroscope rejects valid profiles in its present shape.