### PR TITLE
perf: add searchHint to getSeriesIndex

### DIFF
--- a/pkg/phlaredb/profile_store.go
+++ b/pkg/phlaredb/profile_store.go
@@ -540,11 +540,12 @@ func (r *seriesIDRowsRewriter) ReadRows(rows []parquet.Row) (int, error) {
 	if err != nil {
 		return n, err
 	}
-
+	// searchHint for next call of getSeriesIndex
+	var searchHint int
 	for pos, row := range rows[:n] {
 		// actual row num
 		rowNum := r.pos + int64(pos)
-		row[colIdxSeriesIndex] = parquet.ValueOf(r.seriesIndexes.getSeriesIndex(rowNum)).Level(0, 0, colIdxSeriesIndex)
+		row[colIdxSeriesIndex] = parquet.ValueOf(r.seriesIndexes.getSeriesIndex(rowNum, &searchHint)).Level(0, 0, colIdxSeriesIndex)
 	}
 
 	r.pos += int64(n)

--- a/pkg/phlaredb/profiles.go
+++ b/pkg/phlaredb/profiles.go
@@ -40,13 +40,26 @@ type rowRangeWithSeriesIndex struct {
 // those need to be strictly ordered
 type rowRangesWithSeriesIndex []rowRangeWithSeriesIndex
 
-func (s rowRangesWithSeriesIndex) getSeriesIndex(rowNum int64) uint32 {
-	for _, rg := range s {
+func (s rowRangesWithSeriesIndex) getSeriesIndex(rowNum int64, searchHint *int) uint32 {
+	for i := *searchHint; i < len(s); i++ {
+		rg := s[i]
 		// it is possible that the series is not existing
 		if rg.rowRange == nil {
 			continue
 		}
 		if rg.rowNum <= rowNum && rg.rowNum+int64(rg.length) > rowNum {
+			*searchHint = i
+			return rg.seriesIndex
+		}
+	}
+	for i := 0; i < *searchHint; i++ {
+		rg := s[i]
+		// it is possible that the series is not existing
+		if rg.rowRange == nil {
+			continue
+		}
+		if rg.rowNum <= rowNum && rg.rowNum+int64(rg.length) > rowNum {
+			*searchHint = i
 			return rg.seriesIndex
 		}
 	}


### PR DESCRIPTION
The `phlaredb.getSeriesIndex()` function is a performance bottleneck during "flushing", consuming approximately 12% of CPU.  

https://github.com/grafana/pyroscope/blob/4a2d0a8ed450c9b1e2bd249347b197efd723e99b/pkg/phlaredb/profiles.go#L43-L54
Since `rowRangesWithSeriesIndex` is strictly ordered and `rowNum` increments sequentially, implementing a `searchHint` is beneficial. This optimization reduced CPU usage of `getSeriesIndex` to 5% and reduced the "flushing" operation's duration from minutes to seconds in our tests.

Furthermore, if `seriesIDRowsRewriter.ReadRows()` has no data-race, adding `searchHint` to `seriesIDRowsRewriter`  struct would further improve efficiency.
https://github.com/grafana/pyroscope/blob/4a2d0a8ed450c9b1e2bd249347b197efd723e99b/pkg/phlaredb/profile_store.go#L538-L553