### PR TITLE
fix: change `settings.v1.SettingsService` pathType to work with grafana

### DIFF
--- a/operations/pyroscope/helm/pyroscope/Chart.yaml
+++ b/operations/pyroscope/helm/pyroscope/Chart.yaml
@@ -3,7 +3,7 @@ name: pyroscope
 description: 🔥 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 home: https://grafana.com/oss/pyroscope/
 type: application
-version: 1.14.0
+version: 1.14.1
 appVersion: 1.14.0
 dependencies:
   - name: grafana-agent

--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -27,6 +27,7 @@
 | alloy | object | `{"alloy":{"clustering":{"enabled":true},"configMap":{"create":false,"name":"alloy-config-pyroscope"},"stabilityLevel":"public-preview"},"controller":{"podAnnotations":{"profiles.grafana.com/cpu.port_name":"http-metrics","profiles.grafana.com/cpu.scrape":"true","profiles.grafana.com/goroutine.port_name":"http-metrics","profiles.grafana.com/goroutine.scrape":"true","profiles.grafana.com/memory.port_name":"http-metrics","profiles.grafana.com/memory.scrape":"true","profiles.grafana.com/service_git_ref":"v1.8.1","profiles.grafana.com/service_repository":"https://github.com/grafana/alloy"},"replicas":1,"type":"statefulset"},"enabled":true}` | ----------------------------------- |
 | ingress.className | string | `""` |  |
 | ingress.enabled | bool | `false` |  |
+| ingress.pathType | string | `"ImplementationSpecific"` |  |
 | minio | object | `{"buckets":[{"name":"grafana-pyroscope-data","policy":"none","purge":false}],"drivesPerNode":2,"enabled":false,"persistence":{"size":"5Gi"},"podAnnotations":{},"replicas":1,"resources":{"requests":{"cpu":"100m","memory":"128Mi"}},"rootPassword":"supersecret","rootUser":"grafana-pyroscope"}` | ----------------------------------- |
 | pyroscope.affinity | object | `{}` |  |
 | pyroscope.cluster_domain | string | `".cluster.local."` | Kubernetes cluster domain suffix for DNS discovery |

--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -1,6 +1,6 @@
 # pyroscope
 
-![Version: 1.14.0](https://img.shields.io/badge/Version-1.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.14.0](https://img.shields.io/badge/AppVersion-1.14.0-informational?style=flat-square)
+![Version: 1.14.1](https://img.shields.io/badge/Version-1.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.14.0](https://img.shields.io/badge/AppVersion-1.14.0-informational?style=flat-square)
 
 🔥 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services-hpa.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services-hpa.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -27,7 +27,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -48,7 +48,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -69,7 +69,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -90,7 +90,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -111,7 +111,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -132,7 +132,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -176,7 +176,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -523,7 +523,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1381,7 +1381,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1398,7 +1398,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1669,7 +1669,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1696,7 +1696,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1721,7 +1721,7 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1747,7 +1747,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1772,7 +1772,7 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1798,7 +1798,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1823,7 +1823,7 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1849,7 +1849,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1874,7 +1874,7 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1900,7 +1900,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1925,7 +1925,7 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1951,7 +1951,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1976,7 +1976,7 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2002,7 +2002,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2027,7 +2027,7 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2053,7 +2053,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2068,7 +2068,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc298d26c0525ed19a15d60af5da46a0e332b0039336f4bfa43a6605a86d9cf0
+        checksum/config: e5408b4e3b17c008d6ed1e7cf8379e04c63d80fe800e0bca69896c98df56d412
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.0"
         profiles.grafana.com/cpu.port_name: http2
@@ -2155,7 +2155,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2170,7 +2170,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc298d26c0525ed19a15d60af5da46a0e332b0039336f4bfa43a6605a86d9cf0
+        checksum/config: e5408b4e3b17c008d6ed1e7cf8379e04c63d80fe800e0bca69896c98df56d412
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.0"
         profiles.grafana.com/cpu.port_name: http2
@@ -2257,7 +2257,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2272,7 +2272,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc298d26c0525ed19a15d60af5da46a0e332b0039336f4bfa43a6605a86d9cf0
+        checksum/config: e5408b4e3b17c008d6ed1e7cf8379e04c63d80fe800e0bca69896c98df56d412
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.0"
         profiles.grafana.com/cpu.port_name: http2
@@ -2359,7 +2359,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2374,7 +2374,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc298d26c0525ed19a15d60af5da46a0e332b0039336f4bfa43a6605a86d9cf0
+        checksum/config: e5408b4e3b17c008d6ed1e7cf8379e04c63d80fe800e0bca69896c98df56d412
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.0"
         profiles.grafana.com/cpu.port_name: http2
@@ -2461,7 +2461,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2489,7 +2489,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2520,7 +2520,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2548,7 +2548,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2759,7 +2759,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2777,7 +2777,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc298d26c0525ed19a15d60af5da46a0e332b0039336f4bfa43a6605a86d9cf0
+        checksum/config: e5408b4e3b17c008d6ed1e7cf8379e04c63d80fe800e0bca69896c98df56d412
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.0"
         profiles.grafana.com/cpu.port_name: http2
@@ -2869,7 +2869,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2887,7 +2887,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc298d26c0525ed19a15d60af5da46a0e332b0039336f4bfa43a6605a86d9cf0
+        checksum/config: e5408b4e3b17c008d6ed1e7cf8379e04c63d80fe800e0bca69896c98df56d412
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.0"
         profiles.grafana.com/cpu.port_name: http2
@@ -2975,7 +2975,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2993,7 +2993,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc298d26c0525ed19a15d60af5da46a0e332b0039336f4bfa43a6605a86d9cf0
+        checksum/config: e5408b4e3b17c008d6ed1e7cf8379e04c63d80fe800e0bca69896c98df56d412
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.0"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -27,7 +27,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -48,7 +48,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -69,7 +69,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -90,7 +90,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -111,7 +111,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -132,7 +132,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -153,7 +153,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -174,7 +174,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -218,7 +218,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -565,7 +565,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1423,7 +1423,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1440,7 +1440,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1711,7 +1711,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1738,7 +1738,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1763,7 +1763,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1789,7 +1789,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1814,7 +1814,7 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1840,7 +1840,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1865,7 +1865,7 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1891,7 +1891,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1916,7 +1916,7 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1942,7 +1942,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1967,7 +1967,7 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1993,7 +1993,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2018,7 +2018,7 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2044,7 +2044,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2069,7 +2069,7 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2095,7 +2095,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2120,7 +2120,7 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2146,7 +2146,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2171,7 +2171,7 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2197,7 +2197,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2213,7 +2213,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc298d26c0525ed19a15d60af5da46a0e332b0039336f4bfa43a6605a86d9cf0
+        checksum/config: e5408b4e3b17c008d6ed1e7cf8379e04c63d80fe800e0bca69896c98df56d412
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.0"
         profiles.grafana.com/cpu.port_name: http2
@@ -2300,7 +2300,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2316,7 +2316,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc298d26c0525ed19a15d60af5da46a0e332b0039336f4bfa43a6605a86d9cf0
+        checksum/config: e5408b4e3b17c008d6ed1e7cf8379e04c63d80fe800e0bca69896c98df56d412
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.0"
         profiles.grafana.com/cpu.port_name: http2
@@ -2403,7 +2403,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2419,7 +2419,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc298d26c0525ed19a15d60af5da46a0e332b0039336f4bfa43a6605a86d9cf0
+        checksum/config: e5408b4e3b17c008d6ed1e7cf8379e04c63d80fe800e0bca69896c98df56d412
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.0"
         profiles.grafana.com/cpu.port_name: http2
@@ -2506,7 +2506,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2522,7 +2522,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc298d26c0525ed19a15d60af5da46a0e332b0039336f4bfa43a6605a86d9cf0
+        checksum/config: e5408b4e3b17c008d6ed1e7cf8379e04c63d80fe800e0bca69896c98df56d412
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.0"
         profiles.grafana.com/cpu.port_name: http2
@@ -2609,7 +2609,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2625,7 +2625,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc298d26c0525ed19a15d60af5da46a0e332b0039336f4bfa43a6605a86d9cf0
+        checksum/config: e5408b4e3b17c008d6ed1e7cf8379e04c63d80fe800e0bca69896c98df56d412
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.0"
         profiles.grafana.com/cpu.port_name: http2
@@ -2712,7 +2712,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -2728,7 +2728,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc298d26c0525ed19a15d60af5da46a0e332b0039336f4bfa43a6605a86d9cf0
+        checksum/config: e5408b4e3b17c008d6ed1e7cf8379e04c63d80fe800e0bca69896c98df56d412
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.0"
         profiles.grafana.com/cpu.port_name: http2
@@ -2998,7 +2998,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -3016,7 +3016,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc298d26c0525ed19a15d60af5da46a0e332b0039336f4bfa43a6605a86d9cf0
+        checksum/config: e5408b4e3b17c008d6ed1e7cf8379e04c63d80fe800e0bca69896c98df56d412
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.0"
         profiles.grafana.com/cpu.port_name: http2
@@ -3108,7 +3108,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -3126,7 +3126,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc298d26c0525ed19a15d60af5da46a0e332b0039336f4bfa43a6605a86d9cf0
+        checksum/config: e5408b4e3b17c008d6ed1e7cf8379e04c63d80fe800e0bca69896c98df56d412
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.0"
         profiles.grafana.com/cpu.port_name: http2
@@ -3214,7 +3214,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -3232,7 +3232,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cc298d26c0525ed19a15d60af5da46a0e332b0039336f4bfa43a6605a86d9cf0
+        checksum/config: e5408b4e3b17c008d6ed1e7cf8379e04c63d80fe800e0bca69896c98df56d412
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.0"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -43,7 +43,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -56,7 +56,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -914,7 +914,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -931,7 +931,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1127,7 +1127,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1154,7 +1154,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1179,7 +1179,7 @@ metadata:
   name: pyroscope-dev-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1295,7 +1295,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.0
+    helm.sh/chart: pyroscope-1.14.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.0"
@@ -1313,7 +1313,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 08ee1233d89130c4f36d19ace48be3e524ebd99f80a2a6c2ad76040697c16eec
+        checksum/config: fbe4bbe688271b18afc57a2491678b66e36829276d826c41cb030380350c551d
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.0"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/templates/ingress.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/ingress.yaml
@@ -33,7 +33,7 @@ spec:
             port:
               number: {{ $.Values.pyroscope.service.port }}
         path: /
-        pathType: Prefix
+        pathType: {{ $.Values.ingress.pathType }}
       - backend:
           service:
             {{- if gt (len $.Values.pyroscope.components) 1}}
@@ -44,7 +44,7 @@ spec:
             port:
               number: {{ $.Values.pyroscope.service.port }}
         path: /querier.v1.QuerierService/
-        pathType: ImplementationSpecific
+        pathType: {{ $.Values.ingress.pathType }}
       - backend:
           service:
             {{- if gt (len $.Values.pyroscope.components) 1}}
@@ -55,7 +55,7 @@ spec:
             port:
               number: {{ $.Values.pyroscope.service.port }}
         path: /render
-        pathType: Prefix
+        pathType: {{ $.Values.ingress.pathType }}
       - backend:
           service:
             {{- if gt (len $.Values.pyroscope.components) 1}}
@@ -66,7 +66,7 @@ spec:
             port:
               number: {{ $.Values.pyroscope.service.port }}
         path: /render-diff
-        pathType: Prefix
+        pathType: {{ $.Values.ingress.pathType }}
       - backend:
           service:
             {{- if gt (len $.Values.pyroscope.components) 1}}
@@ -77,7 +77,7 @@ spec:
             port:
               number: {{ $.Values.pyroscope.service.port }}
         path: /push.v1.PusherService/
-        pathType: ImplementationSpecific
+        pathType: {{ $.Values.ingress.pathType }}
       - backend:
           service:
             {{- if gt (len $.Values.pyroscope.components) 1}}
@@ -88,7 +88,7 @@ spec:
             port:
               number: {{ $.Values.pyroscope.service.port }}
         path: /ingest
-        pathType: Prefix
+        pathType: {{ $.Values.ingress.pathType }}
       - backend:
           service:
             {{- if gt (len $.Values.pyroscope.components) 1}}
@@ -99,7 +99,7 @@ spec:
             port:
               number: {{ $.Values.pyroscope.service.port }}
         path: /settings.v1.SettingsService/
-        pathType: ImplementationSpecific
+        pathType: {{ $.Values.ingress.pathType }}
       - backend:
           service:
             {{- if gt (len $.Values.pyroscope.components) 1}}
@@ -110,6 +110,6 @@ spec:
             port:
               number: {{ $.Values.pyroscope.service.port }}
         path: /adhocprofiles.v1.AdHocProfileService/
-        pathType: ImplementationSpecific
+        pathType: {{ $.Values.ingress.pathType }}
   {{- end }}
 {{- end }}

--- a/operations/pyroscope/helm/pyroscope/values.yaml
+++ b/operations/pyroscope/helm/pyroscope/values.yaml
@@ -251,6 +251,7 @@ minio:
 ingress:
   enabled: false
   className: ""
+  pathType: ImplementationSpecific
   # hosts:
   #   - localhost
   # tls:

--- a/operations/pyroscope/jsonnet/values.json
+++ b/operations/pyroscope/jsonnet/values.json
@@ -52,7 +52,8 @@
   },
   "ingress": {
     "className": "",
-    "enabled": false
+    "enabled": false,
+    "pathType": "ImplementationSpecific"
   },
   "minio": {
     "buckets": [


### PR DESCRIPTION
Our grafana instance was not able to actually change the Profiles Settings in drilldown because traffic could not route to tenant settings. Our configuration is using an AWS ALB via the alb controller and it was configuring these paths as exact matches and putting them  _after_ the prefix path of `/*`. 

This change may need to be applied to the other routes in here which have `ImplementationSpecific` configured as their `PathType`.
