### PR TITLE
chore: log query params

### DIFF
--- a/pkg/frontend/frontend_analyze_query.go
+++ b/pkg/frontend/frontend_analyze_query.go
@@ -5,7 +5,6 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/grafana/dskit/tenant"
-	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/common/model"
 
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
@@ -19,8 +18,6 @@ func (f *Frontend) AnalyzeQuery(
 	ctx context.Context,
 	c *connect.Request[querierv1.AnalyzeQueryRequest],
 ) (*connect.Response[querierv1.AnalyzeQueryResponse], error) {
-	opentracing.SpanFromContext(ctx)
-
 	tenantID, err := tenant.TenantID(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)

--- a/pkg/frontend/frontend_get_profile_stats.go
+++ b/pkg/frontend/frontend_get_profile_stats.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"connectrpc.com/connect"
-	"github.com/opentracing/opentracing-go"
 
 	"github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
@@ -15,8 +14,6 @@ func (f *Frontend) GetProfileStats(
 	ctx context.Context,
 	c *connect.Request[typesv1.GetProfileStatsRequest],
 ) (*connect.Response[typesv1.GetProfileStatsResponse], error) {
-	opentracing.SpanFromContext(ctx)
-
 	ctx = connectgrpc.WithProcedure(ctx, querierv1connect.QuerierServiceGetProfileStatsProcedure)
 	res, err := connectgrpc.RoundTripUnary[typesv1.GetProfileStatsRequest, typesv1.GetProfileStatsResponse](ctx, f, c)
 	return res, err

--- a/pkg/frontend/frontend_label_names.go
+++ b/pkg/frontend/frontend_label_names.go
@@ -5,7 +5,6 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/grafana/dskit/tenant"
-	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect"
@@ -19,11 +18,6 @@ func (f *Frontend) LabelNames(
 	ctx context.Context,
 	c *connect.Request[typesv1.LabelNamesRequest],
 ) (*connect.Response[typesv1.LabelNamesResponse], error) {
-	opentracing.SpanFromContext(ctx).
-		SetTag("start", model.Time(c.Msg.Start).Time().String()).
-		SetTag("end", model.Time(c.Msg.End).Time().String()).
-		SetTag("matchers", c.Msg.Matchers)
-
 	ctx = connectgrpc.WithProcedure(ctx, querierv1connect.QuerierServiceLabelNamesProcedure)
 
 	tenantIDs, err := tenant.TenantIDs(ctx)

--- a/pkg/frontend/frontend_label_values.go
+++ b/pkg/frontend/frontend_label_values.go
@@ -5,7 +5,6 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/grafana/dskit/tenant"
-	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect"
@@ -19,12 +18,6 @@ func (f *Frontend) LabelValues(
 	ctx context.Context,
 	c *connect.Request[typesv1.LabelValuesRequest],
 ) (*connect.Response[typesv1.LabelValuesResponse], error) {
-	opentracing.SpanFromContext(ctx).
-		SetTag("start", model.Time(c.Msg.Start).Time().String()).
-		SetTag("end", model.Time(c.Msg.End).Time().String()).
-		SetTag("matchers", c.Msg.Matchers).
-		SetTag("name", c.Msg.Name)
-
 	ctx = connectgrpc.WithProcedure(ctx, querierv1connect.QuerierServiceLabelValuesProcedure)
 
 	interval, ok := phlaremodel.GetTimeRange(c.Msg)

--- a/pkg/frontend/frontend_profile_types.go
+++ b/pkg/frontend/frontend_profile_types.go
@@ -5,7 +5,6 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/grafana/dskit/tenant"
-	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/common/model"
 
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
@@ -19,10 +18,6 @@ func (f *Frontend) ProfileTypes(
 	ctx context.Context,
 	c *connect.Request[querierv1.ProfileTypesRequest],
 ) (*connect.Response[querierv1.ProfileTypesResponse], error) {
-	opentracing.SpanFromContext(ctx).
-		SetTag("start", model.Time(c.Msg.Start).Time().String()).
-		SetTag("end", model.Time(c.Msg.End).Time().String())
-
 	ctx = connectgrpc.WithProcedure(ctx, querierv1connect.QuerierServiceProfileTypesProcedure)
 
 	interval, ok := phlaremodel.GetTimeRange(c.Msg)

--- a/pkg/frontend/frontend_select_merge_profile.go
+++ b/pkg/frontend/frontend_select_merge_profile.go
@@ -6,7 +6,6 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/grafana/dskit/tenant"
-	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/common/model"
 	"golang.org/x/sync/errgroup"
 
@@ -23,13 +22,6 @@ func (f *Frontend) SelectMergeProfile(
 	ctx context.Context,
 	c *connect.Request[querierv1.SelectMergeProfileRequest],
 ) (*connect.Response[profilev1.Profile], error) {
-	opentracing.SpanFromContext(ctx).
-		SetTag("start", model.Time(c.Msg.Start).Time().String()).
-		SetTag("end", model.Time(c.Msg.End).Time().String()).
-		SetTag("selector", c.Msg.LabelSelector).
-		SetTag("max_nodes", c.Msg.GetMaxNodes()).
-		SetTag("profile_type", c.Msg.ProfileTypeID)
-
 	ctx = connectgrpc.WithProcedure(ctx, querierv1connect.QuerierServiceSelectMergeProfileProcedure)
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {

--- a/pkg/frontend/frontend_select_merge_span_profile.go
+++ b/pkg/frontend/frontend_select_merge_span_profile.go
@@ -6,7 +6,6 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/grafana/dskit/tenant"
-	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/common/model"
 	"golang.org/x/sync/errgroup"
 
@@ -22,13 +21,6 @@ func (f *Frontend) SelectMergeSpanProfile(
 	ctx context.Context,
 	c *connect.Request[querierv1.SelectMergeSpanProfileRequest],
 ) (*connect.Response[querierv1.SelectMergeSpanProfileResponse], error) {
-	opentracing.SpanFromContext(ctx).
-		SetTag("start", model.Time(c.Msg.Start).Time().String()).
-		SetTag("end", model.Time(c.Msg.End).Time().String()).
-		SetTag("selector", c.Msg.LabelSelector).
-		SetTag("max_nodes", c.Msg.MaxNodes).
-		SetTag("profile_type", c.Msg.ProfileTypeID)
-
 	ctx = connectgrpc.WithProcedure(ctx, querierv1connect.QuerierServiceSelectMergeSpanProfileProcedure)
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {

--- a/pkg/frontend/frontend_select_merge_stacktraces.go
+++ b/pkg/frontend/frontend_select_merge_stacktraces.go
@@ -6,7 +6,6 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/grafana/dskit/tenant"
-	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/common/model"
 	"golang.org/x/sync/errgroup"
 
@@ -40,13 +39,6 @@ func (f *Frontend) selectMergeStacktracesTree(
 	ctx context.Context,
 	c *connect.Request[querierv1.SelectMergeStacktracesRequest],
 ) (*phlaremodel.Tree, error) {
-	opentracing.SpanFromContext(ctx).
-		SetTag("start", model.Time(c.Msg.Start).Time().String()).
-		SetTag("end", model.Time(c.Msg.End).Time().String()).
-		SetTag("selector", c.Msg.LabelSelector).
-		SetTag("max_nodes", c.Msg.GetMaxNodes()).
-		SetTag("profile_type", c.Msg.ProfileTypeID)
-
 	ctx = connectgrpc.WithProcedure(ctx, querierv1connect.QuerierServiceSelectMergeStacktracesProcedure)
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {

--- a/pkg/frontend/frontend_select_time_series.go
+++ b/pkg/frontend/frontend_select_time_series.go
@@ -6,7 +6,6 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/grafana/dskit/tenant"
-	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/common/model"
 	"golang.org/x/sync/errgroup"
 
@@ -22,14 +21,6 @@ func (f *Frontend) SelectSeries(
 	ctx context.Context,
 	c *connect.Request[querierv1.SelectSeriesRequest],
 ) (*connect.Response[querierv1.SelectSeriesResponse], error) {
-	opentracing.SpanFromContext(ctx).
-		SetTag("start", model.Time(c.Msg.Start).Time().String()).
-		SetTag("end", model.Time(c.Msg.End).Time().String()).
-		SetTag("selector", c.Msg.LabelSelector).
-		SetTag("step", c.Msg.Step).
-		SetTag("by", c.Msg.GroupBy).
-		SetTag("profile_type", c.Msg.ProfileTypeID)
-
 	ctx = connectgrpc.WithProcedure(ctx, querierv1connect.QuerierServiceSelectSeriesProcedure)
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {

--- a/pkg/frontend/frontend_series_labels.go
+++ b/pkg/frontend/frontend_series_labels.go
@@ -5,7 +5,6 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/grafana/dskit/tenant"
-	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/common/model"
 
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
@@ -19,12 +18,6 @@ func (f *Frontend) Series(
 	ctx context.Context,
 	c *connect.Request[querierv1.SeriesRequest],
 ) (*connect.Response[querierv1.SeriesResponse], error) {
-	opentracing.SpanFromContext(ctx).
-		SetTag("start", model.Time(c.Msg.Start).Time().String()).
-		SetTag("end", model.Time(c.Msg.End).Time().String()).
-		SetTag("matchers", c.Msg.Matchers).
-		SetTag("label_names", c.Msg.LabelNames)
-
 	ctx = connectgrpc.WithProcedure(ctx, querierv1connect.QuerierServiceSeriesProcedure)
 
 	tenantIDs, err := tenant.TenantIDs(ctx)

--- a/pkg/frontend/readpath/queryfrontend/query_label_names.go
+++ b/pkg/frontend/readpath/queryfrontend/query_label_names.go
@@ -5,8 +5,6 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/grafana/dskit/tenant"
-	"github.com/opentracing/opentracing-go"
-	"github.com/prometheus/common/model"
 
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
@@ -17,11 +15,6 @@ func (q *QueryFrontend) LabelNames(
 	ctx context.Context,
 	c *connect.Request[typesv1.LabelNamesRequest],
 ) (*connect.Response[typesv1.LabelNamesResponse], error) {
-	opentracing.SpanFromContext(ctx).
-		SetTag("start", model.Time(c.Msg.Start).Time().String()).
-		SetTag("end", model.Time(c.Msg.End).Time().String()).
-		SetTag("matchers", c.Msg.Matchers)
-
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)

--- a/pkg/frontend/readpath/queryfrontend/query_label_values.go
+++ b/pkg/frontend/readpath/queryfrontend/query_label_values.go
@@ -5,8 +5,6 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/grafana/dskit/tenant"
-	"github.com/opentracing/opentracing-go"
-	"github.com/prometheus/common/model"
 
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
@@ -17,12 +15,6 @@ func (q *QueryFrontend) LabelValues(
 	ctx context.Context,
 	c *connect.Request[typesv1.LabelValuesRequest],
 ) (*connect.Response[typesv1.LabelValuesResponse], error) {
-	opentracing.SpanFromContext(ctx).
-		SetTag("start", model.Time(c.Msg.Start).Time().String()).
-		SetTag("end", model.Time(c.Msg.End).Time().String()).
-		SetTag("matchers", c.Msg.Matchers).
-		SetTag("name", c.Msg.Name)
-
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_profile.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_profile.go
@@ -5,8 +5,6 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/grafana/dskit/tenant"
-	"github.com/opentracing/opentracing-go"
-	"github.com/prometheus/common/model"
 
 	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
@@ -19,13 +17,6 @@ func (q *QueryFrontend) SelectMergeProfile(
 	ctx context.Context,
 	c *connect.Request[querierv1.SelectMergeProfileRequest],
 ) (*connect.Response[profilev1.Profile], error) {
-	opentracing.SpanFromContext(ctx).
-		SetTag("start", model.Time(c.Msg.Start).Time().String()).
-		SetTag("end", model.Time(c.Msg.End).Time().String()).
-		SetTag("selector", c.Msg.LabelSelector).
-		SetTag("max_nodes", c.Msg.GetMaxNodes()).
-		SetTag("profile_type", c.Msg.ProfileTypeID)
-
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_span_profile.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_span_profile.go
@@ -5,8 +5,6 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/grafana/dskit/tenant"
-	"github.com/opentracing/opentracing-go"
-	"github.com/prometheus/common/model"
 
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
@@ -20,13 +18,6 @@ func (q *QueryFrontend) SelectMergeSpanProfile(
 	ctx context.Context,
 	c *connect.Request[querierv1.SelectMergeSpanProfileRequest],
 ) (*connect.Response[querierv1.SelectMergeSpanProfileResponse], error) {
-	opentracing.SpanFromContext(ctx).
-		SetTag("start", model.Time(c.Msg.Start).Time().String()).
-		SetTag("end", model.Time(c.Msg.End).Time().String()).
-		SetTag("selector", c.Msg.LabelSelector).
-		SetTag("max_nodes", c.Msg.GetMaxNodes()).
-		SetTag("profile_type", c.Msg.ProfileTypeID)
-
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces.go
@@ -5,8 +5,6 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/grafana/dskit/tenant"
-	"github.com/opentracing/opentracing-go"
-	"github.com/prometheus/common/model"
 
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
@@ -40,13 +38,6 @@ func (q *QueryFrontend) selectMergeStacktracesTree(
 	ctx context.Context,
 	c *connect.Request[querierv1.SelectMergeStacktracesRequest],
 ) (tree []byte, err error) {
-	opentracing.SpanFromContext(ctx).
-		SetTag("start", model.Time(c.Msg.Start).Time().String()).
-		SetTag("end", model.Time(c.Msg.End).Time().String()).
-		SetTag("selector", c.Msg.LabelSelector).
-		SetTag("max_nodes", c.Msg.GetMaxNodes()).
-		SetTag("profile_type", c.Msg.ProfileTypeID)
-
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)

--- a/pkg/frontend/readpath/queryfrontend/query_select_time_series.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_time_series.go
@@ -6,8 +6,6 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/grafana/dskit/tenant"
-	"github.com/opentracing/opentracing-go"
-	"github.com/prometheus/common/model"
 
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
@@ -19,14 +17,6 @@ func (q *QueryFrontend) SelectSeries(
 	ctx context.Context,
 	c *connect.Request[querierv1.SelectSeriesRequest],
 ) (*connect.Response[querierv1.SelectSeriesResponse], error) {
-	opentracing.SpanFromContext(ctx).
-		SetTag("start", model.Time(c.Msg.Start).Time().String()).
-		SetTag("end", model.Time(c.Msg.End).Time().String()).
-		SetTag("selector", c.Msg.LabelSelector).
-		SetTag("step", c.Msg.Step).
-		SetTag("by", c.Msg.GroupBy).
-		SetTag("profile_type", c.Msg.ProfileTypeID)
-
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)

--- a/pkg/frontend/readpath/queryfrontend/query_series_labels.go
+++ b/pkg/frontend/readpath/queryfrontend/query_series_labels.go
@@ -6,8 +6,6 @@ import (
 	"connectrpc.com/connect"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/tenant"
-	"github.com/opentracing/opentracing-go"
-	"github.com/prometheus/common/model"
 
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
@@ -18,12 +16,6 @@ func (q *QueryFrontend) Series(
 	ctx context.Context,
 	c *connect.Request[querierv1.SeriesRequest],
 ) (*connect.Response[querierv1.SeriesResponse], error) {
-	opentracing.SpanFromContext(ctx).
-		SetTag("start", model.Time(c.Msg.Start).Time().String()).
-		SetTag("end", model.Time(c.Msg.End).Time().String()).
-		SetTag("matchers", c.Msg.Matchers).
-		SetTag("label_names", c.Msg.LabelNames)
-
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)

--- a/pkg/pyroscope/modules_experimental.go
+++ b/pkg/pyroscope/modules_experimental.go
@@ -39,6 +39,7 @@ import (
 	"github.com/grafana/pyroscope/pkg/tenant"
 	"github.com/grafana/pyroscope/pkg/util"
 	"github.com/grafana/pyroscope/pkg/util/health"
+	"github.com/grafana/pyroscope/pkg/util/spanlogger"
 )
 
 func (f *Pyroscope) initQueryFrontend() (services.Service, error) {
@@ -78,7 +79,7 @@ func (f *Pyroscope) initQueryFrontendV1() (services.Service, error) {
 		return nil, err
 	}
 	f.API.RegisterFrontendForQuerierHandler(f.frontend)
-	f.API.RegisterQuerierServiceHandler(f.frontend)
+	f.API.RegisterQuerierServiceHandler(spanlogger.NewLogSpanParametersWrapper(f.frontend, f.logger))
 	f.API.RegisterPyroscopeHandlers(f.frontend)
 	f.API.RegisterVCSServiceHandler(f.frontend)
 	return f.frontend, nil
@@ -99,7 +100,7 @@ func (f *Pyroscope) initQueryFrontendV2() (services.Service, error) {
 		f.reg,
 	)
 
-	f.API.RegisterQuerierServiceHandler(queryFrontend)
+	f.API.RegisterQuerierServiceHandler(spanlogger.NewLogSpanParametersWrapper(queryFrontend, f.logger))
 	f.API.RegisterPyroscopeHandlers(queryFrontend)
 	f.API.RegisterVCSServiceHandler(vcsService)
 
@@ -142,7 +143,7 @@ func (f *Pyroscope) initQueryFrontendV12() (services.Service, error) {
 	)
 
 	f.API.RegisterFrontendForQuerierHandler(f.frontend)
-	f.API.RegisterQuerierServiceHandler(handler)
+	f.API.RegisterQuerierServiceHandler(spanlogger.NewLogSpanParametersWrapper(handler, f.logger))
 	f.API.RegisterPyroscopeHandlers(handler)
 	f.API.RegisterVCSServiceHandler(vcsService)
 

--- a/pkg/util/spanlogger/query_log.go
+++ b/pkg/util/spanlogger/query_log.go
@@ -1,0 +1,180 @@
+package spanlogger
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/common/model"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+)
+
+type LogSpanParametersWrapper struct {
+	client querierv1connect.QuerierServiceClient
+	logger log.Logger
+}
+
+func NewLogSpanParametersWrapper(client querierv1connect.QuerierServiceClient, logger log.Logger) *LogSpanParametersWrapper {
+	return &LogSpanParametersWrapper{
+		client: client,
+		logger: logger,
+	}
+}
+
+func (l LogSpanParametersWrapper) ProfileTypes(ctx context.Context, c *connect.Request[querierv1.ProfileTypesRequest]) (*connect.Response[querierv1.ProfileTypesResponse], error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "ProfileTypes")
+	level.Info(FromContext(ctx, l.logger)).Log(
+		"start", model.Time(c.Msg.Start).Time().String(),
+		"end", model.Time(c.Msg.End).Time().String(),
+	)
+	defer sp.Finish()
+
+	return l.client.ProfileTypes(ctx, c)
+}
+
+func (l LogSpanParametersWrapper) LabelValues(ctx context.Context, c *connect.Request[typesv1.LabelValuesRequest]) (*connect.Response[typesv1.LabelValuesResponse], error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "LabelValues")
+	level.Info(FromContext(ctx, l.logger)).Log(
+		"start", model.Time(c.Msg.Start).Time().String(),
+		"end", model.Time(c.Msg.End).Time().String(),
+		"matchers", c.Msg.Matchers,
+		"name", c.Msg.Name,
+	)
+	defer sp.Finish()
+
+	return l.client.LabelValues(ctx, c)
+}
+
+func (l LogSpanParametersWrapper) LabelNames(ctx context.Context, c *connect.Request[typesv1.LabelNamesRequest]) (*connect.Response[typesv1.LabelNamesResponse], error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "LabelNames")
+	level.Info(FromContext(ctx, l.logger)).Log(
+		"start", model.Time(c.Msg.Start).Time().String(),
+		"end", model.Time(c.Msg.End).Time().String(),
+		"matchers", c.Msg.Matchers,
+	)
+	defer sp.Finish()
+
+	return l.client.LabelNames(ctx, c)
+}
+
+func (l LogSpanParametersWrapper) Series(ctx context.Context, c *connect.Request[querierv1.SeriesRequest]) (*connect.Response[querierv1.SeriesResponse], error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "Series")
+	level.Info(FromContext(ctx, l.logger)).Log(
+		"start", model.Time(c.Msg.Start).Time().String(),
+		"end", model.Time(c.Msg.End).Time().String(),
+		"matchers", c.Msg.Matchers,
+		"label_names", c.Msg.LabelNames,
+	)
+	defer sp.Finish()
+
+	return l.client.Series(ctx, c)
+}
+
+func (l LogSpanParametersWrapper) SelectMergeStacktraces(ctx context.Context, c *connect.Request[querierv1.SelectMergeStacktracesRequest]) (*connect.Response[querierv1.SelectMergeStacktracesResponse], error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "SelectMergeStacktraces")
+	level.Info(FromContext(ctx, l.logger)).Log(
+		"start", model.Time(c.Msg.Start).Time().String(),
+		"end", model.Time(c.Msg.End).Time().String(),
+		"selector", c.Msg.LabelSelector,
+		"profile_type", c.Msg.ProfileTypeID,
+		"format", c.Msg.Format,
+		"max_nodes", c.Msg.GetMaxNodes(),
+	)
+	defer sp.Finish()
+
+	return l.client.SelectMergeStacktraces(ctx, c)
+}
+
+func (l LogSpanParametersWrapper) SelectMergeSpanProfile(ctx context.Context, c *connect.Request[querierv1.SelectMergeSpanProfileRequest]) (*connect.Response[querierv1.SelectMergeSpanProfileResponse], error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "SelectMergeSpanProfile")
+	level.Info(FromContext(ctx, l.logger)).Log(
+		"start", model.Time(c.Msg.Start).Time().String(),
+		"end", model.Time(c.Msg.End).Time().String(),
+		"selector", c.Msg.LabelSelector,
+		"profile_type", c.Msg.ProfileTypeID,
+		"format", c.Msg.Format,
+		"max_nodes", c.Msg.GetMaxNodes(),
+	)
+	defer sp.Finish()
+
+	return l.client.SelectMergeSpanProfile(ctx, c)
+}
+
+func (l LogSpanParametersWrapper) SelectMergeProfile(ctx context.Context, c *connect.Request[querierv1.SelectMergeProfileRequest]) (*connect.Response[profilev1.Profile], error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "SelectMergeProfile")
+	level.Info(FromContext(ctx, l.logger)).Log(
+		"start", model.Time(c.Msg.Start).Time().String(),
+		"end", model.Time(c.Msg.End).Time().String(),
+		"selector", c.Msg.LabelSelector,
+		"max_nodes", c.Msg.GetMaxNodes(),
+		"profile_type", c.Msg.ProfileTypeID,
+		"stacktrace_selector", c.Msg.StackTraceSelector,
+	)
+	defer sp.Finish()
+
+	return l.client.SelectMergeProfile(ctx, c)
+}
+
+func (l LogSpanParametersWrapper) SelectSeries(ctx context.Context, c *connect.Request[querierv1.SelectSeriesRequest]) (*connect.Response[querierv1.SelectSeriesResponse], error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "SelectSeries")
+	level.Info(FromContext(ctx, l.logger)).Log(
+		"start", model.Time(c.Msg.Start).Time().String(),
+		"end", model.Time(c.Msg.End).Time().String(),
+		"selector", c.Msg.LabelSelector,
+		"profile_type", c.Msg.ProfileTypeID,
+		"stacktrace_selector", c.Msg.StackTraceSelector,
+		"step", c.Msg.Step,
+		"by", c.Msg.GroupBy,
+		"aggregation", c.Msg.Aggregation,
+		"limit", c.Msg.Limit,
+	)
+	defer sp.Finish()
+
+	return l.client.SelectSeries(ctx, c)
+}
+
+func (l LogSpanParametersWrapper) Diff(ctx context.Context, c *connect.Request[querierv1.DiffRequest]) (*connect.Response[querierv1.DiffResponse], error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "Diff")
+	level.Info(FromContext(ctx, l.logger)).Log(
+		"left_start", model.Time(c.Msg.Left.Start).Time().String(),
+		"left_end", model.Time(c.Msg.Left.End).Time().String(),
+		"left_selector", c.Msg.Left.LabelSelector,
+		"left_profile_type", c.Msg.Left.ProfileTypeID,
+		"left_format", c.Msg.Left.Format,
+		"left_max_nodes", c.Msg.Left.GetMaxNodes(),
+		"right_start", model.Time(c.Msg.Right.Start).Time().String(),
+		"right_end", model.Time(c.Msg.Right.End).Time().String(),
+		"right_selector", c.Msg.Right.LabelSelector,
+		"right_profile_type", c.Msg.Right.ProfileTypeID,
+		"right_format", c.Msg.Right.Format,
+		"right_max_nodes", c.Msg.Right.GetMaxNodes(),
+	)
+	defer sp.Finish()
+
+	return l.client.Diff(ctx, c)
+}
+
+func (l LogSpanParametersWrapper) GetProfileStats(ctx context.Context, c *connect.Request[typesv1.GetProfileStatsRequest]) (*connect.Response[typesv1.GetProfileStatsResponse], error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "GetProfileStats")
+	defer sp.Finish()
+	
+	return l.client.GetProfileStats(ctx, c)
+}
+
+func (l LogSpanParametersWrapper) AnalyzeQuery(ctx context.Context, c *connect.Request[querierv1.AnalyzeQueryRequest]) (*connect.Response[querierv1.AnalyzeQueryResponse], error) {
+	sp, ctx := opentracing.StartSpanFromContext(ctx, "AnalyzeQuery")
+	level.Info(FromContext(ctx, l.logger)).Log(
+		"start", model.Time(c.Msg.Start).Time().String(),
+		"end", model.Time(c.Msg.End).Time().String(),
+		"query", c.Msg.Query,
+	)
+	defer sp.Finish()
+
+	return l.client.AnalyzeQuery(ctx, c)
+}


### PR DESCRIPTION
Implementing this in a single wrapper helps having it in V1 and V2 at the same time. Also, on extending the query API, we will be forced to add log in there as well.

Logs work fine for such queries, couldn't manage to test traces, probably will give a shot directly at dev.