### PR TITLE
chore: Add profilecli command to delete v1 blocks

### DIFF
--- a/cmd/profilecli/main.go
+++ b/cmd/profilecli/main.go
@@ -102,6 +102,10 @@ func main() {
 	raftInfoCmd := raftCmd.Command("info", "Print info about a Raft node.")
 	raftInfoParams := addRaftInfoParams(raftInfoCmd)
 
+	v2MigrationCmd := adminCmd.Command("v2-migration", "Operation to aid the v1 to v2 storage migration.")
+	v2MigrationBucketCleanupCmd := v2MigrationCmd.Command("bucket-cleanup", "Clean up v1 artificats from data bucket.")
+	v2MigrationBucketCleanupParams := addV2MigrationBackupCleanupParam(v2MigrationBucketCleanupCmd)
+
 	// parse command line arguments
 	parsedCmd := kingpin.MustParse(app.Parse(os.Args[1:]))
 
@@ -179,6 +183,10 @@ func main() {
 		}
 	case raftInfoCmd.FullCommand():
 		if err := raftInfo(ctx, raftInfoParams); err != nil {
+			os.Exit(checkError(err))
+		}
+	case v2MigrationBucketCleanupCmd.FullCommand():
+		if err := v2MigrationBucketCleanup(ctx, v2MigrationBucketCleanupParams); err != nil {
 			os.Exit(checkError(err))
 		}
 	default:

--- a/cmd/profilecli/v2-migration.go
+++ b/cmd/profilecli/v2-migration.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"container/list"
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/grafana/dskit/flagext"
+	"golang.org/x/sync/errgroup"
+
+	pyroscopecfg "github.com/grafana/pyroscope/pkg/cfg"
+	pyroscopeobj "github.com/grafana/pyroscope/pkg/objstore"
+	objstoreclient "github.com/grafana/pyroscope/pkg/objstore/client"
+)
+
+type v2MigrationBucketCleanupParams struct {
+	configFile      string
+	configExpandEnv bool
+	dryRun          string
+}
+
+func (p *v2MigrationBucketCleanupParams) isDryRun() bool {
+	return p.dryRun != "false"
+}
+
+type minimalConfig struct {
+	Bucket objstoreclient.Config `yaml:"storage"`
+}
+
+// Note: These are not the flags used, but we need to register them to get the defaults.
+func (c *minimalConfig) RegisterFlags(f *flag.FlagSet) {
+	c.Bucket.RegisterFlags(f)
+}
+
+func (c *minimalConfig) ApplyDynamicConfig() pyroscopecfg.Source {
+	return func(dst pyroscopecfg.Cloneable) error {
+		return nil
+	}
+}
+
+func (c *minimalConfig) Clone() flagext.Registerer {
+	return func(c minimalConfig) *minimalConfig {
+		return &c
+	}(*c)
+}
+
+func clientFromParams(ctx context.Context, params *v2MigrationBucketCleanupParams) (pyroscopeobj.Bucket, error) {
+	if params.configFile == "" {
+		return nil, fmt.Errorf("config file is required")
+	}
+	cfg := &minimalConfig{}
+	fs := flag.NewFlagSet("config-file-loader", flag.ContinueOnError)
+	if err := pyroscopecfg.Unmarshal(cfg,
+		pyroscopecfg.Defaults(fs),
+		pyroscopecfg.YAMLIgnoreUnknownFields(params.configFile, params.configExpandEnv),
+	); err != nil {
+		return nil, fmt.Errorf("failed parsing config: %w", err)
+	}
+
+	return objstoreclient.NewBucket(ctx, cfg.Bucket, "profilecli")
+}
+
+func addV2MigrationBackupCleanupParam(c commander) *v2MigrationBucketCleanupParams {
+	var (
+		params = &v2MigrationBucketCleanupParams{}
+	)
+	c.Flag("config.file", "The path to the pyroscope config").Default("/etc/pyroscope/config.yaml").StringVar(&params.configFile)
+	c.Flag("config.expand-env", "").Default("false").BoolVar(&params.configExpandEnv)
+	c.Flag("dry-run", "Dry run the operation.").Default("true").StringVar(&params.dryRun)
+	return params
+}
+
+func v2MigrationBucketCleanup(ctx context.Context, params *v2MigrationBucketCleanupParams) error {
+	client, err := clientFromParams(ctx, params)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	var pathsToDelete []string
+	// find prefix called "phlaredb/" on the second level
+	if err := client.Iter(ctx, "", func(name string) error {
+		if !strings.HasSuffix(name, "/") {
+			return nil
+		}
+		err := client.Iter(ctx, name, func(name string) error {
+			if strings.HasSuffix(name, "phlaredb/") {
+				pathsToDelete = append(pathsToDelete, name)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil
+		}
+
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to list tenants: %w", err)
+	}
+
+	if len(pathsToDelete) == 0 {
+		fmt.Println("No paths to delete")
+		return nil
+	}
+
+	if params.isDryRun() {
+		fmt.Println("DRY-RUN: If ran with --dry-run=false, this will delete everything under:")
+	} else {
+		fmt.Println("This will delete everything under:")
+	}
+	for _, path := range pathsToDelete {
+		fmt.Println(" - ", path)
+	}
+
+	threads := 16
+	if params.isDryRun() {
+		fmt.Println("DRY-RUN: If ran with --dry-run=false, this will delete those object store keys:")
+		return recurse(ctx, client, threads, func(key string) error {
+			fmt.Println(" - ", key)
+			return nil
+		}, pathsToDelete)
+	}
+
+	// We do actually delete here
+	fmt.Println("Last chance to cancel, waiting 3 seconds...")
+	<-time.After(3 * time.Second)
+
+	fmt.Println("Deleted object store keys:")
+	return recurse(ctx, client, threads, func(key string) error {
+		if err := client.Delete(ctx, key); err != nil {
+			return fmt.Errorf("failed to delete %s: %w", key, err)
+		}
+		fmt.Println(" - ", key)
+		return nil
+	}, pathsToDelete)
+}
+
+func recurse(ctx context.Context, b pyroscopeobj.Bucket, threads int, action func(key string) error, paths []string) error {
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(threads)
+
+	g.Go(func() error {
+		iters := list.New()
+		for _, path := range paths {
+			iters.PushBack(path)
+		}
+
+		for iters.Len() > 0 {
+			e := iters.Front()
+			path := e.Value.(string)
+
+			if err := b.Iter(gctx, path, func(path string) error {
+				if strings.HasSuffix(path, "/") {
+					iters.PushBack(path)
+					return nil
+				}
+
+				g.Go(func() error {
+					return action(path)
+				})
+
+				return nil
+			}); err != nil {
+				return fmt.Errorf("failed to iterate over %s: %w", path, err)
+			}
+			iters.Remove(e)
+		}
+
+		return nil
+	})
+
+	return g.Wait()
+}

--- a/pkg/cfg/cfg_test.go
+++ b/pkg/cfg/cfg_test.go
@@ -18,7 +18,7 @@ server:
   timeout: 60h
 tls:
   key: YAML
-`))
+`), true)
 
 	fs := flag.NewFlagSet(t.Name(), flag.PanicOnError)
 	flagSource := dFlags(fs, []string{"-verbose", "-server.port=21"})
@@ -51,7 +51,7 @@ servers:
   timeoutz: 60h
 tls:
   keey: YAML
-`))
+`), true)
 
 	fs := flag.NewFlagSet(t.Name(), flag.PanicOnError)
 	flagSource := dFlags(fs, []string{"-verbose", "-server.port=21"})

--- a/pkg/cfg/precedence_test.go
+++ b/pkg/cfg/precedence_test.go
@@ -28,7 +28,7 @@ func TestYAMLOverDefaults(t *testing.T) {
 	fs := flag.NewFlagSet(t.Name(), flag.PanicOnError)
 	err := Unmarshal(&data,
 		Defaults(fs),
-		dYAML([]byte(y)),
+		dYAML([]byte(y), true),
 	)
 
 	require.NoError(t, err)
@@ -51,7 +51,7 @@ func TestFlagOverYAML(t *testing.T) {
 
 	err := Unmarshal(&data,
 		Defaults(fs),
-		dYAML([]byte(y)),
+		dYAML([]byte(y), true),
 		dFlags(fs, []string{"-verbose=false", "-tls.cert=CLI"}),
 	)
 


### PR DESCRIPTION
As part of the v1 to v2 migration it is useful to clear out the bucket of old v1 blocks. This command will help to dry run this step and then also run the actual deletion.

The idea is based on a script from @aleks-p.

Generally ideas is you would run this using `kubectl exec` in a pod that has access to the bucket anyhow.

This is what it produced for my test example:

```
$ profilecli admin v2-migration bucket-cleanup --config.file ./cmd/pyroscope/pyroscope.yaml
DRY-RUN: If ran with --dry-run=false, this will delete everything under:
 -  adaptive_placement/phlaredb/
 -  anonymous/phlaredb/
 -  blocks/phlaredb/
 -  segments/phlaredb/
DRY-RUN: If ran with --dry-run=false, this will delete those object store keys:
 -  adaptive_placement/phlaredb/bucket-index.json.gz
 -  anonymous/phlaredb/bucket-index.json.gz
 -  blocks/phlaredb/bucket-index.json.gz
 -  segments/phlaredb/bucket-index.json.gz

$ profilecli admin v2-migration bucket-cleanup --config.file ./cmd/pyroscope/pyroscope.yaml --dry-run=false
This will delete everything under:
 -  adaptive_placement/phlaredb/
 -  anonymous/phlaredb/
 -  blocks/phlaredb/
 -  segments/phlaredb/
Last chance to cancel, waiting 3 seconds...
Deleted object store keys:
 -  adaptive_placement/phlaredb/bucket-index.json.gz
 -  anonymous/phlaredb/bucket-index.json.gz
 -  blocks/phlaredb/bucket-index.json.gz
 -  segments/phlaredb/bucket-index.json.gz
```


