### PR TITLE
fix: vcs.decodeToken can eat an error

### DIFF
--- a/pkg/frontend/vcs/token.go
+++ b/pkg/frontend/vcs/token.go
@@ -153,8 +153,11 @@ func decodeToken(value string, key []byte) (*oauth2.Token, error) {
 		// This may be a deprecated cookie. Deprecated cookies are base64 encoded deprecatedGitSessionTokenCookie objects.
 		token, innerErr := decodeDeprecatedToken(decoded, key)
 		if innerErr != nil {
-			// Deprecated fallback failed, return the original error.
-			return nil, err
+			// Deprecated fallback failed, return the original error if exists.
+			if err != nil {
+				return nil, err
+			}
+			return nil, innerErr
 		}
 		return token, nil
 	}


### PR DESCRIPTION
When the cookie contains valid base64 in json, with an empty token field. We return a nil token and eat the innerError, which leads to nil pointer exception down the line.