### PR TITLE
docs: Update ebpf supported languages content

### DIFF
--- a/docs/sources/configure-client/_index.md
+++ b/docs/sources/configure-client/_index.md
@@ -25,6 +25,11 @@ This document explains these techniques and guide you when to choose each one.
 You can send data from your application using Grafana Alloy (preferred) or Grafana Agent (legacy) collectors.
 Both collectors support profiling with eBPF, Java, and Golang in pull mode.
 
+[//]: # 'Shared content for supported languages with eBPF'
+[//]: # 'This content is located in /pyroscope/docs/sources/shared/supported-languages-ebpf.md'
+
+{{< docs/shared source="pyroscope" lookup="supported-languages-ebpf.md" version="latest" >}}
+
 [Grafana Alloy](https://grafana.com/docs/alloy/latest/) is a vendor-neutral distribution of the OpenTelemetry (OTel) Collector.
 Alloy uniquely combines the very best OSS observability signals in the community.
 Grafana Alloy uses configuration file written using River.

--- a/docs/sources/configure-client/grafana-alloy/_index.md
+++ b/docs/sources/configure-client/grafana-alloy/_index.md
@@ -13,6 +13,11 @@ aliases:
 You can send data from your application using Grafana Alloy (preferred) or Grafana Agent (legacy) collectors.
 Both collectors support profiling with eBPF, Java, and Golang in pull mode.
 
+[//]: # 'Shared content for supported languages with eBPF'
+[//]: # 'This content is located in /pyroscope/docs/sources/shared/supported-languages-ebpf.md'
+
+{{< docs/shared source="pyroscope" lookup="supported-languages-ebpf.md" version="latest" >}}
+
 [Grafana Alloy](https://grafana.com/docs/alloy/<ALLOY_VERSION>/) is a vendor-neutral distribution of the OpenTelemetry (OTel) Collector.
 Alloy uniquely combines the very best OSS observability signals in the community.
 Alloy uses configuration files written in Alloy configuration syntax.
@@ -56,13 +61,10 @@ Benefits of eBPF profiling:
 
 ### Supported languages
 
-This eBPF profiler only collects CPU profiles.
-Generally, natively compiled languages like C/C++, Go, and Rust are supported.
-Refer to [Troubleshooting unknown symbols][troubleshooting] for additional requirements.
+[//]: # 'Shared content for supported languages with eBPF'
+[//]: # 'This content is located in /pyroscope/docs/sources/shared/supported-languages-ebpf.md'
 
-Python is the only supported high-level language, as long as `python_enabled=true`.
-Other high-level languages like Java, Ruby, PHP, and JavaScript require additional work to show stack traces of methods in these languages correctly.
-Currently, the CPU usage for these languages is reported as belonging to the runtime's methods.
+{{< docs/shared source="pyroscope" lookup="supported-languages-ebpf.md" version="latest" >}}
 
 ## Golang profiling in pull mode
 

--- a/docs/sources/configure-client/grafana-alloy/ebpf/_index.md
+++ b/docs/sources/configure-client/grafana-alloy/ebpf/_index.md
@@ -32,11 +32,10 @@ However, eBPF has some limitations that make it unsuitable for certain use cases
 
 ## Supported languages
 
-This eBPF profiler only collects CPU profiles. Generally, natively compiled languages like C/C++, Go, and Rust are supported. Refer to [Troubleshooting unknown symbols][troubleshooting] for additional requirements.
+[//]: # 'Shared content for supported languages with eBPF'
+[//]: # 'This content is located in /pyroscope/docs/sources/shared/supported-languages-ebpf.md'
 
-Python is the only supported high-level language, as long as `python_enabled=true`.
-Other high-level languages like Java, Ruby, PHP, and JavaScript require additional work to show stack traces of methods in these languages correctly.
-Currently, the CPU usage for these languages is reported as belonging to the runtime's methods.
+{{< docs/shared source="pyroscope" lookup="supported-languages-ebpf.md" version="latest" >}}
 
 ## eBPF using Alloy
 

--- a/docs/sources/configure-client/grafana-alloy/ebpf/configuration/_index.md
+++ b/docs/sources/configure-client/grafana-alloy/ebpf/configuration/_index.md
@@ -41,8 +41,8 @@ The `forward_to` parameter should point to a `pyroscope.write` component to send
 
 The `pyroscope.ebpf` component supports the following languages:
 
-- Go
-- Rust
+- Go with frame pointers enabled (default)
+- Rust with frame pointers enabled
 - C/C++ with frame pointers enabled
 - Python
 

--- a/docs/sources/configure-client/profile-types.md
+++ b/docs/sources/configure-client/profile-types.md
@@ -34,6 +34,11 @@ The instrumentation method you use determines which profile types are available.
 
 You can send data from your application using Grafana Alloy collector. Alloy supports profiling with eBPF, Java, and Golang in pull mode.
 
+[//]: # 'Shared content for supported languages with eBPF'
+[//]: # 'This content is located in /pyroscope/docs/sources/shared/supported-languages-ebpf.md'
+
+{{< docs/shared source="pyroscope" lookup="supported-languages-ebpf.md" version="latest" >}}
+
 For more information, refer to [Configure the client to send profiles with Grafana Alloy](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/grafana-alloy/).
 
 This table lists the available profile types based on auto instrumentation using Alloy.

--- a/docs/sources/shared/supported-languages-ebpf.md
+++ b/docs/sources/shared/supported-languages-ebpf.md
@@ -1,0 +1,20 @@
+---
+headless: true
+description: Shared file for supported languages when using eBPF.
+---
+
+[//]: # 'This file documents the supported languages when using eBPF in Pyroscope.'
+[//]: # 'This shared file is included in these locations:'
+[//]: # '/pyroscope/docs/sources/configure-client/grafana-alloy/_index.md'
+[//]: # '/pyroscope/docs/sources/configure-client/grafana-alloy/ebpf/_index.md'
+[//]: #
+[//]: # 'If you make changes to this file, verify that the meaning and content are not changed in any place where the file is included.'
+[//]: # 'Any links should be fully qualified and not relative: /docs/grafana/ instead of ../grafana/.'
+
+The eBPF profiler only collects CPU profiles.
+Generally, natively compiled languages like C/C++, Go, and Rust are supported. They should have frame pointers enabled (enabled by default in Go).
+Refer to [Troubleshooting unknown symbols][troubleshooting] for additional requirements and information.
+
+Python is the only supported high-level language, as long as `python_enabled=true`.
+Other high-level languages like Java, Ruby, PHP, and JavaScript require additional work to show stack traces of methods in these languages correctly.
+Currently, the CPU usage for these languages is reported as belonging to the runtime's methods.


### PR DESCRIPTION
A few places use the same text so I consolidated it into a shared file. 

Also, several places mention ebpf, but unless someone is more familiar with ebpf if they're looking if Python/c/c++/rust is supported for auto instrumentation, it is several layers deep to find it so I bubbled it up. I also put that frame pointers are needed (except Python)

@Rperry2174 @korniltsev 