### PR TITLE
[DOC] Add doc for finding URL, password, and user in Cloud Profiles

### DIFF
--- a/docs/sources/configure-client/language-sdks/dotnet.md
+++ b/docs/sources/configure-client/language-sdks/dotnet.md
@@ -204,3 +204,10 @@ To configure the .NET SDK to send data to Grafana Cloud Profiles or Pyroscope, r
 If you need to send data to Grafana Cloud, you'll have to configure HTTP Basic authentication. Replace `<User>` with your Grafana Cloud stack user and `<Password>` with your Grafana Cloud API key.
 
 If your open source Pyroscope server has multi-tenancy enabled, you'll need to specify a tenant ID. Replace `<TenantID>` with your Pyroscope tenant ID.
+
+### Locate the URL, user, and password in Grafana Cloud Profiles
+
+[//]: # 'Shared content for URl locationin Grafana Cloud Profiles'
+[//]: # 'This content is located in /pyroscope/docs/sources/shared/locate-url-pw-user-cloud-profiles.md'
+
+{{< docs/shared source="pyroscope" lookup="locate-url-pw-user-cloud-profiles.md" version="latest" >}}

--- a/docs/sources/configure-client/language-sdks/dotnet.md
+++ b/docs/sources/configure-client/language-sdks/dotnet.md
@@ -207,7 +207,7 @@ If your open source Pyroscope server has multi-tenancy enabled, you'll need to s
 
 ### Locate the URL, user, and password in Grafana Cloud Profiles
 
-[//]: # 'Shared content for URl locationin Grafana Cloud Profiles'
+[//]: # 'Shared content for URl location in Grafana Cloud Profiles'
 [//]: # 'This content is located in /pyroscope/docs/sources/shared/locate-url-pw-user-cloud-profiles.md'
 
 {{< docs/shared source="pyroscope" lookup="locate-url-pw-user-cloud-profiles.md" version="latest" >}}

--- a/docs/sources/configure-client/language-sdks/go_push.md
+++ b/docs/sources/configure-client/language-sdks/go_push.md
@@ -89,7 +89,7 @@ Alternatively, if you want more control over the profiling process, you can manu
 
 ```go
   profiler, err := pyroscope.Start(pyroscope.Config{
-    // omitted for brevity 
+    // omitted for brevity
   })
   if err != nil {
     // the only reason this would fail is if the configuration is not valid
@@ -177,6 +177,13 @@ pyroscope.Start(pyroscope.Config{
   },
 })
 ```
+
+### Locate the URL, user, and password in Grafana Cloud Profiles
+
+[//]: # 'Shared content for URl locationin Grafana Cloud Profiles'
+[//]: # 'This content is located in /pyroscope/docs/sources/shared/locate-url-pw-user-cloud-profiles.md'
+
+{{< docs/shared source="pyroscope" lookup="locate-url-pw-user-cloud-profiles.md" version="latest" >}}
 
 ### Option: Use `DisableGCRuns` for handling increased memory usage
 

--- a/docs/sources/configure-client/language-sdks/go_push.md
+++ b/docs/sources/configure-client/language-sdks/go_push.md
@@ -180,7 +180,7 @@ pyroscope.Start(pyroscope.Config{
 
 ### Locate the URL, user, and password in Grafana Cloud Profiles
 
-[//]: # 'Shared content for URl locationin Grafana Cloud Profiles'
+[//]: # 'Shared content for URl location in Grafana Cloud Profiles'
 [//]: # 'This content is located in /pyroscope/docs/sources/shared/locate-url-pw-user-cloud-profiles.md'
 
 {{< docs/shared source="pyroscope" lookup="locate-url-pw-user-cloud-profiles.md" version="latest" >}}

--- a/docs/sources/configure-client/language-sdks/java.md
+++ b/docs/sources/configure-client/language-sdks/java.md
@@ -178,7 +178,7 @@ The Java integration supports JFR format to be able to support multiple events (
 | `PYROSCOPE_PROFILER_LOCK`                   | Sets the threshold to register lock events, in nanoseconds (equivalent to `--lock=` in `async-profiler`). The default value is `""` - empty string, which means that lock profiling is disabled. Setting it to `0` will register every event, causing significant CPU and network overhead, making it not suitable for production environments. We recommend setting a starting value of 10ms and adjusting it as needed.        |
 | `PYROSCOPE_UPLOAD_INTERVAL`                 | Sets the interval for uploading profiling data. The default is `10s`.                                                                                                                                                                                                                                                                                                                                                            |
 | `PYROSCOPE_JAVA_STACK_DEPTH_MAX`            | Sets the maximum stack depth. The default is `2048`.                                                                                                                                                                                                                                                                                                                                                                             |
-| `PYROSCOPE_SERVER_ADDRESS`                  | Address of the Pyroscope server. The default is `http://localhost:4040`                                                                                                                                                                                                                                                                                                                                                          | 
+| `PYROSCOPE_SERVER_ADDRESS`                  | Address of the Pyroscope server. The default is `http://localhost:4040`                                                                                                                                                                                                                                                                                                                                                          |
 | `PYROSCOPE_CONFIGURATION_FILE`              | Sets an additional properties configuration file. The default value is `pyroscope.properties`.                                                                                                                                                                                                                                                                                                                                   |
 | `PYROSCOPE_BASIC_AUTH_USER`                 | HTTP Basic authentication username. The default value is `""` - empty string, no authentication.                                                                                                                                                                                                                                                                                                                                 |
 | `PYROSCOPE_BASIC_AUTH_PASSWORD`             | HTTP Basic authentication password. The default value is `""` - empty string, no authentication.                                                                                                                                                                                                                                                                                                                                 |
@@ -218,7 +218,14 @@ If you need to send data to Grafana Cloud, you'll have to configure HTTP Basic a
 
 If your Pyroscope server has multi-tenancy enabled, you'll need to configure a tenant ID. Replace `<TenantID>` with your Pyroscope tenant ID.
 
-#### Example configurations
+### Locate the URL, user, and password in Grafana Cloud Profiles
+
+[//]: # 'Shared content for URl locationin Grafana Cloud Profiles'
+[//]: # 'This content is located in /pyroscope/docs/sources/shared/locate-url-pw-user-cloud-profiles.md'
+
+{{< docs/shared source="pyroscope" lookup="locate-url-pw-user-cloud-profiles.md" version="latest" >}}
+
+### Example configurations
 
 The following configuration sets application name, Pyroscope format, profiling interval, event, and lock.
 This example is an excerpt from the [`rideshare` Dockerfile](https://github.com/grafana/pyroscope/blob/main/examples/language-sdk-instrumentation/java/rideshare/Dockerfile#L24-L34) available in the Pyroscope repository.

--- a/docs/sources/configure-client/language-sdks/java.md
+++ b/docs/sources/configure-client/language-sdks/java.md
@@ -220,7 +220,7 @@ If your Pyroscope server has multi-tenancy enabled, you'll need to configure a t
 
 ### Locate the URL, user, and password in Grafana Cloud Profiles
 
-[//]: # 'Shared content for URl locationin Grafana Cloud Profiles'
+[//]: # 'Shared content for URl location in Grafana Cloud Profiles'
 [//]: # 'This content is located in /pyroscope/docs/sources/shared/locate-url-pw-user-cloud-profiles.md'
 
 {{< docs/shared source="pyroscope" lookup="locate-url-pw-user-cloud-profiles.md" version="latest" >}}

--- a/docs/sources/configure-client/language-sdks/nodejs.md
+++ b/docs/sources/configure-client/language-sdks/nodejs.md
@@ -137,6 +137,13 @@ If you need to send data to Grafana Cloud, you’ll have to configure HTTP Basic
 
 If your Pyroscope server has multi-tenancy enabled, you’ll need to configure a tenant ID. Replace `tenantID` with your Pyroscope tenant ID.
 
+### Locate the URL, user, and password in Grafana Cloud Profiles
+
+[//]: # 'Shared content for URl locationin Grafana Cloud Profiles'
+[//]: # 'This content is located in /pyroscope/docs/sources/shared/locate-url-pw-user-cloud-profiles.md'
+
+{{< docs/shared source="pyroscope" lookup="locate-url-pw-user-cloud-profiles.md" version="latest" >}}
+
 ## Troubleshoot
 
 Setting `DEBUG` env to `pyroscope` provides additional debugging information.

--- a/docs/sources/configure-client/language-sdks/nodejs.md
+++ b/docs/sources/configure-client/language-sdks/nodejs.md
@@ -139,7 +139,7 @@ If your Pyroscope server has multi-tenancy enabled, you’ll need to configure a
 
 ### Locate the URL, user, and password in Grafana Cloud Profiles
 
-[//]: # 'Shared content for URl locationin Grafana Cloud Profiles'
+[//]: # 'Shared content for URl location in Grafana Cloud Profiles'
 [//]: # 'This content is located in /pyroscope/docs/sources/shared/locate-url-pw-user-cloud-profiles.md'
 
 {{< docs/shared source="pyroscope" lookup="locate-url-pw-user-cloud-profiles.md" version="latest" >}}

--- a/docs/sources/configure-client/language-sdks/python.md
+++ b/docs/sources/configure-client/language-sdks/python.md
@@ -115,6 +115,13 @@ If you need to send data to Grafana Cloud, you'll have to configure HTTP Basic a
 
 If your Pyroscope server has multi-tenancy enabled, you'll need to configure a tenant ID. Replace `<TenantID>` with your Pyroscope tenant ID.
 
+### Locate the URL, user, and password in Grafana Cloud Profiles
+
+[//]: # 'Shared content for URl locationin Grafana Cloud Profiles'
+[//]: # 'This content is located in /pyroscope/docs/sources/shared/locate-url-pw-user-cloud-profiles.md'
+
+{{< docs/shared source="pyroscope" lookup="locate-url-pw-user-cloud-profiles.md" version="latest" >}}
+
 ## Python profiling examples
 
 Check out the following resources to learn more about Python profiling:

--- a/docs/sources/configure-client/language-sdks/python.md
+++ b/docs/sources/configure-client/language-sdks/python.md
@@ -117,7 +117,7 @@ If your Pyroscope server has multi-tenancy enabled, you'll need to configure a t
 
 ### Locate the URL, user, and password in Grafana Cloud Profiles
 
-[//]: # 'Shared content for URl locationin Grafana Cloud Profiles'
+[//]: # 'Shared content for URl location in Grafana Cloud Profiles'
 [//]: # 'This content is located in /pyroscope/docs/sources/shared/locate-url-pw-user-cloud-profiles.md'
 
 {{< docs/shared source="pyroscope" lookup="locate-url-pw-user-cloud-profiles.md" version="latest" >}}

--- a/docs/sources/configure-client/language-sdks/ruby.md
+++ b/docs/sources/configure-client/language-sdks/ruby.md
@@ -102,6 +102,13 @@ If you need to send data to Grafana Cloud, you'll have to configure HTTP Basic a
 
 If your Pyroscope server has multi-tenancy enabled, you'll need to configure a tenant ID. Replace `<TenantID>` with your Pyroscope tenant ID.
 
+### Locate the URL, user, and password in Grafana Cloud Profiles
+
+[//]: # 'Shared content for URl locationin Grafana Cloud Profiles'
+[//]: # 'This content is located in /pyroscope/docs/sources/shared/locate-url-pw-user-cloud-profiles.md'
+
+{{< docs/shared source="pyroscope" lookup="locate-url-pw-user-cloud-profiles.md" version="latest" >}}
+
 ## Ruby profiling examples
 
 Check out the following resources to learn more about Ruby profiling:

--- a/docs/sources/configure-client/language-sdks/ruby.md
+++ b/docs/sources/configure-client/language-sdks/ruby.md
@@ -104,7 +104,7 @@ If your Pyroscope server has multi-tenancy enabled, you'll need to configure a t
 
 ### Locate the URL, user, and password in Grafana Cloud Profiles
 
-[//]: # 'Shared content for URl locationin Grafana Cloud Profiles'
+[//]: # 'Shared content for URl location in Grafana Cloud Profiles'
 [//]: # 'This content is located in /pyroscope/docs/sources/shared/locate-url-pw-user-cloud-profiles.md'
 
 {{< docs/shared source="pyroscope" lookup="locate-url-pw-user-cloud-profiles.md" version="latest" >}}

--- a/docs/sources/configure-client/language-sdks/rust.md
+++ b/docs/sources/configure-client/language-sdks/rust.md
@@ -88,7 +88,7 @@ agent_ready.shutdown();
 
 ### Locate the URL, user, and password in Grafana Cloud Profiles
 
-[//]: # 'Shared content for URl locationin Grafana Cloud Profiles'
+[//]: # 'Shared content for URl location in Grafana Cloud Profiles'
 [//]: # 'This content is located in /pyroscope/docs/sources/shared/locate-url-pw-user-cloud-profiles.md'
 
 {{< docs/shared source="pyroscope" lookup="locate-url-pw-user-cloud-profiles.md" version="latest" >}}

--- a/docs/sources/configure-client/language-sdks/rust.md
+++ b/docs/sources/configure-client/language-sdks/rust.md
@@ -86,6 +86,13 @@ request to the server might be missed if the agent is not shutdown properly.
 agent_ready.shutdown();
 ```
 
+### Locate the URL, user, and password in Grafana Cloud Profiles
+
+[//]: # 'Shared content for URl locationin Grafana Cloud Profiles'
+[//]: # 'This content is located in /pyroscope/docs/sources/shared/locate-url-pw-user-cloud-profiles.md'
+
+{{< docs/shared source="pyroscope" lookup="locate-url-pw-user-cloud-profiles.md" version="latest" >}}
+
 ## Add profiling labels to Rust applications
 
 Tags can be added or removed after the agent is started. As of 0.5.0, the

--- a/docs/sources/shared/locate-url-pw-user-cloud-profiles.md
+++ b/docs/sources/shared/locate-url-pw-user-cloud-profiles.md
@@ -18,7 +18,7 @@ This information is located in the **Pyroscope** section of your Grafana Cloud s
 
 1. Navigate to your Grafana Cloud stack.
 1. Select **Details** next to your stack.
-1. Locate the **Pyroscope** section and select **Send Profiles**.
+1. Locate the **Pyroscope** section and select **Details**.
 1. Copy the **URL**, **User**, and **Password** values in the **Configure the client and data source using Grafana credentials** section.
    ![Locate the SDK or Grafana Alloy configuration values](/media/docs/pyroscope/cloud-profiles-url-user-password.png)
 1. Use these values to complete the configuration.

--- a/docs/sources/shared/locate-url-pw-user-cloud-profiles.md
+++ b/docs/sources/shared/locate-url-pw-user-cloud-profiles.md
@@ -1,0 +1,27 @@
+---
+headless: true
+description: Shared file for available profile types.
+---
+
+[//]: # 'This file where to locate the username, password, and URL in Cloud Profiles.'
+[//]: # 'This shared file is included in these locations:'
+[//]: # '/website/docs/grafana-cloud/monitor-applications/profiles/send-profile-data.md'
+[//]: #
+[//]: #
+[//]: # 'If you make changes to this file, verify that the meaning and content are not changed in any place where the file is included.'
+[//]: # 'Any links should be fully qualified and not relative: /docs/grafana/ instead of ../grafana/.'
+
+<!-- Locate your stack's URL, user, and password -->
+
+When you configure Alloy or your SDK, you need to provide the URL, user, and password for your Grafana Cloud stack.
+This information is located in the **Pyroscope** section of your Grafana Cloud stack.
+
+1. Navigate to your Grafana Cloud stack.
+1. Select **Details** next to your stack.
+1. Locate the **Pyroscope** section and select **Send Profiles**.
+1. Copy the **URL**, **User**, and **Password** values in the **Configure the client and data source using Grafana credentials** section.
+   ![Locate the SDK or Grafana Alloy configuration values](/media/docs/pyroscope/cloud-profiles-url-user-password.png)
+1. Use these values to complete the configuration.
+
+As an alternative, you can also create a Cloud Access Policy and generate a token to use instead of the user and password.
+For more information, refer to [Create a Cloud Access Policy](https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies/).


### PR DESCRIPTION
Adds documentation for locating the user, password, and URL in the Grafana Cloud Profiles stack. 

This PR:
* Add a shared file that explains how to find the user, password, and URL in the Grafana Cloud Profiles stack. 
* Inserts the shared file into all of the SDK docs

Fixes https://github.com/grafana/pyroscope/issues/3672
Related: https://github.com/grafana/website/pull/26886