### PR TITLE
chore: Fix reference in grafana-alloy/ebp/setup-linux.md

### DIFF
--- a/docs/sources/configure-client/grafana-alloy/ebpf/setup-linux.md
+++ b/docs/sources/configure-client/grafana-alloy/ebpf/setup-linux.md
@@ -23,7 +23,7 @@ Before you begin, you need:
 - Access to Grafana with the [Grafana Pyroscope data source][pyroscope-ds] provisioned.
 
 {{% admonition type="note" %}}
-If you don't have a Grafana or a Pyroscope server, you can use the [Grafana Cloud][gcloud] free plan to get started.
+If you don't have a Grafana or a Pyroscope server, you can use the [Grafana Cloud][https://grafana.com/auth/sign-up/create-user?pg=pricing&plcmt=free&cta=create-free-account] free plan to get started.
 {{% /admonition %}}
 
 ## Verify system meets the requirements


### PR DESCRIPTION
There was a link missing from  https://grafana.com/docs/pyroscope/latest/configure-client/grafana-alloy/ebpf/setup-linux/#before-you-begin for the free trial