### PR TITLE
distributor: add new metrics

### DIFF
--- a/pkg/distributor/metrics.go
+++ b/pkg/distributor/metrics.go
@@ -17,6 +17,9 @@ type metrics struct {
 	receivedSamplesBytes      *prometheus.HistogramVec
 	receivedSymbolsBytes      *prometheus.HistogramVec
 	replicationFactor         prometheus.Gauge
+
+	receivedDecompressedBytesTotal *prometheus.HistogramVec
+	processedDecompressedBytes     *prometheus.HistogramVec
 }
 
 func newMetrics(reg prometheus.Registerer) *metrics {
@@ -39,7 +42,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			prometheus.HistogramOpts{
 				Namespace: "pyroscope",
 				Name:      "distributor_received_decompressed_bytes",
-				Help:      "The number of decompressed bytes per profiles received by the distributor.",
+				Help:      "The number of decompressed bytes per profiles received by the distributor after limits/sampling checks.",
 				Buckets:   prometheus.ExponentialBucketsRange(minBytes, maxBytes, bucketsCount),
 			},
 			[]string{"type", "tenant"},
@@ -71,6 +74,24 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			},
 			[]string{"type", "tenant"},
 		),
+		receivedDecompressedBytesTotal: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: "pyroscope",
+				Name:      "distributor_received_decompressed_bytes_total",
+				Help:      "The total number of decompressed bytes per profile received by the distributor before limits/sampling checks.",
+				Buckets:   prometheus.ExponentialBucketsRange(minBytes, maxBytes, bucketsCount),
+			},
+			[]string{"tenant"},
+		),
+		processedDecompressedBytes: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: "pyroscope",
+				Name:      "distributor_processed_decompressed_bytes",
+				Help:      "The number of decompressed bytes per profile received (processed) by the distributor after limits/sampling checks and normalization.",
+				Buckets:   prometheus.ExponentialBucketsRange(minBytes, maxBytes, bucketsCount),
+			},
+			[]string{"tenant"},
+		),
 	}
 	if reg != nil {
 		reg.MustRegister(
@@ -80,6 +101,8 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			m.receivedSamplesBytes,
 			m.receivedSymbolsBytes,
 			m.replicationFactor,
+			m.receivedDecompressedBytesTotal,
+			m.processedDecompressedBytes,
 		)
 	}
 	return m

--- a/pkg/distributor/model/push.go
+++ b/pkg/distributor/model/push.go
@@ -35,9 +35,11 @@ type ProfileSeries struct {
 
 	Annotations []*v1.ProfileAnnotation
 
-	// always 1
+	// always 1 todo delete
 	TotalProfiles          int64
 	TotalBytesUncompressed int64
+
+	TotalBytesUncompressedProcessed int64 // after normalization and other size-reducing manipulation
 
 	DiscardedProfilesRelabeling int64
 	DiscardedBytesRelabeling    int64
@@ -80,7 +82,6 @@ func getProfileLanguageFromSpy(spyName string) string {
 func (req *ProfileSeries) Clone() *ProfileSeries {
 	c := &ProfileSeries{
 		TenantID:               req.TenantID,
-		TotalProfiles:          req.TotalProfiles,
 		TotalBytesUncompressed: req.TotalBytesUncompressed,
 		Labels:                 phlaremodel.Labels(req.Labels).Clone(),
 		Profile:                &pprof.Profile{Profile: req.Profile.CloneVT()},


### PR DESCRIPTION
Suggesting new metrics for these issues

https://github.com/grafana/pyroscope-squad/issues/557
https://github.com/grafana/pyroscope-squad/issues/346

1. `distributor_received_decompressed_bytes_total` - incremented for each received profile as soon we try processing the profile, before any ratelimit/sampling checks
2. `distributor_processed_decompressed_bytes` - incremented after ratelimit/sampling checks at the exit of the processing routine with `defer` (note : potentially after normalization if the profile is valid)


TODO: add tests

