### PR TITLE
feat: Set querier.max-flamegraph-nodes-max default to 1,000,000

### DIFF
--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -180,7 +180,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxProfileSymbolValueLength, "validation.max-profile-symbol-value-length", 65535, "Maximum length of a profile symbol value (labels, function names and filenames, etc...). Profiles are not rejected instead symbol values are truncated. 0 to disable.")
 
 	f.IntVar(&l.MaxFlameGraphNodesDefault, "querier.max-flamegraph-nodes-default", 8<<10, "Maximum number of flame graph nodes by default. 0 to disable.")
-	f.IntVar(&l.MaxFlameGraphNodesMax, "querier.max-flamegraph-nodes-max", 0, "Maximum number of flame graph nodes allowed. 0 to disable.")
+	f.IntVar(&l.MaxFlameGraphNodesMax, "querier.max-flamegraph-nodes-max", 1_000_000, "Maximum number of flame graph nodes allowed. 0 to disable.")
 
 	f.Var(&l.DistributorAggregationWindow, "distributor.aggregation-window", "Duration of the distributor aggregation window. Requires aggregation period to be specified. 0 to disable.")
 	f.Var(&l.DistributorAggregationPeriod, "distributor.aggregation-period", "Duration of the distributor aggregation period. Requires aggregation window to be specified. 0 to disable.")


### PR DESCRIPTION
closes https://github.com/grafana/pyroscope-squad/issues/560

This config value previously defaulted to 0 (unlimited). In retrospect, it's valuable for it to be set to some (quite high) limit to stop unmanageably large values of `maxNodes` to be sent in query requests.

This will apply to any endpoint which supports `maxNodes` EXCEPT `/SelectMergeProfile`. See 

https://github.com/grafana/pyroscope/blob/b201c2c3954cd19b5be3036967ba239f25c22540/pkg/frontend/readpath/queryfrontend/query_select_merge_profile.go#L32-L34