### PR TITLE
fix(update): Insecure TLS configuration

### DIFF
--- a/pkg/metastore/discovery/kuberesolver/kubernetes.go
+++ b/pkg/metastore/discovery/kuberesolver/kubernetes.go
@@ -86,7 +86,7 @@ func NewInClusterK8sClient() (K8sClient, error) {
 	certPool := x509.NewCertPool()
 	certPool.AppendCertsFromPEM(ca)
 	transport := &http.Transport{TLSClientConfig: &tls.Config{
-		MinVersion: tls.VersionTLS10,
+		MinVersion: tls.VersionTLS12,
 		RootCAs:    certPool,
 	}}
 	httpClient := &http.Client{Transport: transport, Timeout: time.Nanosecond * 0}


### PR DESCRIPTION
fix the problem, update the TLS configuration in the `NewInClusterK8sClient` function so that the minimum TLS version is set to `tls.VersionTLS12` instead of `tls.VersionTLS10`. This change should be made directly in the assignment to the `MinVersion` field of the `tls.Config` struct on line 89. No other changes are required, as the rest of the TLS configuration is appropriate. The fix only requires changing the constant used for the minimum version.

#### References
Wikipedia: [Transport Layer Security](https://en.wikipedia.org/wiki/Transport_Layer_Security)
Mozilla: [Security/Server Side TLS](https://wiki.mozilla.org/Security/Server_Side_TLS)
OWASP: [Transport Layer Protection Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Protection_Cheat_Sheet.html)