### PR TITLE
distributor: collect receive metrics at multiple stages

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -187,6 +187,8 @@ Usage of ./pyroscope:
     	The tenant's shard size used by shuffle-sharding. Must be set both on ingesters and distributors. 0 disables shuffle sharding.
   -distributor.push.timeout duration
     	Timeout when pushing data to ingester. (default 5s)
+  -distributor.receive-metric-stage value
+    	The stage at which to record receive metrics. Valid values are: received, sampled, normalized. Default is sampled. (default sampled)
   -distributor.replication-factor int
     	The number of ingesters to write to and read from. (default 1)
   -distributor.ring.consul.acl-token string

--- a/pkg/distributor/distributor_recvmetric_test.go
+++ b/pkg/distributor/distributor_recvmetric_test.go
@@ -1,0 +1,197 @@
+package distributor
+
+import (
+	"context"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/ring"
+	"github.com/grafana/dskit/ring/client"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	distributormodel "github.com/grafana/pyroscope/pkg/distributor/model"
+	"github.com/grafana/pyroscope/pkg/distributor/recvmetric"
+	phlaremodel "github.com/grafana/pyroscope/pkg/model"
+	"github.com/grafana/pyroscope/pkg/pprof"
+	"github.com/grafana/pyroscope/pkg/tenant"
+	"github.com/grafana/pyroscope/pkg/testhelper"
+	"github.com/grafana/pyroscope/pkg/validation"
+)
+
+func TestDistributorPushWithDifferentTenantStages(t *testing.T) {
+	testCases := []struct {
+		name            string
+		tenant          string
+		profilePath     string
+		tenantStage     recvmetric.Stage
+		limitOverrides  func(l *validation.Limits)
+		failIngester    bool
+		expectErr       bool
+		expectedErrMsg  string
+		expectedMetrics []string
+	}{
+		{
+			name:        "tenant with received stage - successful push",
+			tenant:      "tenant-received",
+			profilePath: "../../pkg/og/convert/testdata/cpu.pprof",
+			tenantStage: recvmetric.StageReceived,
+			expectedMetrics: []string{
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="normalized",tenant="tenant-received"} 2024`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="sampled",tenant="tenant-received"} 2144`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="true",stage="received",tenant="tenant-received"} 2198`,
+			},
+		},
+		{
+			name:        "tenant with sampled stage - successful push",
+			tenant:      "tenant-sampled",
+			profilePath: "../../pkg/og/convert/testdata/cpu.pprof",
+			tenantStage: recvmetric.StageSampled,
+			expectedMetrics: []string{
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="normalized",tenant="tenant-sampled"} 2024`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="received",tenant="tenant-sampled"} 2198`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="true",stage="sampled",tenant="tenant-sampled"} 2144`,
+			},
+		},
+		{
+			name:        "tenant with normalized stage - successful push",
+			tenant:      "tenant-normalized",
+			profilePath: "../../pkg/og/convert/testdata/cpu.pprof",
+			tenantStage: recvmetric.StageNormalized,
+			expectedMetrics: []string{
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="received",tenant="tenant-normalized"} 2198`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="sampled",tenant="tenant-normalized"} 2144`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="true",stage="normalized",tenant="tenant-normalized"} 2024`,
+			},
+		},
+		{
+			name:        "tenant with rate limit - only received stage",
+			tenant:      "tenant-rate-limited",
+			profilePath: "../../pkg/og/convert/testdata/cpu.pprof",
+			tenantStage: recvmetric.StageSampled,
+			limitOverrides: func(l *validation.Limits) {
+				l.IngestionRateMB = 0.000001
+				l.IngestionBurstSizeMB = 0.000001
+			},
+			expectErr:      true,
+			expectedErrMsg: "rate limit",
+			expectedMetrics: []string{
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="received",tenant="tenant-rate-limited"} 2198`,
+			},
+		},
+		{
+			name:         "tenant with normalized stage but ingester fails",
+			tenant:       "tenant-ingester-fail",
+			profilePath:  "../../pkg/og/convert/testdata/cpu.pprof",
+			tenantStage:  recvmetric.StageNormalized,
+			failIngester: true,
+			expectErr:    true,
+			expectedMetrics: []string{
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="received",tenant="tenant-ingester-fail"} 2198`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="sampled",tenant="tenant-ingester-fail"} 2144`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="true",stage="normalized",tenant="tenant-ingester-fail"} 2024`,
+			},
+		},
+		{
+			name:        "heap profile with sample type relabeling - keep only inuse_space",
+			tenant:      "tenant-heap-relabel",
+			profilePath: "../../pkg/pprof/testdata/heap",
+			tenantStage: recvmetric.StageNormalized,
+			limitOverrides: func(l *validation.Limits) {
+				l.SampleTypeRelabelingRules = []*relabel.Config{
+					{
+						SourceLabels: []model.LabelName{"__type__"},
+						Regex:        relabel.MustNewRegexp("inuse_space"),
+						Action:       relabel.Keep,
+					},
+				}
+			},
+			expectedMetrics: []string{
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="received",tenant="tenant-heap-relabel"} 847192`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="sampled",tenant="tenant-heap-relabel"} 847138`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="true",stage="normalized",tenant="tenant-heap-relabel"} 46234`,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := prometheus.NewRegistry()
+
+			ing := newFakeIngester(t, tc.failIngester)
+
+			overrides := validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+				l := validation.MockDefaultLimits()
+				l.DistributorReceiveMetricStage = tc.tenantStage
+
+				if tc.limitOverrides != nil {
+					tc.limitOverrides(l)
+				}
+
+				tenantLimits[tc.tenant] = l
+			})
+
+			d, err := New(
+				Config{DistributorRing: ringConfig},
+				testhelper.NewMockRing([]ring.InstanceDesc{{Addr: "foo"}}, 3),
+				&poolFactory{func(addr string) (client.PoolClient, error) {
+					return ing, nil
+				}},
+				overrides,
+				reg,
+				log.NewLogfmtLogger(os.Stdout),
+				nil,
+			)
+			require.NoError(t, err)
+
+			profileBytes, err := os.ReadFile(tc.profilePath)
+			require.NoError(t, err)
+
+			parsedProfile, err := pprof.RawFromBytes(profileBytes)
+			require.NoError(t, err)
+
+			ctx := tenant.InjectTenantID(context.Background(), tc.tenant)
+			req := &distributormodel.PushRequest{
+				Series: []*distributormodel.ProfileSeries{
+					{
+						Labels: []*typesv1.LabelPair{
+							{Name: "cluster", Value: "test-cluster"},
+							{Name: phlaremodel.LabelNameServiceName, Value: "test-service"},
+							{Name: "__name__", Value: "cpu"},
+						},
+						RawProfile: profileBytes,
+						Profile:    parsedProfile,
+					},
+				},
+				RawProfileType: distributormodel.RawProfileTypePPROF,
+			}
+
+			err = d.PushBatch(ctx, req)
+
+			if tc.expectErr {
+				require.Error(t, err)
+				if tc.expectedErrMsg != "" {
+					require.Contains(t, err.Error(), tc.expectedErrMsg)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+
+			bs, err := testutil.CollectAndFormat(reg, expfmt.TypeTextPlain, recvmetric.NamespacedMetricName)
+			require.NoError(t, err)
+
+			sums := regexp.MustCompile(recvmetric.NamespacedMetricName+`_sum.*`).
+				FindAllString(string(bs), -1)
+
+			assert.Equal(t, tc.expectedMetrics, sums)
+		})
+	}
+}

--- a/pkg/distributor/distributor_recvmetric_test.go
+++ b/pkg/distributor/distributor_recvmetric_test.go
@@ -45,9 +45,9 @@ func TestDistributorPushWithDifferentTenantStages(t *testing.T) {
 			profilePath: "../../pkg/og/convert/testdata/cpu.pprof",
 			tenantStage: recvmetric.StageReceived,
 			expectedMetrics: []string{
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="normalized",tenant="tenant-received"} 2024`,
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="sampled",tenant="tenant-received"} 2144`,
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="true",stage="received",tenant="tenant-received"} 2198`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="normalized",tenant="tenant-received",tenant_stage="false"} 2024`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="received",tenant="tenant-received",tenant_stage="true"} 2198`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="sampled",tenant="tenant-received",tenant_stage="false"} 2144`,
 			},
 		},
 		{
@@ -56,9 +56,9 @@ func TestDistributorPushWithDifferentTenantStages(t *testing.T) {
 			profilePath: "../../pkg/og/convert/testdata/cpu.pprof",
 			tenantStage: recvmetric.StageSampled,
 			expectedMetrics: []string{
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="normalized",tenant="tenant-sampled"} 2024`,
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="received",tenant="tenant-sampled"} 2198`,
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="true",stage="sampled",tenant="tenant-sampled"} 2144`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="normalized",tenant="tenant-sampled",tenant_stage="false"} 2024`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="received",tenant="tenant-sampled",tenant_stage="false"} 2198`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="sampled",tenant="tenant-sampled",tenant_stage="true"} 2144`,
 			},
 		},
 		{
@@ -67,9 +67,9 @@ func TestDistributorPushWithDifferentTenantStages(t *testing.T) {
 			profilePath: "../../pkg/og/convert/testdata/cpu.pprof",
 			tenantStage: recvmetric.StageNormalized,
 			expectedMetrics: []string{
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="received",tenant="tenant-normalized"} 2198`,
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="sampled",tenant="tenant-normalized"} 2144`,
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="true",stage="normalized",tenant="tenant-normalized"} 2024`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="normalized",tenant="tenant-normalized",tenant_stage="true"} 2024`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="received",tenant="tenant-normalized",tenant_stage="false"} 2198`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="sampled",tenant="tenant-normalized",tenant_stage="false"} 2144`,
 			},
 		},
 		{
@@ -84,7 +84,7 @@ func TestDistributorPushWithDifferentTenantStages(t *testing.T) {
 			expectErr:      true,
 			expectedErrMsg: "rate limit",
 			expectedMetrics: []string{
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="received",tenant="tenant-rate-limited"} 2198`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="received",tenant="tenant-rate-limited",tenant_stage="false"} 2198`,
 			},
 		},
 		{
@@ -95,9 +95,9 @@ func TestDistributorPushWithDifferentTenantStages(t *testing.T) {
 			failIngester: true,
 			expectErr:    true,
 			expectedMetrics: []string{
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="received",tenant="tenant-ingester-fail"} 2198`,
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="sampled",tenant="tenant-ingester-fail"} 2144`,
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="true",stage="normalized",tenant="tenant-ingester-fail"} 2024`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="normalized",tenant="tenant-ingester-fail",tenant_stage="true"} 2024`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="received",tenant="tenant-ingester-fail",tenant_stage="false"} 2198`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="sampled",tenant="tenant-ingester-fail",tenant_stage="false"} 2144`,
 			},
 		},
 		{
@@ -115,9 +115,9 @@ func TestDistributorPushWithDifferentTenantStages(t *testing.T) {
 				}
 			},
 			expectedMetrics: []string{
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="received",tenant="tenant-heap-relabel"} 847192`,
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="sampled",tenant="tenant-heap-relabel"} 847138`,
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="true",stage="normalized",tenant="tenant-heap-relabel"} 46234`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="normalized",tenant="tenant-heap-relabel",tenant_stage="true"} 46234`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="received",tenant="tenant-heap-relabel",tenant_stage="false"} 847192`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="sampled",tenant="tenant-heap-relabel",tenant_stage="false"} 847138`,
 			},
 		},
 	}

--- a/pkg/distributor/model/push.go
+++ b/pkg/distributor/model/push.go
@@ -39,9 +39,7 @@ type ProfileSeries struct {
 
 	// always 1 todo delete
 	TotalProfiles          int64
-	TotalBytesUncompressed int64
-
-	TotalBytesUncompressedProcessed int64 // after normalization and other size-reducing manipulation
+	TotalBytesUncompressed uint64
 
 	DiscardedProfilesRelabeling int64
 	DiscardedBytesRelabeling    int64

--- a/pkg/distributor/recvmetric/recvmetric.go
+++ b/pkg/distributor/recvmetric/recvmetric.go
@@ -67,13 +67,13 @@ func (s Stage) MarshalYAML() (interface{}, error) {
 	return s.String(), nil
 }
 
+const metricName = "distributor_received_decompressed_bytes_total"
+const NamespacedMetricName = "pyroscope_" + metricName
+
 type Metric struct {
 	metric *prometheus.HistogramVec
 	//	todo move discarded and usage group metrics to this package
 }
-
-const metricName = "distributor_received_decompressed_bytes_total"
-const NamespacedMetricName = "pyroscope_" + metricName
 
 func New(reg prometheus.Registerer) *Metric {
 	const (
@@ -92,7 +92,7 @@ func New(reg prometheus.Registerer) *Metric {
 			[]string{
 				"tenant",
 				"stage",
-				"is_tenant_stage", // bool todo better name
+				"tenant_stage", // bool: "true" if this stage matches the tenant's configured stage
 			},
 		),
 	}

--- a/pkg/distributor/recvmetric/recvmetric.go
+++ b/pkg/distributor/recvmetric/recvmetric.go
@@ -1,0 +1,158 @@
+package recvmetric
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/yaml.v3"
+)
+
+type Stage int
+
+const (
+	// StageReceived is the earliest stage
+	// Recorded as soon as we begin processing a profile, before any rate-limit/sampling checks
+	StageReceived Stage = iota
+	// StageSampled is recorded after the profile is not discarded by rate-limit/sampling checks
+	StageSampled
+	// StageNormalized is recorded after the profile is validated and normalized.
+	// If the profile passed rate-limit/sampling checks but failed validation checks, then
+	// the size of StageSampled is used
+	StageNormalized
+	totalStages
+)
+
+func (s Stage) String() string {
+	switch s {
+	case StageSampled:
+		return "sampled"
+	case StageReceived:
+		return "received"
+	case StageNormalized:
+		return "normalized"
+	default:
+		return fmt.Sprintf("unknown stage %d", int(s))
+	}
+}
+
+func (s *Stage) Set(str string) error {
+	switch str {
+	case "sampled":
+		*s = StageSampled
+		return nil
+	case "received":
+		*s = StageReceived
+		return nil
+	case "normalized":
+		*s = StageNormalized
+		return nil
+	default:
+		return fmt.Errorf("unexpected Stage value: %s. valid values are: %s %s %s", str,
+			StageSampled.String(), StageReceived.String(), StageNormalized.String())
+	}
+}
+
+func (s *Stage) UnmarshalYAML(value *yaml.Node) error {
+	m := ""
+	err := value.DecodeWithOptions(&m, yaml.DecodeOptions{
+		KnownFields: true,
+	})
+	if err != nil {
+		return fmt.Errorf("malformed Stage: %w %+v", err, value)
+	}
+	return s.Set(m)
+}
+
+func (s Stage) MarshalYAML() (interface{}, error) {
+	return s.String(), nil
+}
+
+type Metric struct {
+	metric *prometheus.HistogramVec
+	//	todo move discarded and usage group metrics to this package
+}
+
+const metricName = "distributor_received_decompressed_bytes_total"
+const NamespacedMetricName = "pyroscope_" + metricName
+
+func New(reg prometheus.Registerer) *Metric {
+	const (
+		minBytes     = 10 * 1024
+		maxBytes     = 15 * 1024 * 1024
+		bucketsCount = 30
+	)
+	m := &Metric{
+		metric: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: "pyroscope",
+				Name:      metricName,
+				Help:      "The total number of decompressed bytes per profile received by the distributor at different processing stages.",
+				Buckets:   prometheus.ExponentialBucketsRange(minBytes, maxBytes, bucketsCount),
+			},
+			[]string{
+				"tenant",
+				"stage",
+				"is_tenant_stage", // bool todo better name
+			},
+		),
+	}
+	if reg != nil {
+		reg.MustRegister(m.metric)
+	}
+	return m
+}
+
+func (r *Metric) NewRequest(tenant string, tenantStage Stage, receivedSize uint64) *Request {
+	res := &Request{
+		metric:      r.metric,
+		tenant:      tenant,
+		tenantStage: tenantStage,
+	}
+	res.set[StageReceived] = true
+	res.sizes[StageReceived] = receivedSize
+	return res
+}
+
+type Request struct {
+	metric      *prometheus.HistogramVec
+	tenant      string
+	tenantStage Stage
+	sizes       [totalStages]uint64
+	set         [totalStages]bool
+}
+
+func (m *Request) Record(stage Stage, size uint64) {
+	if stage == StageReceived {
+		panic("programming error. StageReceived is recorded at Request initialization")
+	}
+	m.set[stage] = true
+	m.sizes[stage] = size
+}
+
+func (m *Request) Observe() {
+	m.observe(StageReceived)
+	if !m.set[StageSampled] {
+		return
+	}
+	m.observe(StageSampled)
+	if !m.set[StageNormalized] {
+		// Invalid profile. Normalization happens after validation for valid profiles.
+		// If we did not perform normalization - use previous stage value
+		m.sizes[StageNormalized] = m.sizes[StageSampled]
+		m.set[StageNormalized] = true
+	}
+	m.observe(StageNormalized)
+
+}
+
+func (m *Request) observe(stage Stage) {
+	sz := m.sizes[stage]
+	if !m.set[stage] {
+		panic(fmt.Sprintf("Received metric stage %d not set", stage))
+	}
+	isTenantStage := "false"
+	if stage == m.tenantStage {
+		isTenantStage = "true"
+	}
+	m.metric.WithLabelValues(m.tenant, stage.String(), isTenantStage).Observe(float64(sz))
+}

--- a/pkg/distributor/recvmetric/recvmetric_test.go
+++ b/pkg/distributor/recvmetric/recvmetric_test.go
@@ -1,0 +1,129 @@
+package recvmetric
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/common/expfmt"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetricWithDifferentTenantStages(t *testing.T) {
+
+	testCases := []struct {
+		name            string
+		tenant          string
+		tenantStage     Stage
+		receivedSize    uint64
+		sampled         bool
+		normalized      bool
+		expectedMetrics []string
+	}{
+		{
+			name:         "tenant with received stage",
+			tenant:       "tenant-received",
+			tenantStage:  StageReceived,
+			receivedSize: 1000,
+			sampled:      true,
+			normalized:   true,
+			expectedMetrics: []string{
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="normalized",tenant="tenant-received"} 980`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="sampled",tenant="tenant-received"} 990`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="true",stage="received",tenant="tenant-received"} 1000`,
+			},
+		},
+		{
+			name:         "tenant with sampled stage",
+			tenant:       "tenant-sampled",
+			tenantStage:  StageSampled,
+			receivedSize: 2000,
+			sampled:      true,
+			normalized:   true,
+			expectedMetrics: []string{
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="normalized",tenant="tenant-sampled"} 1980`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="received",tenant="tenant-sampled"} 2000`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="true",stage="sampled",tenant="tenant-sampled"} 1990`,
+			},
+		},
+		{
+			name:         "tenant with normalized stage",
+			tenant:       "tenant-normalized",
+			tenantStage:  StageNormalized,
+			receivedSize: 3000,
+			sampled:      true,
+			normalized:   true,
+			expectedMetrics: []string{
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="received",tenant="tenant-normalized"} 3000`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="sampled",tenant="tenant-normalized"} 2990`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="true",stage="normalized",tenant="tenant-normalized"} 2980`,
+			},
+		},
+		{
+			name:         "tenant with sampled stage but no normalization",
+			tenant:       "tenant-no-norm",
+			tenantStage:  StageSampled,
+			receivedSize: 4000,
+			sampled:      true,
+			normalized:   false,
+			expectedMetrics: []string{
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="normalized",tenant="tenant-no-norm"} 3990`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="received",tenant="tenant-no-norm"} 4000`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="true",stage="sampled",tenant="tenant-no-norm"} 3990`,
+			},
+		},
+		{
+			name:         "tenant without sampled stage recorded",
+			tenant:       "tenant-no-sampled",
+			tenantStage:  StageSampled,
+			receivedSize: 5000,
+			sampled:      false,
+			normalized:   false,
+			expectedMetrics: []string{
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="received",tenant="tenant-no-sampled"} 5000`,
+			},
+		},
+		{
+			name:         "tenant with normalized stage but not normalized",
+			tenant:       "tenant-norm-not-normalized",
+			tenantStage:  StageNormalized,
+			receivedSize: 6000,
+			sampled:      true,
+			normalized:   false,
+			expectedMetrics: []string{
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="received",tenant="tenant-norm-not-normalized"} 6000`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="sampled",tenant="tenant-norm-not-normalized"} 5990`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="true",stage="normalized",tenant="tenant-norm-not-normalized"} 5990`,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := prometheus.NewRegistry()
+			m := New(reg)
+			req := m.NewRequest(tc.tenant, tc.tenantStage, tc.receivedSize)
+
+			if tc.sampled {
+				sampledSize := tc.receivedSize - 10
+				req.Record(StageSampled, sampledSize)
+
+				if tc.normalized {
+					normalizedSize := sampledSize - 10
+					req.Record(StageNormalized, normalizedSize)
+				}
+			}
+
+			req.Observe()
+
+			bs, err := testutil.CollectAndFormat(reg, expfmt.TypeTextPlain, NamespacedMetricName)
+			require.NoError(t, err)
+
+			sums := regexp.MustCompile(NamespacedMetricName+"_sum.*").
+				FindAllString(string(bs), -1) // do not depend on buckets
+
+			require.Equal(t, tc.expectedMetrics, sums)
+		})
+	}
+}

--- a/pkg/distributor/recvmetric/recvmetric_test.go
+++ b/pkg/distributor/recvmetric/recvmetric_test.go
@@ -29,9 +29,9 @@ func TestMetricWithDifferentTenantStages(t *testing.T) {
 			sampled:      true,
 			normalized:   true,
 			expectedMetrics: []string{
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="normalized",tenant="tenant-received"} 980`,
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="sampled",tenant="tenant-received"} 990`,
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="true",stage="received",tenant="tenant-received"} 1000`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="normalized",tenant="tenant-received",tenant_stage="false"} 980`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="received",tenant="tenant-received",tenant_stage="true"} 1000`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="sampled",tenant="tenant-received",tenant_stage="false"} 990`,
 			},
 		},
 		{
@@ -42,9 +42,9 @@ func TestMetricWithDifferentTenantStages(t *testing.T) {
 			sampled:      true,
 			normalized:   true,
 			expectedMetrics: []string{
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="normalized",tenant="tenant-sampled"} 1980`,
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="received",tenant="tenant-sampled"} 2000`,
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="true",stage="sampled",tenant="tenant-sampled"} 1990`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="normalized",tenant="tenant-sampled",tenant_stage="false"} 1980`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="received",tenant="tenant-sampled",tenant_stage="false"} 2000`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="sampled",tenant="tenant-sampled",tenant_stage="true"} 1990`,
 			},
 		},
 		{
@@ -55,9 +55,9 @@ func TestMetricWithDifferentTenantStages(t *testing.T) {
 			sampled:      true,
 			normalized:   true,
 			expectedMetrics: []string{
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="received",tenant="tenant-normalized"} 3000`,
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="sampled",tenant="tenant-normalized"} 2990`,
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="true",stage="normalized",tenant="tenant-normalized"} 2980`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="normalized",tenant="tenant-normalized",tenant_stage="true"} 2980`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="received",tenant="tenant-normalized",tenant_stage="false"} 3000`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="sampled",tenant="tenant-normalized",tenant_stage="false"} 2990`,
 			},
 		},
 		{
@@ -68,9 +68,9 @@ func TestMetricWithDifferentTenantStages(t *testing.T) {
 			sampled:      true,
 			normalized:   false,
 			expectedMetrics: []string{
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="normalized",tenant="tenant-no-norm"} 3990`,
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="received",tenant="tenant-no-norm"} 4000`,
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="true",stage="sampled",tenant="tenant-no-norm"} 3990`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="normalized",tenant="tenant-no-norm",tenant_stage="false"} 3990`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="received",tenant="tenant-no-norm",tenant_stage="false"} 4000`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="sampled",tenant="tenant-no-norm",tenant_stage="true"} 3990`,
 			},
 		},
 		{
@@ -81,7 +81,7 @@ func TestMetricWithDifferentTenantStages(t *testing.T) {
 			sampled:      false,
 			normalized:   false,
 			expectedMetrics: []string{
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="received",tenant="tenant-no-sampled"} 5000`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="received",tenant="tenant-no-sampled",tenant_stage="false"} 5000`,
 			},
 		},
 		{
@@ -92,9 +92,9 @@ func TestMetricWithDifferentTenantStages(t *testing.T) {
 			sampled:      true,
 			normalized:   false,
 			expectedMetrics: []string{
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="received",tenant="tenant-norm-not-normalized"} 6000`,
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="false",stage="sampled",tenant="tenant-norm-not-normalized"} 5990`,
-				`pyroscope_distributor_received_decompressed_bytes_total_sum{is_tenant_stage="true",stage="normalized",tenant="tenant-norm-not-normalized"} 5990`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="normalized",tenant="tenant-norm-not-normalized",tenant_stage="true"} 5990`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="received",tenant="tenant-norm-not-normalized",tenant_stage="false"} 6000`,
+				`pyroscope_distributor_received_decompressed_bytes_total_sum{stage="sampled",tenant="tenant-norm-not-normalized",tenant_stage="false"} 5990`,
 			},
 		},
 	}
@@ -126,4 +126,18 @@ func TestMetricWithDifferentTenantStages(t *testing.T) {
 			require.Equal(t, tc.expectedMetrics, sums)
 		})
 	}
+}
+
+func TestRecordPanic(t *testing.T) {
+	m := New(nil)
+	req := m.NewRequest("test-tenant", StageSampled, 1000)
+
+	require.Panics(t, func() {
+		req.Record(StageReceived, 500)
+	})
+
+	require.NotPanics(t, func() {
+		req.Record(StageSampled, 900)
+		req.Record(StageNormalized, 800)
+	})
 }

--- a/pkg/ingester/ingester.go
+++ b/pkg/ingester/ingester.go
@@ -351,7 +351,7 @@ func (i *Ingester) Push(ctx context.Context, req *connect.Request[pushv1.PushReq
 						if reason != validation.Unknown {
 							validation.DiscardedProfiles.WithLabelValues(string(reason), instance.tenantID).Add(float64(1))
 							validation.DiscardedBytes.WithLabelValues(string(reason), instance.tenantID).Add(float64(size))
-							groups.CountDiscardedBytes(string(reason), int64(size))
+							groups.CountDiscardedBytes(string(reason), uint64(size))
 
 							switch validation.ReasonOf(err) {
 							case validation.SeriesLimit:

--- a/pkg/validation/limits_recvmetric_runtime_test.go
+++ b/pkg/validation/limits_recvmetric_runtime_test.go
@@ -1,0 +1,87 @@
+package validation
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/pyroscope/pkg/distributor/recvmetric"
+)
+
+const distributorReceiveMetricStageOverrideConfig = `
+overrides:
+  no-overrides: {}
+  tenant-received:
+    distributor_receive_metric_stage: received
+  tenant-sampled:
+    distributor_receive_metric_stage: sampled
+  tenant-normalized:
+    distributor_receive_metric_stage: normalized
+`
+
+func Test_DistributorReceiveMetricStageInvalidConfig(t *testing.T) {
+	invalidConfig := `
+overrides:
+  invalid-stage:
+    distributor_receive_metric_stage: invalid
+`
+	_, err := LoadRuntimeConfig(bytes.NewReader([]byte(invalidConfig)))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected Stage value")
+}
+
+func Test_DistributorReceiveMetricStageDifferentDefaults(t *testing.T) {
+	testCases := []struct {
+		name           string
+		defaultStage   recvmetric.Stage
+		expectedValues map[string]recvmetric.Stage
+	}{
+		{
+			name:         "default received",
+			defaultStage: recvmetric.StageReceived,
+			expectedValues: map[string]recvmetric.Stage{
+				"no-overrides":      recvmetric.StageReceived,
+				"tenant-received":   recvmetric.StageReceived,
+				"tenant-sampled":    recvmetric.StageSampled,
+				"tenant-normalized": recvmetric.StageNormalized,
+				"unknown-tenant":    recvmetric.StageReceived,
+			},
+		},
+		{
+			name:         "default normalized",
+			defaultStage: recvmetric.StageNormalized,
+			expectedValues: map[string]recvmetric.Stage{
+				"no-overrides":      recvmetric.StageNormalized,
+				"tenant-received":   recvmetric.StageReceived,
+				"tenant-sampled":    recvmetric.StageSampled,
+				"tenant-normalized": recvmetric.StageNormalized,
+				"unknown-tenant":    recvmetric.StageNormalized,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testDefaults := Limits{
+				DistributorReceiveMetricStage: tc.defaultStage,
+			}
+			restore := SetDefaultLimitsForYAMLUnmarshalling(testDefaults)
+			defer restore()
+
+			rc, err := LoadRuntimeConfig(bytes.NewReader([]byte(distributorReceiveMetricStageOverrideConfig)))
+			require.NoError(t, err)
+
+			o, err := NewOverrides(testDefaults, &wrappedRuntimeConfig{rc})
+			require.NoError(t, err)
+
+			for tenant, expectedStage := range tc.expectedValues {
+				actualStage := o.DistributorReceiveMetricStage(tenant)
+				assert.Equal(t, expectedStage, actualStage,
+					"Tenant %s should have stage %s but got %s",
+					tenant, expectedStage.String(), actualStage.String())
+			}
+		})
+	}
+}

--- a/pkg/validation/usage_groups.go
+++ b/pkg/validation/usage_groups.go
@@ -177,7 +177,7 @@ func (m *UsageGroupMatchName) String() string {
 	return fmt.Sprintf("{configured: %s, resolved: %s}", m.ConfiguredName, m.ResolvedName)
 }
 
-func (m UsageGroupMatch) CountReceivedBytes(profileType string, n int64) {
+func (m UsageGroupMatch) CountReceivedBytes(profileType string, n uint64) {
 	if len(m.names) == 0 {
 		usageGroupReceivedDecompressedBytes.WithLabelValues(profileType, m.tenantID, noMatchName).Add(float64(n))
 		return
@@ -188,7 +188,7 @@ func (m UsageGroupMatch) CountReceivedBytes(profileType string, n int64) {
 	}
 }
 
-func (m UsageGroupMatch) CountDiscardedBytes(reason string, n int64) {
+func (m UsageGroupMatch) CountDiscardedBytes(reason string, n uint64) {
 	if len(m.names) == 0 {
 		usageGroupDiscardedBytes.WithLabelValues(reason, m.tenantID, noMatchName).Add(float64(n))
 		return

--- a/pkg/validation/usage_groups_test.go
+++ b/pkg/validation/usage_groups_test.go
@@ -153,7 +153,7 @@ func TestUsageGroupMatch_CountReceivedBytes(t *testing.T) {
 	tests := []struct {
 		Name       string
 		Match      UsageGroupMatch
-		Count      int64
+		Count      uint64
 		WantCounts map[string]float64
 	}{
 		{
@@ -225,7 +225,7 @@ func TestUsageGroupMatch_CountDiscardedBytes(t *testing.T) {
 	tests := []struct {
 		Name       string
 		Match      UsageGroupMatch
-		Count      int64
+		Count      uint64
 		WantCounts map[string]float64
 	}{
 		{


### PR DESCRIPTION
  Summary

  This PR refactors the distributor's received bytes metrics to support collection at multiple processing stages, providing better observability into profile processing pipeline.

  Key Changes

  - New recvmetric package: Introduces a dedicated package for managing multi-stage metrics collection with three stages:
    - received: Tracks all profiles as soon as processing begins
    - sampled: Tracks profiles that pass rate-limiting/sampling checks
    - normalized: Tracks profiles after successful validation and normalization
  - Enhanced metrics granularity: The new distributor_received_decompressed_bytes_total histogram now includes:
    - stage label to differentiate processing stages
    - is_tenant_stage label for tenant-specific stage tracking
    - Configurable stage collection via runtime overrides
  - Runtime configuration: Added support for per-tenant configuration of which stages to collect metrics for(we collect all stages, just set `is_tenant_stage` based on the tenant override), allowing flexible monitoring without code changes