### PR TITLE
jetbrains: commit run configurations for v1 and v2

### DIFF
--- a/.idea/runConfigurations/help.xml
+++ b/.idea/runConfigurations/help.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="help" type="GoApplicationRunConfiguration" factoryName="Go Application">
+    <module name="pyroscope" />
+    <working_directory value="$PROJECT_DIR$" />
+    <go_parameters value="-tags embedassets" />
+    <parameters value="--help" />
+    <kind value="FILE" />
+    <package value="github.com/grafana/pyroscope" />
+    <directory value="$PROJECT_DIR$" />
+    <filePath value="$PROJECT_DIR$/cmd/pyroscope/main.go" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/v1.xml
+++ b/.idea/runConfigurations/v1.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="v1" type="GoApplicationRunConfiguration" factoryName="Go Application">
+    <module name="pyroscope" />
+    <working_directory value="$PROJECT_DIR$" />
+    <go_parameters value="-tags embedassets" />
+    <kind value="FILE" />
+    <package value="github.com/grafana/pyroscope" />
+    <directory value="$PROJECT_DIR$" />
+    <filePath value="$PROJECT_DIR$/cmd/pyroscope/main.go" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/v2.xml
+++ b/.idea/runConfigurations/v2.xml
@@ -3,7 +3,7 @@
     <module name="pyroscope" />
     <working_directory value="$PROJECT_DIR$" />
     <go_parameters value="-tags embedassets" />
-    <parameters value="-storage.backend=filesystem" />
+    <parameters value="-storage.backend=filesystem -write-path=segment-writer -enable-query-backend=true" />
     <envs>
       <env name="PYROSCOPE_V2" value="true" />
     </envs>

--- a/.idea/runConfigurations/v2.xml
+++ b/.idea/runConfigurations/v2.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="v2" type="GoApplicationRunConfiguration" factoryName="Go Application">
+    <module name="pyroscope" />
+    <working_directory value="$PROJECT_DIR$" />
+    <go_parameters value="-tags embedassets" />
+    <parameters value="-storage.backend=filesystem" />
+    <envs>
+      <env name="PYROSCOPE_V2" value="true" />
+    </envs>
+    <kind value="FILE" />
+    <package value="github.com/grafana/pyroscope" />
+    <directory value="$PROJECT_DIR$" />
+    <filePath value="$PROJECT_DIR$/cmd/pyroscope/main.go" />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
I recently started using git work trees more and now for each corktree I create new run configurations.

I usually do not commit run configurations to not confuse non-jet brains users, but this time thinking it may be a good idea.

Jetbrains themselves seem to commit some of their common run configurations https://github.com/JetBrains/intellij-community/tree/master/.idea/runConfigurations so it dos not look like something completely crazy.

Curious what other jetbrains users think and what running configurations they have

This PR adds v1 and v2 run configurations with embedassets go tag.

This is how to save one, btw
<img width="573" height="691" alt="Screenshot 2025-08-25 at 2 13 50 PM" src="https://github.com/user-attachments/assets/378d10a1-e9ad-4868-8e47-077163d29859" />
