### PR TITLE
chore: Log details about each profile processed

### DIFF
--- a/pkg/pyroscope/pyroscope.go
+++ b/pkg/pyroscope/pyroscope.go
@@ -30,6 +30,7 @@ import (
 	"github.com/grafana/dskit/server"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/signals"
+	"github.com/grafana/dskit/spanlogger"
 	"github.com/grafana/dskit/spanprofiler"
 	wwtracing "github.com/grafana/dskit/tracing"
 	"github.com/grafana/pyroscope-go"
@@ -768,7 +769,7 @@ func initLogger(logFormat string, logLevel dslog.Level) *logger {
 
 	// Use UTC timestamps and skip 5 stack frames.
 	l := dslog.NewGoKitWithWriter(logFormat, w)
-	l = log.With(l, "ts", log.DefaultTimestampUTC, "caller", log.Caller(5))
+	l = log.With(l, "ts", log.DefaultTimestampUTC, "caller", spanlogger.Caller(5))
 
 	// Must put the level filter last for efficiency.
 	l = level.NewFilter(l, logLevel.Option)


### PR DESCRIPTION
This will allow us to investigate write path problems better.

Here few examples:

```
ts=2025-08-29T11:58:20.380943Z caller=distributor.go:395 component=distributor tenant=anonymous user=anonymous trace_id=5174ff0105f9fb8e level=warn msg="profile rejected" service_name=profilecli-upload profile_id=bcf63641-d59f-4e93-a67e-4313c8492d0f err="resource_exhausted: push rate limit (4.0 MiB) exceeded while adding 9.3 MiB"
ts=2025-08-29T11:59:01.013059Z caller=distributor.go:395 component=distributor tenant=anonymous user=anonymous trace_id=2d91abf859d32e67 level=debug msg="profile accepted" service_name=pyroscope profile_type=process_cpu detected_language=go profile_time=2025-08-29T12:58:30.504+01:00 ingestion_delay=30.033s decompressed_size=29605 sample_count=28
ts=2025-08-29T11:59:02.815882Z caller=distributor.go:395 component=distributor tenant=anonymous user=anonymous trace_id=7a424b79c185de4c level=warn msg="profile rejected" service_name=profilecli-upload profile_id=a96952a3-7651-4da7-a1b6-43d0e8e2a012 profile_type=unknown detected_language=go profile_time=2023-02-02T08:53:24.394Z ingestion_delay=22539h5m38.421s decompressed_size=295 sample_count=5 reason=not_in_ingestion_window err="invalid_argument: profile with labels '{__name__=\"unknown\", service_name=\"profilecli-upload\"}' is outside of ingestion window (profile timestamp: 2023-02-02 08:53:24.394 +0000 UTC, the ingestion window starts at 2025-08-29 10:59:02.815 +0000 UTC and ends at 2025-08-29 12:09:02.815 +0000 UTC)"
```
Note: I notice there is `user=` and `tenant=`, not  found it quickly why that is.

This should also fix #4399 