### PR TITLE
Adds  configuration option to enable external-dns integration and other ingress labeling use cases.

### DIFF
--- a/operations/pyroscope/helm/pyroscope/Chart.yaml
+++ b/operations/pyroscope/helm/pyroscope/Chart.yaml
@@ -3,7 +3,7 @@ name: pyroscope
 description: 🔥 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 home: https://grafana.com/oss/pyroscope/
 type: application
-version: 1.14.2
+version: 1.15.0
 appVersion: 1.14.1
 dependencies:
   - name: grafana-agent

--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -1,6 +1,6 @@
 # pyroscope
 
-![Version: 1.14.2](https://img.shields.io/badge/Version-1.14.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.14.1](https://img.shields.io/badge/AppVersion-1.14.1-informational?style=flat-square)
+![Version: 1.15.0](https://img.shields.io/badge/Version-1.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.14.1](https://img.shields.io/badge/AppVersion-1.14.1-informational?style=flat-square)
 
 🔥 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 
@@ -25,8 +25,10 @@
 |-----|------|---------|-------------|
 | agent | object | `{"agent":{"clustering":{"enabled":true},"configMap":{"create":false,"name":"grafana-agent-config-pyroscope"}},"controller":{"podAnnotations":{"profiles.grafana.com/cpu.port_name":"http-metrics","profiles.grafana.com/cpu.scrape":"true","profiles.grafana.com/goroutine.port_name":"http-metrics","profiles.grafana.com/goroutine.scrape":"true","profiles.grafana.com/memory.port_name":"http-metrics","profiles.grafana.com/memory.scrape":"true"},"replicas":1,"type":"statefulset"},"enabled":false}` | ----------------------------------- |
 | alloy | object | `{"alloy":{"clustering":{"enabled":true},"configMap":{"create":false,"name":"alloy-config-pyroscope"},"stabilityLevel":"public-preview"},"controller":{"podAnnotations":{"profiles.grafana.com/cpu.port_name":"http-metrics","profiles.grafana.com/cpu.scrape":"true","profiles.grafana.com/goroutine.port_name":"http-metrics","profiles.grafana.com/goroutine.scrape":"true","profiles.grafana.com/memory.port_name":"http-metrics","profiles.grafana.com/memory.scrape":"true","profiles.grafana.com/service_git_ref":"v1.8.1","profiles.grafana.com/service_repository":"https://github.com/grafana/alloy"},"replicas":1,"type":"statefulset"},"enabled":true}` | ----------------------------------- |
+| ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
 | ingress.enabled | bool | `false` |  |
+| ingress.labels | object | `{}` |  |
 | ingress.pathType | string | `"ImplementationSpecific"` |  |
 | minio | object | `{"buckets":[{"name":"grafana-pyroscope-data","policy":"none","purge":false}],"drivesPerNode":2,"enabled":false,"persistence":{"size":"5Gi"},"podAnnotations":{},"replicas":1,"resources":{"requests":{"cpu":"100m","memory":"128Mi"}},"rootPassword":"supersecret","rootUser":"grafana-pyroscope"}` | ----------------------------------- |
 | pyroscope.affinity | object | `{}` |  |

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services-hpa.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services-hpa.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -27,7 +27,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -48,7 +48,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -69,7 +69,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -90,7 +90,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -111,7 +111,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -132,7 +132,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -176,7 +176,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -523,7 +523,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1381,7 +1381,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1398,7 +1398,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1669,7 +1669,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1696,7 +1696,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1721,7 +1721,7 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1747,7 +1747,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1772,7 +1772,7 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1798,7 +1798,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1823,7 +1823,7 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1849,7 +1849,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1874,7 +1874,7 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1900,7 +1900,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1925,7 +1925,7 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1951,7 +1951,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1976,7 +1976,7 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2002,7 +2002,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2027,7 +2027,7 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2053,7 +2053,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2068,7 +2068,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 05ff8d95908a3bc2263564acd48334f92326c4764a37c8575ae2270360dfc4c0
+        checksum/config: 54b9a9b3df6dff29765c333b6e8f8bc250822cad39900620f5b3fc8ed37dec8f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2155,7 +2155,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2170,7 +2170,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 05ff8d95908a3bc2263564acd48334f92326c4764a37c8575ae2270360dfc4c0
+        checksum/config: 54b9a9b3df6dff29765c333b6e8f8bc250822cad39900620f5b3fc8ed37dec8f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2257,7 +2257,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2272,7 +2272,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 05ff8d95908a3bc2263564acd48334f92326c4764a37c8575ae2270360dfc4c0
+        checksum/config: 54b9a9b3df6dff29765c333b6e8f8bc250822cad39900620f5b3fc8ed37dec8f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2359,7 +2359,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2374,7 +2374,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 05ff8d95908a3bc2263564acd48334f92326c4764a37c8575ae2270360dfc4c0
+        checksum/config: 54b9a9b3df6dff29765c333b6e8f8bc250822cad39900620f5b3fc8ed37dec8f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2461,7 +2461,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2489,7 +2489,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2520,7 +2520,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2548,7 +2548,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2759,7 +2759,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2777,7 +2777,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 05ff8d95908a3bc2263564acd48334f92326c4764a37c8575ae2270360dfc4c0
+        checksum/config: 54b9a9b3df6dff29765c333b6e8f8bc250822cad39900620f5b3fc8ed37dec8f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2869,7 +2869,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2887,7 +2887,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 05ff8d95908a3bc2263564acd48334f92326c4764a37c8575ae2270360dfc4c0
+        checksum/config: 54b9a9b3df6dff29765c333b6e8f8bc250822cad39900620f5b3fc8ed37dec8f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2975,7 +2975,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2993,7 +2993,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 05ff8d95908a3bc2263564acd48334f92326c4764a37c8575ae2270360dfc4c0
+        checksum/config: 54b9a9b3df6dff29765c333b6e8f8bc250822cad39900620f5b3fc8ed37dec8f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.1"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -27,7 +27,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -48,7 +48,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -69,7 +69,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -90,7 +90,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -111,7 +111,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -132,7 +132,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -153,7 +153,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -174,7 +174,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -218,7 +218,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -565,7 +565,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1423,7 +1423,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1440,7 +1440,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1711,7 +1711,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1738,7 +1738,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1763,7 +1763,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1789,7 +1789,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1814,7 +1814,7 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1840,7 +1840,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1865,7 +1865,7 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1891,7 +1891,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1916,7 +1916,7 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1942,7 +1942,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1967,7 +1967,7 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1993,7 +1993,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2018,7 +2018,7 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2044,7 +2044,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2069,7 +2069,7 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2095,7 +2095,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2120,7 +2120,7 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2146,7 +2146,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2171,7 +2171,7 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2197,7 +2197,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2213,7 +2213,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 05ff8d95908a3bc2263564acd48334f92326c4764a37c8575ae2270360dfc4c0
+        checksum/config: 54b9a9b3df6dff29765c333b6e8f8bc250822cad39900620f5b3fc8ed37dec8f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2300,7 +2300,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2316,7 +2316,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 05ff8d95908a3bc2263564acd48334f92326c4764a37c8575ae2270360dfc4c0
+        checksum/config: 54b9a9b3df6dff29765c333b6e8f8bc250822cad39900620f5b3fc8ed37dec8f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2403,7 +2403,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2419,7 +2419,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 05ff8d95908a3bc2263564acd48334f92326c4764a37c8575ae2270360dfc4c0
+        checksum/config: 54b9a9b3df6dff29765c333b6e8f8bc250822cad39900620f5b3fc8ed37dec8f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2506,7 +2506,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2522,7 +2522,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 05ff8d95908a3bc2263564acd48334f92326c4764a37c8575ae2270360dfc4c0
+        checksum/config: 54b9a9b3df6dff29765c333b6e8f8bc250822cad39900620f5b3fc8ed37dec8f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2609,7 +2609,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2625,7 +2625,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 05ff8d95908a3bc2263564acd48334f92326c4764a37c8575ae2270360dfc4c0
+        checksum/config: 54b9a9b3df6dff29765c333b6e8f8bc250822cad39900620f5b3fc8ed37dec8f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2712,7 +2712,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -2728,7 +2728,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 05ff8d95908a3bc2263564acd48334f92326c4764a37c8575ae2270360dfc4c0
+        checksum/config: 54b9a9b3df6dff29765c333b6e8f8bc250822cad39900620f5b3fc8ed37dec8f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2998,7 +2998,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -3016,7 +3016,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 05ff8d95908a3bc2263564acd48334f92326c4764a37c8575ae2270360dfc4c0
+        checksum/config: 54b9a9b3df6dff29765c333b6e8f8bc250822cad39900620f5b3fc8ed37dec8f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3108,7 +3108,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -3126,7 +3126,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 05ff8d95908a3bc2263564acd48334f92326c4764a37c8575ae2270360dfc4c0
+        checksum/config: 54b9a9b3df6dff29765c333b6e8f8bc250822cad39900620f5b3fc8ed37dec8f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3214,7 +3214,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -3232,7 +3232,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 05ff8d95908a3bc2263564acd48334f92326c4764a37c8575ae2270360dfc4c0
+        checksum/config: 54b9a9b3df6dff29765c333b6e8f8bc250822cad39900620f5b3fc8ed37dec8f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.1"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -43,7 +43,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -56,7 +56,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -914,7 +914,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -931,7 +931,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1127,7 +1127,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1154,7 +1154,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1179,7 +1179,7 @@ metadata:
   name: pyroscope-dev-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1295,7 +1295,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.14.2
+    helm.sh/chart: pyroscope-1.15.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "1.14.1"
@@ -1313,7 +1313,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 777ae0c1b7f6217bc891ecc358abfcff00e67cd237f26dfea6d2b768390aabe7
+        checksum/config: 2abfdf1a69704c9fc2be9fb65b69eca0adf4fb79270f75d19746c3cdac44aae1
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v1.14.1"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/templates/ingress.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/ingress.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "pyroscope.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/operations/pyroscope/helm/pyroscope/values.yaml
+++ b/operations/pyroscope/helm/pyroscope/values.yaml
@@ -252,6 +252,10 @@ ingress:
   enabled: false
   className: ""
   pathType: ImplementationSpecific
+  # Additional labels to add to the ingress resource
+  labels: {}
+  # Additional annotations to add to the ingress resource
+  annotations: {}
   # hosts:
   #   - localhost
   # tls:

--- a/operations/pyroscope/jsonnet/values.json
+++ b/operations/pyroscope/jsonnet/values.json
@@ -51,8 +51,10 @@
     "enabled": true
   },
   "ingress": {
+    "annotations": {},
     "className": "",
     "enabled": false,
+    "labels": {},
     "pathType": "ImplementationSpecific"
   },
   "minio": {


### PR DESCRIPTION
# Add support for custom ingress labels

## Summary
Adds `ingress.labels` configuration option to enable external-dns integration and other ingress labeling use cases.

## What changed
- Added `ingress.labels: {}` to values.yaml (also fixed missing `ingress.annotations: {}` docs)
- Updated ingress template to render custom labels alongside default pyroscope labels  
- Bumped chart version 1.14.2 → 1.15.0 (minor bump for new feature)
- Updated jsonnet values.json to match

## Usage
```yaml
ingress:
  enabled: true
  labels:
    external-dns.alpha.kubernetes.io/hostname: "pyroscope.example.com" 
    external-dns.alpha.kubernetes.io/ttl: "300"
  annotations:
    nginx.ingress.kubernetes.io/rewrite-target: /
  hosts:
    - pyroscope.example.com
```

## Files modified
- `operations/pyroscope/helm/pyroscope/Chart.yaml` - version bump
- `operations/pyroscope/helm/pyroscope/values.yaml` - added labels + annotations config
- `operations/pyroscope/helm/pyroscope/templates/ingress.yaml` - template renders custom labels
- `operations/pyroscope/jsonnet/values.json` - matching JSON config

## Notes  
- Backward compatible - existing deployments unaffected
- Fixed inconsistency where template supported annotations but values.yaml didn't document them
- Custom labels merge with default pyroscope labels (no conflicts)