### PR TITLE
fix: goroutine leak in compaction-worker

### DIFF
--- a/pkg/compactionworker/worker.go
+++ b/pkg/compactionworker/worker.go
@@ -603,7 +603,22 @@ func (d *deleter) handleShardTombstone(ctx context.Context, pool *deleterPool, t
 	logger := log.With(d.logger, "tombstone_name", t.Name)
 	level.Info(logger).Log("msg", "cleaning up shard", "max_time", maxTime, "dir", dir)
 
+	// Workaround for MinIO/S3 ListObjects: if we stop consuming before cancelling,
+	// the producer goroutine can block on a final send. Cancel first and keep
+	// draining so the producer exits cleanly. Thanos Iter does not drain on early
+	// return, so we do it here.
+	// See: https://github.com/minio/minio-go/blame/f64cdbde257f48f1a44b0f5aeee0475bad7e0e8d/api-list.go#L784
+	iterCtx, iterCancel := context.WithCancel(ctx)
+	defer iterCancel()
+	stop := false
+
 	deleteBlock := func(path string) error {
+		// After we cancel iterCtx, the provider (e.g., MinIO ListObjects) may do
+		// one final blocking send on its results channel. Returning nil here keeps
+		// draining without scheduling new work so the producer isn't left blocked.
+		if stop || iterCtx.Err() != nil {
+			return nil
+		}
 		blockID, err := block.ParseBlockIDFromPath(path)
 		if err != nil {
 			level.Warn(logger).Log("msg", "failed to parse block ID from path", "path", path, "err", err)
@@ -619,7 +634,12 @@ func (d *deleter) handleShardTombstone(ctx context.Context, pool *deleterPool, t
 		blockTs := time.UnixMilli(int64(blockID.Time()))
 		if !blockTs.Before(maxTime) {
 			level.Debug(logger).Log("msg", "reached range end, exiting", "path", path)
-			return filepath.SkipAll
+			// Cancel the iterator so the underlying producer exits promptly.
+			// Keep consuming to drain any buffered items and allow the producer's
+			// final send on ctx.Done() to be received.
+			iterCancel()
+			stop = true
+			return nil
 		}
 		d.wg.Add(1)
 		pool.run(func() {
@@ -629,10 +649,9 @@ func (d *deleter) handleShardTombstone(ctx context.Context, pool *deleterPool, t
 		return nil
 	}
 
-	if err := d.bucket.Iter(ctx, dir, deleteBlock, thanosstore.WithRecursiveIter()); err != nil {
-		if errors.Is(err, filepath.SkipAll) {
-			// This is expected if we successfully handled the tombstone.
-			// This is logged in the deleteBlock function.
+	if err := d.bucket.Iter(iterCtx, dir, deleteBlock, thanosstore.WithRecursiveIter()); err != nil {
+		if errors.Is(err, context.Canceled) {
+			// Expected when the iteration context is cancelled.
 			return
 		}
 		// It's only possible if the error is returned by the iterator itself.


### PR DESCRIPTION
While analyzing the performance of Pyroscope deployments, I identified a goroutine leak introduced in [https://github.com/grafana/pyroscope/pull/4148](https://github.com/grafana/pyroscope/pull/4148?utm_source=chatgpt.com).

The problem is specific to the Minio S3 implementation of the object store client (I've only seen it in AWS, and not in every deployment). I'd suggest fixing it in the thanos package we use, but the issue is quite specific: in `bucket.Iter`, if we return from the iterator before the context is canceled, the internal producer/generator goroutine blocks forever (not exact versions, but this bit is unchanged):
1. https://github.com/minio/minio-go/blob/f64cdbde257f48f1a44b0f5aeee0475bad7e0e8d/api-list.go#L781-L788
2. https://github.com/thanos-io/objstore/blob/4e5fd4289b5052ec0fed3a27dc025c364a0e354e/providers/s3/s3.go#L417-L441

Typically, this is an error case, so a leak is barely noticeable. In our case, however, we do not want to iterate over all the objects and need to stop earlier, therefore return a special error to indicate that.

Interestingly, this was relatively harmless and could go unnoticed until [https://github.com/grafana/pyroscope/pull/4381](https://github.com/grafana/pyroscope/pull/4381?utm_source=chatgpt.com). In the latest version, however, the amount of retained memory is substantial and may cause OOMs.

I also recommend setting up an alert on the number of goroutines in compaction-workers – this is the second leak there.

<img width="3452" height="1530" alt="image" src="https://github.com/user-attachments/assets/0ebefcd7-9eca-43ad-a962-195b663c9646" />
