### PR TITLE
fix: `pyroscope/build` and `profilecli/build` had undefined rules in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,14 @@ go/bin-pyroscope-debug:
 go/bin-profilecli-debug:
 	$(call go_build_profilecli,$(GO_LDFLAGS),$(GO_GCFLAGS_DEBUG))
 
+.PHONY: go/bin-pyroscope
+go/bin-pyroscope:
+	$(call go_build_pyroscope,-s -w $(GO_LDFLAGS),)
+
+.PHONY: go/bin-profilecli
+go/bin-profilecli:
+	$(call go_build_profilecli,-s -w $(GO_LDFLAGS),)
+
 .PHONY: go/lint
 go/lint: $(BIN)/golangci-lint
 	$(BIN)/golangci-lint run ./... ./lidia/...


### PR DESCRIPTION
```
$ make pyroscope/build
make: *** No rule to make target `go/bin-pyroscope', needed by `pyroscope/build'.  Stop.
$ make profilecli/build
make: *** No rule to make target `go/bin-profilecli', needed by `profilecli/build'.  Stop.
```
