### PR TITLE
chore: add V2 integration test with symbolization support

### DIFF
--- a/pkg/test/integration/cluster/cluster.go
+++ b/pkg/test/integration/cluster/cluster.go
@@ -133,6 +133,7 @@ type Cluster struct {
 	wg sync.WaitGroup // components wait group
 
 	v2                 bool     // is this a v2 cluster
+	debuginfodURL      string   // debuginfod URL for symbolization
 	expectedComponents []string // number of expected components
 
 	tmpDir     string

--- a/pkg/test/integration/cluster/cluster_v1.go
+++ b/pkg/test/integration/cluster/cluster_v1.go
@@ -25,6 +25,12 @@ func WithV1() ClusterOption {
 	}
 }
 
+func WithSymbolizer(debuginfodURL string) ClusterOption {
+	return func(c *Cluster) {
+		c.debuginfodURL = debuginfodURL
+	}
+}
+
 func (c *Cluster) v1ReadyCheckComponent(ctx context.Context, t *Component) (bool, error) {
 	switch t.Target {
 	case "querier":

--- a/pkg/test/integration/cluster/cluster_v2.go
+++ b/pkg/test/integration/cluster/cluster_v2.go
@@ -113,6 +113,13 @@ func (c *Cluster) v2Prepare(_ context.Context, memberlistJoin []string) error {
 			fmt.Sprintf("-metastore.address=%s:%d/%s", listenAddr, metastoreLeader.grpcPort, metastoreLeader.nodeName()),
 		)
 
+		if c.debuginfodURL != "" && comp.Target == "query-frontend" {
+			comp.flags = append(comp.flags,
+				fmt.Sprintf("-symbolizer.debuginfod-url=%s", c.debuginfodURL),
+				"-symbolizer.enabled=true",
+			)
+		}
+
 		if comp.Target == "segment-writer" {
 			comp.flags = append(comp.flags,
 				"-segment-writer.num-tokens=1",

--- a/pkg/test/integration/debuginfod_server.go
+++ b/pkg/test/integration/debuginfod_server.go
@@ -11,9 +11,9 @@ import (
 )
 
 type TestDebuginfodServer struct {
-	server       *http.Server
-	debugFiles   map[string]string
-	listener     net.Listener
+	server     *http.Server
+	debugFiles map[string]string
+	listener   net.Listener
 }
 
 func NewTestDebuginfodServer() (*TestDebuginfodServer, error) {

--- a/pkg/test/integration/debuginfod_server.go
+++ b/pkg/test/integration/debuginfod_server.go
@@ -1,0 +1,94 @@
+package integration
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type TestDebuginfodServer struct {
+	server       *http.Server
+	debugFiles   map[string]string
+	listener     net.Listener
+}
+
+func NewTestDebuginfodServer() (*TestDebuginfodServer, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen: %w", err)
+	}
+
+	s := &TestDebuginfodServer{
+		debugFiles: make(map[string]string),
+		listener:   listener,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/buildid/", s.handleBuildID)
+
+	s.server = &http.Server{
+		Handler: mux,
+	}
+
+	return s, nil
+}
+
+func (s *TestDebuginfodServer) AddDebugFile(buildID, filePath string) {
+	s.debugFiles[buildID] = filePath
+}
+
+func (s *TestDebuginfodServer) URL() string {
+	return fmt.Sprintf("http://%s", s.listener.Addr().String())
+}
+
+func (s *TestDebuginfodServer) Start() error {
+	go func() {
+		_ = s.server.Serve(s.listener)
+	}()
+	return nil
+}
+
+func (s *TestDebuginfodServer) Stop() error {
+	return s.server.Close()
+}
+
+func (s *TestDebuginfodServer) handleBuildID(w http.ResponseWriter, r *http.Request) {
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/buildid/"), "/")
+	if len(parts) != 2 || parts[1] != "debuginfo" {
+		http.Error(w, "Invalid path", http.StatusBadRequest)
+		return
+	}
+
+	buildID := parts[0]
+	filePath, ok := s.debugFiles[buildID]
+	if !ok {
+		http.Error(w, "Build ID not found", http.StatusNotFound)
+		return
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to open debug file: %v", err), http.StatusInternalServerError)
+		return
+	}
+	defer file.Close()
+
+	fileInfo, err := file.Stat()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to stat debug file: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", fileInfo.Size()))
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filepath.Base(filePath)))
+
+	_, err = io.Copy(w, file)
+	if err != nil {
+		return
+	}
+}

--- a/pkg/test/integration/symbolization_test.go
+++ b/pkg/test/integration/symbolization_test.go
@@ -1,0 +1,162 @@
+package integration
+
+import (
+	"context"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	googlev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	pushv1 "github.com/grafana/pyroscope/api/gen/proto/go/push/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	"github.com/grafana/pyroscope/pkg/pprof/testhelper"
+	"github.com/grafana/pyroscope/pkg/tenant"
+	"github.com/grafana/pyroscope/pkg/test/integration/cluster"
+)
+
+const testBuildID = "2fa2055ef20fabc972d5751147e093275514b142"
+
+func TestMicroServicesIntegrationV2Symbolization(t *testing.T) {
+	debuginfodServer, err := NewTestDebuginfodServer()
+	require.NoError(t, err)
+
+	_, currentFile, _, _ := runtime.Caller(0)
+	testDataDir := filepath.Join(filepath.Dir(currentFile), "..", "..", "symbolizer", "testdata")
+	debugFilePath := filepath.Join(testDataDir, "symbols.debug")
+
+	debuginfodServer.AddDebugFile(testBuildID, debugFilePath)
+
+	require.NoError(t, debuginfodServer.Start())
+	defer func() {
+		_ = debuginfodServer.Stop()
+	}()
+
+	c := cluster.NewMicroServiceCluster(
+		cluster.WithV2(),
+		cluster.WithSymbolizer(debuginfodServer.URL()),
+	)
+
+	ctx := context.Background()
+
+	require.NoError(t, c.Prepare(ctx))
+	for _, comp := range c.Components {
+		t.Log(comp.String())
+	}
+
+	require.NoError(t, c.Start(ctx))
+	t.Log("Cluster ready")
+	defer func() {
+		waitStopped := c.Stop()
+		require.NoError(t, waitStopped(ctx))
+	}()
+
+	t.Run("SymbolizationFlow", func(t *testing.T) {
+		testSymbolizationFlow(t, ctx, c)
+	})
+}
+
+func testSymbolizationFlow(t *testing.T, ctx context.Context, c *cluster.Cluster) {
+	pusher := c.PushClient()
+	querier := c.QueryClient()
+
+	now := time.Now().Truncate(time.Second)
+	tenantID := "test-tenant"
+	serviceName := "test-symbolization-service"
+
+	builder := testhelper.NewProfileBuilder(now.UnixNano()).
+		CPUProfile().
+		WithLabels(
+			"service_name", serviceName,
+		)
+
+	builder.ForStacktraceString("placeholder").AddSamples(100)
+
+	profile := builder.Profile
+
+	buildIDIdx := int64(len(profile.StringTable))
+	profile.StringTable = append(profile.StringTable, testBuildID)
+
+	profile.Mapping[0].BuildId = buildIDIdx
+	profile.Mapping[0].HasFunctions = false
+	profile.Mapping[0].MemoryStart = 0x0
+	profile.Mapping[0].MemoryLimit = 0x1000000
+	profile.Mapping[0].FileOffset = 0x0
+
+	profile.Location = []*googlev1.Location{
+		{
+			Id:        1,
+			MappingId: 1,
+			Address:   0x1500,
+		},
+		{
+			Id:        2,
+			MappingId: 1,
+			Address:   0x3c5a,
+		},
+	}
+
+	profile.Sample = []*googlev1.Sample{
+		{
+			LocationId: []uint64{1},
+			Value:      []int64{100},
+		},
+		{
+			LocationId: []uint64{2},
+			Value:      []int64{200},
+		},
+	}
+
+	profile.Function = nil
+	rawProfile, err := profile.MarshalVT()
+	require.NoError(t, err)
+
+	ctx = tenant.InjectTenantID(ctx, tenantID)
+	_, err = pusher.Push(ctx, connect.NewRequest(&pushv1.PushRequest{
+		Series: []*pushv1.RawProfileSeries{{
+			Labels: []*typesv1.LabelPair{
+				{Name: "service_name", Value: serviceName},
+				{Name: "__name__", Value: "process_cpu"},
+			},
+			Samples: []*pushv1.RawSample{{RawProfile: rawProfile}},
+		}},
+	}))
+	require.NoError(t, err)
+
+	time.Sleep(5 * time.Second)
+
+	resp, err := querier.SelectMergeProfile(ctx, connect.NewRequest(&querierv1.SelectMergeProfileRequest{
+		ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+		Start:         now.Add(-time.Hour).UnixMilli(),
+		End:           now.Add(time.Hour).UnixMilli(),
+		LabelSelector: `{service_name="` + serviceName + `"}`,
+	}))
+	require.NoError(t, err, "Failed to query profile")
+	require.NotNil(t, resp.Msg, "Response message is nil")
+
+	require.Len(t, resp.Msg.Mapping, 1)
+	assert.True(t, resp.Msg.Mapping[0].HasFunctions, "Mapping should have HasFunctions=true after symbolization")
+
+	foundMain := false
+	foundAtollB := false
+
+	for _, fn := range resp.Msg.Function {
+		if fn.Name > 0 && fn.Name < int64(len(resp.Msg.StringTable)) {
+			functionName := resp.Msg.StringTable[fn.Name]
+			if functionName == "main" {
+				foundMain = true
+			}
+			if functionName == "atoll_b" {
+				foundAtollB = true
+			}
+		}
+	}
+
+	assert.True(t, foundMain && foundAtollB, "Expected to find both symbolized function names (main and atoll_b) in profile")
+	t.Log("Symbolization successful! Found both 'main' and 'atoll_b' functions")
+}

--- a/pkg/test/integration/symbolization_test.go
+++ b/pkg/test/integration/symbolization_test.go
@@ -11,13 +11,13 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/google/pprof/profile"
-	"github.com/grafana/pyroscope/pkg/pprof"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	pushv1 "github.com/grafana/pyroscope/api/gen/proto/go/push/v1"
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	"github.com/grafana/pyroscope/pkg/pprof"
 	"github.com/grafana/pyroscope/pkg/tenant"
 	"github.com/grafana/pyroscope/pkg/test/integration/cluster"
 )


### PR DESCRIPTION
## Summary

This PR adds a new integration test that verifies the symbolization functionality in V2 storage.

## Changes

- Added  cluster option to enable symbolization with a custom debuginfod URL
- Created a test debuginfod server implementation for serving debug information
- Added integration test that:
  - Starts a local debuginfod server with test debug symbols
  - Configures a V2 cluster with symbolization enabled
  - Ingests unsymbolized profiles with known build IDs
  - Verifies that profiles are correctly symbolized with function names

## Test Details

The test uses an existing test binary () with a known build ID and verifies that specific memory addresses (0x1500 for 'main', 0x3c5a for 'atoll_b') are correctly resolved to function names.

Co-authored-by: Claude <noreply@anthropic.com>