### PR TITLE
Fix: strengthen Input validation and prevent Integer overflows

### DIFF
--- a/pkg/ingester/pyroscope/ingest_handler.go
+++ b/pkg/ingester/pyroscope/ingest_handler.go
@@ -124,7 +124,7 @@ func (h ingestHandler) parseInputMetadataFromRequest(_ context.Context, r *http.
 	}
 
 	if sr := q.Get("sampleRate"); sr != "" {
-		sampleRate, err := strconv.Atoi(sr)
+		sampleRate, err := strconv.ParseUint(sr, 10, 32)
 		if err != nil {
 			_ = h.log.Log(
 				"err", err,

--- a/pkg/metastore/fsm/log_entry.go
+++ b/pkg/metastore/fsm/log_entry.go
@@ -58,6 +58,10 @@ func marshal(v proto.Message) ([]byte, error) {
 	if err != nil {
 		return raw, err
 	}
+	maxRawSize := 64 * 1024 * 1024 // 64 MB guard
+	if len(raw) > maxRawSize {
+		return nil, fmt.Errorf("marshaled message too large: %d bytes", len(raw))
+	}
 	buf := make([]byte, 4+len(raw))
 	copy(buf[4:], raw)
 	return buf, err

--- a/pkg/og/util/bytesize/bytesize.go
+++ b/pkg/og/util/bytesize/bytesize.go
@@ -3,6 +3,7 @@ package bytesize
 import (
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -86,6 +87,9 @@ func Parse(str string) (ByteSize, error) {
 
 	val, err := strconv.ParseUint(r[1], 10, 64)
 	if err != nil {
+		return 0, errParse
+	}
+	if val > uint64(math.MaxInt64) {
 		return 0, errParse
 	}
 	return ByteSize(val) * multiplier, nil

--- a/pkg/querier/replication.go
+++ b/pkg/querier/replication.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"math"
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/go-kit/log"
@@ -249,6 +250,15 @@ func (r *replicasPerBlockID) pruneIncompleteShardedBlocks() (bool, error) {
 				// not a sharded block continue
 				continue
 			}
+
+			// Bounds check before converting shards and using as slice length or index
+			if shards == 0 || shards > uint64(math.MaxInt) {
+				return false, fmt.Errorf("invalid shard count (must be 1..%d), got: %d, for block id %s", math.MaxInt, shards, block)
+			}
+			if shardIdx >= shards {
+				return false, fmt.Errorf("invalid shardIdx: %d for shard count %d", shardIdx, shards)
+			}
+
 			hasShardedBlocks = true
 			shardedBlocks = append(shardedBlocks, block)
 

--- a/pkg/storegateway/gateway_blocks_http.go
+++ b/pkg/storegateway/gateway_blocks_http.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"time"
+	"math"
 
 	"github.com/dustin/go-humanize"
 	"github.com/gorilla/mux"
@@ -74,9 +75,11 @@ func (s *StoreGateway) BlocksHandler(w http.ResponseWriter, req *http.Request) {
 	showParents := req.Form.Get("show_parents") == "on"
 	var splitCount int
 	if sc := req.Form.Get("split_count"); sc != "" {
-		splitCount, _ = strconv.Atoi(sc)
-		if splitCount < 0 {
+		parsed, _ := strconv.ParseInt(sc, 10, 32)
+		if parsed < 0 || parsed > int64(math.MaxUint32) {
 			splitCount = 0
+		} else {
+			splitCount = int(parsed)
 		}
 	}
 


### PR DESCRIPTION


#### Summary of Description
This request introduces several security and robustness improvements across multiple components of the Pyroscope codebase. The changes focus on strengthening input validation, preventing integer overflows, and ensuring safer error handling.


1. **Safe Parsing of Sample Rate (`pkg/ingester/pyroscope/ingest_handler.go`)**

   * Replaced `strconv.Atoi` with `strconv.ParseUint(sr, 10, 32)` to ensure that only values safely representable as `uint32` are accepted.
   * If parsing fails, a default value is used as before.
   * Prevents unsafe conversions and potential overflows.

2. **Bounds Check for ByteSize (`pkg/og/util/bytesize/bytesize.go`)**

   * Added a check to ensure that parsed values do not exceed `math.MaxInt64` before converting to `ByteSize (int64)`.
   * Returns a parse error if the value is out of range.
   * Imported `math` where required.

3. **Validation for Shards (`pkg/querier/replication.go`)**

   * Introduced validation to ensure that `shards` is greater than 0 and does not exceed `math.MaxInt`.
   * Added checks to confirm that `shardIdx` is within bounds before being used as an index.
   * Prevents invalid slice operations and potential panics.

4. **Safe Handling of Split Count (`pkg/storegateway/gateway_blocks_http.go`)**

   * Replaced `strconv.Atoi` with `strconv.ParseInt(sc, 10, 32)` and added validation.
   * Ensured that `splitCount` is within `[0, math.MaxUint32]`; otherwise, reset to a safe default (0).
   * Prevents unsafe casting and integer overflows.

5. **Validation of Log Entry Buffer Size (`pkg/metastore/fsm/log_entry.go`)**

   * Introduced a maximum allowed size constant (64 MB) for `len(raw)`.
   * If `len(raw)` exceeds this threshold, return an error instead of allocating a large buffer.
   * Ensures safe and bounded memory allocation.

#### Rationale

These changes improve the overall security and stability of Pyroscope by:

* Preventing unsafe integer conversions.
* Avoiding integer overflows and out-of-bounds slice usage.
* Enforcing safer defaults for untrusted input.
* Reducing the risk of excessive memory allocation.

All modifications are scoped to the mentioned files and functions. No external dependencies were added, and the fixes are fully compatible with existing functionality.


[Go Language Integer overflow](https://golang.org/ref/spec#Integer_overflow)
[Making slices, maps and channels](https://golang.org/ref/spec#Making_slices_maps_and_channels)