### PR TITLE
feat(helm): add option to add annotations to headless service

### DIFF
--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -73,6 +73,7 @@
 | pyroscope.resources | object | `{}` |  |
 | pyroscope.securityContext | object | `{}` |  |
 | pyroscope.service.annotations | object | `{}` |  |
+| pyroscope.service.headlessAnnotations | object | `{}` |  |
 | pyroscope.service.port | int | `4040` |  |
 | pyroscope.service.port_name | string | `"http2"` |  |
 | pyroscope.service.scheme | string | `"HTTP"` |  |

--- a/operations/pyroscope/helm/pyroscope/templates/services.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/services.yaml
@@ -37,9 +37,15 @@ metadata:
   labels:
     {{- include "pyroscope.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ $component | quote }}
+  {{- if or .Values.serviceMonitor.enabled $values.service.headlessAnnotations }}
+  annotations:
     {{- if .Values.serviceMonitor.enabled }}
     prometheus.io/service-monitor: "false"
     {{- end }}
+    {{- with $values.service.headlessAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/operations/pyroscope/helm/pyroscope/values.yaml
+++ b/operations/pyroscope/helm/pyroscope/values.yaml
@@ -88,6 +88,7 @@ pyroscope:
     port_name: http2
     scheme: HTTP
     annotations: {}
+    headlessAnnotations: {}
 
   memberlist:
     port: 7946

--- a/operations/pyroscope/jsonnet/values.json
+++ b/operations/pyroscope/jsonnet/values.json
@@ -141,6 +141,7 @@
     "securityContext": {},
     "service": {
       "annotations": {},
+      "headlessAnnotations": {},
       "port": 4040,
       "port_name": "http2",
       "scheme": "HTTP",


### PR DESCRIPTION
It would also be great to be able to add extra annotations to the headless service.
We want to use this to add external dns settings to the headless service for ingest path.

tested with:
Single Binary:
```
helm template pyroscope . \
  --set pyroscope.components.ingester.service.headlessAnnotations."istio\.io/rev"="stable"
```
Microservices
```
helm template pyroscope . \
  --values values-micro-services.yaml \
  --set pyroscope.components.ingester.service.headlessAnnotations."istio\.io/rev"="stable"
```
