### PR TITLE
fix: avoid flushing empty tenant settings (quick win)

### DIFF
--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -70,38 +70,12 @@ func (ts *TenantSettings) starting(ctx context.Context) error {
 }
 
 func (ts *TenantSettings) running(ctx context.Context) error {
-	ticker := time.NewTicker(24 * time.Hour)
-	done := false
-
-	for !done {
-		select {
-		case <-ticker.C:
-			err := ts.store.Flush(ctx)
-			if err != nil {
-				level.Warn(ts.logger).Log(
-					"msg", "failed to refresh tenant settings",
-					"err", err,
-				)
-			}
-		case <-ctx.Done():
-			ticker.Stop()
-			done = true
-		}
-	}
-
+	<-ctx.Done()
 	return nil
 }
 
 func (ts *TenantSettings) stopping(_ error) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	err := ts.store.Flush(ctx)
-	if err != nil {
-		return err
-	}
-
-	err = ts.store.Close()
+	err := ts.store.Close()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We have a design problem in [pkg/settings/bucket.go](https://github.com/grafana/pyroscope/blob/main/pkg/settings/bucket.go)

It holds a _kind_ of in [in-memory cache](https://github.com/grafana/pyroscope/blob/main/pkg/settings/bucket.go#L39) of the tenant settings stored in the bucket file `tenant_settings.json`. BUT that struct is reload before every read or write operation (hence, it doesn't act as a cache), and gets flushed after every write operation (hence we could completely discard after flush).

tenant-settings flushes the in-memory version on graceful shutdowns and every 24h. The problem comes when tenant-settings has not received a single CRUD operation during a release or 24h cycle, then an empty store is flushed.

This causes this very prominent bug to appear, where settings are completely wiped out. 
<img width="1161" height="468" alt="image" src="https://github.com/user-attachments/assets/b20084e9-ca9c-4bc1-80f9-e78f20316fe5" />
(note the 2B files, corresponding to empty json `{}`).

This PR  is just a quick win, where we remove the flush from the service lifecycle. I'm not removing the unneeded in-memory cache. I think that the extended solution should be through directly using a proper object definition over [pkg/settings/store/store.go](https://github.com/grafana/pyroscope/blob/main/pkg/settings/store/store.go)