### PR TITLE
feat: metastore auto-join

### DIFF
--- a/pkg/metastore/raftnode/node.go
+++ b/pkg/metastore/raftnode/node.go
@@ -182,19 +182,17 @@ func (n *Node) Init() (err error) {
 		return fmt.Errorf("failed to check for existing state: %w", err)
 	}
 	if !hasState {
-		level.Warn(n.logger).Log("msg", "no existing state found")
-
 		if n.config.AutoJoin {
-			level.Info(n.logger).Log("msg", "auto-join enabled, trying to join a cluster")
+			level.Info(n.logger).Log("msg", "no existing state found and auto-join is enabled, trying to join existing raft cluster...")
 			if err = n.tryAutoJoin(); err != nil {
-				level.Warn(n.logger).Log("msg", "failed to auto-join cluster", "err", err)
+				level.Warn(n.logger).Log("msg", "failed to auto-join raft cluster", "err", err)
 			} else {
-				level.Info(n.logger).Log("msg", "successfully auto-joined cluster")
+				level.Info(n.logger).Log("msg", "successfully joined existing raft cluster")
 				return nil
 			}
 		}
 
-		level.Info(n.logger).Log("msg", "bootstrapping cluster")
+		level.Info(n.logger).Log("msg", "no existing state found and auto-join is disabled, bootstrapping raft cluster...")
 		if err = n.bootstrap(); err != nil {
 			return fmt.Errorf("failed to bootstrap cluster: %w", err)
 		}

--- a/pkg/metastore/raftnode/node_bootstrap.go
+++ b/pkg/metastore/raftnode/node_bootstrap.go
@@ -86,7 +86,7 @@ func (n *Node) tryAutoJoin() error {
 		"advertise_address", n.config.AdvertiseAddress)
 
 	// try to join the cluster via the leader
-	level.Info(logger).Log("msg", "attempting to auto-join existing cluster", "current_term", readIndexResp.Term)
+	level.Info(logger).Log("msg", "attempting to join existing cluster", "current_term", readIndexResp.Term)
 	_, err = n.raftNodeClient.AddNode(ctx, &raftnodepb.AddNodeRequest{
 		ServerId:    n.config.AdvertiseAddress,
 		CurrentTerm: readIndexResp.Term,
@@ -96,7 +96,6 @@ func (n *Node) tryAutoJoin() error {
 		return fmt.Errorf("failed to auto-join cluster: %w", err)
 	}
 
-	level.Info(logger).Log("msg", "successfully joined cluster via auto-join")
 	return nil
 }
 

--- a/pkg/metastore/raftnode/node_bootstrap.go
+++ b/pkg/metastore/raftnode/node_bootstrap.go
@@ -88,7 +88,7 @@ func (n *Node) tryAutoJoin() error {
 	// try to join the cluster via the leader
 	level.Info(logger).Log("msg", "attempting to auto-join existing cluster", "current_term", readIndexResp.Term)
 	_, err = n.raftNodeClient.AddNode(ctx, &raftnodepb.AddNodeRequest{
-		ServerId:    n.config.ServerID,
+		ServerId:    n.config.AdvertiseAddress,
 		CurrentTerm: readIndexResp.Term,
 	})
 

--- a/pkg/metastore/raftnode/node_bootstrap.go
+++ b/pkg/metastore/raftnode/node_bootstrap.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/raft"
 
 	"github.com/grafana/pyroscope/pkg/metastore/discovery"
+	"github.com/grafana/pyroscope/pkg/metastore/raftnode/raftnodepb"
 )
 
 func (n *Node) bootstrap() error {
@@ -66,6 +67,37 @@ func (n *Node) bootstrapPeersWithRetries() (peers []raft.Server, err error) {
 		}
 	}
 	return nil, fmt.Errorf("failed to resolve bootstrap peers after %d retries %w", backOff.NumRetries(), err)
+}
+
+const autoJoinTimeout = 10 * time.Second
+
+func (n *Node) tryAutoJoin() error {
+	// we can only auto-join if there is a real raft cluster running
+	ctx, cancel := context.WithTimeout(context.Background(), autoJoinTimeout)
+	defer cancel()
+
+	readIndexResp, err := n.raftNodeClient.ReadIndex(ctx, &raftnodepb.ReadIndexRequest{})
+	if err != nil {
+		return fmt.Errorf("failed to get current term for auto-join: %w", err)
+	}
+
+	logger := log.With(n.logger,
+		"server_id", n.config.ServerID,
+		"advertise_address", n.config.AdvertiseAddress)
+
+	// try to join the cluster via the leader
+	level.Info(logger).Log("msg", "attempting to auto-join existing cluster", "current_term", readIndexResp.Term)
+	_, err = n.raftNodeClient.AddNode(ctx, &raftnodepb.AddNodeRequest{
+		ServerId:    n.config.ServerID,
+		CurrentTerm: readIndexResp.Term,
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to auto-join cluster: %w", err)
+	}
+
+	level.Info(logger).Log("msg", "successfully joined cluster via auto-join")
+	return nil
 }
 
 func (n *Node) bootstrapPeers(prov *dns.Provider) ([]raft.Server, error) {

--- a/pkg/test/integration/cluster/cluster_v2.go
+++ b/pkg/test/integration/cluster/cluster_v2.go
@@ -101,79 +101,88 @@ func (c *Cluster) v2Prepare(_ context.Context, memberlistJoin []string) error {
 	metastoreLeader := c.metastoreExpectedLeader()
 
 	for _, comp := range c.Components {
-		dataDir := c.dataDir(comp)
-
-		comp.cfg.V2 = true
-		comp.flags = c.commonFlags(comp)
-
-		comp.flags = append(comp.flags,
-			"-enable-query-backend=true",
-			"-write-path=segment-writer",
-			"-metastore.min-ready-duration=0",
-			fmt.Sprintf("-metastore.address=%s:%d/%s", listenAddr, metastoreLeader.grpcPort, metastoreLeader.nodeName()),
-		)
-
-		if c.debuginfodURL != "" && comp.Target == "query-frontend" {
-			comp.flags = append(comp.flags,
-				fmt.Sprintf("-symbolizer.debuginfod-url=%s", c.debuginfodURL),
-				"-symbolizer.enabled=true",
-			)
+		if err := c.v2PrepareComponent(comp, metastoreLeader); err != nil {
+			return err
 		}
 
-		if comp.Target == "segment-writer" {
-			comp.flags = append(comp.flags,
-				"-segment-writer.num-tokens=1",
-				"-segment-writer.min-ready-duration=0",
-				"-segment-writer.lifecycler.addr="+listenAddr,
-				"-segment-writer.lifecycler.ID="+comp.nodeName(),
-				"-segment-writer.heartbeat-period=1s",
-			)
-		}
-
-		if comp.Target == "compaction-worker" {
-			comp.flags = append(comp.flags,
-				"-compaction-worker.job-concurrency=20",
-				"-compaction-worker.job-poll-interval=1s",
-			)
-		}
-
-		// register query-backends in the frontend and themselves
-		if comp.Target == "query-frontend" || comp.Target == "query-backend" {
-			for _, compidx := range c.perTarget["query-backend"] {
-				comp.flags = append(comp.flags,
-					fmt.Sprintf("-query-backend.address=%s:%d", listenAddr, c.Components[compidx].grpcPort),
-				)
-			}
-		}
-
-		// handle metastore folders and ports
-		if comp.Target == "metastore" {
-			cfgPath, err := c.metastoreConfig()
-			if err != nil {
-				return err
-			}
-			comp.flags = append(comp.flags,
-				fmt.Sprint("-config.file=", cfgPath),
-				fmt.Sprintf("-metastore.data-dir=%s", dataDir+"../metastore-ephemeral"),
-				fmt.Sprintf("-metastore.raft.dir=%s", dataDir+"../metastore-raft"),
-				fmt.Sprintf("-metastore.raft.snapshots-dir=%s", dataDir+"../metastore-snapshots"),
-				fmt.Sprintf("-metastore.raft.bind-address=%s:%d", listenAddr, comp.raftPort),
-				fmt.Sprintf("-metastore.raft.advertise-address=%s:%d", listenAddr, comp.raftPort),
-				fmt.Sprintf("-metastore.raft.server-id=%s", comp.nodeName()),
-				fmt.Sprintf("-metastore.raft.bootstrap-expect-peers=%d", len(c.perTarget[comp.Target])),
-			)
-
-			// add bootstrap peers
-			for _, compidx := range c.perTarget[comp.Target] {
-				peer := c.Components[compidx]
-				comp.flags = append(comp.flags,
-					fmt.Sprintf("-metastore.raft.bootstrap-peers=%s:%d/%s", listenAddr, peer.raftPort, peer.nodeName()),
-				)
-			}
-		}
 		// handle memberlist join
 		for _, m := range memberlistJoin {
 			comp.flags = append(comp.flags, fmt.Sprintf("-memberlist.join=%s", m))
+		}
+	}
+
+	return nil
+}
+
+func (c *Cluster) v2PrepareComponent(comp *Component, metastoreLeader *Component) error {
+	dataDir := c.dataDir(comp)
+
+	comp.cfg.V2 = true
+	comp.flags = c.commonFlags(comp)
+
+	comp.flags = append(comp.flags,
+		"-enable-query-backend=true",
+		"-write-path=segment-writer",
+		"-metastore.min-ready-duration=0",
+		fmt.Sprintf("-metastore.address=%s:%d/%s", listenAddr, metastoreLeader.grpcPort, metastoreLeader.nodeName()),
+	)
+
+	if c.debuginfodURL != "" && comp.Target == "query-frontend" {
+		comp.flags = append(comp.flags,
+			fmt.Sprintf("-symbolizer.debuginfod-url=%s", c.debuginfodURL),
+			"-symbolizer.enabled=true",
+		)
+	}
+
+	if comp.Target == "segment-writer" {
+		comp.flags = append(comp.flags,
+			"-segment-writer.num-tokens=1",
+			"-segment-writer.min-ready-duration=0",
+			"-segment-writer.lifecycler.addr="+listenAddr,
+			"-segment-writer.lifecycler.ID="+comp.nodeName(),
+			"-segment-writer.heartbeat-period=1s",
+		)
+	}
+
+	if comp.Target == "compaction-worker" {
+		comp.flags = append(comp.flags,
+			"-compaction-worker.job-concurrency=20",
+			"-compaction-worker.job-poll-interval=1s",
+		)
+	}
+
+	// register query-backends in the frontend and themselves
+	if comp.Target == "query-frontend" || comp.Target == "query-backend" {
+		for _, compidx := range c.perTarget["query-backend"] {
+			comp.flags = append(comp.flags,
+				fmt.Sprintf("-query-backend.address=%s:%d", listenAddr, c.Components[compidx].grpcPort),
+			)
+		}
+	}
+
+	// handle metastore folders and ports
+	if comp.Target == "metastore" {
+		cfgPath, err := c.metastoreConfig()
+		if err != nil {
+			return err
+		}
+		comp.flags = append(comp.flags,
+			fmt.Sprint("-config.file=", cfgPath),
+			fmt.Sprintf("-metastore.data-dir=%s", dataDir+"../metastore-ephemeral"),
+			fmt.Sprintf("-metastore.raft.dir=%s", dataDir+"../metastore-raft"),
+			fmt.Sprintf("-metastore.raft.snapshots-dir=%s", dataDir+"../metastore-snapshots"),
+			fmt.Sprintf("-metastore.raft.bind-address=%s:%d", listenAddr, comp.raftPort),
+			fmt.Sprintf("-metastore.raft.advertise-address=%s:%d", listenAddr, comp.raftPort),
+			fmt.Sprintf("-metastore.raft.server-id=%s", comp.nodeName()),
+			fmt.Sprintf("-metastore.raft.bootstrap-expect-peers=%d", len(c.perTarget[comp.Target])),
+		)
+
+		// add bootstrap peers
+		for _, compidx := range c.perTarget[comp.Target] {
+			peer := c.Components[compidx]
+			comp.flags = append(comp.flags,
+				fmt.Sprintf("-metastore.raft.bootstrap-peers=%s:%d/%s", listenAddr, peer.raftPort, peer.nodeName()),
+			)
 		}
 	}
 
@@ -235,4 +244,47 @@ func (comp *Component) metastoreReadyCheck(ctx context.Context, metastores []*Co
 		CurrentTerm: nodeInfo.Node.CurrentTerm,
 	})
 	return err
+}
+
+func (c *Cluster) GetMetastoreRaftNodeClient() (raftnodepb.RaftNodeServiceClient, error) {
+	leader := c.metastoreExpectedLeader()
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+	cc, err := grpc.NewClient(fmt.Sprintf("127.0.0.1:%d", leader.grpcPort), opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return raftnodepb.NewRaftNodeServiceClient(cc), nil
+}
+
+func (c *Cluster) AddMetastoreWithAutoJoin(ctx context.Context) error {
+	leader := c.metastoreExpectedLeader()
+
+	comp := newComponent("metastore")
+	comp.replica = len(c.perTarget["metastore"])
+	c.Components = append(c.Components, comp)
+	c.perTarget["metastore"] = append(c.perTarget["metastore"], len(c.Components)-1)
+
+	if err := c.v2PrepareComponent(comp, leader); err != nil {
+		return err
+	}
+	comp.flags = append(comp.flags, "-metastore.raft.auto-join=true")
+
+	p, err := comp.start(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to start component: %w", err)
+	}
+	comp.p = p
+
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		if err := p.Run(); err != nil {
+			fmt.Printf("metastore with auto-join stopped with error: %v\n", err)
+		}
+	}()
+
+	return nil
 }


### PR DESCRIPTION
When we want to increase the number of metastore replicas (e.g., to increase availability), currently we need to rely on the admin UI and manually add the new replicas to the Raft cluster.

This change adds a `-metastore.raft.auto-join` flag. When set to `true` **and** the application has no raft state (is a freshly created replica) - we will attempt to add the node to an existing Raft cluster using the same API endpoint used by the admin UI. If auto-join fails, we fallback to the existing behavior and the replica will need to be manually added.

Tested in a local cluster, as well as with the provided integration test.