### PR TITLE
fix(memberlist): add pyroscope_ prefix to memberlist metrics

### DIFF
--- a/pkg/pyroscope/modules.go
+++ b/pkg/pyroscope/modules.go
@@ -346,6 +346,7 @@ func (f *Pyroscope) initMemberlistKV() (services.Service, error) {
 	)
 	dnsProvider := dns.NewProvider(f.logger, dnsProviderReg, dns.GolangResolverType)
 
+	f.Cfg.MemberlistKV.MetricsNamespace = "pyroscope"
 	f.MemberlistKV = memberlist.NewKVInitService(&f.Cfg.MemberlistKV, f.logger, dnsProvider, f.reg)
 
 	f.Cfg.Distributor.DistributorRing.KVStore.MemberlistKV = f.MemberlistKV.GetMemberlistKV


### PR DESCRIPTION
Fixes #2889

## Summary
Add the `pyroscope_` prefix to memberlist metrics by setting `MetricsNamespace` in the memberlist KVConfig. This changes the metric `memberlist_client_cluster_members_count` to `pyroscope_memberlist_client_cluster_members_count`, making it consistent with other Pyroscope metrics.

## Changes
- Set `f.Cfg.MemberlistKV.MetricsNamespace = "pyroscope"` in `initMemberlistKV()` before initializing the memberlist service

## Testing
Verified that the `MetricsNamespace` field exists in the dskit library's `KVConfig` struct and is used to construct metric names with the namespace prefix.

Diff stats:
```
pkg/pyroscope/modules.go | 1 +
1 file changed, 1 insertion(+)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single configuration change affecting only metric naming; main risk is dashboards/alerts needing updates to new metric names.
> 
> **Overview**
> Sets `f.Cfg.MemberlistKV.MetricsNamespace = "pyroscope"` during `initMemberlistKV()` so memberlist KV metrics are emitted with the `pyroscope_` namespace (e.g., `pyroscope_memberlist_*`) to match the rest of Pyroscope’s Prometheus metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51cc96901fc5887bba6c912d9c1e72abd25b3662. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->