### PR TITLE
helm: add e2e integration tests for HTTPRoute

### DIFF
--- a/.github/workflows/helm-integration-httproute.yml
+++ b/.github/workflows/helm-integration-httproute.yml
@@ -1,0 +1,45 @@
+name: helm-integration-httproute
+
+on:
+  pull_request:
+    paths:
+      - 'operations/pyroscope/helm/**'
+      - '.github/workflows/helm-integration-httproute.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  integration-test-httproute:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # kind, kubectl, and helm must be on PATH; the test binary orchestrates
+      # everything else (cluster creation, gateway setup, chart install).
+      - name: Install kind
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          install_only: true
+
+      - name: Install Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.14.3
+
+      # kubectl is pre-installed on ubuntu-latest; this just verifies it.
+      - name: Check kubectl
+        run: kubectl version --client
+
+      - name: Run HTTPRoute integration tests
+        run: go test ./operations/pyroscope/helm/pyroscope/e2e/... -v -timeout 60m

--- a/operations/pyroscope/helm/pyroscope/.helmignore
+++ b/operations/pyroscope/helm/pyroscope/.helmignore
@@ -21,3 +21,7 @@
 .idea/
 *.tmproj
 .vscode/
+# Integration tests and rendered reference manifests — not part of the chart package
+e2e/
+ci/integration/
+rendered/

--- a/operations/pyroscope/helm/pyroscope/ci/gateway-resources.yaml
+++ b/operations/pyroscope/helm/pyroscope/ci/gateway-resources.yaml
@@ -1,0 +1,48 @@
+# GatewayClass, EnvoyProxy config, and Gateway for the HTTPRoute e2e integration test.
+# Applied to the Kind cluster by the Go test infrastructure in main_test.go.
+#
+# EnvoyProxy sets service type to ClusterIP so the Gateway reaches Programmed=True
+# in Kind clusters where LoadBalancer external IPs are never assigned.
+#
+# allowedRoutes: from: All is required because each test variant installs the chart
+# into its own namespace, and the HTTPRoute must cross namespaces to bind to the
+# Gateway in the default namespace.
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: proxy-config
+  namespace: envoy-gateway-system
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyService:
+        type: ClusterIP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: envoy
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: proxy-config
+    namespace: envoy-gateway-system
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: pyroscope
+  namespace: default
+spec:
+  gatewayClassName: envoy
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/operations/pyroscope/helm/pyroscope/ci/integration/httproute-microservices-values.yaml
+++ b/operations/pyroscope/helm/pyroscope/ci/integration/httproute-microservices-values.yaml
@@ -1,0 +1,127 @@
+# Values for v2 microservices e2e integration test of HTTPRoute support.
+# Placed in ci/integration/ (not ci/) so the standard call-lint-test-pyroscope
+# job does not try to install this on a bare cluster without Gateway API CRDs.
+
+architecture:
+  storage:
+    v1: false
+    v2: true
+  microservices:
+    enabled: true
+
+pyroscope:
+  components:
+    distributor:
+      kind: Deployment
+      replicaCount: 1
+      resources:
+        limits:
+          memory: 1Gi
+        requests:
+          memory: 32Mi
+          cpu: 10m
+    query-frontend:
+      kind: Deployment
+      replicaCount: 1
+      resources:
+        limits:
+          memory: 1Gi
+        requests:
+          memory: 32Mi
+          cpu: 10m
+    query-backend:
+      kind: Deployment
+      replicaCount: 1
+      resources:
+        limits:
+          memory: 1Gi
+        requests:
+          memory: 32Mi
+          cpu: 10m
+    segment-writer:
+      kind: StatefulSet
+      replicaCount: 1
+      resources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 256Mi
+          cpu: 100m
+      initContainers:
+        - name: create-bucket
+          image: minio/mc:RELEASE.2025-04-08T15-39-49Z
+          command:
+            - /bin/sh
+            - -c
+            - |
+              export MC_CONFIG_DIR="/tmp/mc"
+              mkdir -p "$MC_CONFIG_DIR"
+              until mc config host add myminio http://$MINIO_ENDPOINT:9000 grafana-pyroscope supersecret; do
+                echo "Waiting for Minio to be available..."
+                sleep 5
+              done
+              mc mb myminio/grafana-pyroscope-data --ignore-existing
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MINIO_ENDPOINT
+              value: $(POD_NAMESPACE)-minio
+    metastore:
+      kind: StatefulSet
+      replicaCount: 1
+      # Default bootstrap-expect-peers is 3 (HA). Override for single-replica CI.
+      extraArgs:
+        metastore.raft.bootstrap-expect-peers: 1
+      resources:
+        limits:
+          memory: 1Gi
+        requests:
+          memory: 64Mi
+          cpu: 10m
+    compaction-worker:
+      kind: StatefulSet
+      replicaCount: 1
+      resources:
+        limits:
+          memory: 1Gi
+        requests:
+          memory: 64Mi
+          cpu: 10m
+    tenant-settings:
+      kind: Deployment
+      replicaCount: 1
+      resources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 32Mi
+          cpu: 10m
+    ad-hoc-profiles:
+      kind: Deployment
+      replicaCount: 1
+      resources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 32Mi
+          cpu: 10m
+
+minio:
+  enabled: true
+
+# Not needed for routing tests — saves image pull time and startup overhead
+alloy:
+  enabled: false
+agent:
+  enabled: false
+
+httpRoute:
+  enabled: true
+  gateway:
+    name: pyroscope
+    namespace: default
+    sectionName: http
+  hostnames:
+    - pyroscope.test

--- a/operations/pyroscope/helm/pyroscope/ci/integration/httproute-values.yaml
+++ b/operations/pyroscope/helm/pyroscope/ci/integration/httproute-values.yaml
@@ -1,0 +1,17 @@
+# Values for v2 single-binary e2e integration test of HTTPRoute support.
+# Placed in ci/integration/ (not ci/) so the standard call-lint-test-pyroscope
+# job does not try to install this on a bare cluster without Gateway API CRDs.
+
+architecture:
+  storage:
+    v1: false
+    v2: true
+
+httpRoute:
+  enabled: true
+  gateway:
+    name: pyroscope
+    namespace: default
+    sectionName: http
+  hostnames:
+    - pyroscope.test

--- a/operations/pyroscope/helm/pyroscope/e2e/httproute_test.go
+++ b/operations/pyroscope/helm/pyroscope/e2e/httproute_test.go
@@ -1,0 +1,130 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/google/pprof/profile"
+	"github.com/stretchr/testify/require"
+
+	adhocprofilesv1 "github.com/grafana/pyroscope/api/gen/proto/go/adhocprofiles/v1"
+	"github.com/grafana/pyroscope/api/gen/proto/go/adhocprofiles/v1/adhocprofilesv1connect"
+	pushv1 "github.com/grafana/pyroscope/api/gen/proto/go/push/v1"
+	"github.com/grafana/pyroscope/api/gen/proto/go/push/v1/pushv1connect"
+	querierv1connect "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect"
+	settingsv1 "github.com/grafana/pyroscope/api/gen/proto/go/settings/v1"
+	"github.com/grafana/pyroscope/api/gen/proto/go/settings/v1/settingsv1connect"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+)
+
+// variants defines the chart configurations under test.
+// Each installs the chart, runs all route assertions, then uninstalls.
+var variants = []struct {
+	name       string
+	valuesFile string
+}{
+	{"single-binary", "ci/integration/httproute-values.yaml"},
+	{"microservices", "ci/integration/httproute-microservices-values.yaml"},
+}
+
+// TestHTTPRoute installs the chart for each variant and verifies that all four
+// HTTPRoute routing rules correctly deliver requests to Pyroscope.
+func TestHTTPRoute(t *testing.T) {
+	for _, v := range variants {
+		t.Run(v.name, func(t *testing.T) {
+			installChart(t, v.valuesFile)
+
+			httpClient := gatewayClient()
+			baseURL := "http://localhost:" + gatewayPort
+			ctx := context.Background()
+
+			// ── query rule: / /querier.v1.QuerierService/ /render /render-diff ──
+			t.Run("querier", func(t *testing.T) {
+				client := querierv1connect.NewQuerierServiceClient(httpClient, baseURL)
+				now := time.Now()
+				_, err := client.LabelNames(ctx, connect.NewRequest(&typesv1.LabelNamesRequest{
+					Start: now.Add(-time.Hour).UnixMilli(),
+					End:   now.UnixMilli(),
+				}))
+				require.NoError(t, err)
+			})
+
+			// ── ingest rule: /push.v1.PusherService/ /ingest ──────────────────
+			t.Run("pusher", func(t *testing.T) {
+				client := pushv1connect.NewPusherServiceClient(httpClient, baseURL)
+				_, err := client.Push(ctx, connect.NewRequest(&pushv1.PushRequest{
+					Series: []*pushv1.RawProfileSeries{{
+						Labels: []*typesv1.LabelPair{
+							{Name: "__name__", Value: "e2e.test.cpu.samples"},
+							{Name: "service_name", Value: "e2e-test"},
+						},
+						Samples: []*pushv1.RawSample{{
+							RawProfile: minimalPprofBytes(),
+						}},
+					}},
+				}))
+				require.NoError(t, err)
+			})
+
+			// ── settings rule: /settings.v1.SettingsService/ ─────────────────
+			t.Run("settings", func(t *testing.T) {
+				client := settingsv1connect.NewSettingsServiceClient(httpClient, baseURL)
+				_, err := client.Get(ctx, connect.NewRequest(&settingsv1.GetSettingsRequest{}))
+				require.NoError(t, err)
+			})
+
+			// ── adhoc profiles rule: /adhocprofiles.v1.AdHocProfileService/ ──
+			t.Run("adhoc-profiles", func(t *testing.T) {
+				client := adhocprofilesv1connect.NewAdHocProfileServiceClient(httpClient, baseURL)
+				_, err := client.List(ctx, connect.NewRequest(&adhocprofilesv1.AdHocProfilesListRequest{}))
+				require.NoError(t, err)
+			})
+		})
+	}
+}
+
+// gatewayClient returns an HTTP client that routes through the Envoy Gateway
+// by setting the Host and tenant headers on every request.
+func gatewayClient() *http.Client {
+	return &http.Client{
+		Timeout:   10 * time.Second,
+		Transport: &gatewayTransport{base: http.DefaultTransport},
+	}
+}
+
+type gatewayTransport struct {
+	base http.RoundTripper
+}
+
+func (t *gatewayTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Host = gatewayHost
+	req.Header.Set("X-Scope-OrgID", "anonymous")
+	return t.base.RoundTrip(req)
+}
+
+// minimalPprofBytes returns a minimal but valid gzip-compressed pprof profile
+// with a single CPU sample, sufficient for routing tests.
+func minimalPprofBytes() []byte {
+	fn := &profile.Function{ID: 1, Name: "test.main", SystemName: "test.main", Filename: "test.go"}
+	loc := &profile.Location{ID: 1, Line: []profile.Line{{Function: fn, Line: 1}}}
+	p := &profile.Profile{
+		SampleType:    []*profile.ValueType{{Type: "cpu", Unit: "nanoseconds"}},
+		PeriodType:    &profile.ValueType{Type: "cpu", Unit: "nanoseconds"},
+		Period:        10000000, // 10ms
+		Function:      []*profile.Function{fn},
+		Location:      []*profile.Location{loc},
+		Sample:        []*profile.Sample{{Location: []*profile.Location{loc}, Value: []int64{1000000}}},
+		TimeNanos:     time.Now().UnixNano(),
+		DurationNanos: int64(time.Second),
+	}
+	var buf bytes.Buffer
+	if err := p.Write(&buf); err != nil {
+		panic("minimalPprofBytes: " + err.Error())
+	}
+	return buf.Bytes()
+}

--- a/operations/pyroscope/helm/pyroscope/e2e/httproute_test.go
+++ b/operations/pyroscope/helm/pyroscope/e2e/httproute_test.go
@@ -3,7 +3,12 @@ package e2e
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,6 +35,117 @@ const (
 	gwAPIVersion   = "v1.2.0"
 	envoyGWVersion = "v1.2.0"
 )
+
+func init() {
+	suiteSetup = setupHTTPRoute
+}
+
+// setupHTTPRoute installs the Gateway API CRDs, Envoy Gateway, the test
+// GatewayClass/Gateway, and starts a port-forward to the Envoy proxy.
+func setupHTTPRoute() (func(), error) {
+	// ── 1. Gateway API CRDs ──────────────────────────────────────────────────
+	fmt.Println("==> Installing Gateway API CRDs")
+	if err := kubectl("apply", "-f",
+		"https://github.com/kubernetes-sigs/gateway-api/releases/download/"+gwAPIVersion+"/standard-install.yaml",
+	); err != nil {
+		return nil, fmt.Errorf("gateway API CRDs: %w", err)
+	}
+	for _, crd := range []string{
+		"gateways.gateway.networking.k8s.io",
+		"httproutes.gateway.networking.k8s.io",
+		"gatewayclasses.gateway.networking.k8s.io",
+	} {
+		if err := kubectl("wait", "--for=condition=established", "--timeout=1m", "crd/"+crd); err != nil {
+			return nil, fmt.Errorf("wait for CRD %s: %w", crd, err)
+		}
+	}
+
+	// ── 2. Envoy Gateway ─────────────────────────────────────────────────────
+	fmt.Println("==> Installing Envoy Gateway", envoyGWVersion)
+	if err := kubectl("apply", "--server-side", "-f",
+		"https://github.com/envoyproxy/gateway/releases/download/"+envoyGWVersion+"/install.yaml",
+	); err != nil {
+		return nil, fmt.Errorf("envoy gateway: %w", err)
+	}
+	if err := kubectl("wait", "--timeout=5m",
+		"-n", envoyGWNS,
+		"deployment/envoy-gateway",
+		"--for=condition=Available",
+	); err != nil {
+		return nil, fmt.Errorf("wait for envoy-gateway deployment: %w", err)
+	}
+
+	// ── 3. GatewayClass + Gateway ─────────────────────────────────────────────
+	fmt.Println("==> Applying GatewayClass and Gateway")
+	if err := kubectl("apply", "-f", filepath.Join(chartDir, "ci/gateway-resources.yaml")); err != nil {
+		return nil, fmt.Errorf("gateway resources: %w", err)
+	}
+	if err := kubectl("wait", "gatewayclass/envoy", "--for=condition=Accepted", "--timeout=1m"); err != nil {
+		return nil, fmt.Errorf("wait for GatewayClass: %w", err)
+	}
+	if err := kubectl("wait", "gateway/"+gatewayName,
+		"-n", gatewayNS,
+		"--for=condition=Programmed",
+		"--timeout=2m",
+	); err != nil {
+		return nil, fmt.Errorf("wait for Gateway: %w", err)
+	}
+
+	// ── 4. Port-forward Envoy proxy ───────────────────────────────────────────
+	fmt.Println("==> Port-forwarding Envoy proxy on :" + gatewayPort)
+	pfCmd, err := startPortForward()
+	if err != nil {
+		return nil, fmt.Errorf("port-forward: %w", err)
+	}
+	return func() { _ = pfCmd.Process.Kill() }, nil
+}
+
+func startPortForward() (*exec.Cmd, error) {
+	// Find the Envoy proxy service by label.
+	out, err := exec.Command("kubectl",
+		"--context", "kind-"+clusterName,
+		"get", "svc", "-n", envoyGWNS,
+		"-l", fmt.Sprintf(
+			"gateway.envoyproxy.io/owning-gateway-name=%s,gateway.envoyproxy.io/owning-gateway-namespace=%s",
+			gatewayName, gatewayNS,
+		),
+		"-o", "jsonpath={.items[0].metadata.name}",
+	).Output()
+	if err != nil {
+		return nil, fmt.Errorf("get envoy svc: %w", err)
+	}
+	svcName := strings.TrimSpace(string(out))
+	if svcName == "" {
+		return nil, fmt.Errorf("envoy proxy service not found")
+	}
+
+	cmd := exec.Command("kubectl",
+		"--context", "kind-"+clusterName,
+		"port-forward",
+		"-n", envoyGWNS,
+		"svc/"+svcName,
+		gatewayPort+":80",
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start port-forward: %w", err)
+	}
+
+	// Wait until the port-forward is accepting connections.
+	deadline := time.Now().Add(30 * time.Second)
+	client := &http.Client{Timeout: time.Second}
+	for time.Now().Before(deadline) {
+		resp, err := client.Get("http://localhost:" + gatewayPort + "/")
+		if err == nil {
+			resp.Body.Close()
+			return cmd, nil
+		}
+		time.Sleep(time.Second)
+	}
+	// Return the command even if not ready; the tests will produce clear errors.
+	return cmd, nil
+}
 
 // variants defines the chart configurations under test.
 // Each installs the chart, runs all route assertions, then uninstalls.

--- a/operations/pyroscope/helm/pyroscope/e2e/httproute_test.go
+++ b/operations/pyroscope/helm/pyroscope/e2e/httproute_test.go
@@ -21,6 +21,16 @@ import (
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 )
 
+const (
+	gatewayName    = "pyroscope"
+	gatewayNS      = "default"
+	gatewayHost    = "pyroscope.test"
+	gatewayPort    = "8080"
+	envoyGWNS      = "envoy-gateway-system"
+	gwAPIVersion   = "v1.2.0"
+	envoyGWVersion = "v1.2.0"
+)
+
 // variants defines the chart configurations under test.
 // Each installs the chart, runs all route assertions, then uninstalls.
 var variants = []struct {

--- a/operations/pyroscope/helm/pyroscope/e2e/main_test.go
+++ b/operations/pyroscope/helm/pyroscope/e2e/main_test.go
@@ -169,7 +169,7 @@ func kubectl(args ...string) error {
 }
 
 func helm(args ...string) error {
-	return runCmd("helm", args...)
+	return runCmd("helm", append([]string{"--kube-context", "kind-" + clusterName}, args...)...)
 }
 
 func runCmd(name string, args ...string) error {

--- a/operations/pyroscope/helm/pyroscope/e2e/main_test.go
+++ b/operations/pyroscope/helm/pyroscope/e2e/main_test.go
@@ -1,0 +1,240 @@
+package e2e
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	clusterName    = "pyroscope-httproute"
+	gatewayName    = "pyroscope"
+	gatewayNS      = "default"
+	gatewayHost    = "pyroscope.test"
+	gatewayPort    = "8080"
+	envoyGWNS      = "envoy-gateway-system"
+	gwAPIVersion   = "v1.2.0"
+	envoyGWVersion = "v1.2.0"
+	kindNodeImage  = "kindest/node:v1.33.7"
+)
+
+// chartDir is the path to the Helm chart root (the e2e/ package directory's parent).
+// Tests are run with the working directory set to the package directory.
+var chartDir = ".."
+
+func TestMain(m *testing.M) {
+	os.Exit(run(m))
+}
+
+func run(m *testing.M) (code int) {
+	// ── 1. Kind cluster ──────────────────────────────────────────────────────
+	fmt.Println("==> Creating Kind cluster", clusterName)
+	if err := kubectl("cluster-info", "--context", "kind-"+clusterName); err != nil {
+		// Cluster doesn't exist yet, create it.
+		if err := kind("create", "cluster",
+			"--name", clusterName,
+			"--image", kindNodeImage,
+			"--wait", "5m",
+		); err != nil {
+			fmt.Fprintf(os.Stderr, "kind create cluster: %v\n", err)
+			return 1
+		}
+	} else {
+		fmt.Println("   (reusing existing cluster)")
+	}
+	defer func() {
+		fmt.Println("==> Deleting Kind cluster", clusterName)
+		_ = kind("delete", "cluster", "--name", clusterName)
+	}()
+
+	// ── 2. Gateway API CRDs ──────────────────────────────────────────────────
+	fmt.Println("==> Installing Gateway API CRDs")
+	if err := kubectl("apply", "-f",
+		"https://github.com/kubernetes-sigs/gateway-api/releases/download/"+gwAPIVersion+"/standard-install.yaml",
+	); err != nil {
+		fmt.Fprintf(os.Stderr, "gateway API CRDs: %v\n", err)
+		return 1
+	}
+	for _, crd := range []string{
+		"gateways.gateway.networking.k8s.io",
+		"httproutes.gateway.networking.k8s.io",
+		"gatewayclasses.gateway.networking.k8s.io",
+	} {
+		if err := kubectl("wait", "--for=condition=established", "--timeout=60s", "crd/"+crd); err != nil {
+			fmt.Fprintf(os.Stderr, "wait for CRD %s: %v\n", crd, err)
+			return 1
+		}
+	}
+
+	// ── 3. Envoy Gateway ─────────────────────────────────────────────────────
+	fmt.Println("==> Installing Envoy Gateway", envoyGWVersion)
+	if err := kubectl("apply", "--server-side", "-f",
+		"https://github.com/envoyproxy/gateway/releases/download/"+envoyGWVersion+"/install.yaml",
+	); err != nil {
+		fmt.Fprintf(os.Stderr, "envoy gateway: %v\n", err)
+		return 1
+	}
+	if err := kubectl("wait", "--timeout=5m",
+		"-n", envoyGWNS,
+		"deployment/envoy-gateway",
+		"--for=condition=Available",
+	); err != nil {
+		fmt.Fprintf(os.Stderr, "wait for envoy-gateway deployment: %v\n", err)
+		return 1
+	}
+
+	// ── 4. GatewayClass + Gateway ─────────────────────────────────────────────
+	fmt.Println("==> Applying GatewayClass and Gateway")
+	if err := kubectl("apply", "-f", filepath.Join(chartDir, "ci/gateway-resources.yaml")); err != nil {
+		fmt.Fprintf(os.Stderr, "gateway resources: %v\n", err)
+		return 1
+	}
+	if err := kubectl("wait", "gatewayclass/envoy", "--for=condition=Accepted", "--timeout=60s"); err != nil {
+		fmt.Fprintf(os.Stderr, "wait for GatewayClass: %v\n", err)
+		return 1
+	}
+	if err := kubectl("wait", "gateway/"+gatewayName,
+		"-n", gatewayNS,
+		"--for=condition=Programmed",
+		"--timeout=120s",
+	); err != nil {
+		fmt.Fprintf(os.Stderr, "wait for Gateway: %v\n", err)
+		return 1
+	}
+
+	// ── 5. Helm chart dependencies ────────────────────────────────────────────
+	fmt.Println("==> Updating Helm chart dependencies")
+	_ = helm("repo", "add", "minio", "https://charts.min.io/")
+	_ = helm("repo", "add", "grafana", "https://grafana.github.io/helm-charts")
+	if err := helm("dependency", "update", chartDir); err != nil {
+		fmt.Fprintf(os.Stderr, "helm dependency update: %v\n", err)
+		return 1
+	}
+
+	// ── 6. Port-forward Envoy proxy ───────────────────────────────────────────
+	fmt.Println("==> Port-forwarding Envoy proxy on :" + gatewayPort)
+	pfCmd, err := startPortForward()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "port-forward: %v\n", err)
+		return 1
+	}
+	defer pfCmd.Process.Kill() //nolint:errcheck
+
+	return m.Run()
+}
+
+// installChart installs the Helm chart with the given values file and returns
+// the release name. It registers cleanup with t so the release is always removed.
+func installChart(t *testing.T, valuesFile string) string {
+	t.Helper()
+	release := fmt.Sprintf("pyroscope-%s", randStr(8))
+	ns := release
+
+	t.Logf("helm install %s (values: %s)", release, valuesFile)
+	if err := kubectl("create", "namespace", ns); err != nil {
+		t.Fatalf("create namespace: %v", err)
+	}
+	if err := helm("install", release, chartDir,
+		"--namespace", ns,
+		"--values", filepath.Join(chartDir, valuesFile),
+		"--wait",
+		"--timeout", "1200s",
+	); err != nil {
+		_ = kubectl("get", "pods", "-n", ns)
+		t.Fatalf("helm install: %v", err)
+	}
+	t.Cleanup(func() {
+		t.Logf("helm uninstall %s", release)
+		_ = helm("uninstall", release, "--namespace", ns)
+		_ = kubectl("delete", "namespace", ns, "--ignore-not-found")
+	})
+	return release
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+func kind(args ...string) error {
+	return runCmd("kind", args...)
+}
+
+func kubectl(args ...string) error {
+	return runCmd("kubectl", append([]string{"--context", "kind-" + clusterName}, args...)...)
+}
+
+func helm(args ...string) error {
+	return runCmd("helm", args...)
+}
+
+func runCmd(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	var buf bytes.Buffer
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s %s: %w\n%s", name, strings.Join(args, " "), err, buf.String())
+	}
+	return nil
+}
+
+func startPortForward() (*exec.Cmd, error) {
+	// Find the Envoy proxy service by label.
+	out, err := exec.Command("kubectl",
+		"--context", "kind-"+clusterName,
+		"get", "svc", "-n", envoyGWNS,
+		"-l", fmt.Sprintf(
+			"gateway.envoyproxy.io/owning-gateway-name=%s,gateway.envoyproxy.io/owning-gateway-namespace=%s",
+			gatewayName, gatewayNS,
+		),
+		"-o", "jsonpath={.items[0].metadata.name}",
+	).Output()
+	if err != nil {
+		return nil, fmt.Errorf("get envoy svc: %w", err)
+	}
+	svcName := strings.TrimSpace(string(out))
+	if svcName == "" {
+		return nil, fmt.Errorf("envoy proxy service not found")
+	}
+
+	cmd := exec.Command("kubectl",
+		"--context", "kind-"+clusterName,
+		"port-forward",
+		"-n", envoyGWNS,
+		"svc/"+svcName,
+		gatewayPort+":80",
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start port-forward: %w", err)
+	}
+
+	// Wait until the port-forward is accepting connections.
+	deadline := time.Now().Add(30 * time.Second)
+	client := &http.Client{Timeout: time.Second}
+	for time.Now().Before(deadline) {
+		resp, err := client.Get("http://localhost:" + gatewayPort + "/")
+		if err == nil {
+			resp.Body.Close()
+			return cmd, nil
+		}
+		time.Sleep(time.Second)
+	}
+	// Return the command even if not ready; the tests will produce clear errors.
+	return cmd, nil
+}
+
+func randStr(n int) string {
+	const letters = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}

--- a/operations/pyroscope/helm/pyroscope/e2e/main_test.go
+++ b/operations/pyroscope/helm/pyroscope/e2e/main_test.go
@@ -67,7 +67,7 @@ func run(m *testing.M) (code int) {
 		"httproutes.gateway.networking.k8s.io",
 		"gatewayclasses.gateway.networking.k8s.io",
 	} {
-		if err := kubectl("wait", "--for=condition=established", "--timeout=60s", "crd/"+crd); err != nil {
+		if err := kubectl("wait", "--for=condition=established", "--timeout=1m", "crd/"+crd); err != nil {
 			fmt.Fprintf(os.Stderr, "wait for CRD %s: %v\n", crd, err)
 			return 1
 		}
@@ -103,7 +103,7 @@ func run(m *testing.M) (code int) {
 	if err := kubectl("wait", "gateway/"+gatewayName,
 		"-n", gatewayNS,
 		"--for=condition=Programmed",
-		"--timeout=120s",
+		"--timeout=2m",
 	); err != nil {
 		fmt.Fprintf(os.Stderr, "wait for Gateway: %v\n", err)
 		return 1
@@ -145,7 +145,7 @@ func installChart(t *testing.T, valuesFile string) string {
 		"--namespace", ns,
 		"--values", filepath.Join(chartDir, valuesFile),
 		"--wait",
-		"--timeout", "1200s",
+		"--timeout", "20m",
 	); err != nil {
 		_ = kubectl("get", "pods", "-n", ns)
 		t.Fatalf("helm install: %v", err)

--- a/operations/pyroscope/helm/pyroscope/e2e/main_test.go
+++ b/operations/pyroscope/helm/pyroscope/e2e/main_test.go
@@ -14,15 +14,8 @@ import (
 )
 
 const (
-	clusterName    = "pyroscope-httproute"
-	gatewayName    = "pyroscope"
-	gatewayNS      = "default"
-	gatewayHost    = "pyroscope.test"
-	gatewayPort    = "8080"
-	envoyGWNS      = "envoy-gateway-system"
-	gwAPIVersion   = "v1.2.0"
-	envoyGWVersion = "v1.2.0"
-	kindNodeImage  = "kindest/node:v1.33.7"
+	clusterName   = "pyroscope-helm-e2e"
+	kindNodeImage = "kindest/node:v1.33.7"
 )
 
 // chartDir is the path to the Helm chart root (the e2e/ package directory's parent).

--- a/operations/pyroscope/helm/pyroscope/e2e/main_test.go
+++ b/operations/pyroscope/helm/pyroscope/e2e/main_test.go
@@ -4,13 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"math/rand"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 )
 
 const (
@@ -21,6 +19,10 @@ const (
 // chartDir is the path to the Helm chart root (the e2e/ package directory's parent).
 // Tests are run with the working directory set to the package directory.
 var chartDir = ".."
+
+// suiteSetup is registered by a test suite's init() to run suite-specific
+// infrastructure after the cluster is ready. It returns a cleanup function.
+var suiteSetup func() (func(), error)
 
 func TestMain(m *testing.M) {
 	os.Exit(run(m))
@@ -47,62 +49,7 @@ func run(m *testing.M) (code int) {
 		_ = kind("delete", "cluster", "--name", clusterName)
 	}()
 
-	// ── 2. Gateway API CRDs ──────────────────────────────────────────────────
-	fmt.Println("==> Installing Gateway API CRDs")
-	if err := kubectl("apply", "-f",
-		"https://github.com/kubernetes-sigs/gateway-api/releases/download/"+gwAPIVersion+"/standard-install.yaml",
-	); err != nil {
-		fmt.Fprintf(os.Stderr, "gateway API CRDs: %v\n", err)
-		return 1
-	}
-	for _, crd := range []string{
-		"gateways.gateway.networking.k8s.io",
-		"httproutes.gateway.networking.k8s.io",
-		"gatewayclasses.gateway.networking.k8s.io",
-	} {
-		if err := kubectl("wait", "--for=condition=established", "--timeout=1m", "crd/"+crd); err != nil {
-			fmt.Fprintf(os.Stderr, "wait for CRD %s: %v\n", crd, err)
-			return 1
-		}
-	}
-
-	// ── 3. Envoy Gateway ─────────────────────────────────────────────────────
-	fmt.Println("==> Installing Envoy Gateway", envoyGWVersion)
-	if err := kubectl("apply", "--server-side", "-f",
-		"https://github.com/envoyproxy/gateway/releases/download/"+envoyGWVersion+"/install.yaml",
-	); err != nil {
-		fmt.Fprintf(os.Stderr, "envoy gateway: %v\n", err)
-		return 1
-	}
-	if err := kubectl("wait", "--timeout=5m",
-		"-n", envoyGWNS,
-		"deployment/envoy-gateway",
-		"--for=condition=Available",
-	); err != nil {
-		fmt.Fprintf(os.Stderr, "wait for envoy-gateway deployment: %v\n", err)
-		return 1
-	}
-
-	// ── 4. GatewayClass + Gateway ─────────────────────────────────────────────
-	fmt.Println("==> Applying GatewayClass and Gateway")
-	if err := kubectl("apply", "-f", filepath.Join(chartDir, "ci/gateway-resources.yaml")); err != nil {
-		fmt.Fprintf(os.Stderr, "gateway resources: %v\n", err)
-		return 1
-	}
-	if err := kubectl("wait", "gatewayclass/envoy", "--for=condition=Accepted", "--timeout=60s"); err != nil {
-		fmt.Fprintf(os.Stderr, "wait for GatewayClass: %v\n", err)
-		return 1
-	}
-	if err := kubectl("wait", "gateway/"+gatewayName,
-		"-n", gatewayNS,
-		"--for=condition=Programmed",
-		"--timeout=2m",
-	); err != nil {
-		fmt.Fprintf(os.Stderr, "wait for Gateway: %v\n", err)
-		return 1
-	}
-
-	// ── 5. Helm chart dependencies ────────────────────────────────────────────
+	// ── 2. Helm chart dependencies ────────────────────────────────────────────
 	fmt.Println("==> Updating Helm chart dependencies")
 	_ = helm("repo", "add", "minio", "https://charts.min.io/")
 	_ = helm("repo", "add", "grafana", "https://grafana.github.io/helm-charts")
@@ -111,14 +58,15 @@ func run(m *testing.M) (code int) {
 		return 1
 	}
 
-	// ── 6. Port-forward Envoy proxy ───────────────────────────────────────────
-	fmt.Println("==> Port-forwarding Envoy proxy on :" + gatewayPort)
-	pfCmd, err := startPortForward()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "port-forward: %v\n", err)
-		return 1
+	// ── 3. Suite-specific setup ───────────────────────────────────────────────
+	if suiteSetup != nil {
+		cleanup, err := suiteSetup()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "suite setup: %v\n", err)
+			return 1
+		}
+		defer cleanup()
 	}
-	defer pfCmd.Process.Kill() //nolint:errcheck
 
 	return m.Run()
 }
@@ -174,53 +122,6 @@ func runCmd(name string, args ...string) error {
 		return fmt.Errorf("%s %s: %w\n%s", name, strings.Join(args, " "), err, buf.String())
 	}
 	return nil
-}
-
-func startPortForward() (*exec.Cmd, error) {
-	// Find the Envoy proxy service by label.
-	out, err := exec.Command("kubectl",
-		"--context", "kind-"+clusterName,
-		"get", "svc", "-n", envoyGWNS,
-		"-l", fmt.Sprintf(
-			"gateway.envoyproxy.io/owning-gateway-name=%s,gateway.envoyproxy.io/owning-gateway-namespace=%s",
-			gatewayName, gatewayNS,
-		),
-		"-o", "jsonpath={.items[0].metadata.name}",
-	).Output()
-	if err != nil {
-		return nil, fmt.Errorf("get envoy svc: %w", err)
-	}
-	svcName := strings.TrimSpace(string(out))
-	if svcName == "" {
-		return nil, fmt.Errorf("envoy proxy service not found")
-	}
-
-	cmd := exec.Command("kubectl",
-		"--context", "kind-"+clusterName,
-		"port-forward",
-		"-n", envoyGWNS,
-		"svc/"+svcName,
-		gatewayPort+":80",
-	)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("start port-forward: %w", err)
-	}
-
-	// Wait until the port-forward is accepting connections.
-	deadline := time.Now().Add(30 * time.Second)
-	client := &http.Client{Timeout: time.Second}
-	for time.Now().Before(deadline) {
-		resp, err := client.Get("http://localhost:" + gatewayPort + "/")
-		if err == nil {
-			resp.Body.Close()
-			return cmd, nil
-		}
-		time.Sleep(time.Second)
-	}
-	// Return the command even if not ready; the tests will produce clear errors.
-	return cmd, nil
 }
 
 func randStr(n int) string {

--- a/operations/pyroscope/helm/pyroscope/e2e/main_test.go
+++ b/operations/pyroscope/helm/pyroscope/e2e/main_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 func run(m *testing.M) (code int) {
 	// ── 1. Kind cluster ──────────────────────────────────────────────────────
 	fmt.Println("==> Creating Kind cluster", clusterName)
-	if err := kubectl("cluster-info", "--context", "kind-"+clusterName); err != nil {
+	if err := kubectl("cluster-info"); err != nil {
 		// Cluster doesn't exist yet, create it.
 		if err := kind("create", "cluster",
 			"--name", clusterName,


### PR DESCRIPTION
Follow-up to #4983.

Adds e2e integration tests that verify all four HTTPRoute routing rules deliver traffic to the correct Pyroscope backends, using both the v2 single-binary and v2 microservices chart configurations.

## What's added

- **`e2e/main_test.go`** — `TestMain` that orchestrates the full test environment: creates a Kind cluster, installs Gateway API CRDs + Envoy Gateway, applies the `GatewayClass`/`Gateway`, runs `helm install` for each variant, and cleans everything up
- **`e2e/httproute_test.go`** — tests each routing rule using the repo's own connect-go clients with real proto payloads (typed `LabelNamesRequest`, `PushRequest` with a minimal pprof profile, `GetSettingsRequest`, `AdHocProfilesListRequest`); asserts `require.NoError` so any routing failure surfaces as a clear connect error
- **`ci/integration/`** — values files for v2 single-binary and v2 microservices (placed outside `ci/` so the standard `call-lint-test-pyroscope` job doesn't try to install them on a bare cluster)
- **`ci/gateway-resources.yaml`** — `EnvoyProxy` + `GatewayClass` + `Gateway` manifests for the test cluster
- **`.helmignore`** — excludes `e2e/`, `ci/integration/`, and `rendered/` from the packaged chart
- **`.github/workflows/helm-integration-httproute.yml`** — installs kind/helm/kubectl then runs `go test ./operations/pyroscope/helm/pyroscope/e2e/... -v -timeout 60m`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Kind/Gateway API/Envoy-based e2e test suite and GitHub Actions workflow, which can introduce CI flakiness and longer runtimes. Chart packaging is minimally affected via `.helmignore` updates.
> 
> **Overview**
> Adds an end-to-end Helm integration test suite that spins up a Kind cluster, installs Gateway API CRDs + Envoy Gateway, applies a test `GatewayClass`/`Gateway`, then installs the Pyroscope chart and verifies the `HTTPRoute` rules route to the expected backends for both *v2 single-binary* and *v2 microservices* configurations.
> 
> Introduces a dedicated GitHub Actions workflow (`helm-integration-httproute`) to run these tests on PRs touching `operations/pyroscope/helm/**`, adds CI-only values/manifests under `ci/integration/` and `ci/gateway-resources.yaml`, and updates `.helmignore` to exclude `e2e/`, `ci/integration/`, and `rendered/` from the packaged chart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65a1dfdfb6cf7b9ba3a07323fba97f7590f021da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->