### PR TITLE
docs: fix vertical stacking of contributors grid in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,68 +159,70 @@ To start contributing, check out our [Contributing Guide](docs/internal/contribu
 ### Thanks to the contributors of Pyroscope!
 
 [//]: contributor-faces
-<a href="https://github.com/simonswine"><img src="https://avatars.githubusercontent.com/u/223048?v=4" title="simonswine" width="80" height="80"></a>
-<a href="https://github.com/petethepig"><img src="https://avatars.githubusercontent.com/u/662636?v=4" title="petethepig" width="80" height="80"></a>
-<a href="https://github.com/cyriltovena"><img src="https://avatars.githubusercontent.com/u/1053421?v=4" title="cyriltovena" width="80" height="80"></a>
-<a href="https://github.com/eh-am"><img src="https://avatars.githubusercontent.com/u/6951209?v=4" title="eh-am" width="80" height="80"></a>
-<a href="https://github.com/kolesnikovae"><img src="https://avatars.githubusercontent.com/u/12090599?v=4" title="kolesnikovae" width="80" height="80"></a>
-<a href="https://github.com/korniltsev"><img src="https://avatars.githubusercontent.com/u/331773?v=4" title="korniltsev" width="80" height="80"></a>
-<a href="https://github.com/Rperry2174"><img src="https://avatars.githubusercontent.com/u/23323466?v=4" title="Rperry2174" width="80" height="80"></a>
-<a href="https://github.com/aleks-p"><img src="https://avatars.githubusercontent.com/u/8142643?v=4" title="aleks-p" width="80" height="80"></a>
-<a href="https://github.com/aocenas"><img src="https://avatars.githubusercontent.com/u/1014802?v=4" title="aocenas" width="80" height="80"></a>
-<a href="https://github.com/marcsanmi"><img src="https://avatars.githubusercontent.com/u/8235696?v=4" title="marcsanmi" width="80" height="80"></a>
-<a href="https://github.com/bryanhuhta"><img src="https://avatars.githubusercontent.com/u/32787160?v=4" title="bryanhuhta" width="80" height="80"></a>
-<a href="https://github.com/dogfrogfog"><img src="https://avatars.githubusercontent.com/u/47758224?v=4" title="dogfrogfog" width="80" height="80"></a>
-<a href="https://github.com/abeaumont"><img src="https://avatars.githubusercontent.com/u/80059?v=4" title="abeaumont" width="80" height="80"></a>
-<a href="https://github.com/pavelpashkovsky"><img src="https://avatars.githubusercontent.com/u/7372044?v=4" title="pavelpashkovsky" width="80" height="80"></a>
-<a href="https://github.com/jake-kramer"><img src="https://avatars.githubusercontent.com/u/899428?v=4" title="jake-kramer" width="80" height="80"></a>
-<a href="https://github.com/knylander-grafana"><img src="https://avatars.githubusercontent.com/u/104772500?v=4" title="knylander-grafana" width="80" height="80"></a>
-<a href="https://github.com/alsoba13"><img src="https://avatars.githubusercontent.com/u/3586560?v=4" title="alsoba13" width="80" height="80"></a>
-<a href="https://github.com/0xPoe"><img src="https://avatars.githubusercontent.com/u/29879298?v=4" title="0xPoe" width="80" height="80"></a>
-<a href="https://github.com/darrenjaneczek"><img src="https://avatars.githubusercontent.com/u/38694490?v=4" title="darrenjaneczek" width="80" height="80"></a>
-<a href="https://github.com/LouisInFlow"><img src="https://avatars.githubusercontent.com/u/84481279?v=4" title="LouisInFlow" width="80" height="80"></a>
-<a href="https://github.com/korniltsev-grafanista"><img src="https://avatars.githubusercontent.com/u/229453617?v=4" title="korniltsev-grafanista" width="80" height="80"></a>
-<a href="https://github.com/oleg-kozlyuk-grafana"><img src="https://avatars.githubusercontent.com/u/229985674?v=4" title="oleg-kozlyuk-grafana" width="80" height="80"></a>
-<a href="https://github.com/jdbaldry"><img src="https://avatars.githubusercontent.com/u/4599384?v=4" title="jdbaldry" width="80" height="80"></a>
-<a href="https://github.com/shaleynikov"><img src="https://avatars.githubusercontent.com/u/8720058?v=4" title="shaleynikov" width="80" height="80"></a>
-<a href="https://github.com/09jvilla"><img src="https://avatars.githubusercontent.com/u/9610816?v=4" title="09jvilla" width="80" height="80"></a>
-<a href="https://github.com/grafakus"><img src="https://avatars.githubusercontent.com/u/146180665?v=4" title="grafakus" width="80" height="80"></a>
-<a href="https://github.com/joey-grafana"><img src="https://avatars.githubusercontent.com/u/90795735?v=4" title="joey-grafana" width="80" height="80"></a>
-<a href="https://github.com/Eve832"><img src="https://avatars.githubusercontent.com/u/81647476?v=4" title="Eve832" width="80" height="80"></a>
-<a href="https://github.com/iOliverNguyen"><img src="https://avatars.githubusercontent.com/u/6618620?v=4" title="iOliverNguyen" width="80" height="80"></a>
-<a href="https://github.com/AdrK"><img src="https://avatars.githubusercontent.com/u/15175440?v=4" title="AdrK" width="80" height="80"></a>
-<a href="https://github.com/alonlong"><img src="https://avatars.githubusercontent.com/u/3090383?v=4" title="alonlong" width="80" height="80"></a>
-<a href="https://github.com/Loggy"><img src="https://avatars.githubusercontent.com/u/3171097?v=4" title="Loggy" width="80" height="80"></a>
-<a href="https://github.com/robbymilo"><img src="https://avatars.githubusercontent.com/u/8106669?v=4" title="robbymilo" width="80" height="80"></a>
-<a href="https://github.com/RichiH"><img src="https://avatars.githubusercontent.com/u/754723?v=4" title="RichiH" width="80" height="80"></a>
-<a href="https://github.com/cjsampson"><img src="https://avatars.githubusercontent.com/u/8391857?v=4" title="cjsampson" width="80" height="80"></a>
-<a href="https://github.com/cristiangreco"><img src="https://avatars.githubusercontent.com/u/316923?v=4" title="cristiangreco" width="80" height="80"></a>
-<a href="https://github.com/callpraths"><img src="https://avatars.githubusercontent.com/u/2848904?v=4" title="callpraths" width="80" height="80"></a>
-<a href="https://github.com/ekpatrice"><img src="https://avatars.githubusercontent.com/u/77462462?v=4" title="ekpatrice" width="80" height="80"></a>
-<a href="https://github.com/ruslanpascoal2"><img src="https://avatars.githubusercontent.com/u/61955096?v=4" title="ruslanpascoal2" width="80" height="80"></a>
-<a href="https://github.com/StasDachinsky"><img src="https://avatars.githubusercontent.com/u/23450818?v=4" title="StasDachinsky" width="80" height="80"></a>
-<a href="https://github.com/gawicks"><img src="https://avatars.githubusercontent.com/u/1481491?v=4" title="gawicks" width="80" height="80"></a>
-<a href="https://github.com/omarabid"><img src="https://avatars.githubusercontent.com/u/909237?v=4" title="omarabid" width="80" height="80"></a>
-<a href="https://github.com/scottzhlin"><img src="https://avatars.githubusercontent.com/u/37504582?v=4" title="scottzhlin" width="80" height="80"></a>
-<a href="https://github.com/Skemba"><img src="https://avatars.githubusercontent.com/u/8813875?v=4" title="Skemba" width="80" height="80"></a>
-<a href="https://github.com/cuishuang"><img src="https://avatars.githubusercontent.com/u/15921519?v=4" title="cuishuang" width="80" height="80"></a>
-<a href="https://github.com/wilfriedroset"><img src="https://avatars.githubusercontent.com/u/12611310?v=4" title="wilfriedroset" width="80" height="80"></a>
-<a href="https://github.com/rajat2004"><img src="https://avatars.githubusercontent.com/u/37938604?v=4" title="rajat2004" width="80" height="80"></a>
-<a href="https://github.com/nlamirault"><img src="https://avatars.githubusercontent.com/u/29233?v=4" title="nlamirault" width="80" height="80"></a>
-<a href="https://github.com/fandreuz"><img src="https://avatars.githubusercontent.com/u/8464342?v=4" title="fandreuz" width="80" height="80"></a>
-<a href="https://github.com/cmonez"><img src="https://avatars.githubusercontent.com/u/39146411?v=4" title="cmonez" width="80" height="80"></a>
-<a href="https://github.com/EgorMozheiko"><img src="https://avatars.githubusercontent.com/u/90687109?v=4" title="EgorMozheiko" width="80" height="80"></a>
-<a href="https://github.com/cstyan"><img src="https://avatars.githubusercontent.com/u/3246492?v=4" title="cstyan" width="80" height="80"></a>
-<a href="https://github.com/luweglarz"><img src="https://avatars.githubusercontent.com/u/54635394?v=4" title="luweglarz" width="80" height="80"></a>
-<a href="https://github.com/liaol"><img src="https://avatars.githubusercontent.com/u/5674087?v=4" title="liaol" width="80" height="80"></a>
-<a href="https://github.com/dancer1325"><img src="https://avatars.githubusercontent.com/u/39351487?v=4" title="dancer1325" width="80" height="80"></a>
-<a href="https://github.com/QuantumEnigmaa"><img src="https://avatars.githubusercontent.com/u/64951262?v=4" title="QuantumEnigmaa" width="80" height="80"></a>
-<a href="https://github.com/Pranay0302"><img src="https://avatars.githubusercontent.com/u/55592629?v=4" title="Pranay0302" width="80" height="80"></a>
-<a href="https://github.com/alrs"><img src="https://avatars.githubusercontent.com/u/28523?v=4" title="alrs" width="80" height="80"></a>
-<a href="https://github.com/juliosaraiva"><img src="https://avatars.githubusercontent.com/u/6595701?v=4" title="juliosaraiva" width="80" height="80"></a>
-<a href="https://github.com/clovis1122"><img src="https://avatars.githubusercontent.com/u/22270042?v=4" title="clovis1122" width="80" height="80"></a>
-<a href="https://github.com/linthan"><img src="https://avatars.githubusercontent.com/u/13914829?v=4" title="linthan" width="80" height="80"></a>
-<a href="https://github.com/dapirian"><img src="https://avatars.githubusercontent.com/u/3904462?v=4" title="dapirian" width="80" height="80"></a>
-<a href="https://github.com/Cluas"><img src="https://avatars.githubusercontent.com/u/10056928?v=4" title="Cluas" width="80" height="80"></a>
+<p>
+<a href="https://github.com/simonswine"><img src="https://avatars.githubusercontent.com/u/223048?v=4" title="simonswine" width="80"></a>
+<a href="https://github.com/petethepig"><img src="https://avatars.githubusercontent.com/u/662636?v=4" title="petethepig" width="80"></a>
+<a href="https://github.com/cyriltovena"><img src="https://avatars.githubusercontent.com/u/1053421?v=4" title="cyriltovena" width="80"></a>
+<a href="https://github.com/eh-am"><img src="https://avatars.githubusercontent.com/u/6951209?v=4" title="eh-am" width="80"></a>
+<a href="https://github.com/kolesnikovae"><img src="https://avatars.githubusercontent.com/u/12090599?v=4" title="kolesnikovae" width="80"></a>
+<a href="https://github.com/korniltsev"><img src="https://avatars.githubusercontent.com/u/331773?v=4" title="korniltsev" width="80"></a>
+<a href="https://github.com/Rperry2174"><img src="https://avatars.githubusercontent.com/u/23323466?v=4" title="Rperry2174" width="80"></a>
+<a href="https://github.com/aleks-p"><img src="https://avatars.githubusercontent.com/u/8142643?v=4" title="aleks-p" width="80"></a>
+<a href="https://github.com/aocenas"><img src="https://avatars.githubusercontent.com/u/1014802?v=4" title="aocenas" width="80"></a>
+<a href="https://github.com/marcsanmi"><img src="https://avatars.githubusercontent.com/u/8235696?v=4" title="marcsanmi" width="80"></a>
+<a href="https://github.com/bryanhuhta"><img src="https://avatars.githubusercontent.com/u/32787160?v=4" title="bryanhuhta" width="80"></a>
+<a href="https://github.com/dogfrogfog"><img src="https://avatars.githubusercontent.com/u/47758224?v=4" title="dogfrogfog" width="80"></a>
+<a href="https://github.com/abeaumont"><img src="https://avatars.githubusercontent.com/u/80059?v=4" title="abeaumont" width="80"></a>
+<a href="https://github.com/pavelpashkovsky"><img src="https://avatars.githubusercontent.com/u/7372044?v=4" title="pavelpashkovsky" width="80"></a>
+<a href="https://github.com/jake-kramer"><img src="https://avatars.githubusercontent.com/u/899428?v=4" title="jake-kramer" width="80"></a>
+<a href="https://github.com/knylander-grafana"><img src="https://avatars.githubusercontent.com/u/104772500?v=4" title="knylander-grafana" width="80"></a>
+<a href="https://github.com/alsoba13"><img src="https://avatars.githubusercontent.com/u/3586560?v=4" title="alsoba13" width="80"></a>
+<a href="https://github.com/0xPoe"><img src="https://avatars.githubusercontent.com/u/29879298?v=4" title="0xPoe" width="80"></a>
+<a href="https://github.com/darrenjaneczek"><img src="https://avatars.githubusercontent.com/u/38694490?v=4" title="darrenjaneczek" width="80"></a>
+<a href="https://github.com/LouisInFlow"><img src="https://avatars.githubusercontent.com/u/84481279?v=4" title="LouisInFlow" width="80"></a>
+<a href="https://github.com/korniltsev-grafanista"><img src="https://avatars.githubusercontent.com/u/229453617?v=4" title="korniltsev-grafanista" width="80"></a>
+<a href="https://github.com/oleg-kozlyuk-grafana"><img src="https://avatars.githubusercontent.com/u/229985674?v=4" title="oleg-kozlyuk-grafana" width="80"></a>
+<a href="https://github.com/jdbaldry"><img src="https://avatars.githubusercontent.com/u/4599384?v=4" title="jdbaldry" width="80"></a>
+<a href="https://github.com/shaleynikov"><img src="https://avatars.githubusercontent.com/u/8720058?v=4" title="shaleynikov" width="80"></a>
+<a href="https://github.com/09jvilla"><img src="https://avatars.githubusercontent.com/u/9610816?v=4" title="09jvilla" width="80"></a>
+<a href="https://github.com/grafakus"><img src="https://avatars.githubusercontent.com/u/146180665?v=4" title="grafakus" width="80"></a>
+<a href="https://github.com/joey-grafana"><img src="https://avatars.githubusercontent.com/u/90795735?v=4" title="joey-grafana" width="80"></a>
+<a href="https://github.com/Eve832"><img src="https://avatars.githubusercontent.com/u/81647476?v=4" title="Eve832" width="80"></a>
+<a href="https://github.com/iOliverNguyen"><img src="https://avatars.githubusercontent.com/u/6618620?v=4" title="iOliverNguyen" width="80"></a>
+<a href="https://github.com/AdrK"><img src="https://avatars.githubusercontent.com/u/15175440?v=4" title="AdrK" width="80"></a>
+<a href="https://github.com/alonlong"><img src="https://avatars.githubusercontent.com/u/3090383?v=4" title="alonlong" width="80"></a>
+<a href="https://github.com/Loggy"><img src="https://avatars.githubusercontent.com/u/3171097?v=4" title="Loggy" width="80"></a>
+<a href="https://github.com/robbymilo"><img src="https://avatars.githubusercontent.com/u/8106669?v=4" title="robbymilo" width="80"></a>
+<a href="https://github.com/RichiH"><img src="https://avatars.githubusercontent.com/u/754723?v=4" title="RichiH" width="80"></a>
+<a href="https://github.com/cjsampson"><img src="https://avatars.githubusercontent.com/u/8391857?v=4" title="cjsampson" width="80"></a>
+<a href="https://github.com/cristiangreco"><img src="https://avatars.githubusercontent.com/u/316923?v=4" title="cristiangreco" width="80"></a>
+<a href="https://github.com/callpraths"><img src="https://avatars.githubusercontent.com/u/2848904?v=4" title="callpraths" width="80"></a>
+<a href="https://github.com/ekpatrice"><img src="https://avatars.githubusercontent.com/u/77462462?v=4" title="ekpatrice" width="80"></a>
+<a href="https://github.com/ruslanpascoal2"><img src="https://avatars.githubusercontent.com/u/61955096?v=4" title="ruslanpascoal2" width="80"></a>
+<a href="https://github.com/StasDachinsky"><img src="https://avatars.githubusercontent.com/u/23450818?v=4" title="StasDachinsky" width="80"></a>
+<a href="https://github.com/gawicks"><img src="https://avatars.githubusercontent.com/u/1481491?v=4" title="gawicks" width="80"></a>
+<a href="https://github.com/omarabid"><img src="https://avatars.githubusercontent.com/u/909237?v=4" title="omarabid" width="80"></a>
+<a href="https://github.com/scottzhlin"><img src="https://avatars.githubusercontent.com/u/37504582?v=4" title="scottzhlin" width="80"></a>
+<a href="https://github.com/Skemba"><img src="https://avatars.githubusercontent.com/u/8813875?v=4" title="Skemba" width="80"></a>
+<a href="https://github.com/cuishuang"><img src="https://avatars.githubusercontent.com/u/15921519?v=4" title="cuishuang" width="80"></a>
+<a href="https://github.com/wilfriedroset"><img src="https://avatars.githubusercontent.com/u/12611310?v=4" title="wilfriedroset" width="80"></a>
+<a href="https://github.com/rajat2004"><img src="https://avatars.githubusercontent.com/u/37938604?v=4" title="rajat2004" width="80"></a>
+<a href="https://github.com/nlamirault"><img src="https://avatars.githubusercontent.com/u/29233?v=4" title="nlamirault" width="80"></a>
+<a href="https://github.com/fandreuz"><img src="https://avatars.githubusercontent.com/u/8464342?v=4" title="fandreuz" width="80"></a>
+<a href="https://github.com/cmonez"><img src="https://avatars.githubusercontent.com/u/39146411?v=4" title="cmonez" width="80"></a>
+<a href="https://github.com/EgorMozheiko"><img src="https://avatars.githubusercontent.com/u/90687109?v=4" title="EgorMozheiko" width="80"></a>
+<a href="https://github.com/cstyan"><img src="https://avatars.githubusercontent.com/u/3246492?v=4" title="cstyan" width="80"></a>
+<a href="https://github.com/luweglarz"><img src="https://avatars.githubusercontent.com/u/54635394?v=4" title="luweglarz" width="80"></a>
+<a href="https://github.com/liaol"><img src="https://avatars.githubusercontent.com/u/5674087?v=4" title="liaol" width="80"></a>
+<a href="https://github.com/dancer1325"><img src="https://avatars.githubusercontent.com/u/39351487?v=4" title="dancer1325" width="80"></a>
+<a href="https://github.com/QuantumEnigmaa"><img src="https://avatars.githubusercontent.com/u/64951262?v=4" title="QuantumEnigmaa" width="80"></a>
+<a href="https://github.com/Pranay0302"><img src="https://avatars.githubusercontent.com/u/55592629?v=4" title="Pranay0302" width="80"></a>
+<a href="https://github.com/alrs"><img src="https://avatars.githubusercontent.com/u/28523?v=4" title="alrs" width="80"></a>
+<a href="https://github.com/juliosaraiva"><img src="https://avatars.githubusercontent.com/u/6595701?v=4" title="juliosaraiva" width="80"></a>
+<a href="https://github.com/clovis1122"><img src="https://avatars.githubusercontent.com/u/22270042?v=4" title="clovis1122" width="80"></a>
+<a href="https://github.com/linthan"><img src="https://avatars.githubusercontent.com/u/13914829?v=4" title="linthan" width="80"></a>
+<a href="https://github.com/dapirian"><img src="https://avatars.githubusercontent.com/u/3904462?v=4" title="dapirian" width="80"></a>
+<a href="https://github.com/Cluas"><img src="https://avatars.githubusercontent.com/u/10056928?v=4" title="Cluas" width="80"></a>
+</p>
 
 [//]: contributor-faces

--- a/tools/update-contributors/main.go
+++ b/tools/update-contributors/main.go
@@ -51,6 +51,11 @@ func generateContributors() (string, error) {
 
 	sb := strings.Builder{}
 
+	// Wrap in <p> so GitHub treats this as an HTML block and does not insert
+	// <br> between lines; omit the height attribute so GitHub does not inject
+	// a display:block aspect-ratio style that breaks the horizontal grid.
+	sb.WriteString("<p>\n")
+
 	limit := 9 * 7
 
 	for _, c := range contributors {
@@ -64,13 +69,15 @@ func generateContributors() (string, error) {
 		sb.WriteString(c.AvatarURL)
 		sb.WriteString(`" title="`)
 		sb.WriteString(c.Login)
-		sb.WriteString(`" width="80" height="80"></a>`)
+		sb.WriteString(`" width="80"></a>`)
 		sb.WriteByte('\n')
 		limit--
 		if limit == 0 {
 			break
 		}
 	}
+
+	sb.WriteString("</p>\n")
 
 	return sb.String(), nil
 }


### PR DESCRIPTION
## Summary

The contributor avatars in the README have been rendering one-per-row (vertically stacked) since the April 1 monthly contributors update landed (#4963). This PR restores the horizontal grid.

- **Current broken render on `main`:** https://github.com/grafana/pyroscope?tab=readme-ov-file#thanks-to-the-contributors-of-pyroscope
- **Fixed render on this branch:** https://github.com/grafana/pyroscope/blob/fix/readme-contributors-layout/README.md#thanks-to-the-contributors-of-pyroscope

## Root cause

GitHub's markdown renderer was updated (first reports: [community discussion #165090](https://github.com/orgs/community/discussions/165090), July 2025) to inject aspect-ratio placeholder CSS on `<img>` tags that have both `width` and `height` attributes:

```html
<!-- What we write -->
<a href="..."><img src="..." width="80" height="80"></a>

<!-- What GitHub renders -->
<a href="..."><img src="..." width="80" height="80"
  style="max-width: 100%; height: auto; max-height: 80px; aspect-ratio: 80/80;
         background-color: var(--bgColor-muted); border-radius: 6px;
         display: block"
  class="js-gh-image-fallback"></a>
```

The injected `display: block` propagates up through the enclosing inline `<a>`, making each anchor block-level. Combined with GFM turning newlines between `<a>` lines into `<br>`, every avatar ends up on its own row.

PR #4963 itself was harmless — only reordered/added names — but it was the first README edit since GitHub's sanitizer change rolled out to the cache for this repo, so it was the commit that made the regression visible. Nothing in our repo caused this; our format simply happens to trigger the new renderer behavior.

## Fix

Two small changes, applied both to the live README and to the generator so the monthly automation produces the same shape (no churn PR next month):

1. **Wrap the block in `<p>...</p>`.** This makes the section a CommonMark HTML block, so GFM stops converting each source-line newline into `<br>`.
2. **Drop `height="80"` from each `<img>` (keep `width="80"`).** GitHub only injects the `display: block` style when *both* attributes are present. With width-only, the injection is just `max-width: 100%;` — no block-ification.

Avatars are square (GitHub serves them that way), so `width=80` alone still renders at 80×80 — the browser derives the height from the intrinsic aspect ratio. Visually identical to the pre-break grid.

This is the same workaround confirmed by multiple users in the GitHub community thread above.

## Files changed

- `tools/update-contributors/main.go` — emit `<p>` / `</p>` wrappers; drop `height="80"` from generated `<img>` tags.
- `README.md` — mirror the same shape in the currently-committed content, so the fix renders immediately and the next monthly cron produces a zero-diff regeneration.

## Test plan

- [x] Verified rendered output via `POST /markdown` against GitHub's API — no `<br>`, no `display: block`, just `max-width: 100%;`.
- [ ] Visually check the rendered README on this branch (link above).
- [ ] After merge, confirm `github.com/grafana/pyroscope` shows avatars in a grid again.
- [ ] Next month's automated contributors PR produces only name-level changes (no structural diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
