### PR TITLE
docs(v2): improve v1->v2 migration docs

### DIFF
--- a/docs/sources/reference-pyroscope-v2-architecture/migrate-from-v1/index.md
+++ b/docs/sources/reference-pyroscope-v2-architecture/migrate-from-v1/index.md
@@ -31,8 +31,6 @@ Before starting the migration, make sure you have:
 
   You should see `v1: true` and `v2: false`. If you see `v2: true`, your installation is already using v2 or is mid-migration.
 
-- **Persistence enabled** (`pyroscope.persistence.enabled=true`).
-
 - **Object storage configured.** v2 writes directly to object storage — it doesn't use local disk for block storage. If you haven't configured object storage yet, add it to your Helm values. For example, for S3:
 
   ```yaml
@@ -74,8 +72,8 @@ The steps below are specific to your deployment mode. Follow the section that ma
 In this phase, the single-binary process enables the v2 storage modules alongside v1. Writes go to both storage backends simultaneously, and the read path serves data from both v1 and v2.
 
 ```bash
-helm upgrade -n pyroscope pyroscope grafana/pyroscope \
-  --reuse-values \
+helm upgrade -n pyroscope pyroscope grafana/pyroscope --version 2.0.0 \
+  --reset-then-reuse-values \
   --set architecture.storage.v1=true \
   --set architecture.storage.v2=true
 ```
@@ -181,8 +179,8 @@ After this step, data ingested before Phase 1 is no longer queryable through Pyr
 {{< /admonition >}}
 
 ```bash
-helm upgrade -n pyroscope pyroscope grafana/pyroscope \
-  --reuse-values \
+helm upgrade -n pyroscope pyroscope grafana/pyroscope --version 2.0.0 \
+  --reset-then-reuse-values \
   --set architecture.storage.v1=false \
   --set architecture.storage.v2=true
 ```


### PR DESCRIPTION
`helm upgrade --reuse-values` will fail if the new chart has features that rely on values bundled with the chart (e.g. failed for me because of how #5067 and #4983 are set up).

Hence we switch to `--reset-then-reuse-values` which will overlay the installation values on top of the chart-bundled defaults.

Also updating the target chart version to 2.0.0 which is not yet released. We might want to backport this, but it is probably fine if we don't.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes with no runtime impact, though pinning to an unreleased chart version could confuse users if they follow the commands verbatim.
> 
> **Overview**
> Adjusts the v1→v2 storage migration guide to recommend `helm upgrade` with `--reset-then-reuse-values` (instead of `--reuse-values`) so chart-default values are retained while overlaying existing install values.
> 
> Pins the single-binary migration commands (Phase 1 dual ingest and Phase 3 cutover) to `grafana/pyroscope --version 2.0.0`, and removes the prerequisite callout about persistence being enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37f2e1244457128da6aa15628be802d44b6e58f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->