### PR TITLE
profilecli: add a debuginfo upload subcommand

### DIFF
--- a/cmd/profilecli/debuginfo.go
+++ b/cmd/profilecli/debuginfo.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"context"
+	"debug/elf"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"connectrpc.com/connect"
+	"github.com/go-kit/log/level"
+
+	debuginfov1alpha1 "github.com/grafana/pyroscope/api/gen/proto/go/debuginfo/v1alpha1"
+	debuginfov1alpha1connect "github.com/grafana/pyroscope/api/gen/proto/go/debuginfo/v1alpha1/debuginfov1alpha1connect"
+	connectapi "github.com/grafana/pyroscope/v2/pkg/api/connect"
+	"github.com/grafana/pyroscope/v2/pkg/debuginfo"
+)
+
+func (c *phlareClient) debuginfoServiceClient() debuginfov1alpha1connect.DebuginfoServiceClient {
+	return debuginfov1alpha1connect.NewDebuginfoServiceClient(
+		c.httpClient(),
+		c.URL,
+		append(
+			connectapi.DefaultClientOptions(),
+			c.protocolOption(),
+		)...,
+	)
+}
+
+// extractGnuBuildIdFromReader parses the GNU build ID out of an already-open
+// ELF file. The caller is responsible for closing/seeking the reader.
+func extractGnuBuildIdFromReader(r io.ReaderAt) (string, error) {
+	elfFile, err := elf.NewFile(r)
+	if err != nil {
+		return "", err
+	}
+	defer elfFile.Close()
+
+	for _, section := range elfFile.Sections {
+		if section.Name != ".note.gnu.build-id" {
+			continue
+		}
+		data, err := section.Data()
+		if err != nil {
+			return "", err
+		}
+		if len(data) < 12 {
+			return "", fmt.Errorf(".note.gnu.build-id section too short: %d bytes", len(data))
+		}
+		namesz := binary.LittleEndian.Uint32(data[0:4])
+		descsz := binary.LittleEndian.Uint32(data[4:8])
+		nameEnd := 12 + int(namesz)
+		descStart := (nameEnd + 3) &^ 3 // align to 4 bytes
+		descEnd := descStart + int(descsz)
+		if descStart < nameEnd || descEnd > len(data) {
+			return "", fmt.Errorf(".note.gnu.build-id section truncated: need %d bytes, have %d", descEnd, len(data))
+		}
+		return hex.EncodeToString(data[descStart:descEnd]), nil
+	}
+	return "", nil
+}
+
+// extractGnuBuildId opens path and returns the file's GNU build ID.
+func extractGnuBuildId(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	return extractGnuBuildIdFromReader(f)
+}
+
+func shouldInitiateUploadCheck(ctx context.Context, client debuginfov1alpha1connect.DebuginfoServiceClient, gnuBuildId string, fileType debuginfov1alpha1.FileMetadata_Type) (bool, string, error) {
+	req := &debuginfov1alpha1.ShouldInitiateUploadRequest{
+		File: &debuginfov1alpha1.FileMetadata{
+			GnuBuildId: gnuBuildId,
+			Type:       fileType,
+		},
+	}
+	resp, err := client.ShouldInitiateUpload(ctx, connect.NewRequest(req))
+	if err != nil {
+		return false, "", err
+	}
+	return resp.Msg.ShouldInitiateUpload, resp.Msg.Reason, nil
+}
+
+func uploadDebuginfo(ctx context.Context, params *debuginfoUploadParams) error {
+	client := params.debuginfoServiceClient()
+
+	f, err := os.Open(params.path)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	defer f.Close()
+
+	gnuBuildId, err := extractGnuBuildIdFromReader(f)
+	if err != nil {
+		return fmt.Errorf("failed to extract GNU build ID from %q: %w", params.path, err)
+	}
+	if gnuBuildId == "" {
+		return fmt.Errorf("file %q has no .note.gnu.build-id section; cannot upload", params.path)
+	}
+
+	var fileType debuginfov1alpha1.FileMetadata_Type
+	switch params.fileType {
+	case "executable-full":
+		fileType = debuginfov1alpha1.FileMetadata_TYPE_EXECUTABLE_FULL
+	case "executable-no-text":
+		fileType = debuginfov1alpha1.FileMetadata_TYPE_EXECUTABLE_NO_TEXT
+	default:
+		fileType = debuginfov1alpha1.FileMetadata_TYPE_UNSPECIFIED
+	}
+
+	shouldUpload, reason, err := shouldInitiateUploadCheck(ctx, client, gnuBuildId, fileType)
+	if err != nil {
+		return fmt.Errorf("ShouldInitiateUpload check failed: %w", err)
+	}
+	if !shouldUpload {
+		if reason == debuginfo.ReasonDisabled {
+			return fmt.Errorf("server has debuginfo upload disabled")
+		}
+		level.Info(logger).Log("msg", "server declined upload", "build_id", gnuBuildId, "reason", reason)
+		return nil
+	}
+
+	// Rewind so the upload reads the file from the start.
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("failed to rewind file: %w", err)
+	}
+
+	uploadURL := params.URL + "/debuginfo.v1alpha1.DebuginfoService/Upload/" + gnuBuildId
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, f)
+	if err != nil {
+		return fmt.Errorf("failed to create upload request: %w", err)
+	}
+
+	resp, err := params.httpClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to upload: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("upload failed with status %s", resp.Status)
+	}
+
+	if _, err := client.UploadFinished(ctx, connect.NewRequest(&debuginfov1alpha1.UploadFinishedRequest{
+		GnuBuildId: gnuBuildId,
+	})); err != nil {
+		return fmt.Errorf("failed to finish upload: %w", err)
+	}
+
+	level.Info(logger).Log("msg", "successfully uploaded debuginfo", "build_id", gnuBuildId, "path", params.path)
+	return nil
+}
+
+type debuginfoUploadParams struct {
+	path     string
+	fileType string
+	*phlareClient
+}
+
+func addDebuginfoUploadParams(cmd commander) *debuginfoUploadParams {
+	params := new(debuginfoUploadParams)
+	cmd.Arg("path", "Path to the file to upload").Required().ExistingFileVar(&params.path)
+	cmd.Flag("type", "Type of executable: executable-full, executable-no-text").Default("executable-full").StringVar(&params.fileType)
+
+	params.phlareClient = addPhlareClient(cmd)
+	return params
+}

--- a/cmd/profilecli/debuginfo_test.go
+++ b/cmd/profilecli/debuginfo_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"debug/elf"
+	"encoding/binary"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/go-kit/log"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	debuginfov1alpha1connect "github.com/grafana/pyroscope/api/gen/proto/go/debuginfo/v1alpha1/debuginfov1alpha1connect"
+	"github.com/grafana/pyroscope/v2/pkg/debuginfo"
+	"github.com/grafana/pyroscope/v2/pkg/objstore/providers/memory"
+	"github.com/grafana/pyroscope/v2/pkg/tenant"
+	"github.com/grafana/pyroscope/v2/pkg/util"
+)
+
+// makeTestELF writes a minimal 64-bit ELF with a .note.gnu.build-id section
+// containing buildID, and returns its path. Uses debug/elf's exported header
+// types so we don't have to lay out raw bytes by hand.
+func makeTestELF(t *testing.T, buildID []byte) string {
+	t.Helper()
+
+	// Note payload: namesz | descsz | type | "GNU\0" | buildID | pad to 4.
+	// Errors from binary.Write to a bytes.Buffer are impossible, so we ignore them.
+	var note bytes.Buffer
+	_ = binary.Write(&note, binary.LittleEndian, uint32(4))            // namesz: len("GNU\0")
+	_ = binary.Write(&note, binary.LittleEndian, uint32(len(buildID))) // descsz
+	_ = binary.Write(&note, binary.LittleEndian, uint32(3))            // NT_GNU_BUILD_ID
+	note.WriteString("GNU\x00")
+	note.Write(buildID)
+	for note.Len()%4 != 0 {
+		note.WriteByte(0)
+	}
+
+	shstrtab := []byte("\x00.note.gnu.build-id\x00.shstrtab\x00")
+	const ehdrSz, phdrSz, shdrSz = 64, 56, 64
+	noteOff := uint64(ehdrSz + phdrSz)
+	shstrOff := noteOff + uint64(note.Len())
+	shdrOff := shstrOff + uint64(len(shstrtab))
+
+	var buf bytes.Buffer
+	_ = binary.Write(&buf, binary.LittleEndian, elf.Header64{
+		Ident:     [16]byte{0x7f, 'E', 'L', 'F', 2 /*64-bit*/, 1 /*LE*/, 1 /*ver*/},
+		Type:      uint16(elf.ET_EXEC),
+		Machine:   uint16(elf.EM_X86_64),
+		Version:   1,
+		Phoff:     ehdrSz,
+		Shoff:     shdrOff,
+		Ehsize:    ehdrSz,
+		Phentsize: phdrSz,
+		Phnum:     1,
+		Shentsize: shdrSz,
+		Shnum:     3, // null, .note.gnu.build-id, .shstrtab
+		Shstrndx:  2,
+	})
+	_ = binary.Write(&buf, binary.LittleEndian, elf.Prog64{
+		Type:   uint32(elf.PT_NOTE),
+		Flags:  uint32(elf.PF_R),
+		Off:    noteOff,
+		Filesz: uint64(note.Len()),
+		Memsz:  uint64(note.Len()),
+		Align:  4,
+	})
+	buf.Write(note.Bytes())
+	buf.Write(shstrtab)
+
+	// Three section headers: null, .note.gnu.build-id, .shstrtab.
+	_ = binary.Write(&buf, binary.LittleEndian, elf.Section64{})
+	_ = binary.Write(&buf, binary.LittleEndian, elf.Section64{
+		Name: 1, Type: uint32(elf.SHT_NOTE),
+		Off: noteOff, Size: uint64(note.Len()), Addralign: 4,
+	})
+	_ = binary.Write(&buf, binary.LittleEndian, elf.Section64{
+		Name: 20, Type: uint32(elf.SHT_STRTAB),
+		Off: shstrOff, Size: uint64(len(shstrtab)), Addralign: 1,
+	})
+
+	path := filepath.Join(t.TempDir(), "test.elf")
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0o644))
+	return path
+}
+
+func startDebuginfoTestServer(t *testing.T, enabled bool) *httptest.Server {
+	t.Helper()
+	store, err := debuginfo.NewStore(log.NewNopLogger(), memory.NewInMemBucket(), debuginfo.Config{
+		Enabled:           enabled,
+		MaxUploadSize:     100 * 1024 * 1024,
+		UploadStalePeriod: time.Minute,
+	})
+	require.NoError(t, err)
+
+	router := mux.NewRouter()
+	debuginfov1alpha1connect.RegisterDebuginfoServiceHandler(
+		router, store,
+		connect.WithInterceptors(tenant.NewAuthInterceptor(true)),
+	)
+	router.Handle(
+		"/debuginfo.v1alpha1.DebuginfoService/Upload/{gnu_build_id}",
+		util.AuthenticateUser(true).Wrap(store.UploadHTTPHandler()),
+	).Methods("POST")
+
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestExtractGnuBuildId(t *testing.T) {
+	t.Parallel()
+
+	id := []byte{0xde, 0xad, 0xbe, 0xef, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+		0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	got, err := extractGnuBuildId(makeTestELF(t, id))
+	require.NoError(t, err)
+	assert.Equal(t, "deadbeef0102030405060708090a0b0c0d0e0f10", got)
+
+	_, err = extractGnuBuildId("/nonexistent")
+	require.Error(t, err)
+}
+
+// TestExtractGnuBuildId_Truncated checks that a .note.gnu.build-id section
+// with a descsz larger than the actual data returns an error instead of
+// panicking on out-of-bounds slicing.
+func TestExtractGnuBuildId_Truncated(t *testing.T) {
+	t.Parallel()
+
+	// Build an ELF with a valid build ID, then patch the note's descsz field
+	// to claim a much larger payload than is actually present.
+	path := makeTestELF(t, []byte{0xaa, 0xbb, 0xcc, 0xdd})
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	// Note payload starts at ehdrSz+phdrSz = 64+56 = 120; descsz is at offset +4.
+	const noteOff = 120
+	binary.LittleEndian.PutUint32(data[noteOff+4:], 0xffff)
+	require.NoError(t, os.WriteFile(path, data, 0o644))
+
+	_, err = extractGnuBuildId(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "truncated")
+}
+
+func TestUploadDebuginfo(t *testing.T) {
+	t.Parallel()
+	srv := startDebuginfoTestServer(t, true)
+	id := []byte{0xca, 0xfe, 0xba, 0xbe, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+
+	params := &debuginfoUploadParams{
+		path:         makeTestELF(t, id),
+		fileType:     "executable-full",
+		phlareClient: &phlareClient{URL: srv.URL, TenantID: "t1"},
+	}
+
+	// First upload succeeds, second is a no-op (server says it already has it).
+	require.NoError(t, uploadDebuginfo(context.Background(), params))
+	require.NoError(t, uploadDebuginfo(context.Background(), params))
+}
+
+func TestUploadDebuginfo_Disabled(t *testing.T) {
+	t.Parallel()
+	srv := startDebuginfoTestServer(t, false)
+	id := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}
+
+	err := uploadDebuginfo(context.Background(), &debuginfoUploadParams{
+		path:         makeTestELF(t, id),
+		fileType:     "executable-full",
+		phlareClient: &phlareClient{URL: srv.URL, TenantID: "t2"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disabled")
+}
+
+func TestUploadDebuginfo_NotAnELF(t *testing.T) {
+	t.Parallel()
+	srv := startDebuginfoTestServer(t, true)
+
+	bogus := filepath.Join(t.TempDir(), "not-an-elf")
+	require.NoError(t, os.WriteFile(bogus, []byte("not elf"), 0o644))
+
+	err := uploadDebuginfo(context.Background(), &debuginfoUploadParams{
+		path:         bogus,
+		fileType:     "executable-full",
+		phlareClient: &phlareClient{URL: srv.URL, TenantID: "t3"},
+	})
+	require.Error(t, err)
+}

--- a/cmd/profilecli/main.go
+++ b/cmd/profilecli/main.go
@@ -143,6 +143,10 @@ func main() {
 	recordingRulesDeleteId := recordingRulesDeleteCmd.Arg("rule_id", "Recording rule Id to delete").Required().String()
 	recordingRulesParams := addRecordingRulesListParams(recordingRulesCmd)
 
+	debuginfoCmd := app.Command("debuginfo", "Operations on debuginfo (experimental).")
+	debuginfoUploadCmd := debuginfoCmd.Command("upload", "Upload debuginfo.")
+	debuginfoUploadParams := addDebuginfoUploadParams(debuginfoUploadCmd)
+
 	// parse command line arguments
 	parsedCmd := kingpin.MustParse(app.Parse(os.Args[1:]))
 
@@ -268,6 +272,10 @@ func main() {
 		}
 	case recordingRulesDeleteCmd.FullCommand():
 		if err := deleteRecordingRule(ctx, recordingRulesDeleteId, recordingRulesParams); err != nil {
+			os.Exit(checkError(err))
+		}
+	case debuginfoUploadCmd.FullCommand():
+		if err := uploadDebuginfo(ctx, debuginfoUploadParams); err != nil {
 			os.Exit(checkError(err))
 		}
 	default:


### PR DESCRIPTION
This PR adds a debuginfo upload sub command to allow manual upload linked to issue #5081

**Description:**

Adds a new `profilecli debuginfo upload <path>` subcommand for manually uploading an ELF binary's debuginfo to a Pyroscope server.

Uses the existing DebuginfoService API (the same one Alloy's eBPF agent calls):

1. Extract the GNU build ID from the ELF
3. ShouldInitiateUpload to check if the server already has it
4. POST /debuginfo.v1alpha1.DebuginfoService/Upload/{build_id} to stream the file
5. UploadFinished to commit


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CLI pathway that parses ELF binaries and performs authenticated HTTP uploads to the server; main risk is robustness around file parsing and error handling, not core service logic.
> 
> **Overview**
> Adds an experimental `profilecli debuginfo upload <path>` command to manually upload ELF debuginfo to a Pyroscope server.
> 
> The command extracts the ELF `.note.gnu.build-id`, calls `ShouldInitiateUpload` to avoid redundant uploads (and surfaces the server-disabled case), streams the file to the `Upload/{build_id}` HTTP endpoint, then finalizes via `UploadFinished`.
> 
> Includes new unit/integration-style tests that generate minimal ELF fixtures (including a truncated-note regression case) and exercise upload behavior against an in-memory debuginfo store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84222c1da6d327a0f0ad7291ac91f2b5df8da599. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->