### PR TITLE
docs: add v1.21 release notes

### DIFF
--- a/docs/sources/release-notes/v1-21.md
+++ b/docs/sources/release-notes/v1-21.md
@@ -1,0 +1,56 @@
+---
+title: Version 1.21 release notes
+menuTitle: V1.21
+description: Release notes for Grafana Pyroscope 1.21
+weight: 690
+---
+
+## Version 1.21.0 release notes
+
+The Pyroscope team is excited to present Grafana Pyroscope 1.21.0.
+
+This release contains enhancements, fixes, and improves stability & performance. It is the final v1.x feature release before Pyroscope 2.0 ships v2 storage as the default.
+
+Notable changes are listed below. For the full diff, check out the [1.21.0 changelog](https://github.com/grafana/pyroscope/compare/v1.20.4...v1.21.0).
+
+### Enhancements
+
+* **debuginfo**: Rewrite upload API to work over HTTP/1.1 ([#5046](https://github.com/grafana/pyroscope/pull/5046))
+* **debuginfo**: Add per-request timeout for upload handler ([#5056](https://github.com/grafana/pyroscope/pull/5056))
+* **querier**: Add DOT format support to `SelectMergeStacktraces` Connect API ([#5047](https://github.com/grafana/pyroscope/pull/5047))
+* **query-frontend**: Log `user_agent` on query log lines ([#5042](https://github.com/grafana/pyroscope/pull/5042))
+* **v2**: Move default storage paths under `./data/v2/` ([#4978](https://github.com/grafana/pyroscope/pull/4978))
+* Log HTTP protocol version in per-request logs ([#5014](https://github.com/grafana/pyroscope/pull/5014))
+* Helm: Add `pyroscope.rbac.create` toggle ([#5067](https://github.com/grafana/pyroscope/pull/5067))
+* Helm: Add `HTTPRoute` support ([#4983](https://github.com/grafana/pyroscope/pull/4983))
+* Bump `go.opentelemetry.io/otel` to v1.43.0 across all modules ([#5037](https://github.com/grafana/pyroscope/pull/5037))
+* Update Go toolchain to 1.25.9 ([#5015](https://github.com/grafana/pyroscope/pull/5015))
+
+### Fixes
+
+* **compactor**: Fix blocks cleaner hanging indefinitely after `SIGTERM` ([#4992](https://github.com/grafana/pyroscope/pull/4992))
+* **segment-writer**: Tolerate `ErrServerStopped` in client test suite ([#4977](https://github.com/grafana/pyroscope/pull/4977))
+* **scheduler**: Replace `bufconn` with TCP listener to fix flaky test ([#5052](https://github.com/grafana/pyroscope/pull/5052))
+* **ui**: Align time-series line graph with actual data points ([#5041](https://github.com/grafana/pyroscope/pull/5041))
+* **ui**: Fix file-naming collision when building UI on macOS ([#5055](https://github.com/grafana/pyroscope/pull/5055))
+* **ui**: Bump `dompurify`, `immutable`, `brace-expansion` to fix Trivy CVEs ([#5070](https://github.com/grafana/pyroscope/pull/5070))
+* **profilecli**: Preserve label-name casing in table output ([#4989](https://github.com/grafana/pyroscope/pull/4989))
+* Helm: Remove redundant adaptive-placement default ([#5057](https://github.com/grafana/pyroscope/pull/5057))
+* Fix `pkg/test/integration.TestStatusCode` ([#5058](https://github.com/grafana/pyroscope/pull/5058))
+
+### Security fixes
+
+* Bump `protobufjs` to 7.5.5 (security) ([#5062](https://github.com/grafana/pyroscope/pull/5062))
+* Bump `protocol-buffers-schema` to 3.6.1 (security) ([#5059](https://github.com/grafana/pyroscope/pull/5059))
+* Bump `axios` (security) ([#5045](https://github.com/grafana/pyroscope/pull/5045))
+* Bump `lodash` from 4.17.23 to 4.18.1 (security) ([#4974](https://github.com/grafana/pyroscope/pull/4974))
+* Bump `rack-session` (security) ([#5003](https://github.com/grafana/pyroscope/pull/5003))
+* Bump `rack-session` in `/examples/tracing/ruby` (security) ([#5011](https://github.com/grafana/pyroscope/pull/5011))
+* Update `vite` to v8.0.5 (security) ([#4994](https://github.com/grafana/pyroscope/pull/4994))
+* Update `github.com/go-jose/go-jose/v4` to v4.1.4 (security) ([#4984](https://github.com/grafana/pyroscope/pull/4984))
+
+### Documentation
+
+* Fix v1 → v2 migration guide prereq check and port-forward race ([#5044](https://github.com/grafana/pyroscope/pull/5044))
+* Clarify `HeatmapSlot` timestamp semantics ([#4986](https://github.com/grafana/pyroscope/pull/4986))
+* Fix Rust SDK documentation and examples for v2.0.0 ([#4972](https://github.com/grafana/pyroscope/pull/4972))


### PR DESCRIPTION
## Summary

- Adds curated release notes for Pyroscope 1.21.0 to the docs site.
- Mirrors the format of [`v1-20.md`](./docs/sources/release-notes/v1-20.md): enhancements, fixes, security fixes, documentation.
- v1.21.0 shipped on GitHub on 2026-04-17 but the grafana.com docs site has no entry for it; this fills that gap.

Source of truth cross-checked against the [v1.21.0 GitHub release](https://github.com/grafana/pyroscope/releases/tag/v1.21.0) and \`git log v1.20.4..v1.21.0\`.

## Test plan

- [ ] Verify docs build renders \`v1-21.md\` in the release-notes section.
- [ ] Confirm no PRs from the auto-generated GitHub changelog are missing that should be in the curated list (meta/doc-only/CI/chart-bump/renovate commits intentionally skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that adds a new markdown release-notes page; no runtime code or configuration behavior is modified.
> 
> **Overview**
> Adds a new `docs/sources/release-notes/v1-21.md` page documenting the Grafana Pyroscope **1.21.0** release.
> 
> The page follows the existing release-notes structure and curates the key *Enhancements*, *Fixes*, *Security fixes*, and *Documentation* items with links to the corresponding PRs/changelog comparison.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82b8ba3da4cc531f26deac6b12dd48f077833ea8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->