### PR TITLE
fix(goreleaser): stamp v2 module path in build ldflags

### DIFF
--- a/.cursor/rules/go-backend.mdc
+++ b/.cursor/rules/go-backend.mdc
@@ -22,8 +22,8 @@ import (
     "go.uber.org/atomic"
 
     // Internal packages
-    "github.com/grafana/pyroscope/pkg/model"
-    "github.com/grafana/pyroscope/pkg/objstore"
+    "github.com/grafana/pyroscope/v2/pkg/model"
+    "github.com/grafana/pyroscope/v2/pkg/objstore"
 )
 ```
 
@@ -86,7 +86,7 @@ func process(ctx context.Context, items []Item) error {
 All requests must include a tenant ID. Extract from context:
 
 ```go
-import "github.com/grafana/pyroscope/pkg/tenant"
+import "github.com/grafana/pyroscope/v2/pkg/tenant"
 
 tenantID, err := tenant.ExtractTenantIDFromContext(ctx)
 if err != nil {
@@ -101,7 +101,7 @@ if err != nil {
 Use the abstract Bucket interface:
 
 ```go
-import "github.com/grafana/pyroscope/pkg/objstore"
+import "github.com/grafana/pyroscope/v2/pkg/objstore"
 
 bucket := objstore.NewBucket(cfg)
 reader, err := bucket.Get(ctx, "path/to/object")

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,10 +37,10 @@ builds:
     ldflags:
       - >
         -extldflags "-static" {{ .Env.GORELEASER_DEBUG_INFO_FLAGS }}
-        -X "github.com/grafana/pyroscope/pkg/util/build.Branch={{ .Branch }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.Version={{ .Version }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.Revision={{ .ShortCommit }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.BuildDate={{ .CommitDate }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Branch={{ .Branch }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Version={{ .Version }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Revision={{ .ShortCommit }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.BuildDate={{ .CommitDate }}"
     id: pyroscope
   - env:
       - CGO_ENABLED=0
@@ -61,10 +61,10 @@ builds:
     ldflags:
       - >
         -extldflags "-static" {{ .Env.GORELEASER_DEBUG_INFO_FLAGS }}
-        -X "github.com/grafana/pyroscope/pkg/util/build.Branch={{ .Branch }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.Version={{ .Version }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.Revision={{ .ShortCommit }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.BuildDate={{ .CommitDate }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Branch={{ .Branch }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Version={{ .Version }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Revision={{ .ShortCommit }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.BuildDate={{ .CommitDate }}"
     id: pyroscope_non_linux
     skip: '{{ if eq .Env.GORELEASER_LINUX_ONLY "true" }}true{{ else }}false{{ end }}'
   - env:
@@ -74,10 +74,10 @@ builds:
     ldflags:
       - >
         -extldflags "-static" {{ .Env.GORELEASER_DEBUG_INFO_FLAGS }}
-        -X "github.com/grafana/pyroscope/pkg/util/build.Branch={{ .Branch }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.Version={{ .Version }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.Revision={{ .ShortCommit }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.BuildDate={{ .CommitDate }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Branch={{ .Branch }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Version={{ .Version }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Revision={{ .ShortCommit }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.BuildDate={{ .CommitDate }}"
     goos:
       - linux
     goarch:
@@ -101,10 +101,10 @@ builds:
     ldflags:
       - >
         -extldflags "-static" {{ .Env.GORELEASER_DEBUG_INFO_FLAGS }}
-        -X "github.com/grafana/pyroscope/pkg/util/build.Branch={{ .Branch }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.Version={{ .Version }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.Revision={{ .ShortCommit }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.BuildDate={{ .CommitDate }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Branch={{ .Branch }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Version={{ .Version }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Revision={{ .ShortCommit }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.BuildDate={{ .CommitDate }}"
     goos:
       - windows
       - darwin

--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -5,7 +5,7 @@ mockname: "Mock{{.InterfaceName}}"
 filename: "mock_{{.InterfaceName | snakecase}}.go"
 dir: "pkg/test/mocks/mock{{.PackageName}}"
 packages:
-  github.com/grafana/pyroscope/pkg/objstore:
+  github.com/grafana/pyroscope/v2/pkg/objstore:
     interfaces:
       Bucket:
   github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1:
@@ -21,57 +21,57 @@ packages:
   github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect:
     interfaces:
       QuerierServiceClient:
-  github.com/grafana/pyroscope/pkg/frontend:
+  github.com/grafana/pyroscope/v2/pkg/frontend:
     interfaces:
       Limits:
-  github.com/grafana/pyroscope/pkg/frontend/readpath/queryfrontend:
+  github.com/grafana/pyroscope/v2/pkg/frontend/readpath/queryfrontend:
     interfaces:
       QueryBackend:
       Symbolizer:
-  github.com/grafana/pyroscope/pkg/ingester/otlp:
+  github.com/grafana/pyroscope/v2/pkg/ingester/otlp:
     interfaces:
       PushService:
-  github.com/grafana/pyroscope/pkg/ingester/pyroscope:
+  github.com/grafana/pyroscope/v2/pkg/ingester/pyroscope:
     interfaces:
       PushService:
-  github.com/grafana/pyroscope/pkg/metastore/compaction/compactor:
+  github.com/grafana/pyroscope/v2/pkg/metastore/compaction/compactor:
     interfaces:
       BlockQueueStore:
       Tombstones:
-  github.com/grafana/pyroscope/pkg/metastore/compaction/scheduler:
+  github.com/grafana/pyroscope/v2/pkg/metastore/compaction/scheduler:
     interfaces:
       JobStore:
-  github.com/grafana/pyroscope/pkg/metastore/discovery:
+  github.com/grafana/pyroscope/v2/pkg/metastore/discovery:
     interfaces:
       Discovery:
-  github.com/grafana/pyroscope/pkg/metastore/index:
+  github.com/grafana/pyroscope/v2/pkg/metastore/index:
     interfaces:
       Store:
-  github.com/grafana/pyroscope/pkg/metastore/index/dlq:
+  github.com/grafana/pyroscope/v2/pkg/metastore/index/dlq:
     interfaces:
       Metastore:
-  github.com/grafana/pyroscope/pkg/segmentwriter/client/distributor/placement:
+  github.com/grafana/pyroscope/v2/pkg/segmentwriter/client/distributor/placement:
     interfaces:
       Placement:
-  github.com/grafana/pyroscope/pkg/segmentwriter/client/distributor/placement/adaptiveplacement:
+  github.com/grafana/pyroscope/v2/pkg/segmentwriter/client/distributor/placement/adaptiveplacement:
     interfaces:
       Store:
-  github.com/grafana/pyroscope/pkg/distributor/writepath:
+  github.com/grafana/pyroscope/v2/pkg/distributor/writepath:
     interfaces:
       SegmentWriterClient:
       IngesterClient:
-  github.com/grafana/pyroscope/pkg/metastore/raftnode/raftnodepb:
+  github.com/grafana/pyroscope/v2/pkg/metastore/raftnode/raftnodepb:
     interfaces:
       RaftNodeServiceClient:
       RaftNodeServiceServer:
-  github.com/grafana/pyroscope/pkg/metrics:
+  github.com/grafana/pyroscope/v2/pkg/metrics:
     interfaces:
       Exporter:
       Ruler:
-  github.com/grafana/pyroscope/pkg/frontend/vcs/client:
+  github.com/grafana/pyroscope/v2/pkg/frontend/vcs/client:
     interfaces:
       repositoryService:
-  github.com/grafana/pyroscope/pkg/symbolizer:
+  github.com/grafana/pyroscope/v2/pkg/symbolizer:
     interfaces:
       DebuginfodClient:
       DebugInfoStore:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,8 +162,8 @@ PYROSCOPE_V2=1 go run ./cmd/pyroscope \
        "go.uber.org/atomic"
 
        // Internal packages
-       "github.com/grafana/pyroscope/pkg/model"
-       "github.com/grafana/pyroscope/pkg/objstore"
+       "github.com/grafana/pyroscope/v2/pkg/model"
+       "github.com/grafana/pyroscope/v2/pkg/objstore"
    )
    ```
 
@@ -206,7 +206,7 @@ PYROSCOPE_V2=1 go run ./cmd/pyroscope \
 All requests must include a tenant ID in the `X-Scope-OrgID` header:
 
 ```go
-import "github.com/grafana/pyroscope/pkg/tenant"
+import "github.com/grafana/pyroscope/v2/pkg/tenant"
 
 // Extract tenant ID from context
 tenantID, err := tenant.ExtractTenantIDFromContext(ctx)
@@ -229,7 +229,7 @@ replicationSet, err := ring.Get(key, op, bufDescs, bufHosts, bufZones)
 Abstract object storage operations:
 
 ```go
-import "github.com/grafana/pyroscope/pkg/objstore"
+import "github.com/grafana/pyroscope/v2/pkg/objstore"
 
 // Use the Bucket interface
 bucket := objstore.NewBucket(cfg)

--- a/pkg/api/index.gohtml
+++ b/pkg/api/index.gohtml
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/grafana/pyroscope/pkg/api.indexPageContents */ -}}
+{{- /*gotype: github.com/grafana/pyroscope/v2/pkg/api.indexPageContents */ -}}
 <!DOCTYPE html>
 <html data-bs-theme="dark">
 <head>

--- a/pkg/storegateway/blocks.gohtml
+++ b/pkg/storegateway/blocks.gohtml
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/grafana/pyroscope/pkg/storegateway.blocksPageContents*/ -}}
+{{- /*gotype: github.com/grafana/pyroscope/v2/pkg/storegateway.blocksPageContents*/ -}}
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/html" data-bs-theme="dark">
 <head>

--- a/pkg/storegateway/ring_status.gohtml
+++ b/pkg/storegateway/ring_status.gohtml
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/grafana/pyroscope/pkg/storegateway.ringStatusPageContents*/ -}}
+{{- /*gotype: github.com/grafana/pyroscope/v2/pkg/storegateway.ringStatusPageContents*/ -}}
 <!DOCTYPE html>
 <html>
 <head>

--- a/pkg/storegateway/tenants.gohtml
+++ b/pkg/storegateway/tenants.gohtml
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/grafana/pyroscope/pkg/storegateway.tenantsPageContents*/ -}}
+{{- /*gotype: github.com/grafana/pyroscope/v2/pkg/storegateway.tenantsPageContents*/ -}}
 <!DOCTYPE html>
 <html data-bs-theme="dark">
 <head>


### PR DESCRIPTION
## Summary

`v2.0.0` binaries ship with empty `Version`, `Branch`, and `BuildDate` fields in ` -version` output and in the `pyroscope_build_info` Prometheus metric. After the Go module path was bumped to `github.com/grafana/pyroscope/v2` in #5073, `.goreleaser.yaml` was not updated — its ldflags still reference the pre-bump package path `github.com/grafana/pyroscope/pkg/util/build`. The Go linker silently drops `-X` directives pointing at unresolved symbols, leaving the build vars zero-value. `Revision` falls back to `debug.ReadBuildInfo()`, which is why it shows the full 40-char SHA suffixed with `-modified` (goreleaser's `make frontend/build` pre-hook generates `ui/dist/*`, dirtying the tree).

`Makefile`'s `VPREFIX` and `pkg/buf.gen.yaml` were already updated to the `/v2` path, which is why local `make` builds are stamped correctly — only release binaries are affected.

### Evidence

```
$ docker run --rm grafana/pyroscope:2.0.0 -version
pyroscope, version  (branch: , revision: 2cc2762d71dee47290dfb732c45f4d10b1dab711-modified)
  build date:
  go version:       go1.25.9
```

vs. v1.21.0:

```
pyroscope, version 1.21.0 (branch: HEAD, revision: 9cd4ab0a1)
  build date:       2026-04-17T10:30:15Z
```

### Scope

**Commit 1** (`fix(goreleaser): ...`) — the release-critical fix. 16 ldflag lines across 4 build targets get the `/v2/` infix.

**Commit 2** (`chore: ...`) — opportunistic cleanup of remaining `/v2` module-path drift found while grepping:
- `.mockery.yaml`: 14 package entries (mocks regen would fail without this).
- `pkg/api/index.gohtml`, `pkg/storegateway/{blocks,ring_status,tenants}.gohtml`: `/*gotype:*/` template type hints (IDE-only).
- `.cursor/rules/go-backend.mdc`, `AGENTS.md`: example imports in AI-assistant docs.

No runtime impact for commit 2 — dev-tooling only. Combined here to close the `/v2` migration in one PR.

### Out of scope

- Test fixtures (`pkg/pprof/testdata/*.txt`, `pkg/querybackend/testdata/fixtures/tree_16.txt`) — recorded profile symbol strings, not Go imports.
- `.golangci.yml` lines 67–68 (`/tools`, `/ebpf` entries) — redundant under existing prefix match; deferred.
- `examples/*/go.mod` — example apps import the separate `/api` Go submodule, unaffected by the main-module bump.

## Release plan

On merge, add label `backport release/v2.0` + `type/bug` for auto-backport to the release branch, then tag `v2.0.1` on `release/v2.0` so goreleaser republishes binaries with correct stamps.

## Test plan

- [ ] `make reference-help` produces no diff (verified locally on branch HEAD before PR).
- [ ] CI goreleaser dry-run stamps Version/Branch/Revision/BuildDate (`GORELEASER_LINUX_ONLY=true goreleaser release --snapshot --clean`).
- [ ] `dist/pyroscope_linux_amd64_v2/pyroscope -version` after snapshot build shows non-empty Version/Branch.
- [ ] After v2.0.1 tag + goreleaser run: `docker run --rm grafana/pyroscope:2.0.1 -version` shows `version 2.0.1`, short revision, non-empty build date.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release build configuration and linker `-X` stamping, which can affect published binaries/metadata if incorrect, but does not change runtime logic.
> 
> **Overview**
> Fixes release binaries missing build metadata by updating `.goreleaser.yaml` linker `-X` flags to target the `github.com/grafana/pyroscope/v2/pkg/util/build` variables (across pyroscope/profilecli and OS variants).
> 
> Also finishes `/v2` module-path drift in dev/IDE tooling and docs by updating `.mockery.yaml` package entries and the `/*gotype:*/` hints in a few `.gohtml` templates, plus import examples in `AGENTS.md` and `.cursor/rules/go-backend.mdc`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 674716bf1b2b13de858a1e8ddaee99f949528c59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->