### PR TITLE
docs: add v2.0.1 release notes

### DIFF
--- a/docs/sources/release-notes/v2-0.md
+++ b/docs/sources/release-notes/v2-0.md
@@ -5,6 +5,12 @@ description: Release notes for Grafana Pyroscope 2.0
 weight: 680
 ---
 
+## Version 2.0.1 release notes
+
+### Fixes
+
+* **goreleaser**: Stamp `github.com/grafana/pyroscope/v2/pkg/util/build` in build ldflags so `pyroscope -version` and the `pyroscope_build_info` metric report `Version`, `Branch`, `Revision`, and `BuildDate` correctly. Restores the v2.0.0 regression where those fields were empty ([#5084](https://github.com/grafana/pyroscope/pull/5084))
+
 ## Version 2.0.0 release notes
 
 The Pyroscope team is excited to present Grafana Pyroscope 2.0.0.


### PR DESCRIPTION
## Summary

Adds the `## Version 2.0.1 release notes` section to `docs/sources/release-notes/v2-0.md`, documenting the goreleaser ldflags fix that restored binary version stamping (#5084).

Newest-first ordering within the file, matching the pattern in `v1-20.md` and prior multi-patch release-notes pages.

Add labels `backport release/v2.0` + `type/docs` to auto-backport to the release branch on merge.

## Test plan

- [ ] Preview renders on grafana.com docs build
- [ ] v2.0.1 heading sorts above v2.0.0 on the published page

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a short 2.0.1 patch release entry; no runtime or behavioral code changes.
> 
> **Overview**
> Adds a **new `Version 2.0.1 release notes`** section to `docs/sources/release-notes/v2-0.md`, documenting the **goreleaser ldflags fix** that restores version/build metadata (`pyroscope -version` and `pyroscope_build_info`) for v2.0.0 regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 071cb4b5b874b369405f4b08d72933aba0318c2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->