### PR TITLE
chore: Release helm chart for v2.0.0

### DIFF
--- a/operations/pyroscope/helm/pyroscope/Chart.yaml
+++ b/operations/pyroscope/helm/pyroscope/Chart.yaml
@@ -3,8 +3,8 @@ name: pyroscope
 description: 🔥 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 home: https://grafana.com/oss/pyroscope/
 type: application
-version: 1.21.0
-appVersion: main-171db75
+version: 2.0.0
+appVersion: 2.0.1
 dependencies:
   - name: grafana-agent
     alias: agent

--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -1,6 +1,6 @@
 # pyroscope
 
-![Version: 1.21.0](https://img.shields.io/badge/Version-1.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main-171db75](https://img.shields.io/badge/AppVersion-main--171db75-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
 
 🔥 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -27,10 +27,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -48,10 +48,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -69,10 +69,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -90,10 +90,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -111,10 +111,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -132,10 +132,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -176,10 +176,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -523,10 +523,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1381,10 +1381,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1398,10 +1398,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1683,10 +1683,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1710,10 +1710,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1735,10 +1735,10 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1761,10 +1761,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1786,10 +1786,10 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1812,10 +1812,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1837,10 +1837,10 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1863,10 +1863,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1888,10 +1888,10 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1914,10 +1914,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -1939,10 +1939,10 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -1965,10 +1965,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -1990,10 +1990,10 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2016,10 +2016,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2041,10 +2041,10 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2067,10 +2067,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2082,9 +2082,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2107,7 +2107,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2171,10 +2171,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2186,9 +2186,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2211,7 +2211,7 @@ spec:
         - name: "querier"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -2275,10 +2275,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2290,9 +2290,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2315,7 +2315,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2379,10 +2379,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2394,9 +2394,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2419,7 +2419,7 @@ spec:
         - name: "query-scheduler"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-scheduler"
@@ -2483,10 +2483,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2511,10 +2511,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2542,10 +2542,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2570,10 +2570,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2781,10 +2781,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -2799,9 +2799,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2824,7 +2824,7 @@ spec:
         - name: "compactor"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -2893,10 +2893,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -2911,9 +2911,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2936,7 +2936,7 @@ spec:
         - name: "ingester"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -3001,10 +3001,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -3019,9 +3019,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3044,7 +3044,7 @@ spec:
         - name: "store-gateway"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -27,10 +27,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -48,10 +48,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -69,10 +69,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -90,10 +90,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -111,10 +111,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -132,10 +132,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -153,10 +153,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -174,10 +174,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -218,10 +218,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -565,10 +565,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1423,10 +1423,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1440,10 +1440,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1725,10 +1725,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1752,10 +1752,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1777,10 +1777,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1803,10 +1803,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1828,10 +1828,10 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1854,10 +1854,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1879,10 +1879,10 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1905,10 +1905,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1930,10 +1930,10 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1956,10 +1956,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1981,10 +1981,10 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2007,10 +2007,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2032,10 +2032,10 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2058,10 +2058,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2083,10 +2083,10 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2109,10 +2109,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2134,10 +2134,10 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2160,10 +2160,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2185,10 +2185,10 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2211,10 +2211,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -2227,9 +2227,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2252,7 +2252,7 @@ spec:
         - name: "ad-hoc-profiles"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ad-hoc-profiles"
@@ -2316,10 +2316,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2332,9 +2332,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2357,7 +2357,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2421,10 +2421,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2437,9 +2437,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2462,7 +2462,7 @@ spec:
         - name: "querier"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -2526,10 +2526,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2542,9 +2542,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2567,7 +2567,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2631,10 +2631,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2647,9 +2647,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2672,7 +2672,7 @@ spec:
         - name: "query-scheduler"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-scheduler"
@@ -2736,10 +2736,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2752,9 +2752,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2777,7 +2777,7 @@ spec:
         - name: "tenant-settings"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tenant-settings"
@@ -3024,10 +3024,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -3042,9 +3042,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3067,7 +3067,7 @@ spec:
         - name: "compactor"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -3136,10 +3136,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -3154,9 +3154,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3179,7 +3179,7 @@ spec:
         - name: "ingester"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -3244,10 +3244,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -3262,9 +3262,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3287,7 +3287,7 @@ spec:
         - name: "store-gateway"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -27,10 +27,10 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -48,10 +48,10 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -69,10 +69,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -90,10 +90,10 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -111,10 +111,10 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -132,10 +132,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -153,10 +153,10 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -174,10 +174,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -218,10 +218,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -565,10 +565,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1423,10 +1423,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1440,10 +1440,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1598,10 +1598,10 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -1623,10 +1623,10 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1770,10 +1770,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1797,10 +1797,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1826,10 +1826,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1856,10 +1856,10 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -1885,10 +1885,10 @@ metadata:
   name: pyroscope-dev-admin-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -1915,10 +1915,10 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -1944,10 +1944,10 @@ metadata:
   name: pyroscope-dev-compaction-worker-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -1974,10 +1974,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2003,10 +2003,10 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2033,10 +2033,10 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -2066,10 +2066,10 @@ metadata:
   name: pyroscope-dev-metastore-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -2101,10 +2101,10 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2130,10 +2130,10 @@ metadata:
   name: pyroscope-dev-query-backend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2160,10 +2160,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2189,10 +2189,10 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2219,10 +2219,10 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -2248,10 +2248,10 @@ metadata:
   name: pyroscope-dev-segment-writer-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -2278,10 +2278,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2307,10 +2307,10 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2337,10 +2337,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -2353,9 +2353,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2378,7 +2378,7 @@ spec:
         - name: "ad-hoc-profiles"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ad-hoc-profiles"
@@ -2447,10 +2447,10 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -2463,9 +2463,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2488,7 +2488,7 @@ spec:
         - name: "admin"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=admin"
@@ -2557,10 +2557,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2573,9 +2573,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2598,7 +2598,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2667,10 +2667,10 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2683,9 +2683,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2708,7 +2708,7 @@ spec:
         - name: "query-backend"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-backend"
@@ -2777,10 +2777,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2793,9 +2793,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2818,7 +2818,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2887,10 +2887,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2903,9 +2903,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2928,7 +2928,7 @@ spec:
         - name: "tenant-settings"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tenant-settings"
@@ -3180,10 +3180,10 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -3198,9 +3198,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3223,7 +3223,7 @@ spec:
         - name: "compaction-worker"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compaction-worker"
@@ -3293,10 +3293,10 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -3311,9 +3311,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3336,7 +3336,7 @@ spec:
         - name: "metastore"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=metastore"
@@ -3422,10 +3422,10 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -3440,9 +3440,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3465,7 +3465,7 @@ spec:
         - name: "segment-writer"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=segment-writer"

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -27,10 +27,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -48,10 +48,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -69,10 +69,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -90,10 +90,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -111,10 +111,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -132,10 +132,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -153,10 +153,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -174,10 +174,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -218,10 +218,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -565,10 +565,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1423,10 +1423,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1440,10 +1440,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1725,10 +1725,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1752,10 +1752,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1777,10 +1777,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1803,10 +1803,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1828,10 +1828,10 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1854,10 +1854,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1879,10 +1879,10 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1905,10 +1905,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1930,10 +1930,10 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1956,10 +1956,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1981,10 +1981,10 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2007,10 +2007,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2032,10 +2032,10 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2058,10 +2058,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2083,10 +2083,10 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2109,10 +2109,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2134,10 +2134,10 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2160,10 +2160,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2185,10 +2185,10 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2211,10 +2211,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -2227,9 +2227,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2252,7 +2252,7 @@ spec:
         - name: "ad-hoc-profiles"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ad-hoc-profiles"
@@ -2315,10 +2315,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2331,9 +2331,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2356,7 +2356,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2419,10 +2419,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2435,9 +2435,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2460,7 +2460,7 @@ spec:
         - name: "querier"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -2524,10 +2524,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2540,9 +2540,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2565,7 +2565,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2628,10 +2628,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2644,9 +2644,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2669,7 +2669,7 @@ spec:
         - name: "query-scheduler"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-scheduler"
@@ -2732,10 +2732,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2748,9 +2748,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2773,7 +2773,7 @@ spec:
         - name: "tenant-settings"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tenant-settings"
@@ -3019,10 +3019,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -3037,9 +3037,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3062,7 +3062,7 @@ spec:
         - name: "compactor"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -3130,10 +3130,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -3148,9 +3148,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3173,7 +3173,7 @@ spec:
         - name: "ingester"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -3237,10 +3237,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -3255,9 +3255,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
+        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3280,7 +3280,7 @@ spec:
         - name: "store-gateway"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -43,10 +43,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/templates/configmap-alloy.yaml
@@ -56,10 +56,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -914,10 +914,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -931,10 +931,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1082,10 +1082,10 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -1107,10 +1107,10 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1186,10 +1186,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1213,10 +1213,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1246,10 +1246,10 @@ metadata:
   name: pyroscope-dev-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1371,10 +1371,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1389,9 +1389,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5c82c812cd288ff8b12368a190656be7f3105dcb893d9a8ae8194319e39ba008
+        checksum/config: 7ec43b2c81007176b25964b78dbdde4d205aaab411747d7d1f527d2570dcf3ca
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -1414,7 +1414,7 @@ spec:
         - name: "pyroscope"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=all"

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -43,10 +43,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/templates/configmap-alloy.yaml
@@ -56,10 +56,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -914,10 +914,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -931,10 +931,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1141,10 +1141,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1168,10 +1168,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1193,10 +1193,10 @@ metadata:
   name: pyroscope-dev-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1309,10 +1309,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.21.0
+    helm.sh/chart: pyroscope-2.0.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-171db75"
+    app.kubernetes.io/version: "2.0.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1327,9 +1327,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5c82c812cd288ff8b12368a190656be7f3105dcb893d9a8ae8194319e39ba008
+        checksum/config: 7ec43b2c81007176b25964b78dbdde4d205aaab411747d7d1f527d2570dcf3ca
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "main-171db75"
+        profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -1352,7 +1352,7 @@ spec:
         - name: "pyroscope"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-171db75"
+          image: "grafana/pyroscope:2.0.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=all"


### PR DESCRIPTION
## Summary

First v2 helm chart release. Chart moves from `1.21.0` to `2.0.0`, `appVersion` pinned to `2.0.1`.

### Versioning rationale

Chart version is `2.0.0`, not `2.0.1`, because the chart itself has no fixes — this is the first publication of the v2 chart lineage. Per RELEASE.md §"Helm Chart Versioning" ("best effort match") the chart and app versions are allowed to diverge.

`appVersion: 2.0.1` skips `2.0.0` because the v2.0.0 pyroscope binary shipped with a goreleaser ldflags regression (empty `Version`, `Branch`, `BuildDate` stamps in `-version` output and `pyroscope_build_info` metric). Fixed in [#5084](https://github.com/grafana/pyroscope/pull/5084) and tagged as v2.0.1. Users installing this chart get the first fully-correct v2 image.

### Changes

- `Chart.yaml`: `version: 1.21.0` → `2.0.0`, `appVersion: main-171db75` → `2.0.1`
- Regenerated `README.md` (`make helm/docs`)
- Regenerated `rendered/*.yaml` (`make helm/check`)

On merge, `.github/workflows/helm-release.yml` publishes chart `2.0.0` to `grafana.github.io/helm-charts`.

## Test plan

- [ ] `make helm/check` passes locally (done — all kubeconform templates valid)
- [ ] CI `check-generated` job passes
- [ ] Post-merge: `helm pull grafana/pyroscope --version 2.0.0` succeeds; `helm template ... | grep 'image:'` points at `grafana/pyroscope:2.0.1`
- [ ] Follow aleks's migration steps from #5079 on a test cluster

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumps the Helm chart to a new major version and updates all rendered Kubernetes manifests to run `grafana/pyroscope:2.0.1`, which can change runtime behavior on upgrade. Risk is mainly operational (deploy/upgrade compatibility) rather than code-level logic changes in this repo.
> 
> **Overview**
> Publishes the first v2 Helm chart release by bumping `operations/pyroscope/helm/pyroscope` chart `version` from `1.21.0` to `2.0.0` and pinning `appVersion`/container images from `main-171db75` to `2.0.1`.
> 
> Regenerates Helm-generated artifacts (`README.md` and `rendered/*.yaml`) so labels, annotations (including `profiles.grafana.com/service_git_ref`), checksums, and manifests consistently reflect the new chart/app versions across single-binary and microservices deployment modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2403e568d54c4450f4b3c6ff24e1238d27ffc2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->