### PR TITLE
fix(goreleaser): stamp v2 module path in build ldflags (#5084)

### DIFF
--- a/.cursor/rules/go-backend.mdc
+++ b/.cursor/rules/go-backend.mdc
@@ -22,8 +22,8 @@ import (
     "go.uber.org/atomic"
 
     // Internal packages
-    "github.com/grafana/pyroscope/pkg/model"
-    "github.com/grafana/pyroscope/pkg/objstore"
+    "github.com/grafana/pyroscope/v2/pkg/model"
+    "github.com/grafana/pyroscope/v2/pkg/objstore"
 )
 ```
 
@@ -86,7 +86,7 @@ func process(ctx context.Context, items []Item) error {
 All requests must include a tenant ID. Extract from context:
 
 ```go
-import "github.com/grafana/pyroscope/pkg/tenant"
+import "github.com/grafana/pyroscope/v2/pkg/tenant"
 
 tenantID, err := tenant.ExtractTenantIDFromContext(ctx)
 if err != nil {
@@ -101,7 +101,7 @@ if err != nil {
 Use the abstract Bucket interface:
 
 ```go
-import "github.com/grafana/pyroscope/pkg/objstore"
+import "github.com/grafana/pyroscope/v2/pkg/objstore"
 
 bucket := objstore.NewBucket(cfg)
 reader, err := bucket.Get(ctx, "path/to/object")

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,10 +37,10 @@ builds:
     ldflags:
       - >
         -extldflags "-static" {{ .Env.GORELEASER_DEBUG_INFO_FLAGS }}
-        -X "github.com/grafana/pyroscope/pkg/util/build.Branch={{ .Branch }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.Version={{ .Version }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.Revision={{ .ShortCommit }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.BuildDate={{ .CommitDate }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Branch={{ .Branch }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Version={{ .Version }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Revision={{ .ShortCommit }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.BuildDate={{ .CommitDate }}"
     id: pyroscope
   - env:
       - CGO_ENABLED=0
@@ -61,10 +61,10 @@ builds:
     ldflags:
       - >
         -extldflags "-static" {{ .Env.GORELEASER_DEBUG_INFO_FLAGS }}
-        -X "github.com/grafana/pyroscope/pkg/util/build.Branch={{ .Branch }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.Version={{ .Version }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.Revision={{ .ShortCommit }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.BuildDate={{ .CommitDate }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Branch={{ .Branch }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Version={{ .Version }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Revision={{ .ShortCommit }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.BuildDate={{ .CommitDate }}"
     id: pyroscope_non_linux
     skip: '{{ if eq .Env.GORELEASER_LINUX_ONLY "true" }}true{{ else }}false{{ end }}'
   - env:
@@ -74,10 +74,10 @@ builds:
     ldflags:
       - >
         -extldflags "-static" {{ .Env.GORELEASER_DEBUG_INFO_FLAGS }}
-        -X "github.com/grafana/pyroscope/pkg/util/build.Branch={{ .Branch }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.Version={{ .Version }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.Revision={{ .ShortCommit }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.BuildDate={{ .CommitDate }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Branch={{ .Branch }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Version={{ .Version }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Revision={{ .ShortCommit }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.BuildDate={{ .CommitDate }}"
     goos:
       - linux
     goarch:
@@ -101,10 +101,10 @@ builds:
     ldflags:
       - >
         -extldflags "-static" {{ .Env.GORELEASER_DEBUG_INFO_FLAGS }}
-        -X "github.com/grafana/pyroscope/pkg/util/build.Branch={{ .Branch }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.Version={{ .Version }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.Revision={{ .ShortCommit }}"
-        -X "github.com/grafana/pyroscope/pkg/util/build.BuildDate={{ .CommitDate }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Branch={{ .Branch }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Version={{ .Version }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.Revision={{ .ShortCommit }}"
+        -X "github.com/grafana/pyroscope/v2/pkg/util/build.BuildDate={{ .CommitDate }}"
     goos:
       - windows
       - darwin

--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -5,7 +5,7 @@ mockname: "Mock{{.InterfaceName}}"
 filename: "mock_{{.InterfaceName | snakecase}}.go"
 dir: "pkg/test/mocks/mock{{.PackageName}}"
 packages:
-  github.com/grafana/pyroscope/pkg/objstore:
+  github.com/grafana/pyroscope/v2/pkg/objstore:
     interfaces:
       Bucket:
   github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1:
@@ -21,57 +21,57 @@ packages:
   github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect:
     interfaces:
       QuerierServiceClient:
-  github.com/grafana/pyroscope/pkg/frontend:
+  github.com/grafana/pyroscope/v2/pkg/frontend:
     interfaces:
       Limits:
-  github.com/grafana/pyroscope/pkg/frontend/readpath/queryfrontend:
+  github.com/grafana/pyroscope/v2/pkg/frontend/readpath/queryfrontend:
     interfaces:
       QueryBackend:
       Symbolizer:
-  github.com/grafana/pyroscope/pkg/ingester/otlp:
+  github.com/grafana/pyroscope/v2/pkg/ingester/otlp:
     interfaces:
       PushService:
-  github.com/grafana/pyroscope/pkg/ingester/pyroscope:
+  github.com/grafana/pyroscope/v2/pkg/ingester/pyroscope:
     interfaces:
       PushService:
-  github.com/grafana/pyroscope/pkg/metastore/compaction/compactor:
+  github.com/grafana/pyroscope/v2/pkg/metastore/compaction/compactor:
     interfaces:
       BlockQueueStore:
       Tombstones:
-  github.com/grafana/pyroscope/pkg/metastore/compaction/scheduler:
+  github.com/grafana/pyroscope/v2/pkg/metastore/compaction/scheduler:
     interfaces:
       JobStore:
-  github.com/grafana/pyroscope/pkg/metastore/discovery:
+  github.com/grafana/pyroscope/v2/pkg/metastore/discovery:
     interfaces:
       Discovery:
-  github.com/grafana/pyroscope/pkg/metastore/index:
+  github.com/grafana/pyroscope/v2/pkg/metastore/index:
     interfaces:
       Store:
-  github.com/grafana/pyroscope/pkg/metastore/index/dlq:
+  github.com/grafana/pyroscope/v2/pkg/metastore/index/dlq:
     interfaces:
       Metastore:
-  github.com/grafana/pyroscope/pkg/segmentwriter/client/distributor/placement:
+  github.com/grafana/pyroscope/v2/pkg/segmentwriter/client/distributor/placement:
     interfaces:
       Placement:
-  github.com/grafana/pyroscope/pkg/segmentwriter/client/distributor/placement/adaptiveplacement:
+  github.com/grafana/pyroscope/v2/pkg/segmentwriter/client/distributor/placement/adaptiveplacement:
     interfaces:
       Store:
-  github.com/grafana/pyroscope/pkg/distributor/writepath:
+  github.com/grafana/pyroscope/v2/pkg/distributor/writepath:
     interfaces:
       SegmentWriterClient:
       IngesterClient:
-  github.com/grafana/pyroscope/pkg/metastore/raftnode/raftnodepb:
+  github.com/grafana/pyroscope/v2/pkg/metastore/raftnode/raftnodepb:
     interfaces:
       RaftNodeServiceClient:
       RaftNodeServiceServer:
-  github.com/grafana/pyroscope/pkg/metrics:
+  github.com/grafana/pyroscope/v2/pkg/metrics:
     interfaces:
       Exporter:
       Ruler:
-  github.com/grafana/pyroscope/pkg/frontend/vcs/client:
+  github.com/grafana/pyroscope/v2/pkg/frontend/vcs/client:
     interfaces:
       repositoryService:
-  github.com/grafana/pyroscope/pkg/symbolizer:
+  github.com/grafana/pyroscope/v2/pkg/symbolizer:
     interfaces:
       DebuginfodClient:
       DebugInfoStore:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,8 +162,8 @@ PYROSCOPE_V2=1 go run ./cmd/pyroscope \
        "go.uber.org/atomic"
 
        // Internal packages
-       "github.com/grafana/pyroscope/pkg/model"
-       "github.com/grafana/pyroscope/pkg/objstore"
+       "github.com/grafana/pyroscope/v2/pkg/model"
+       "github.com/grafana/pyroscope/v2/pkg/objstore"
    )
    ```
 
@@ -206,7 +206,7 @@ PYROSCOPE_V2=1 go run ./cmd/pyroscope \
 All requests must include a tenant ID in the `X-Scope-OrgID` header:
 
 ```go
-import "github.com/grafana/pyroscope/pkg/tenant"
+import "github.com/grafana/pyroscope/v2/pkg/tenant"
 
 // Extract tenant ID from context
 tenantID, err := tenant.ExtractTenantIDFromContext(ctx)
@@ -229,7 +229,7 @@ replicationSet, err := ring.Get(key, op, bufDescs, bufHosts, bufZones)
 Abstract object storage operations:
 
 ```go
-import "github.com/grafana/pyroscope/pkg/objstore"
+import "github.com/grafana/pyroscope/v2/pkg/objstore"
 
 // Use the Bucket interface
 bucket := objstore.NewBucket(cfg)

--- a/pkg/api/index.gohtml
+++ b/pkg/api/index.gohtml
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/grafana/pyroscope/pkg/api.indexPageContents */ -}}
+{{- /*gotype: github.com/grafana/pyroscope/v2/pkg/api.indexPageContents */ -}}
 <!DOCTYPE html>
 <html data-bs-theme="dark">
 <head>

--- a/pkg/storegateway/blocks.gohtml
+++ b/pkg/storegateway/blocks.gohtml
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/grafana/pyroscope/pkg/storegateway.blocksPageContents*/ -}}
+{{- /*gotype: github.com/grafana/pyroscope/v2/pkg/storegateway.blocksPageContents*/ -}}
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/html" data-bs-theme="dark">
 <head>

--- a/pkg/storegateway/ring_status.gohtml
+++ b/pkg/storegateway/ring_status.gohtml
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/grafana/pyroscope/pkg/storegateway.ringStatusPageContents*/ -}}
+{{- /*gotype: github.com/grafana/pyroscope/v2/pkg/storegateway.ringStatusPageContents*/ -}}
 <!DOCTYPE html>
 <html>
 <head>

--- a/pkg/storegateway/tenants.gohtml
+++ b/pkg/storegateway/tenants.gohtml
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/grafana/pyroscope/pkg/storegateway.tenantsPageContents*/ -}}
+{{- /*gotype: github.com/grafana/pyroscope/v2/pkg/storegateway.tenantsPageContents*/ -}}
 <!DOCTYPE html>
 <html data-bs-theme="dark">
 <head>


### PR DESCRIPTION
applying #5084 to the weekly release

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes `goreleaser` ldflags and mock generation package paths, which can break release stamping or CI builds if any references remain mismatched.
> 
> **Overview**
> This PR migrates several build/tooling and documentation references from the legacy `github.com/grafana/pyroscope/pkg/...` import paths to the `github.com/grafana/pyroscope/v2/pkg/...` module path.
> 
> It updates `goreleaser` ldflags to stamp build metadata into the v2 `pkg/util/build` variables, adjusts `.mockery.yaml` package targets accordingly, and fixes template `gotype` annotations in the admin/store-gateway `.gohtml` files to match the v2 paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 177a6051237f6a662e462fb9b6c551703ed209c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->