### PR TITLE
admin: bring back query diagnostics

### DIFF
--- a/pkg/operations/v2/querydiagnostics/diagnostics_list.gohtml
+++ b/pkg/operations/v2/querydiagnostics/diagnostics_list.gohtml
@@ -15,7 +15,7 @@
 </head>
 <body>
 <div id="root"></div>
-<script src="/assets/admin.js"></script>
+<script type="module" src="/assets/admin.js"></script>
 <footer class="footer mt-auto py-3">
     <div class="container">
         <small class="text-muted">Status @ {{ .Now.Format "2006-01-02 15:04:05.000" }}</small>

--- a/pkg/operations/v2/querydiagnostics/query_diagnostics.gohtml
+++ b/pkg/operations/v2/querydiagnostics/query_diagnostics.gohtml
@@ -15,7 +15,7 @@
 </head>
 <body>
 <div id="root"></div>
-<script src="/assets/admin.js"></script>
+<script type="module" src="/assets/admin.js"></script>
 <footer class="footer mt-auto py-3">
     <div class="container">
         <small class="text-muted">Status @ {{ .Now.Format "2006-01-02 15:04:05.000" }}</small>

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@grafana/flamegraph": "patch:@grafana/flamegraph@npm%3A12.4.2#~/.yarn/patches/@grafana-flamegraph-npm-12.4.2-6f441dce57.patch",
+    "@xyflow/react": "^12.10.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/ui/src/admin/AdminApp.tsx
+++ b/ui/src/admin/AdminApp.tsx
@@ -1,0 +1,12 @@
+import { QueryDiagnosticsPage } from './pages/QueryDiagnosticsPage';
+import { DiagnosticsListPage } from './pages/DiagnosticsListPage';
+
+export function AdminApp() {
+  const path = window.location.pathname;
+
+  if (path.endsWith('/query-diagnostics/list')) {
+    return <DiagnosticsListPage />;
+  }
+
+  return <QueryDiagnosticsPage />;
+}

--- a/ui/src/admin/admin.tsx
+++ b/ui/src/admin/admin.tsx
@@ -1,0 +1,9 @@
+import ReactDOM from 'react-dom/client';
+import { AdminApp } from './AdminApp';
+import './styles.css';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = ReactDOM.createRoot(container);
+  root.render(<AdminApp />);
+}

--- a/ui/src/admin/components/ExecutionFlowGraph.tsx
+++ b/ui/src/admin/components/ExecutionFlowGraph.tsx
@@ -136,12 +136,12 @@ interface LayoutNode {
 
 function buildLayoutTree(
   tree: ExecutionTreeNode,
-  idCounter = { value: 0 }
+  idCounter = { value: 0 },
 ): LayoutNode {
   const nodeId = `node-${idCounter.value++}`;
 
   const children: LayoutNode[] = (tree.children || []).map((child) =>
-    buildLayoutTree(child, idCounter)
+    buildLayoutTree(child, idCounter),
   );
 
   return {
@@ -255,7 +255,7 @@ function flattenLayoutTree(
   node: LayoutNode,
   nodes: ExecutionFlowNode[],
   edges: Edge[],
-  parentId: string | null = null
+  parentId: string | null = null,
 ): void {
   const flowNode: ExecutionFlowNode = {
     id: node.id,
@@ -294,7 +294,7 @@ function formatDurationNs(ns: number): string {
 
 function layoutTree(
   tree: ExecutionTreeNode,
-  responseTimeMs: number | null
+  responseTimeMs: number | null,
 ): { nodes: ExecutionFlowNode[]; edges: Edge[] } {
   const layoutRoot = buildLayoutTree(tree);
 
@@ -350,7 +350,7 @@ function calculateTotalDuration(nodes: ExecutionFlowNode[]): number {
 
 function getNodeAnimationState(
   node: ExecutionFlowNode,
-  currentTime: number
+  currentTime: number,
 ): AnimationState {
   const start = node.data.relativeStart;
   const end = start + node.data.duration;
@@ -585,14 +585,14 @@ export function ExecutionFlowGraph({
   // edges, animation timers) initializes fresh and never needs a reset effect.
   const { nodes: initialNodes, edges: initialEdges } = useMemo(
     () => layoutTree(executionTree, responseTimeMs),
-    [executionTree, responseTimeMs]
+    [executionTree, responseTimeMs],
   );
 
   const [nodes, setNodes, onNodesChange] =
     useNodesState<ExecutionFlowNode>(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
   const [selectedNode, setSelectedNode] = useState<ExecutionFlowNode | null>(
-    null
+    null,
   );
 
   const [isPlaying, setIsPlaying] = useState(true); // Auto-play on load
@@ -602,7 +602,7 @@ export function ExecutionFlowGraph({
   const baseNodesRef = useRef<ExecutionFlowNode[]>(initialNodes);
   const totalDuration = useMemo(
     () => calculateTotalDuration(initialNodes),
-    [initialNodes]
+    [initialNodes],
   );
   const currentTimeRef = useRef<number>(0);
   const nodeStatesRef = useRef<Map<string, AnimationState>>(new Map());
@@ -633,7 +633,7 @@ export function ExecutionFlowGraph({
               ...node.data,
               animationState: newStates.get(node.id) || 'pending',
             },
-          }))
+          })),
         );
 
         setEdges((currentEdges) =>
@@ -644,11 +644,11 @@ export function ExecutionFlowGraph({
               animated: targetState === 'active',
               style: getEdgeStyleFromState(targetState),
             };
-          })
+          }),
         );
       }
     },
-    [setNodes, setEdges]
+    [setNodes, setEdges],
   );
 
   useEffect(() => {
@@ -691,7 +691,7 @@ export function ExecutionFlowGraph({
       setCurrentTime(time);
       updateAnimationState(time);
     },
-    [updateAnimationState]
+    [updateAnimationState],
   );
 
   const handleRestart = useCallback(() => {
@@ -706,7 +706,7 @@ export function ExecutionFlowGraph({
     (_event: React.MouseEvent, node: ExecutionFlowNode) => {
       setSelectedNode(node);
     },
-    []
+    [],
   );
 
   const handleClosePanel = useCallback(() => {

--- a/ui/src/admin/components/ExecutionFlowGraph.tsx
+++ b/ui/src/admin/components/ExecutionFlowGraph.tsx
@@ -1,0 +1,751 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  useNodesState,
+  useEdgesState,
+  Handle,
+  Position,
+  Panel,
+} from '@xyflow/react';
+import type { Node, Edge, NodeProps } from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+
+import type { ExecutionTreeNode, BlockExecutionInfo } from '../types';
+
+interface ExecutionFlowGraphProps {
+  executionTree: ExecutionTreeNode;
+  responseTimeMs: number | null;
+}
+
+type AnimationState = 'pending' | 'active' | 'completed';
+
+interface ExecutionNodeData extends Record<string, unknown> {
+  label: string;
+  nodeType: string;
+  executor: string;
+  durationStr: string;
+  relativeStartStr: string;
+  duration: number;
+  relativeStart: number;
+  animationState: AnimationState;
+  stats?: {
+    blocksRead: number;
+    datasetsProcessed: number;
+    blockExecutions?: BlockExecutionInfo[];
+  };
+  error?: string;
+}
+
+type ExecutionFlowNode = Node<ExecutionNodeData, 'executionNode'>;
+
+const NODE_WIDTH = 140;
+const NODE_HEIGHT = 44;
+const HORIZONTAL_GAP = 60;
+const VERTICAL_GAP = 15;
+const LEAF_GRID_THRESHOLD = 6;
+const LEAF_GRID_COLUMNS = 4;
+
+function getNodeClass(nodeType: string): string {
+  switch (nodeType) {
+    case 'MERGE':
+      return 'merge';
+    case 'READ':
+      return 'read';
+    case 'FRONTEND':
+      return 'frontend';
+    default:
+      return 'read';
+  }
+}
+
+function shortenExecutorName(executor: string): string {
+  // Handle k8s-style pod names: prefix-deployment-hash-podid
+  // e.g., "fire-query-backend-0457f4f8d-lx55c" -> "lx55c"
+  const parts = executor.split('-');
+  if (parts.length >= 2) {
+    // Return last part (pod ID) if it looks like a hash
+    const lastPart = parts[parts.length - 1];
+    if (/^[a-z0-9]{4,}$/i.test(lastPart)) {
+      return lastPart;
+    }
+  }
+  // Fallback: return last 12 chars if too long
+  if (executor.length > 12) {
+    return '…' + executor.slice(-11);
+  }
+  return executor;
+}
+
+function ExecutionNode({ data, selected }: NodeProps<ExecutionFlowNode>) {
+  const nodeClass = getNodeClass(data.nodeType);
+  const animClass = data.animationState || 'pending';
+  const isFrontend = data.nodeType === 'FRONTEND';
+  const shortName = isFrontend
+    ? data.executor
+    : shortenExecutorName(data.executor);
+
+  return (
+    <div
+      className={`execution-flow-node ${nodeClass} ${animClass} ${
+        selected ? 'selected' : ''
+      }`}
+    >
+      {!isFrontend && <Handle type="target" position={Position.Left} />}
+      <div className="node-header">
+        <span className="node-executor" title={data.executor}>
+          {shortName}
+        </span>
+      </div>
+      <div className="node-timing">
+        <span className="node-start" title="Started at">
+          @{data.relativeStartStr}
+        </span>
+        <span className="node-duration" title="Duration">
+          {data.durationStr}
+        </span>
+      </div>
+      {data.error && <div className="node-error">Error</div>}
+      <Handle type="source" position={Position.Right} />
+    </div>
+  );
+}
+
+const nodeTypes = {
+  executionNode: ExecutionNode,
+};
+
+interface LayoutNode {
+  id: string;
+  data: ExecutionNodeData;
+  children: LayoutNode[];
+  width: number;
+  height: number;
+  x: number;
+  y: number;
+  subtreeWidth: number;
+  subtreeHeight: number;
+}
+
+function buildLayoutTree(
+  tree: ExecutionTreeNode,
+  idCounter = { value: 0 }
+): LayoutNode {
+  const nodeId = `node-${idCounter.value++}`;
+
+  const children: LayoutNode[] = (tree.children || []).map((child) =>
+    buildLayoutTree(child, idCounter)
+  );
+
+  return {
+    id: nodeId,
+    data: {
+      label: `${tree.type} - ${tree.executor}`,
+      nodeType: tree.type,
+      executor: tree.executor,
+      durationStr: tree.durationStr,
+      relativeStartStr: tree.relativeStartStr,
+      duration: tree.duration,
+      relativeStart: tree.relativeStart,
+      animationState: 'pending' as AnimationState,
+      stats: tree.stats,
+      error: tree.error,
+    },
+    children,
+    width: NODE_WIDTH,
+    height: NODE_HEIGHT,
+    x: 0,
+    y: 0,
+    subtreeWidth: 0,
+    subtreeHeight: 0,
+  };
+}
+
+function isLeafParent(node: LayoutNode): boolean {
+  return (
+    node.children.length > 0 &&
+    node.children.every((c) => c.children.length === 0)
+  );
+}
+
+function shouldUseLeafGrid(node: LayoutNode): boolean {
+  return isLeafParent(node) && node.children.length >= LEAF_GRID_THRESHOLD;
+}
+
+function calculateSubtreeSizes(node: LayoutNode): void {
+  if (node.children.length === 0) {
+    node.subtreeWidth = node.width;
+    node.subtreeHeight = node.height;
+    return;
+  }
+
+  for (const child of node.children) {
+    calculateSubtreeSizes(child);
+  }
+
+  const childCount = node.children.length;
+
+  if (shouldUseLeafGrid(node)) {
+    const cols = LEAF_GRID_COLUMNS;
+    const rows = Math.ceil(childCount / cols);
+
+    const gridWidth = cols * NODE_WIDTH + (cols - 1) * HORIZONTAL_GAP;
+    const gridHeight = rows * NODE_HEIGHT + (rows - 1) * VERTICAL_GAP;
+
+    node.subtreeWidth = node.width + HORIZONTAL_GAP + gridWidth;
+    node.subtreeHeight = Math.max(node.height, gridHeight);
+  } else {
+    const totalChildHeight =
+      node.children.reduce((sum, c) => sum + c.subtreeHeight, 0) +
+      (childCount - 1) * VERTICAL_GAP;
+    const maxChildWidth = Math.max(...node.children.map((c) => c.subtreeWidth));
+
+    node.subtreeWidth = node.width + HORIZONTAL_GAP + maxChildWidth;
+    node.subtreeHeight = Math.max(node.height, totalChildHeight);
+  }
+}
+
+function positionNodes(node: LayoutNode, startX: number, startY: number): void {
+  node.x = startX;
+  node.y = startY + (node.subtreeHeight - node.height) / 2;
+
+  if (node.children.length === 0) {
+    return;
+  }
+
+  const childStartX = startX + node.width + HORIZONTAL_GAP;
+  const childCount = node.children.length;
+
+  if (shouldUseLeafGrid(node)) {
+    const cols = LEAF_GRID_COLUMNS;
+    const rows = Math.ceil(childCount / cols);
+
+    const gridHeight = rows * NODE_HEIGHT + (rows - 1) * VERTICAL_GAP;
+    const gridStartY = startY + (node.subtreeHeight - gridHeight) / 2;
+
+    for (let i = 0; i < node.children.length; i++) {
+      const child = node.children[i];
+      const col = Math.floor(i / rows);
+      const row = i % rows;
+
+      child.x = childStartX + col * (NODE_WIDTH + HORIZONTAL_GAP);
+      child.y = gridStartY + row * (NODE_HEIGHT + VERTICAL_GAP);
+    }
+  } else {
+    const totalChildHeight =
+      node.children.reduce((sum, c) => sum + c.subtreeHeight, 0) +
+      (childCount - 1) * VERTICAL_GAP;
+    let currentY = startY + (node.subtreeHeight - totalChildHeight) / 2;
+
+    for (const child of node.children) {
+      positionNodes(child, childStartX, currentY);
+      currentY += child.subtreeHeight + VERTICAL_GAP;
+    }
+  }
+}
+
+function flattenLayoutTree(
+  node: LayoutNode,
+  nodes: ExecutionFlowNode[],
+  edges: Edge[],
+  parentId: string | null = null
+): void {
+  const flowNode: ExecutionFlowNode = {
+    id: node.id,
+    type: 'executionNode',
+    position: { x: node.x, y: node.y },
+    data: node.data,
+  };
+
+  nodes.push(flowNode);
+
+  if (parentId) {
+    edges.push({
+      id: `edge-${parentId}-${node.id}`,
+      source: parentId,
+      target: node.id,
+      type: 'default',
+      style: { stroke: '#6c757d', strokeWidth: 1.5 },
+    });
+  }
+
+  for (const child of node.children) {
+    flattenLayoutTree(child, nodes, edges, node.id);
+  }
+}
+
+function formatDurationNs(ns: number): string {
+  const ms = ns / NS_PER_MS;
+  if (ms < 1) {
+    return `${(ms * 1000).toFixed(0)}µs`;
+  }
+  if (ms < 1000) {
+    return `${ms.toFixed(2)}ms`;
+  }
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function layoutTree(
+  tree: ExecutionTreeNode,
+  responseTimeMs: number | null
+): { nodes: ExecutionFlowNode[]; edges: Edge[] } {
+  const layoutRoot = buildLayoutTree(tree);
+
+  // Wrap with frontend node if we have response time
+  let rootToLayout: LayoutNode;
+  if (responseTimeMs != null && responseTimeMs > 0) {
+    const frontendDurationNs = responseTimeMs * NS_PER_MS;
+    const frontendNode: LayoutNode = {
+      id: 'frontend',
+      data: {
+        label: 'Query Frontend',
+        nodeType: 'FRONTEND',
+        executor: 'query-frontend',
+        durationStr: formatDurationNs(frontendDurationNs),
+        relativeStartStr: '0.00ms',
+        duration: frontendDurationNs,
+        relativeStart: 0,
+        animationState: 'pending' as AnimationState,
+      },
+      children: [layoutRoot],
+      width: NODE_WIDTH,
+      height: NODE_HEIGHT,
+      x: 0,
+      y: 0,
+      subtreeWidth: 0,
+      subtreeHeight: 0,
+    };
+    rootToLayout = frontendNode;
+  } else {
+    rootToLayout = layoutRoot;
+  }
+
+  calculateSubtreeSizes(rootToLayout);
+  positionNodes(rootToLayout, 0, 0);
+
+  const nodes: ExecutionFlowNode[] = [];
+  const edges: Edge[] = [];
+  flattenLayoutTree(rootToLayout, nodes, edges);
+
+  return { nodes, edges };
+}
+
+function calculateTotalDuration(nodes: ExecutionFlowNode[]): number {
+  let maxEnd = 0;
+  for (const node of nodes) {
+    const end = node.data.relativeStart + node.data.duration;
+    if (end > maxEnd) {
+      maxEnd = end;
+    }
+  }
+  return maxEnd;
+}
+
+function getNodeAnimationState(
+  node: ExecutionFlowNode,
+  currentTime: number
+): AnimationState {
+  const start = node.data.relativeStart;
+  const end = start + node.data.duration;
+
+  if (currentTime < start) {
+    return 'pending';
+  } else if (currentTime < end) {
+    return 'active';
+  } else {
+    return 'completed';
+  }
+}
+
+function getEdgeStyleFromState(state: AnimationState): {
+  stroke: string;
+  strokeWidth: number;
+} {
+  switch (state) {
+    case 'active':
+      return { stroke: '#ffc107', strokeWidth: 2.5 };
+    case 'completed':
+      return { stroke: '#198754', strokeWidth: 2 };
+    default:
+      return { stroke: '#6c757d', strokeWidth: 1.5 };
+  }
+}
+
+function NodeDetailsPanel({
+  node,
+  onClose,
+}: {
+  node: ExecutionFlowNode | null;
+  onClose: () => void;
+}) {
+  if (!node) {
+    return null;
+  }
+
+  const { data } = node;
+
+  return (
+    <div className="node-details-panel">
+      <div className="panel-header">
+        <h6>Node Details</h6>
+        <button
+          type="button"
+          className="btn-close"
+          onClick={onClose}
+          aria-label="Close"
+        />
+      </div>
+      <div className="panel-body">
+        <div className="detail-row">
+          <label>Type:</label>
+          <span
+            className={`badge bg-${
+              data.nodeType === 'MERGE' ? 'primary' : 'success'
+            }`}
+          >
+            {data.nodeType}
+          </span>
+        </div>
+        <div className="detail-row">
+          <label>Executor:</label>
+          <code>{data.executor}</code>
+        </div>
+        <div className="detail-row">
+          <label>Started at:</label>
+          <span className="badge bg-warning text-dark">
+            @{data.relativeStartStr}
+          </span>
+        </div>
+        <div className="detail-row">
+          <label>Duration:</label>
+          <span className="badge bg-info">{data.durationStr}</span>
+        </div>
+
+        {data.error && (
+          <div className="detail-row error-row">
+            <label>Error:</label>
+            <span className="text-danger">{data.error}</span>
+          </div>
+        )}
+
+        {data.stats && (
+          <>
+            <div className="detail-row">
+              <label>Blocks Read:</label>
+              <span>{data.stats.blocksRead}</span>
+            </div>
+            <div className="detail-row">
+              <label>Datasets Processed:</label>
+              <span>{data.stats.datasetsProcessed}</span>
+            </div>
+
+            {data.stats.blockExecutions &&
+              data.stats.blockExecutions.length > 0 && (
+                <div className="block-executions">
+                  <h6>Block Executions</h6>
+                  <div className="block-table-wrapper">
+                    <table className="table table-sm">
+                      <thead>
+                        <tr>
+                          <th>Block ID</th>
+                          <th>Start</th>
+                          <th>Duration</th>
+                          <th>Datasets</th>
+                          <th>Size</th>
+                          <th>Shard</th>
+                          <th>Level</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {data.stats.blockExecutions.map((block, idx) => (
+                          <tr key={idx}>
+                            <td>
+                              <code>{block.blockId}</code>
+                            </td>
+                            <td>
+                              <span className="badge bg-warning text-dark">
+                                @{block.relativeStartStr}
+                              </span>
+                            </td>
+                            <td>
+                              <span className="badge bg-info">
+                                {block.durationStr}
+                              </span>
+                            </td>
+                            <td>{block.datasetsProcessed}</td>
+                            <td>{block.size}</td>
+                            <td>{block.shard}</td>
+                            <td>L{block.compactionLevel}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const NS_PER_MS = 1_000_000; // Nanoseconds per millisecond
+const TICK_INTERVAL = 50; // Check every 50ms
+const SPEED_OPTIONS = [0.1, 0.25, 0.5, 1, 2, 5] as const;
+
+function formatTime(ns: number): string {
+  const ms = ns / NS_PER_MS;
+  if (ms < 1000) {
+    return `${ms.toFixed(0)}ms`;
+  }
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+interface PlaybackControlsProps {
+  isPlaying: boolean;
+  speed: number;
+  currentTime: number;
+  totalDuration: number;
+  onPlayPause: () => void;
+  onSpeedChange: (speed: number) => void;
+  onSeek: (time: number) => void;
+  onRestart: () => void;
+}
+
+function PlaybackControls({
+  isPlaying,
+  speed,
+  currentTime,
+  totalDuration,
+  onPlayPause,
+  onSpeedChange,
+  onSeek,
+  onRestart,
+}: PlaybackControlsProps) {
+  const progress = totalDuration > 0 ? (currentTime / totalDuration) * 100 : 0;
+
+  return (
+    <div className="playback-controls">
+      <button className="playback-btn" onClick={onRestart} title="Restart">
+        ⏮
+      </button>
+      <button
+        className="playback-btn play-pause"
+        onClick={onPlayPause}
+        title={isPlaying ? 'Pause' : 'Play'}
+      >
+        {isPlaying ? '⏸' : '▶'}
+      </button>
+      <div className="playback-progress">
+        <input
+          type="range"
+          min="0"
+          max="100"
+          value={progress}
+          onChange={(e) =>
+            onSeek((parseFloat(e.target.value) / 100) * totalDuration)
+          }
+          className="progress-slider"
+        />
+        <span className="time-display">
+          {formatTime(currentTime)} / {formatTime(totalDuration)}
+        </span>
+      </div>
+      <div className="speed-control">
+        <select
+          value={speed}
+          onChange={(e) => onSpeedChange(parseFloat(e.target.value))}
+          className="speed-select"
+        >
+          {SPEED_OPTIONS.map((s) => (
+            <option key={s} value={s}>
+              {s}x
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}
+
+export function ExecutionFlowGraph({
+  executionTree,
+  responseTimeMs,
+}: ExecutionFlowGraphProps) {
+  // Props are only read during mount — the parent remounts this component via
+  // `key={...}` when a new execution tree arrives, so all state below (nodes,
+  // edges, animation timers) initializes fresh and never needs a reset effect.
+  const { nodes: initialNodes, edges: initialEdges } = useMemo(
+    () => layoutTree(executionTree, responseTimeMs),
+    [executionTree, responseTimeMs]
+  );
+
+  const [nodes, setNodes, onNodesChange] =
+    useNodesState<ExecutionFlowNode>(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+  const [selectedNode, setSelectedNode] = useState<ExecutionFlowNode | null>(
+    null
+  );
+
+  const [isPlaying, setIsPlaying] = useState(true); // Auto-play on load
+  const [speed, setSpeed] = useState(1);
+  const [currentTime, setCurrentTime] = useState(0);
+
+  const baseNodesRef = useRef<ExecutionFlowNode[]>(initialNodes);
+  const totalDuration = useMemo(
+    () => calculateTotalDuration(initialNodes),
+    [initialNodes]
+  );
+  const currentTimeRef = useRef<number>(0);
+  const nodeStatesRef = useRef<Map<string, AnimationState>>(new Map());
+
+  const updateAnimationState = useCallback(
+    (time: number) => {
+      const baseNodes = baseNodesRef.current;
+      const prevStates = nodeStatesRef.current;
+
+      const newStates = new Map<string, AnimationState>();
+      let hasChanges = false;
+
+      for (const node of baseNodes) {
+        const newState = getNodeAnimationState(node, time);
+        newStates.set(node.id, newState);
+        if (prevStates.get(node.id) !== newState) {
+          hasChanges = true;
+        }
+      }
+
+      if (hasChanges) {
+        nodeStatesRef.current = newStates;
+
+        setNodes((currentNodes) =>
+          currentNodes.map((node) => ({
+            ...node,
+            data: {
+              ...node.data,
+              animationState: newStates.get(node.id) || 'pending',
+            },
+          }))
+        );
+
+        setEdges((currentEdges) =>
+          currentEdges.map((edge) => {
+            const targetState = newStates.get(edge.target) || 'pending';
+            return {
+              ...edge,
+              animated: targetState === 'active',
+              style: getEdgeStyleFromState(targetState),
+            };
+          })
+        );
+      }
+    },
+    [setNodes, setEdges]
+  );
+
+  useEffect(() => {
+    if (!isPlaying) {
+      return;
+    }
+
+    const animate = () => {
+      const newTime =
+        currentTimeRef.current + TICK_INTERVAL * speed * NS_PER_MS;
+
+      if (newTime > totalDuration) {
+        currentTimeRef.current = totalDuration;
+        setCurrentTime(totalDuration);
+        updateAnimationState(totalDuration);
+        setIsPlaying(false); // Stop at end, no looping
+        return;
+      }
+
+      currentTimeRef.current = newTime;
+      setCurrentTime(newTime);
+      updateAnimationState(newTime);
+    };
+
+    const intervalId = setInterval(animate, TICK_INTERVAL);
+    return () => clearInterval(intervalId);
+  }, [isPlaying, speed, totalDuration, updateAnimationState]);
+
+  const handlePlayPause = useCallback(() => {
+    setIsPlaying((prev) => !prev);
+  }, []);
+
+  const handleSpeedChange = useCallback((newSpeed: number) => {
+    setSpeed(newSpeed);
+  }, []);
+
+  const handleSeek = useCallback(
+    (time: number) => {
+      currentTimeRef.current = time;
+      setCurrentTime(time);
+      updateAnimationState(time);
+    },
+    [updateAnimationState]
+  );
+
+  const handleRestart = useCallback(() => {
+    currentTimeRef.current = 0;
+    nodeStatesRef.current = new Map();
+    setCurrentTime(0);
+    updateAnimationState(0);
+    setIsPlaying(true);
+  }, [updateAnimationState]);
+
+  const onNodeClick = useCallback(
+    (_event: React.MouseEvent, node: ExecutionFlowNode) => {
+      setSelectedNode(node);
+    },
+    []
+  );
+
+  const handleClosePanel = useCallback(() => {
+    setSelectedNode(null);
+  }, []);
+
+  return (
+    <div className="execution-flow-container">
+      <div className={`flow-wrapper ${selectedNode ? 'with-panel' : ''}`}>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onNodeClick={onNodeClick}
+          nodeTypes={nodeTypes}
+          fitView
+          fitViewOptions={{ padding: 0.2 }}
+          minZoom={0.1}
+          maxZoom={2}
+          colorMode="dark"
+        >
+          <Background color="#444" gap={16} />
+          <Controls />
+          <Panel position="bottom-center">
+            <PlaybackControls
+              isPlaying={isPlaying}
+              speed={speed}
+              currentTime={currentTime}
+              totalDuration={totalDuration}
+              onPlayPause={handlePlayPause}
+              onSpeedChange={handleSpeedChange}
+              onSeek={handleSeek}
+              onRestart={handleRestart}
+            />
+          </Panel>
+        </ReactFlow>
+      </div>
+      <NodeDetailsPanel node={selectedNode} onClose={handleClosePanel} />
+    </div>
+  );
+}

--- a/ui/src/admin/components/ExecutionTraceViewer.tsx
+++ b/ui/src/admin/components/ExecutionTraceViewer.tsx
@@ -54,7 +54,7 @@ export function ExecutionTraceViewer({
       console.error('Failed to export diagnostic:', err);
       alert(
         'Failed to export diagnostic: ' +
-          (err instanceof Error ? err.message : String(err))
+          (err instanceof Error ? err.message : String(err)),
       );
     } finally {
       setIsExporting(false);

--- a/ui/src/admin/components/ExecutionTraceViewer.tsx
+++ b/ui/src/admin/components/ExecutionTraceViewer.tsx
@@ -1,0 +1,112 @@
+import { useCallback, useState } from 'react';
+
+import type { ExecutionTreeNode as ExecutionTreeNodeType } from '../types';
+
+// Bump a key whenever a new execution tree arrives so ExecutionFlowGraph
+// remounts, which resets its React Flow nodes/edges and animation state.
+// Using the derived-state-from-props pattern avoids an internal reset effect.
+function useTreeKey(tree: ExecutionTreeNodeType | null): number {
+  const [prevTree, setPrevTree] = useState(tree);
+  const [treeKey, setTreeKey] = useState(0);
+  if (prevTree !== tree) {
+    setPrevTree(tree);
+    setTreeKey((k) => k + 1);
+  }
+  return treeKey;
+}
+import { ExecutionFlowGraph } from './ExecutionFlowGraph';
+import { formatMs } from '../utils';
+import { exportDiagnostic } from '../services/api';
+
+interface ExecutionTraceViewerProps {
+  executionTree: ExecutionTreeNodeType | null;
+  responseTimeMs: number | null;
+  diagnosticsId: string | null;
+  tenantId?: string;
+}
+
+export function ExecutionTraceViewer({
+  executionTree,
+  responseTimeMs,
+  diagnosticsId,
+  tenantId,
+}: ExecutionTraceViewerProps) {
+  const [isExporting, setIsExporting] = useState(false);
+  const treeKey = useTreeKey(executionTree);
+
+  const handleExport = useCallback(async () => {
+    if (!diagnosticsId || !tenantId) {
+      return;
+    }
+
+    setIsExporting(true);
+    try {
+      const blob = await exportDiagnostic(tenantId, diagnosticsId);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `diagnostic-${tenantId}-${diagnosticsId}.zip`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('Failed to export diagnostic:', err);
+      alert(
+        'Failed to export diagnostic: ' +
+          (err instanceof Error ? err.message : String(err))
+      );
+    } finally {
+      setIsExporting(false);
+    }
+  }, [diagnosticsId, tenantId]);
+
+  if (!executionTree) {
+    return (
+      <div className="execution-trace-empty">
+        <div className="text-muted text-center p-4">
+          <p className="mb-0">No execution trace available.</p>
+          <small>Run a query to see the execution trace.</small>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="execution-trace-container">
+      <div className="execution-trace-header">
+        <h5 className="mb-0">Execution Trace</h5>
+        <div className="d-flex align-items-center gap-2">
+          {responseTimeMs != null && responseTimeMs > 0 && (
+            <span className="badge bg-success">
+              Response time: {formatMs(responseTimeMs)}
+            </span>
+          )}
+          {diagnosticsId && (
+            <span className="badge bg-secondary font-monospace">
+              ID: {diagnosticsId}
+            </span>
+          )}
+          {diagnosticsId && tenantId && (
+            <button
+              type="button"
+              className="btn btn-sm btn-outline-primary"
+              onClick={handleExport}
+              disabled={isExporting}
+              title="Export diagnostic as zip file"
+            >
+              {isExporting ? 'Exporting...' : 'Export'}
+            </button>
+          )}
+        </div>
+      </div>
+      <div className="execution-trace-body">
+        <ExecutionFlowGraph
+          key={treeKey}
+          executionTree={executionTree}
+          responseTimeMs={responseTimeMs}
+        />
+      </div>
+    </div>
+  );
+}

--- a/ui/src/admin/components/ExecutionTreeNode.tsx
+++ b/ui/src/admin/components/ExecutionTreeNode.tsx
@@ -1,0 +1,89 @@
+import type { ExecutionTreeNode as ExecutionTreeNodeType } from '../types';
+
+interface ExecutionTreeNodeProps {
+  node: ExecutionTreeNodeType;
+}
+
+export function ExecutionTreeNode({ node }: ExecutionTreeNodeProps) {
+  return (
+    <div className={`exec-node exec-node-${node.type.toLowerCase()}`}>
+      <div className="exec-node-header">
+        <span className="exec-type">{node.type}</span>
+        <span className="badge bg-secondary">{node.executor}</span>
+        <span className="badge bg-warning text-dark" title="Started at">
+          @{node.relativeStartStr}
+        </span>
+        <span className="badge bg-info" title="Duration">
+          {node.durationStr}
+        </span>
+        {node.stats && (
+          <span className="badge bg-light text-dark">
+            {node.stats.blocksRead} blocks, {node.stats.datasetsProcessed}{' '}
+            datasets
+          </span>
+        )}
+      </div>
+      {node.error && (
+        <div className="exec-error text-danger">
+          <small>Error: {node.error}</small>
+        </div>
+      )}
+      {node.stats?.blockExecutions && node.stats.blockExecutions.length > 0 && (
+        <div className="exec-blocks mt-2">
+          <table
+            className="table table-sm table-hover mb-0"
+            style={{ fontSize: '0.8rem' }}
+          >
+            <thead>
+              <tr>
+                <th>Block ID</th>
+                <th>Start</th>
+                <th>Duration</th>
+                <th>End</th>
+                <th>Datasets</th>
+                <th>Size</th>
+                <th>Shard</th>
+                <th>Level</th>
+              </tr>
+            </thead>
+            <tbody>
+              {node.stats.blockExecutions.map((blockExec, idx) => (
+                <tr key={idx}>
+                  <td>
+                    <code>{blockExec.blockId}</code>
+                  </td>
+                  <td>
+                    <span className="badge bg-warning text-dark">
+                      @{blockExec.relativeStartStr}
+                    </span>
+                  </td>
+                  <td>
+                    <span className="badge bg-info">
+                      {blockExec.durationStr}
+                    </span>
+                  </td>
+                  <td>
+                    <span className="badge bg-secondary">
+                      @{blockExec.relativeEndStr}
+                    </span>
+                  </td>
+                  <td>{blockExec.datasetsProcessed}</td>
+                  <td>{blockExec.size}</td>
+                  <td>{blockExec.shard}</td>
+                  <td>L{blockExec.compactionLevel}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      {node.children && node.children.length > 0 && (
+        <div className="exec-children">
+          {node.children.map((child, idx) => (
+            <ExecutionTreeNode key={idx} node={child} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/admin/components/Header.tsx
+++ b/ui/src/admin/components/Header.tsx
@@ -1,0 +1,53 @@
+import { getBasePath } from '../utils';
+
+interface HeaderProps {
+  title: string;
+  subtitle: string;
+  showNewQueryLink?: boolean;
+  showStoredDiagnosticsLink?: boolean;
+}
+
+export function Header({
+  title,
+  subtitle,
+  showNewQueryLink = true,
+  showStoredDiagnosticsLink = true,
+}: HeaderProps) {
+  const basePath = getBasePath();
+
+  return (
+    <div className="header row border-bottom py-3 flex-column-reverse flex-sm-row">
+      <div className="col-12 col-sm-9 text-center text-sm-start">
+        <h1>{title}</h1>
+        <p className="text-muted">
+          {subtitle}
+          {showNewQueryLink && (
+            <>
+              <span className="ms-2">|</span>
+              <a href={`${basePath}/query-diagnostics`} className="ms-2">
+                + New Query
+              </a>
+            </>
+          )}
+          {showStoredDiagnosticsLink && (
+            <>
+              <span className="ms-2">|</span>
+              <a href={`${basePath}/query-diagnostics/list`} className="ms-2">
+                View Stored Diagnostics
+              </a>
+            </>
+          )}
+        </p>
+      </div>
+      <div className="col-12 col-sm-3 text-center text-sm-end mb-3 mb-sm-0">
+        <a href={`${basePath}/`}>
+          <img
+            alt="Pyroscope logo"
+            className="pyroscope-brand"
+            src={`${basePath}/static/pyroscope-logo.png`}
+          />
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/admin/components/PlanTreeNode.tsx
+++ b/ui/src/admin/components/PlanTreeNode.tsx
@@ -1,0 +1,63 @@
+import type { PlanTreeNode as PlanTreeNodeType } from '../types';
+
+interface PlanTreeNodeProps {
+  node: PlanTreeNodeType;
+}
+
+export function PlanTreeNode({ node }: PlanTreeNodeProps) {
+  return (
+    <div className={`tree-node tree-node-${node.type.toLowerCase()}`}>
+      <div className="tree-node-header">
+        {node.type === 'MERGE' ? (
+          <>
+            <i className="bi bi-arrows-collapse tree-node-icon"></i>
+            <span className="tree-node-label">MERGE</span>
+            <span className="badge bg-primary tree-node-badge">
+              {node.children?.length || 0} children
+            </span>
+            <span className="badge bg-secondary tree-node-badge">
+              {node.totalBlocks} blocks total
+            </span>
+          </>
+        ) : node.type === 'READ' ? (
+          <>
+            <i className="bi bi-database tree-node-icon"></i>
+            <span className="tree-node-label">READ</span>
+            <span className="badge bg-success tree-node-badge">
+              {node.blockCount} blocks
+            </span>
+          </>
+        ) : (
+          <>
+            <i className="bi bi-question-circle tree-node-icon"></i>
+            <span className="tree-node-label">{node.type}</span>
+          </>
+        )}
+      </div>
+      {node.type === 'READ' && node.blocks && node.blocks.length > 0 && (
+        <div className="tree-node-blocks">
+          {node.blocks.slice(0, 5).map((block, idx) => (
+            <div key={idx}>
+              <code>{block.id}</code>{' '}
+              <span className="text-muted">
+                (shard {block.shard}, L{block.compactionLevel}, {block.size})
+              </span>
+            </div>
+          ))}
+          {node.blockCount > 5 && (
+            <div>
+              <em>... and {node.blockCount - 5} more</em>
+            </div>
+          )}
+        </div>
+      )}
+      {node.children && node.children.length > 0 && (
+        <div className="tree-node-children">
+          {node.children.map((child, idx) => (
+            <PlanTreeNode key={idx} node={child} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/admin/components/QueryForm.tsx
+++ b/ui/src/admin/components/QueryForm.tsx
@@ -1,0 +1,665 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import type { QueryMethod, QueryParams } from '../types';
+import { QUERY_METHODS } from '../types';
+import { fetchProfileTypes } from '../services/api';
+
+interface QueryFormProps {
+  tenants: string[];
+  params: QueryParams;
+  onParamsChange: (params: QueryParams) => void;
+  onSubmit: () => void;
+  isSubmitting: boolean;
+  error: string | null;
+}
+
+function parseTimeForApi(timeStr: string): number {
+  if (!timeStr) {
+    return 0;
+  }
+  const now = Date.now();
+  const match = timeStr.match(/^now(-(\d+)([smhd]))?$/);
+  if (match) {
+    if (!match[1]) {
+      return now;
+    }
+    const value = parseInt(match[2], 10);
+    const unit = match[3];
+    const multipliers: Record<string, number> = {
+      s: 1000,
+      m: 60000,
+      h: 3600000,
+      d: 86400000,
+    };
+    return now - value * (multipliers[unit] || 0);
+  }
+  const d = new Date(timeStr);
+  return isNaN(d.getTime()) ? 0 : d.getTime();
+}
+
+export function QueryForm({
+  tenants,
+  params,
+  onParamsChange,
+  onSubmit,
+  isSubmitting,
+  error,
+}: QueryFormProps) {
+  const [profileTypes, setProfileTypes] = useState<string[]>([]);
+  const [profileTypesLoading, setProfileTypesLoading] = useState(false);
+  const [profileTypesError, setProfileTypesError] = useState<string | null>(
+    null
+  );
+
+  const updateParam = useCallback(
+    <K extends keyof QueryParams>(key: K, value: QueryParams[K]) => {
+      onParamsChange({ ...params, [key]: value });
+    },
+    [params, onParamsChange]
+  );
+
+  const loadProfileTypes = useCallback(async () => {
+    if (!params.tenantId) {
+      setProfileTypes([]);
+      return;
+    }
+    setProfileTypesLoading(true);
+    setProfileTypesError(null);
+    try {
+      const startMs = parseTimeForApi(params.startTime);
+      const endMs = parseTimeForApi(params.endTime);
+      const types = await fetchProfileTypes(params.tenantId, startMs, endMs);
+      setProfileTypes(types);
+    } catch (err) {
+      setProfileTypesError(
+        err instanceof Error ? err.message : 'Failed to load profile types'
+      );
+      setProfileTypes([]);
+    } finally {
+      setProfileTypesLoading(false);
+    }
+  }, [params.tenantId, params.startTime, params.endTime]);
+
+  useEffect(() => {
+    loadProfileTypes();
+  }, [loadProfileTypes]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit();
+  };
+
+  const showProfileTypeId =
+    params.method === 'SelectMergeStacktraces' ||
+    params.method === 'SelectMergeProfile' ||
+    params.method === 'SelectMergeSpanProfile' ||
+    params.method === 'SelectSeries' ||
+    params.method === 'SelectHeatmap';
+
+  const showMaxNodes =
+    params.method === 'SelectMergeStacktraces' ||
+    params.method === 'SelectMergeProfile' ||
+    params.method === 'SelectMergeSpanProfile';
+
+  const showFormat =
+    params.method === 'SelectMergeStacktraces' ||
+    params.method === 'SelectMergeProfile' ||
+    params.method === 'SelectMergeSpanProfile';
+
+  const showSpanSelector = params.method === 'SelectMergeSpanProfile';
+
+  const showStep =
+    params.method === 'SelectSeries' || params.method === 'SelectHeatmap';
+
+  const showGroupBy =
+    params.method === 'SelectSeries' || params.method === 'SelectHeatmap';
+
+  const showAggregation = params.method === 'SelectSeries';
+
+  const showLimit =
+    params.method === 'SelectSeries' || params.method === 'SelectHeatmap';
+
+  const showHeatmapQueryType = params.method === 'SelectHeatmap';
+
+  const showExemplarType =
+    params.method === 'SelectSeries' || params.method === 'SelectHeatmap';
+
+  const showLabelName = params.method === 'LabelValues';
+
+  const showLabelNames = params.method === 'Series';
+
+  const showDiff = params.method === 'Diff';
+
+  return (
+    <div className="card">
+      <div className="card-header">
+        <h5 className="mb-0">Query Parameters</h5>
+      </div>
+      <div className="card-body">
+        <form onSubmit={handleSubmit}>
+          <div className="form-section">
+            <label htmlFor="tenant_id" className="form-label">
+              Tenant ID
+            </label>
+            <select
+              className="form-select"
+              id="tenant_id"
+              value={params.tenantId}
+              onChange={(e) => updateParam('tenantId', e.target.value)}
+              required
+            >
+              <option value="">-- Select tenant --</option>
+              {tenants.map((tenant) => (
+                <option key={tenant} value={tenant}>
+                  {tenant}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="form-section">
+            <label htmlFor="method" className="form-label">
+              API Method
+            </label>
+            <select
+              className="form-select"
+              id="method"
+              value={params.method}
+              onChange={(e) =>
+                updateParam('method', e.target.value as QueryMethod)
+              }
+            >
+              {QUERY_METHODS.map((method) => (
+                <option key={method} value={method}>
+                  {method}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="row form-section">
+            <div className="col-6">
+              <label htmlFor="start_time" className="form-label">
+                Start Time
+              </label>
+              <input
+                type="text"
+                className="form-control"
+                id="start_time"
+                value={params.startTime}
+                onChange={(e) => updateParam('startTime', e.target.value)}
+                placeholder="now-1h"
+                required
+              />
+            </div>
+            <div className="col-6">
+              <label htmlFor="end_time" className="form-label">
+                End Time
+              </label>
+              <input
+                type="text"
+                className="form-control"
+                id="end_time"
+                value={params.endTime}
+                onChange={(e) => updateParam('endTime', e.target.value)}
+                placeholder="now"
+                required
+              />
+            </div>
+          </div>
+
+          <div className="form-section">
+            <label htmlFor="label_selector" className="form-label">
+              Label Selector
+            </label>
+            <input
+              type="text"
+              className="form-control"
+              id="label_selector"
+              value={params.labelSelector}
+              onChange={(e) => updateParam('labelSelector', e.target.value)}
+              placeholder='{service_name="my-service"}'
+            />
+          </div>
+
+          {showProfileTypeId && (
+            <div className="form-section">
+              <label htmlFor="profile_type_id" className="form-label">
+                Profile Type ID
+              </label>
+              <select
+                className="form-select"
+                id="profile_type_id"
+                value={params.profileTypeId}
+                onChange={(e) => updateParam('profileTypeId', e.target.value)}
+                disabled={profileTypesLoading}
+              >
+                <option value="">
+                  {profileTypesLoading
+                    ? 'Loading...'
+                    : profileTypesError
+                    ? 'Failed to load'
+                    : params.tenantId
+                    ? '-- Select profile type --'
+                    : '-- Select tenant first --'}
+                </option>
+                {profileTypes.map((pt) => (
+                  <option key={pt} value={pt}>
+                    {pt}
+                  </option>
+                ))}
+              </select>
+              <div className="form-text">
+                Select a tenant to load available profile types
+              </div>
+            </div>
+          )}
+
+          {showMaxNodes && (
+            <div className="form-section">
+              <label htmlFor="max_nodes" className="form-label">
+                Max Nodes
+              </label>
+              <input
+                type="number"
+                className="form-control"
+                id="max_nodes"
+                value={params.maxNodes}
+                onChange={(e) => updateParam('maxNodes', e.target.value)}
+                placeholder="16384"
+              />
+              <div className="form-text">
+                Maximum number of nodes in the result
+              </div>
+            </div>
+          )}
+
+          {showFormat && (
+            <div className="form-section">
+              <label htmlFor="format" className="form-label">
+                Profile Format
+              </label>
+              <select
+                className="form-select"
+                id="format"
+                value={params.format}
+                onChange={(e) => updateParam('format', e.target.value)}
+              >
+                <option value="PROFILE_FORMAT_FLAMEGRAPH">Flame Graph</option>
+                <option value="PROFILE_FORMAT_TREE">Tree</option>
+              </select>
+              <div className="form-text">Format of the profile response</div>
+            </div>
+          )}
+
+          {showSpanSelector && (
+            <div className="form-section">
+              <label htmlFor="span_selector" className="form-label">
+                Span IDs (comma-separated)
+              </label>
+              <input
+                type="text"
+                className="form-control"
+                id="span_selector"
+                value={params.spanSelector}
+                onChange={(e) => updateParam('spanSelector', e.target.value)}
+                placeholder="9a517183f26a089d, 5a4fe264a9c987fe"
+              />
+              <div className="form-text">List of Span IDs to query</div>
+            </div>
+          )}
+
+          {showLabelName && (
+            <div className="form-section">
+              <label htmlFor="label_name" className="form-label">
+                Label Name
+              </label>
+              <input
+                type="text"
+                className="form-control"
+                id="label_name"
+                value={params.labelName}
+                onChange={(e) => updateParam('labelName', e.target.value)}
+                placeholder="service_name"
+              />
+              <div className="form-text">Label name to get values for</div>
+            </div>
+          )}
+
+          {showLabelNames && (
+            <div className="form-section">
+              <label htmlFor="label_names" className="form-label">
+                Label Names (comma-separated)
+              </label>
+              <input
+                type="text"
+                className="form-control"
+                id="label_names"
+                value={params.labelNames}
+                onChange={(e) => updateParam('labelNames', e.target.value)}
+                placeholder="service_name, namespace"
+              />
+              <div className="form-text">
+                Filter which label names to return (empty = all)
+              </div>
+            </div>
+          )}
+
+          {showStep && (
+            <div className="form-section">
+              <label htmlFor="step" className="form-label">
+                Step (seconds)
+              </label>
+              <input
+                type="number"
+                className="form-control"
+                id="step"
+                value={params.step}
+                onChange={(e) => updateParam('step', e.target.value)}
+                placeholder="auto"
+                min="1"
+              />
+              <div className="form-text">
+                Time step between data points (empty = auto, min 15s, ~100
+                points)
+              </div>
+            </div>
+          )}
+
+          {showGroupBy && (
+            <div className="form-section">
+              <label htmlFor="group_by" className="form-label">
+                Group By (comma-separated)
+              </label>
+              <input
+                type="text"
+                className="form-control"
+                id="group_by"
+                value={params.groupBy}
+                onChange={(e) => updateParam('groupBy', e.target.value)}
+                placeholder="service_name"
+              />
+              <div className="form-text">Labels to group time series by</div>
+            </div>
+          )}
+
+          {showAggregation && (
+            <div className="form-section">
+              <label htmlFor="aggregation" className="form-label">
+                Aggregation
+              </label>
+              <select
+                className="form-select"
+                id="aggregation"
+                value={params.aggregation}
+                onChange={(e) => updateParam('aggregation', e.target.value)}
+              >
+                <option value="">None</option>
+                <option value="sum">Sum</option>
+                <option value="avg">Average</option>
+              </select>
+              <div className="form-text">Aggregation type for time series</div>
+            </div>
+          )}
+
+          {showLimit && (
+            <div className="form-section">
+              <label htmlFor="limit" className="form-label">
+                Limit
+              </label>
+              <input
+                type="number"
+                className="form-control"
+                id="limit"
+                value={params.limit}
+                onChange={(e) => updateParam('limit', e.target.value)}
+                placeholder="0"
+                min="0"
+              />
+              <div className="form-text">
+                Maximum number of series (0 = unlimited)
+              </div>
+            </div>
+          )}
+
+          {showHeatmapQueryType && (
+            <div className="form-section">
+              <label htmlFor="heatmap_query_type" className="form-label">
+                Heatmap Query Type
+              </label>
+              <select
+                className="form-select"
+                id="heatmap_query_type"
+                value={params.heatmapQueryType}
+                onChange={(e) =>
+                  updateParam('heatmapQueryType', e.target.value)
+                }
+              >
+                <option value="HEATMAP_QUERY_TYPE_INDIVIDUAL">
+                  Individual Profiles
+                </option>
+                <option value="HEATMAP_QUERY_TYPE_SPAN">Span Profiles</option>
+              </select>
+              <div className="form-text">Type of profiles to query</div>
+            </div>
+          )}
+
+          {showExemplarType && (
+            <div className="form-section">
+              <label htmlFor="exemplar_type" className="form-label">
+                Exemplar Type
+              </label>
+              <select
+                className="form-select"
+                id="exemplar_type"
+                value={params.exemplarType}
+                onChange={(e) => updateParam('exemplarType', e.target.value)}
+              >
+                <option value="">None</option>
+                <option value="EXEMPLAR_TYPE_INDIVIDUAL">Individual</option>
+                <option value="EXEMPLAR_TYPE_SPAN">Span</option>
+              </select>
+              <div className="form-text">
+                Type of exemplars to include in the response
+              </div>
+            </div>
+          )}
+
+          {showDiff && (
+            <div className="diff-params">
+              <h6 className="mb-3">Diff Parameters</h6>
+              <div className="row mb-2">
+                <div className="col-6">
+                  <strong>Left (baseline)</strong>
+                </div>
+                <div className="col-6">
+                  <strong>Right (comparison)</strong>
+                </div>
+              </div>
+              <div className="row form-section">
+                <div className="col-6">
+                  <label htmlFor="diff_left_selector" className="form-label">
+                    Label Selector
+                  </label>
+                  <input
+                    type="text"
+                    className="form-control form-control-sm"
+                    id="diff_left_selector"
+                    value={params.diffLeftSelector}
+                    onChange={(e) =>
+                      updateParam('diffLeftSelector', e.target.value)
+                    }
+                    placeholder='{service_name="my-service"}'
+                  />
+                </div>
+                <div className="col-6">
+                  <label htmlFor="diff_right_selector" className="form-label">
+                    Label Selector
+                  </label>
+                  <input
+                    type="text"
+                    className="form-control form-control-sm"
+                    id="diff_right_selector"
+                    value={params.diffRightSelector}
+                    onChange={(e) =>
+                      updateParam('diffRightSelector', e.target.value)
+                    }
+                    placeholder='{service_name="my-service"}'
+                  />
+                </div>
+              </div>
+              <div className="row form-section">
+                <div className="col-6">
+                  <label
+                    htmlFor="diff_left_profile_type"
+                    className="form-label"
+                  >
+                    Profile Type
+                  </label>
+                  <select
+                    className="form-select form-select-sm"
+                    id="diff_left_profile_type"
+                    value={params.diffLeftProfileType}
+                    onChange={(e) =>
+                      updateParam('diffLeftProfileType', e.target.value)
+                    }
+                    disabled={profileTypesLoading}
+                  >
+                    <option value="">
+                      {profileTypesLoading
+                        ? 'Loading...'
+                        : params.tenantId
+                        ? '-- Select profile type --'
+                        : '-- Select tenant first --'}
+                    </option>
+                    {profileTypes.map((pt) => (
+                      <option key={pt} value={pt}>
+                        {pt}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="col-6">
+                  <label
+                    htmlFor="diff_right_profile_type"
+                    className="form-label"
+                  >
+                    Profile Type
+                  </label>
+                  <select
+                    className="form-select form-select-sm"
+                    id="diff_right_profile_type"
+                    value={params.diffRightProfileType}
+                    onChange={(e) =>
+                      updateParam('diffRightProfileType', e.target.value)
+                    }
+                    disabled={profileTypesLoading}
+                  >
+                    <option value="">
+                      {profileTypesLoading
+                        ? 'Loading...'
+                        : params.tenantId
+                        ? '-- Select profile type --'
+                        : '-- Select tenant first --'}
+                    </option>
+                    {profileTypes.map((pt) => (
+                      <option key={pt} value={pt}>
+                        {pt}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <div className="row form-section">
+                <div className="col-3">
+                  <label htmlFor="diff_left_start" className="form-label">
+                    Start
+                  </label>
+                  <input
+                    type="text"
+                    className="form-control form-control-sm"
+                    id="diff_left_start"
+                    value={params.diffLeftStart}
+                    onChange={(e) =>
+                      updateParam('diffLeftStart', e.target.value)
+                    }
+                    placeholder="now-2h"
+                  />
+                </div>
+                <div className="col-3">
+                  <label htmlFor="diff_left_end" className="form-label">
+                    End
+                  </label>
+                  <input
+                    type="text"
+                    className="form-control form-control-sm"
+                    id="diff_left_end"
+                    value={params.diffLeftEnd}
+                    onChange={(e) => updateParam('diffLeftEnd', e.target.value)}
+                    placeholder="now-1h"
+                  />
+                </div>
+                <div className="col-3">
+                  <label htmlFor="diff_right_start" className="form-label">
+                    Start
+                  </label>
+                  <input
+                    type="text"
+                    className="form-control form-control-sm"
+                    id="diff_right_start"
+                    value={params.diffRightStart}
+                    onChange={(e) =>
+                      updateParam('diffRightStart', e.target.value)
+                    }
+                    placeholder="now-1h"
+                  />
+                </div>
+                <div className="col-3">
+                  <label htmlFor="diff_right_end" className="form-label">
+                    End
+                  </label>
+                  <input
+                    type="text"
+                    className="form-control form-control-sm"
+                    id="diff_right_end"
+                    value={params.diffRightEnd}
+                    onChange={(e) =>
+                      updateParam('diffRightEnd', e.target.value)
+                    }
+                    placeholder="now"
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+
+          <div className="d-grid gap-2 mt-3">
+            <button
+              type="submit"
+              className="btn btn-success"
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? (
+                <>
+                  <span
+                    className="spinner-border spinner-border-sm"
+                    role="status"
+                  ></span>{' '}
+                  Executing...
+                </>
+              ) : (
+                <>
+                  <i className="bi bi-play-fill"></i> Execute Query
+                </>
+              )}
+            </button>
+          </div>
+          {error && (
+            <div className="alert alert-danger mt-3" role="alert">
+              {error}
+            </div>
+          )}
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/admin/components/QueryForm.tsx
+++ b/ui/src/admin/components/QueryForm.tsx
@@ -47,14 +47,14 @@ export function QueryForm({
   const [profileTypes, setProfileTypes] = useState<string[]>([]);
   const [profileTypesLoading, setProfileTypesLoading] = useState(false);
   const [profileTypesError, setProfileTypesError] = useState<string | null>(
-    null
+    null,
   );
 
   const updateParam = useCallback(
     <K extends keyof QueryParams>(key: K, value: QueryParams[K]) => {
       onParamsChange({ ...params, [key]: value });
     },
-    [params, onParamsChange]
+    [params, onParamsChange],
   );
 
   const loadProfileTypes = useCallback(async () => {
@@ -71,7 +71,7 @@ export function QueryForm({
       setProfileTypes(types);
     } catch (err) {
       setProfileTypesError(
-        err instanceof Error ? err.message : 'Failed to load profile types'
+        err instanceof Error ? err.message : 'Failed to load profile types',
       );
       setProfileTypes([]);
     } finally {
@@ -237,10 +237,10 @@ export function QueryForm({
                   {profileTypesLoading
                     ? 'Loading...'
                     : profileTypesError
-                    ? 'Failed to load'
-                    : params.tenantId
-                    ? '-- Select profile type --'
-                    : '-- Select tenant first --'}
+                      ? 'Failed to load'
+                      : params.tenantId
+                        ? '-- Select profile type --'
+                        : '-- Select tenant first --'}
                 </option>
                 {profileTypes.map((pt) => (
                   <option key={pt} value={pt}>
@@ -528,8 +528,8 @@ export function QueryForm({
                       {profileTypesLoading
                         ? 'Loading...'
                         : params.tenantId
-                        ? '-- Select profile type --'
-                        : '-- Select tenant first --'}
+                          ? '-- Select profile type --'
+                          : '-- Select tenant first --'}
                     </option>
                     {profileTypes.map((pt) => (
                       <option key={pt} value={pt}>
@@ -558,8 +558,8 @@ export function QueryForm({
                       {profileTypesLoading
                         ? 'Loading...'
                         : params.tenantId
-                        ? '-- Select profile type --'
-                        : '-- Select tenant first --'}
+                          ? '-- Select profile type --'
+                          : '-- Select tenant first --'}
                     </option>
                     {profileTypes.map((pt) => (
                       <option key={pt} value={pt}>

--- a/ui/src/admin/components/QueryPlanViewer.tsx
+++ b/ui/src/admin/components/QueryPlanViewer.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import type { PlanTreeNode as PlanTreeNodeType } from '../types';
+import { PlanTreeNode } from './PlanTreeNode';
+
+interface QueryPlanViewerProps {
+  planTree: PlanTreeNodeType | null;
+  planJson: string | null;
+  metadataStats: string | null;
+}
+
+export function QueryPlanViewer({
+  planTree,
+  planJson,
+  metadataStats,
+}: QueryPlanViewerProps) {
+  const [activeTab, setActiveTab] = useState<'visual' | 'json'>('visual');
+
+  if (!planTree && !metadataStats) {
+    return (
+      <div className="card">
+        <div className="card-header">
+          <h5 className="mb-0">Results</h5>
+        </div>
+        <div className="card-body text-muted">
+          <p>Execute a query to see the query plan and execution trace.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card">
+      <div className="card-header d-flex justify-content-between align-items-center">
+        <h5 className="mb-0">Query Plan</h5>
+      </div>
+      <div className="card-body">
+        {metadataStats && (
+          <div className="stats-box mb-3">
+            <strong>Metadata Stats:</strong>
+            <pre className="mb-0 mt-2">{metadataStats}</pre>
+          </div>
+        )}
+
+        {planTree && (
+          <>
+            <ul className="nav nav-tabs mb-3" role="tablist">
+              <li className="nav-item" role="presentation">
+                <button
+                  className={`nav-link ${
+                    activeTab === 'visual' ? 'active' : ''
+                  }`}
+                  onClick={() => setActiveTab('visual')}
+                  type="button"
+                  role="tab"
+                >
+                  <i className="bi bi-diagram-3"></i> Visual
+                </button>
+              </li>
+              <li className="nav-item" role="presentation">
+                <button
+                  className={`nav-link ${activeTab === 'json' ? 'active' : ''}`}
+                  onClick={() => setActiveTab('json')}
+                  type="button"
+                  role="tab"
+                >
+                  <i className="bi bi-code-slash"></i> JSON
+                </button>
+              </li>
+            </ul>
+            <div className="tab-content">
+              {activeTab === 'visual' && (
+                <div className="plan-tree">
+                  <PlanTreeNode node={planTree} />
+                </div>
+              )}
+              {activeTab === 'json' && (
+                <textarea
+                  className="form-control plan-textarea"
+                  rows={15}
+                  readOnly
+                  value={planJson || ''}
+                />
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/admin/pages/DiagnosticsListPage.tsx
+++ b/ui/src/admin/pages/DiagnosticsListPage.tsx
@@ -1,0 +1,495 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { Header } from '../components/Header';
+import {
+  fetchTenants,
+  listDiagnostics,
+  importDiagnostic,
+} from '../services/api';
+import { formatBytes, formatMs, formatTime, getBasePath } from '../utils';
+import type { DiagnosticSummary } from '../types';
+
+type SortField =
+  | 'created_at'
+  | 'method'
+  | 'response_time_ms'
+  | 'response_size_bytes';
+type SortDirection = 'asc' | 'desc';
+
+export function DiagnosticsListPage() {
+  const [tenants, setTenants] = useState<string[]>([]);
+  const [selectedTenant, setSelectedTenant] = useState<string | null>(null);
+  const [diagnostics, setDiagnostics] = useState<DiagnosticSummary[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [sortField, setSortField] = useState<SortField>('created_at');
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+  const [filterText, setFilterText] = useState('');
+  const [methodFilter, setMethodFilter] = useState<string>('');
+  const [tenantSearch, setTenantSearch] = useState('');
+
+  useEffect(() => {
+    async function loadTenants() {
+      try {
+        const tenantList = await fetchTenants();
+        setTenants(tenantList);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load tenants');
+      }
+    }
+    loadTenants();
+  }, []);
+
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const tenant = urlParams.get('tenant');
+    if (tenant) {
+      setSelectedTenant(tenant);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!selectedTenant) {
+      setDiagnostics([]);
+      return;
+    }
+
+    async function loadDiagnostics() {
+      setLoading(true);
+      setError(null);
+      try {
+        const diagList = await listDiagnostics(selectedTenant!);
+        setDiagnostics(diagList);
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : 'Failed to load diagnostics'
+        );
+        setDiagnostics([]);
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadDiagnostics();
+  }, [selectedTenant]);
+
+  const filteredTenants = useMemo(() => {
+    if (!tenantSearch) {
+      return tenants;
+    }
+    const lowerSearch = tenantSearch.toLowerCase();
+    return tenants.filter((t) => t.toLowerCase().includes(lowerSearch));
+  }, [tenants, tenantSearch]);
+
+  const availableMethods = useMemo(() => {
+    const methods = new Set(diagnostics.map((d) => d.method));
+    return Array.from(methods).sort();
+  }, [diagnostics]);
+
+  const filteredAndSortedDiagnostics = useMemo(() => {
+    let result = [...diagnostics];
+
+    if (filterText) {
+      const lowerFilter = filterText.toLowerCase();
+      result = result.filter((diag) => {
+        const payloadStr = diag.request
+          ? JSON.stringify(diag.request).toLowerCase()
+          : '';
+        return (
+          diag.method.toLowerCase().includes(lowerFilter) ||
+          payloadStr.includes(lowerFilter) ||
+          diag.id.toLowerCase().includes(lowerFilter)
+        );
+      });
+    }
+
+    if (methodFilter) {
+      result = result.filter((diag) => diag.method === methodFilter);
+    }
+
+    result.sort((a, b) => {
+      let comparison = 0;
+      switch (sortField) {
+        case 'created_at':
+          comparison =
+            new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+          break;
+        case 'method':
+          comparison = a.method.localeCompare(b.method);
+          break;
+        case 'response_time_ms':
+          comparison = (a.response_time_ms || 0) - (b.response_time_ms || 0);
+          break;
+        case 'response_size_bytes':
+          comparison =
+            (a.response_size_bytes || 0) - (b.response_size_bytes || 0);
+          break;
+      }
+      return sortDirection === 'asc' ? comparison : -comparison;
+    });
+
+    return result;
+  }, [diagnostics, filterText, methodFilter, sortField, sortDirection]);
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortField(field);
+      setSortDirection('desc');
+    }
+  };
+
+  const handleTenantSelect = (tenant: string) => {
+    setSelectedTenant(tenant);
+    setFilterText('');
+    setMethodFilter('');
+    window.history.pushState({}, '', `?tenant=${encodeURIComponent(tenant)}`);
+  };
+
+  const handleImportClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleFileChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file || !selectedTenant) {
+        return;
+      }
+
+      setIsImporting(true);
+      setError(null);
+
+      try {
+        const result = await importDiagnostic(selectedTenant, file);
+        // Navigate to the imported diagnostic
+        window.location.href = `${getBasePath()}/query-diagnostics?load=${
+          result.id
+        }&tenant=${encodeURIComponent(selectedTenant)}`;
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : 'Failed to import diagnostic'
+        );
+      } finally {
+        setIsImporting(false);
+        // Reset file input
+        if (fileInputRef.current) {
+          fileInputRef.current.value = '';
+        }
+      }
+    },
+    [selectedTenant]
+  );
+
+  const SortIcon = ({ field }: { field: SortField }) => {
+    if (sortField !== field) {
+      return <span className="sort-icon text-muted">⇅</span>;
+    }
+    return (
+      <span className="sort-icon active">
+        {sortDirection === 'asc' ? '↑' : '↓'}
+      </span>
+    );
+  };
+
+  return (
+    <div className="diagnostics-list-page">
+      <div className="page-header">
+        <Header
+          title="Stored Diagnostics"
+          subtitle="Browse and view stored query diagnostics"
+          showNewQueryLink={true}
+          showStoredDiagnosticsLink={false}
+        />
+      </div>
+
+      {error && (
+        <div className="alert alert-danger mx-3 mt-3" role="alert">
+          <strong>Error:</strong> {error}
+        </div>
+      )}
+
+      <div className="page-content">
+        <div className="tenants-panel">
+          <div className="card">
+            <div className="card-header">
+              <div className="d-flex justify-content-between align-items-center mb-2">
+                <h6 className="mb-0">Tenants</h6>
+                {tenants.length > 0 && (
+                  <span className="badge bg-secondary">
+                    {filteredTenants.length !== tenants.length
+                      ? `${filteredTenants.length}/`
+                      : ''}
+                    {tenants.length}
+                  </span>
+                )}
+              </div>
+              {tenants.length > 0 && (
+                <input
+                  type="text"
+                  className="form-control form-control-sm"
+                  placeholder="Search tenants..."
+                  value={tenantSearch}
+                  onChange={(e) => setTenantSearch(e.target.value)}
+                />
+              )}
+            </div>
+            <div className="card-body p-0">
+              {tenants.length > 0 ? (
+                filteredTenants.length > 0 ? (
+                  <div className="tenant-list">
+                    {filteredTenants.map((tenant) => (
+                      <a
+                        key={tenant}
+                        href={`?tenant=${encodeURIComponent(tenant)}`}
+                        className={`tenant-item ${
+                          selectedTenant === tenant ? 'active' : ''
+                        }`}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          handleTenantSelect(tenant);
+                        }}
+                      >
+                        {tenant}
+                      </a>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="p-3 text-muted text-center">
+                    <small>No matching tenants</small>
+                  </div>
+                )
+              ) : (
+                <div className="p-3 text-muted">
+                  <small>No diagnostics stored yet</small>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="diagnostics-panel">
+          <div className="card h-100">
+            <div className="card-header">
+              <div className="d-flex justify-content-between align-items-center">
+                <h6 className="mb-0">
+                  {selectedTenant ? (
+                    <>
+                      Diagnostics for <code>{selectedTenant}</code>
+                    </>
+                  ) : (
+                    'Select a tenant to view diagnostics'
+                  )}
+                </h6>
+                <div className="d-flex align-items-center gap-2">
+                  {filteredAndSortedDiagnostics.length > 0 && (
+                    <span className="badge bg-secondary">
+                      {filteredAndSortedDiagnostics.length}
+                      {filteredAndSortedDiagnostics.length !==
+                        diagnostics.length && <> / {diagnostics.length}</>}{' '}
+                      entries
+                    </span>
+                  )}
+                  {selectedTenant && (
+                    <>
+                      <input
+                        type="file"
+                        ref={fileInputRef}
+                        style={{ display: 'none' }}
+                        accept=".zip"
+                        onChange={handleFileChange}
+                      />
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-outline-primary"
+                        onClick={handleImportClick}
+                        disabled={isImporting}
+                        title="Import diagnostic from zip file"
+                      >
+                        {isImporting ? 'Importing...' : 'Import'}
+                      </button>
+                    </>
+                  )}
+                </div>
+              </div>
+
+              {selectedTenant && diagnostics.length > 0 && (
+                <div className="filters-row mt-3">
+                  <div className="filter-group">
+                    <input
+                      type="text"
+                      className="form-control form-control-sm"
+                      placeholder="Search in payload, method, or ID..."
+                      value={filterText}
+                      onChange={(e) => setFilterText(e.target.value)}
+                    />
+                  </div>
+                  <div className="filter-group">
+                    <select
+                      className="form-select form-select-sm"
+                      value={methodFilter}
+                      onChange={(e) => setMethodFilter(e.target.value)}
+                    >
+                      <option value="">All Methods</option>
+                      {availableMethods.map((method) => (
+                        <option key={method} value={method}>
+                          {method}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  {(filterText || methodFilter) && (
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-outline-secondary"
+                      onClick={() => {
+                        setFilterText('');
+                        setMethodFilter('');
+                      }}
+                    >
+                      Clear
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+            <div className="card-body p-0">
+              {selectedTenant ? (
+                loading ? (
+                  <div className="text-center py-5">
+                    <div className="spinner-border" role="status">
+                      <span className="visually-hidden">Loading...</span>
+                    </div>
+                  </div>
+                ) : diagnostics.length > 0 ? (
+                  filteredAndSortedDiagnostics.length > 0 ? (
+                    <div className="table-responsive">
+                      <table className="table table-hover diagnostics-table mb-0">
+                        <thead>
+                          <tr>
+                            <th
+                              className="col-narrow sortable"
+                              onClick={() => handleSort('created_at')}
+                            >
+                              Created <SortIcon field="created_at" />
+                            </th>
+                            <th
+                              className="col-narrow sortable"
+                              onClick={() => handleSort('method')}
+                            >
+                              Method <SortIcon field="method" />
+                            </th>
+                            <th className="col-payload">Payload</th>
+                            <th
+                              className="col-narrow sortable"
+                              onClick={() => handleSort('response_time_ms')}
+                            >
+                              Time <SortIcon field="response_time_ms" />
+                            </th>
+                            <th
+                              className="col-narrow sortable"
+                              onClick={() => handleSort('response_size_bytes')}
+                            >
+                              Size <SortIcon field="response_size_bytes" />
+                            </th>
+                            <th className="col-narrow"></th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {filteredAndSortedDiagnostics.map((diag) => (
+                            <tr key={diag.id}>
+                              <td className="col-narrow">
+                                <small>{formatTime(diag.created_at)}</small>
+                              </td>
+                              <td className="col-narrow">
+                                <span className="badge bg-info query-type-badge">
+                                  {diag.method}
+                                </span>
+                              </td>
+                              <td className="col-payload">
+                                {diag.request ? (
+                                  <code
+                                    className="payload-json"
+                                    title={JSON.stringify(diag.request)}
+                                  >
+                                    {JSON.stringify(diag.request)}
+                                  </code>
+                                ) : (
+                                  <span className="text-muted">-</span>
+                                )}
+                              </td>
+                              <td className="col-narrow">
+                                {diag.response_time_ms ? (
+                                  <span className="badge bg-success">
+                                    {formatMs(diag.response_time_ms)}
+                                  </span>
+                                ) : (
+                                  <span className="text-muted">-</span>
+                                )}
+                              </td>
+                              <td className="col-narrow">
+                                <span className="badge bg-secondary">
+                                  {formatBytes(diag.response_size_bytes)}
+                                </span>
+                              </td>
+                              <td className="col-narrow">
+                                <a
+                                  href={`${getBasePath()}/query-diagnostics?load=${
+                                    diag.id
+                                  }&tenant=${selectedTenant}`}
+                                  className="btn btn-sm btn-outline-primary"
+                                >
+                                  View
+                                </a>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  ) : (
+                    <div className="text-center text-muted py-5">
+                      <p className="mb-0">No results match your filters</p>
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-link mt-2"
+                        onClick={() => {
+                          setFilterText('');
+                          setMethodFilter('');
+                        }}
+                      >
+                        Clear filters
+                      </button>
+                    </div>
+                  )
+                ) : (
+                  <div className="text-center text-muted py-5">
+                    <p className="mt-3">
+                      No diagnostics stored for this tenant
+                    </p>
+                  </div>
+                )
+              ) : (
+                <div className="text-center text-muted py-5">
+                  <p className="mt-3">
+                    Select a tenant from the list to view their stored
+                    diagnostics
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/admin/pages/DiagnosticsListPage.tsx
+++ b/ui/src/admin/pages/DiagnosticsListPage.tsx
@@ -71,7 +71,7 @@ export function DiagnosticsListPage() {
         setDiagnostics(diagList);
       } catch (err) {
         setError(
-          err instanceof Error ? err.message : 'Failed to load diagnostics'
+          err instanceof Error ? err.message : 'Failed to load diagnostics',
         );
         setDiagnostics([]);
       } finally {
@@ -177,7 +177,7 @@ export function DiagnosticsListPage() {
         }&tenant=${encodeURIComponent(selectedTenant)}`;
       } catch (err) {
         setError(
-          err instanceof Error ? err.message : 'Failed to import diagnostic'
+          err instanceof Error ? err.message : 'Failed to import diagnostic',
         );
       } finally {
         setIsImporting(false);
@@ -187,7 +187,7 @@ export function DiagnosticsListPage() {
         }
       }
     },
-    [selectedTenant]
+    [selectedTenant],
   );
 
   const SortIcon = ({ field }: { field: SortField }) => {

--- a/ui/src/admin/pages/QueryDiagnosticsPage.tsx
+++ b/ui/src/admin/pages/QueryDiagnosticsPage.tsx
@@ -79,7 +79,7 @@ interface RequestData {
 
 function deserializeRequest(
   method: string,
-  request: unknown
+  request: unknown,
 ): Partial<QueryParams> {
   if (!request) {
     return {};
@@ -246,7 +246,7 @@ export function QueryDiagnosticsPage() {
   const [planJson, setPlanJson] = useState<string | null>(null);
   const [metadataStats, setMetadataStats] = useState<string | null>(null);
   const [executionTree, setExecutionTree] = useState<ExecutionTreeNode | null>(
-    null
+    null,
   );
   const [responseTimeMs, setResponseTimeMs] = useState<number | null>(null);
   const [diagnosticsId, setDiagnosticsId] = useState<string | null>(null);
@@ -271,7 +271,7 @@ export function QueryDiagnosticsPage() {
         // Deserialize request to get form fields
         const requestParams = deserializeRequest(
           diagnostic.method,
-          diagnostic.request
+          diagnostic.request,
         );
 
         const newParams = {
@@ -287,11 +287,11 @@ export function QueryDiagnosticsPage() {
         populateFromDiagnostic(diagnostic, newParams);
       } catch (err) {
         setGlobalError(
-          err instanceof Error ? err.message : 'Failed to load diagnostic'
+          err instanceof Error ? err.message : 'Failed to load diagnostic',
         );
       }
     },
-    []
+    [],
   );
 
   useEffect(() => {
@@ -306,7 +306,7 @@ export function QueryDiagnosticsPage() {
 
   const populateFromDiagnostic = (
     diagnostic: RawDiagnostic,
-    currentParams: QueryParams
+    currentParams: QueryParams,
   ) => {
     setDiagnosticsId(diagnostic.id);
     setResponseTimeMs(diagnostic.response_time_ms);
@@ -349,7 +349,7 @@ export function QueryDiagnosticsPage() {
       }
     } catch (err) {
       setError(
-        'Query failed: ' + (err instanceof Error ? err.message : String(err))
+        'Query failed: ' + (err instanceof Error ? err.message : String(err)),
       );
     } finally {
       setIsSubmitting(false);

--- a/ui/src/admin/pages/QueryDiagnosticsPage.tsx
+++ b/ui/src/admin/pages/QueryDiagnosticsPage.tsx
@@ -1,0 +1,405 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Header } from '../components/Header';
+import { QueryForm } from '../components/QueryForm';
+import { QueryPlanViewer } from '../components/QueryPlanViewer';
+import { ExecutionTraceViewer } from '../components/ExecutionTraceViewer';
+import { executeQuery, fetchTenants, loadDiagnostic } from '../services/api';
+import {
+  buildMetadataStats,
+  convertExecutionNodeToTree,
+  convertQueryPlanToTree,
+  extractBlocksFromPlan,
+  getBasePath,
+} from '../utils';
+import type {
+  ExecutionTreeNode,
+  PlanTreeNode,
+  QueryParams,
+  RawDiagnostic,
+} from '../types';
+
+function parseTimeForStats(timeStr: string): Date {
+  if (!timeStr) {
+    return new Date();
+  }
+  const now = Date.now();
+  const match = timeStr.match(/^now(-(\d+)([smhd]))?$/);
+  if (match) {
+    if (!match[1]) {
+      return new Date(now);
+    }
+    const value = parseInt(match[2], 10);
+    const unit = match[3];
+    const multipliers: Record<string, number> = {
+      s: 1000,
+      m: 60000,
+      h: 3600000,
+      d: 86400000,
+    };
+    return new Date(now - value * (multipliers[unit] || 0));
+  }
+  const d = new Date(timeStr);
+  return isNaN(d.getTime()) ? new Date() : d;
+}
+
+function formatTimestamp(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+interface RequestData {
+  start?: number;
+  end?: number;
+  label_selector?: string;
+  profile_typeID?: string;
+  max_nodes?: number;
+  format?: string;
+  span_selector?: string[];
+  step?: number;
+  group_by?: string[];
+  aggregation?: string;
+  limit?: number;
+  name?: string;
+  label_names?: string[];
+  matchers?: string[];
+  query_type?: string;
+  exemplar_type?: string;
+  left?: {
+    start?: number;
+    end?: number;
+    label_selector?: string;
+    profile_typeID?: string;
+  };
+  right?: {
+    start?: number;
+    end?: number;
+    label_selector?: string;
+    profile_typeID?: string;
+  };
+}
+
+function deserializeRequest(
+  method: string,
+  request: unknown
+): Partial<QueryParams> {
+  if (!request) {
+    return {};
+  }
+
+  const req = request as RequestData;
+  const params: Partial<QueryParams> = {};
+
+  if (req.start) {
+    params.startTime = formatTimestamp(req.start);
+  }
+  if (req.end) {
+    params.endTime = formatTimestamp(req.end);
+  }
+  params.labelSelector = req.label_selector || '';
+  params.profileTypeId = req.profile_typeID || '';
+
+  switch (method) {
+    case 'SelectMergeStacktraces':
+    case 'SelectMergeProfile':
+      if (req.max_nodes) {
+        params.maxNodes = String(req.max_nodes);
+      }
+      if (req.format) {
+        params.format = req.format;
+      }
+      break;
+
+    case 'SelectMergeSpanProfile':
+      if (req.max_nodes) {
+        params.maxNodes = String(req.max_nodes);
+      }
+      if (req.format) {
+        params.format = req.format;
+      }
+      if (req.span_selector && req.span_selector.length > 0) {
+        params.spanSelector = req.span_selector.join(', ');
+      }
+      break;
+
+    case 'SelectSeries':
+      if (req.step) {
+        params.step = String(req.step);
+      }
+      if (req.group_by && req.group_by.length > 0) {
+        params.groupBy = req.group_by.join(', ');
+      }
+      if (req.aggregation) {
+        params.aggregation = req.aggregation;
+      }
+      if (req.limit) {
+        params.limit = String(req.limit);
+      }
+      if (req.exemplar_type) {
+        params.exemplarType = req.exemplar_type;
+      }
+      break;
+
+    case 'SelectHeatmap':
+      if (req.step) {
+        params.step = String(req.step);
+      }
+      if (req.group_by && req.group_by.length > 0) {
+        params.groupBy = req.group_by.join(', ');
+      }
+      if (req.limit) {
+        params.limit = String(req.limit);
+      }
+      if (req.query_type) {
+        params.heatmapQueryType = req.query_type;
+      }
+      if (req.exemplar_type) {
+        params.exemplarType = req.exemplar_type;
+      }
+      break;
+
+    case 'Diff':
+      if (req.left) {
+        if (req.left.start) {
+          params.diffLeftStart = formatTimestamp(req.left.start);
+        }
+        if (req.left.end) {
+          params.diffLeftEnd = formatTimestamp(req.left.end);
+        }
+        params.diffLeftSelector = req.left.label_selector || '';
+        params.diffLeftProfileType = req.left.profile_typeID || '';
+      }
+      if (req.right) {
+        if (req.right.start) {
+          params.diffRightStart = formatTimestamp(req.right.start);
+        }
+        if (req.right.end) {
+          params.diffRightEnd = formatTimestamp(req.right.end);
+        }
+        params.diffRightSelector = req.right.label_selector || '';
+        params.diffRightProfileType = req.right.profile_typeID || '';
+      }
+      break;
+
+    case 'LabelNames':
+      if (req.matchers && req.matchers.length > 0) {
+        params.labelSelector = req.matchers.join(', ');
+      }
+      break;
+
+    case 'LabelValues':
+      if (req.name) {
+        params.labelName = req.name;
+      }
+      if (req.matchers && req.matchers.length > 0) {
+        params.labelSelector = req.matchers.join(', ');
+      }
+      break;
+
+    case 'Series':
+      if (req.matchers && req.matchers.length > 0) {
+        params.labelSelector = req.matchers.join(', ');
+      }
+      if (req.label_names && req.label_names.length > 0) {
+        params.labelNames = req.label_names.join(', ');
+      }
+      break;
+  }
+
+  return params;
+}
+
+const defaultParams: QueryParams = {
+  tenantId: '',
+  method: 'SelectMergeStacktraces',
+  startTime: 'now-1h',
+  endTime: 'now',
+  labelSelector: '',
+  profileTypeId: '',
+  maxNodes: '',
+  format: 'PROFILE_FORMAT_FLAMEGRAPH',
+  spanSelector: '',
+  labelName: '',
+  labelNames: '',
+  step: '',
+  groupBy: '',
+  aggregation: '',
+  limit: '',
+  heatmapQueryType: 'HEATMAP_QUERY_TYPE_INDIVIDUAL',
+  exemplarType: '',
+  diffLeftSelector: '',
+  diffLeftProfileType: '',
+  diffLeftStart: '',
+  diffLeftEnd: '',
+  diffRightSelector: '',
+  diffRightProfileType: '',
+  diffRightStart: '',
+  diffRightEnd: '',
+};
+
+export function QueryDiagnosticsPage() {
+  const [tenants, setTenants] = useState<string[]>([]);
+  const [params, setParams] = useState<QueryParams>(defaultParams);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [globalError, setGlobalError] = useState<string | null>(null);
+
+  const [planTree, setPlanTree] = useState<PlanTreeNode | null>(null);
+  const [planJson, setPlanJson] = useState<string | null>(null);
+  const [metadataStats, setMetadataStats] = useState<string | null>(null);
+  const [executionTree, setExecutionTree] = useState<ExecutionTreeNode | null>(
+    null
+  );
+  const [responseTimeMs, setResponseTimeMs] = useState<number | null>(null);
+  const [diagnosticsId, setDiagnosticsId] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function loadTenants() {
+      try {
+        const tenantList = await fetchTenants();
+        setTenants(tenantList);
+      } catch (err) {
+        console.error('Failed to fetch tenants:', err);
+      }
+    }
+    loadTenants();
+  }, []);
+
+  const loadStoredDiagnostic = useCallback(
+    async (tenant: string, id: string) => {
+      try {
+        const diagnostic: RawDiagnostic = await loadDiagnostic(tenant, id);
+
+        // Deserialize request to get form fields
+        const requestParams = deserializeRequest(
+          diagnostic.method,
+          diagnostic.request
+        );
+
+        const newParams = {
+          ...defaultParams,
+          tenantId: diagnostic.tenant_id,
+          method:
+            (diagnostic.method as QueryParams['method']) ||
+            defaultParams.method,
+          ...requestParams,
+        };
+
+        setParams(newParams);
+        populateFromDiagnostic(diagnostic, newParams);
+      } catch (err) {
+        setGlobalError(
+          err instanceof Error ? err.message : 'Failed to load diagnostic'
+        );
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const loadId = urlParams.get('load');
+    const tenant = urlParams.get('tenant');
+
+    if (loadId && tenant) {
+      loadStoredDiagnostic(tenant, loadId);
+    }
+  }, [loadStoredDiagnostic]);
+
+  const populateFromDiagnostic = (
+    diagnostic: RawDiagnostic,
+    currentParams: QueryParams
+  ) => {
+    setDiagnosticsId(diagnostic.id);
+    setResponseTimeMs(diagnostic.response_time_ms);
+
+    if (diagnostic.plan) {
+      const tree = convertQueryPlanToTree(diagnostic.plan);
+      setPlanTree(tree);
+      setPlanJson(JSON.stringify(diagnostic.plan, null, 2));
+
+      const blocks = extractBlocksFromPlan(diagnostic.plan);
+      const startTime = parseTimeForStats(currentParams.startTime);
+      const endTime = parseTimeForStats(currentParams.endTime);
+      const stats = buildMetadataStats(blocks, startTime, endTime);
+      setMetadataStats(stats);
+    }
+
+    if (diagnostic.execution) {
+      const tree = convertExecutionNodeToTree(diagnostic.execution);
+      setExecutionTree(tree);
+    }
+  };
+
+  const handleSubmit = useCallback(async () => {
+    if (!params.tenantId) {
+      setError('Tenant ID is required');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const result = await executeQuery(params);
+      if (result.diagnosticsId) {
+        window.location.href = `${getBasePath()}/query-diagnostics?load=${
+          result.diagnosticsId
+        }&tenant=${params.tenantId}`;
+      } else {
+        setError('Query succeeded but no diagnostics ID was returned');
+      }
+    } catch (err) {
+      setError(
+        'Query failed: ' + (err instanceof Error ? err.message : String(err))
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [params]);
+
+  return (
+    <div className="query-diagnostics-page">
+      <div className="page-header">
+        <Header
+          title="Query Diagnostics"
+          subtitle="Debug V2 query execution by running queries and viewing execution traces"
+          showNewQueryLink={true}
+          showStoredDiagnosticsLink={true}
+        />
+        {globalError && (
+          <div className="alert alert-danger mt-2 mb-0" role="alert">
+            <strong>Error:</strong> {globalError}
+          </div>
+        )}
+      </div>
+
+      <div className="page-content">
+        <div className="left-panel">
+          <QueryForm
+            tenants={tenants}
+            params={params}
+            onParamsChange={setParams}
+            onSubmit={handleSubmit}
+            isSubmitting={isSubmitting}
+            error={error}
+          />
+          <div className="mt-3">
+            <QueryPlanViewer
+              planTree={planTree}
+              planJson={planJson}
+              metadataStats={metadataStats}
+            />
+          </div>
+        </div>
+
+        <div className="right-panel">
+          <ExecutionTraceViewer
+            executionTree={executionTree}
+            responseTimeMs={responseTimeMs}
+            diagnosticsId={diagnosticsId}
+            tenantId={params.tenantId}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/admin/services/api.ts
+++ b/ui/src/admin/services/api.ts
@@ -1,0 +1,328 @@
+import type {
+  DiagnosticSummary,
+  QueryMethod,
+  QueryParams,
+  RawDiagnostic,
+} from '../types';
+import { getBasePath, getQueryFrontendBasePath } from '../utils';
+
+export async function fetchTenants(): Promise<string[]> {
+  const basePath = getBasePath();
+  const response = await fetch(`${basePath}/query-diagnostics/api/tenants`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch tenants: ${response.status}`);
+  }
+  return response.json();
+}
+
+export async function fetchProfileTypes(
+  tenantId: string,
+  startMs: number,
+  endMs: number
+): Promise<string[]> {
+  const basePath = getQueryFrontendBasePath();
+  const response = await fetch(
+    `${basePath}/querier.v1.QuerierService/ProfileTypes`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Scope-OrgID': tenantId,
+      },
+      body: JSON.stringify({ start: startMs, end: endMs }),
+    }
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to fetch profile types: ${response.status}`);
+  }
+  const data = await response.json();
+  return (data.profileTypes || []).map((pt: { ID: string }) => pt.ID);
+}
+
+export async function listDiagnostics(
+  tenant: string
+): Promise<DiagnosticSummary[]> {
+  const basePath = getBasePath();
+  const response = await fetch(
+    `${basePath}/query-diagnostics/api/diagnostics?tenant=${encodeURIComponent(
+      tenant
+    )}`
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to list diagnostics: ${response.status}`);
+  }
+  return response.json();
+}
+
+export async function loadDiagnostic(
+  tenant: string,
+  id: string
+): Promise<RawDiagnostic> {
+  const basePath = getBasePath();
+  const response = await fetch(
+    `${basePath}/query-diagnostics/api/diagnostics/${encodeURIComponent(
+      id
+    )}?tenant=${encodeURIComponent(tenant)}`
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to load diagnostic: ${response.status}`);
+  }
+  return response.json();
+}
+
+function parseTime(timeStr: string): number {
+  if (!timeStr) {
+    return 0;
+  }
+  const now = Date.now();
+  const match = timeStr.match(/^now(-(\d+)([smhd]))?$/);
+  if (match) {
+    if (!match[1]) {
+      return now;
+    }
+    const value = parseInt(match[2], 10);
+    const unit = match[3];
+    const multipliers: Record<string, number> = {
+      s: 1000,
+      m: 60000,
+      h: 3600000,
+      d: 86400000,
+    };
+    return now - value * (multipliers[unit] || 0);
+  }
+  const d = new Date(timeStr);
+  return isNaN(d.getTime()) ? 0 : d.getTime();
+}
+
+function calculateDefaultStep(startMs: number, endMs: number): number {
+  const minStep = 15;
+  const targetDataPoints = 100;
+  const rangeSeconds = (endMs - startMs) / 1000;
+  const calculatedStep = rangeSeconds / targetDataPoints;
+  return Math.max(minStep, Math.ceil(calculatedStep));
+}
+
+function buildRequestBody(
+  method: QueryMethod,
+  params: QueryParams
+): Record<string, unknown> {
+  const startMs = parseTime(params.startTime);
+  const endMs = parseTime(params.endTime);
+
+  switch (method) {
+    case 'SelectMergeStacktraces':
+    case 'SelectMergeProfile': {
+      const body: Record<string, unknown> = {
+        start: startMs,
+        end: endMs,
+        labelSelector: params.labelSelector,
+        profileTypeID: params.profileTypeId,
+      };
+      if (params.maxNodes) {
+        body.maxNodes = parseInt(params.maxNodes, 10);
+      }
+      if (params.format) {
+        body.format = params.format;
+      }
+      return body;
+    }
+    case 'SelectMergeSpanProfile': {
+      const body: Record<string, unknown> = {
+        start: startMs,
+        end: endMs,
+        labelSelector: params.labelSelector,
+        profileTypeID: params.profileTypeId,
+      };
+      if (params.maxNodes) {
+        body.maxNodes = parseInt(params.maxNodes, 10);
+      }
+      if (params.format) {
+        body.format = params.format;
+      }
+      if (params.spanSelector) {
+        body.spanSelector = params.spanSelector
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+      }
+      return body;
+    }
+    case 'SelectSeries': {
+      const body: Record<string, unknown> = {
+        start: startMs,
+        end: endMs,
+        labelSelector: params.labelSelector,
+        profileTypeID: params.profileTypeId,
+        step: params.step
+          ? parseInt(params.step, 10)
+          : calculateDefaultStep(startMs, endMs),
+      };
+      if (params.groupBy) {
+        body.groupBy = params.groupBy
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+      }
+      if (params.aggregation === 'sum') {
+        body.aggregation = 'TIME_SERIES_AGGREGATION_TYPE_SUM';
+      } else if (params.aggregation === 'avg') {
+        body.aggregation = 'TIME_SERIES_AGGREGATION_TYPE_AVERAGE';
+      }
+      if (params.limit) {
+        body.limit = parseInt(params.limit, 10);
+      }
+      if (params.exemplarType) {
+        body.exemplarType = params.exemplarType;
+      }
+      return body;
+    }
+    case 'SelectHeatmap': {
+      const body: Record<string, unknown> = {
+        start: startMs,
+        end: endMs,
+        labelSelector: params.labelSelector,
+        profileTypeID: params.profileTypeId,
+        queryType: params.heatmapQueryType,
+        step: params.step
+          ? parseInt(params.step, 10)
+          : calculateDefaultStep(startMs, endMs),
+      };
+      if (params.groupBy) {
+        body.groupBy = params.groupBy
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+      }
+      if (params.limit) {
+        body.limit = parseInt(params.limit, 10);
+      }
+      if (params.exemplarType) {
+        body.exemplarType = params.exemplarType;
+      }
+      return body;
+    }
+    case 'Diff': {
+      const leftStartMs = parseTime(params.diffLeftStart);
+      const leftEndMs = parseTime(params.diffLeftEnd);
+      const rightStartMs = parseTime(params.diffRightStart);
+      const rightEndMs = parseTime(params.diffRightEnd);
+      return {
+        left: {
+          start: leftStartMs,
+          end: leftEndMs,
+          labelSelector: params.diffLeftSelector,
+          profileTypeID: params.diffLeftProfileType,
+        },
+        right: {
+          start: rightStartMs,
+          end: rightEndMs,
+          labelSelector: params.diffRightSelector,
+          profileTypeID: params.diffRightProfileType,
+        },
+      };
+    }
+    case 'LabelNames':
+      return {
+        start: startMs,
+        end: endMs,
+        matchers: params.labelSelector ? [params.labelSelector] : [],
+      };
+    case 'LabelValues':
+      return {
+        start: startMs,
+        end: endMs,
+        name: params.labelName,
+        matchers: params.labelSelector ? [params.labelSelector] : [],
+      };
+    case 'Series': {
+      const body: Record<string, unknown> = {
+        start: startMs,
+        end: endMs,
+        matchers: params.labelSelector ? [params.labelSelector] : [],
+      };
+      if (params.labelNames) {
+        body.labelNames = params.labelNames
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+      }
+      return body;
+    }
+    case 'ProfileTypes':
+      return { start: startMs, end: endMs };
+    default:
+      return {};
+  }
+}
+
+export interface ExecuteQueryResult {
+  diagnosticsId: string | null;
+}
+
+export async function executeQuery(
+  params: QueryParams
+): Promise<ExecuteQueryResult> {
+  const basePath = getQueryFrontendBasePath();
+  const endpoint = `${basePath}/querier.v1.QuerierService/${params.method}`;
+  const body = buildRequestBody(params.method, params);
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Scope-OrgID': params.tenantId,
+      'X-Pyroscope-Collect-Diagnostics': 'true',
+    },
+    body: JSON.stringify(body),
+  });
+
+  const diagnosticsId = response.headers.get('X-Pyroscope-Diagnostics-Id');
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || `HTTP ${response.status}`);
+  }
+
+  return { diagnosticsId };
+}
+
+export async function exportDiagnostic(
+  tenant: string,
+  id: string
+): Promise<Blob> {
+  const basePath = getBasePath();
+  const response = await fetch(
+    `${basePath}/query-diagnostics/api/export/${encodeURIComponent(
+      id
+    )}?tenant=${encodeURIComponent(tenant)}`
+  );
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || `Failed to export diagnostic: ${response.status}`);
+  }
+  return response.blob();
+}
+
+export async function importDiagnostic(
+  tenant: string,
+  file: File
+): Promise<{ id: string }> {
+  const basePath = getBasePath();
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const response = await fetch(
+    `${basePath}/query-diagnostics/api/import?tenant=${encodeURIComponent(
+      tenant
+    )}`,
+    {
+      method: 'POST',
+      body: formData,
+    }
+  );
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || `Failed to import diagnostic: ${response.status}`);
+  }
+  return response.json();
+}

--- a/ui/src/admin/services/api.ts
+++ b/ui/src/admin/services/api.ts
@@ -18,7 +18,7 @@ export async function fetchTenants(): Promise<string[]> {
 export async function fetchProfileTypes(
   tenantId: string,
   startMs: number,
-  endMs: number
+  endMs: number,
 ): Promise<string[]> {
   const basePath = getQueryFrontendBasePath();
   const response = await fetch(
@@ -30,7 +30,7 @@ export async function fetchProfileTypes(
         'X-Scope-OrgID': tenantId,
       },
       body: JSON.stringify({ start: startMs, end: endMs }),
-    }
+    },
   );
   if (!response.ok) {
     throw new Error(`Failed to fetch profile types: ${response.status}`);
@@ -40,13 +40,13 @@ export async function fetchProfileTypes(
 }
 
 export async function listDiagnostics(
-  tenant: string
+  tenant: string,
 ): Promise<DiagnosticSummary[]> {
   const basePath = getBasePath();
   const response = await fetch(
     `${basePath}/query-diagnostics/api/diagnostics?tenant=${encodeURIComponent(
-      tenant
-    )}`
+      tenant,
+    )}`,
   );
   if (!response.ok) {
     throw new Error(`Failed to list diagnostics: ${response.status}`);
@@ -56,13 +56,13 @@ export async function listDiagnostics(
 
 export async function loadDiagnostic(
   tenant: string,
-  id: string
+  id: string,
 ): Promise<RawDiagnostic> {
   const basePath = getBasePath();
   const response = await fetch(
     `${basePath}/query-diagnostics/api/diagnostics/${encodeURIComponent(
-      id
-    )}?tenant=${encodeURIComponent(tenant)}`
+      id,
+    )}?tenant=${encodeURIComponent(tenant)}`,
   );
   if (!response.ok) {
     throw new Error(`Failed to load diagnostic: ${response.status}`);
@@ -104,7 +104,7 @@ function calculateDefaultStep(startMs: number, endMs: number): number {
 
 function buildRequestBody(
   method: QueryMethod,
-  params: QueryParams
+  params: QueryParams,
 ): Record<string, unknown> {
   const startMs = parseTime(params.startTime);
   const endMs = parseTime(params.endTime);
@@ -260,7 +260,7 @@ export interface ExecuteQueryResult {
 }
 
 export async function executeQuery(
-  params: QueryParams
+  params: QueryParams,
 ): Promise<ExecuteQueryResult> {
   const basePath = getQueryFrontendBasePath();
   const endpoint = `${basePath}/querier.v1.QuerierService/${params.method}`;
@@ -288,13 +288,13 @@ export async function executeQuery(
 
 export async function exportDiagnostic(
   tenant: string,
-  id: string
+  id: string,
 ): Promise<Blob> {
   const basePath = getBasePath();
   const response = await fetch(
     `${basePath}/query-diagnostics/api/export/${encodeURIComponent(
-      id
-    )}?tenant=${encodeURIComponent(tenant)}`
+      id,
+    )}?tenant=${encodeURIComponent(tenant)}`,
   );
   if (!response.ok) {
     const text = await response.text();
@@ -305,7 +305,7 @@ export async function exportDiagnostic(
 
 export async function importDiagnostic(
   tenant: string,
-  file: File
+  file: File,
 ): Promise<{ id: string }> {
   const basePath = getBasePath();
   const formData = new FormData();
@@ -313,12 +313,12 @@ export async function importDiagnostic(
 
   const response = await fetch(
     `${basePath}/query-diagnostics/api/import?tenant=${encodeURIComponent(
-      tenant
+      tenant,
     )}`,
     {
       method: 'POST',
       body: formData,
-    }
+    },
   );
   if (!response.ok) {
     const text = await response.text();

--- a/ui/src/admin/styles.css
+++ b/ui/src/admin/styles.css
@@ -1,0 +1,1102 @@
+/* Dark Theme Variables */
+.query-diagnostics-page {
+  --dark-bg: #1a1a1a;
+  --dark-bg-secondary: #252525;
+  --dark-bg-tertiary: #2d2d2d;
+  --dark-border: #3a3a3a;
+  --dark-text: #e0e0e0;
+  --dark-text-muted: #999;
+  --dark-accent-blue: #58a6ff;
+  --dark-accent-green: #3fb950;
+  --dark-accent-yellow: #d29922;
+  --dark-accent-cyan: #39c5cf;
+  --dark-accent-red: #f85149;
+}
+
+/* Query Diagnostics Page Layout */
+.query-diagnostics-page {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+  background: var(--dark-bg);
+  color: var(--dark-text);
+}
+
+.query-diagnostics-page .page-header {
+  flex-shrink: 0;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--dark-border);
+  background: var(--dark-bg-secondary);
+}
+
+.query-diagnostics-page .page-header h1 {
+  font-size: 1.5rem;
+  margin-bottom: 0.25rem;
+  color: var(--dark-text);
+}
+
+.query-diagnostics-page .page-header p {
+  margin-bottom: 0;
+  font-size: 0.875rem;
+  color: var(--dark-text-muted);
+}
+
+.query-diagnostics-page .page-content {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.query-diagnostics-page .left-panel {
+  width: 600px;
+  flex-shrink: 0;
+  padding: 1rem;
+  overflow-y: auto;
+  border-right: 1px solid var(--dark-border);
+  background: var(--dark-bg-secondary);
+}
+
+.query-diagnostics-page .right-panel {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--dark-bg);
+}
+
+/* Form Styles for Dark Theme */
+.query-diagnostics-page .card {
+  background: var(--dark-bg-tertiary);
+  border-color: var(--dark-border);
+  color: var(--dark-text);
+}
+
+.query-diagnostics-page .card-header {
+  background: var(--dark-bg-secondary);
+  border-color: var(--dark-border);
+  color: var(--dark-text);
+}
+
+.query-diagnostics-page .card-body {
+  background: var(--dark-bg-tertiary);
+}
+
+.query-diagnostics-page .form-control,
+.query-diagnostics-page .form-select {
+  background: var(--dark-bg);
+  border-color: var(--dark-border);
+  color: var(--dark-text);
+}
+
+.query-diagnostics-page .form-control:focus,
+.query-diagnostics-page .form-select:focus {
+  background: var(--dark-bg);
+  border-color: var(--dark-accent-blue);
+  color: var(--dark-text);
+  box-shadow: 0 0 0 0.2rem rgba(88, 166, 255, 0.25);
+}
+
+.query-diagnostics-page .form-control::placeholder {
+  color: var(--dark-text-muted);
+}
+
+.query-diagnostics-page .form-label {
+  color: var(--dark-text);
+}
+
+.query-diagnostics-page .form-text {
+  color: var(--dark-text-muted);
+}
+
+.query-diagnostics-page .btn-primary {
+  background: var(--dark-accent-blue);
+  border-color: var(--dark-accent-blue);
+}
+
+.query-diagnostics-page .btn-primary:hover {
+  background: #4a90e0;
+  border-color: #4a90e0;
+}
+
+.query-diagnostics-page .nav-tabs {
+  border-color: var(--dark-border);
+}
+
+.query-diagnostics-page .nav-tabs .nav-link {
+  color: var(--dark-text-muted);
+  border-color: transparent;
+}
+
+.query-diagnostics-page .nav-tabs .nav-link:hover {
+  border-color: var(--dark-border);
+  color: var(--dark-text);
+}
+
+.query-diagnostics-page .nav-tabs .nav-link.active {
+  background: var(--dark-bg-tertiary);
+  border-color: var(--dark-border);
+  border-bottom-color: var(--dark-bg-tertiary);
+  color: var(--dark-text);
+}
+
+.query-diagnostics-page .alert-danger {
+  background: rgba(248, 81, 73, 0.15);
+  border-color: var(--dark-accent-red);
+  color: var(--dark-accent-red);
+}
+
+.form-section {
+  margin-bottom: 1.5rem;
+}
+
+.plan-textarea {
+  font-family: monospace;
+  font-size: 0.875rem;
+  background: var(--dark-bg) !important;
+  color: var(--dark-text) !important;
+}
+
+.stats-box {
+  background-color: var(--dark-bg);
+  border-radius: 0.375rem;
+  padding: 1rem;
+  margin-top: 0.5rem;
+  border: 1px solid var(--dark-border);
+}
+
+.stats-box pre {
+  color: var(--dark-text-muted);
+  margin: 0;
+}
+
+/* Query Plan Tree Styles */
+.plan-tree {
+  font-family: monospace;
+  font-size: 0.875rem;
+  padding: 1rem;
+  background-color: var(--dark-bg);
+  border-radius: 0.375rem;
+  max-height: 400px;
+  overflow-y: auto;
+  border: 1px solid var(--dark-border);
+}
+
+.tree-node-children {
+  margin-left: 1.5rem;
+  border-left: 1px dashed var(--dark-border);
+  padding-left: 1rem;
+}
+
+.tree-node-header {
+  display: flex;
+  align-items: center;
+  padding: 0.25rem 0;
+}
+
+.tree-node-icon {
+  margin-right: 0.5rem;
+  font-size: 1rem;
+}
+
+.tree-node-merge .tree-node-icon {
+  color: var(--dark-accent-blue);
+}
+
+.tree-node-read .tree-node-icon {
+  color: var(--dark-accent-green);
+}
+
+.tree-node-label {
+  font-weight: 600;
+  color: var(--dark-text);
+}
+
+.tree-node-badge {
+  margin-left: 0.5rem;
+  font-size: 0.75rem;
+}
+
+.tree-node-blocks {
+  margin-left: 1.5rem;
+  font-size: 0.8rem;
+  color: var(--dark-text-muted);
+}
+
+.tree-node-blocks code {
+  font-size: 0.75rem;
+  color: var(--dark-accent-cyan);
+}
+
+/* Execution Tree Styles (legacy) */
+.execution-tree {
+  font-family: monospace;
+  font-size: 0.875rem;
+  padding: 1rem;
+  background-color: var(--dark-bg);
+  border-radius: 0.375rem;
+}
+
+.exec-node {
+  margin: 0.25rem 0;
+}
+
+.exec-node-merge > .exec-node-header {
+  border-left: 3px solid var(--dark-accent-blue);
+  padding-left: 0.5rem;
+}
+
+.exec-node-read > .exec-node-header {
+  border-left: 3px solid var(--dark-accent-green);
+  padding-left: 0.5rem;
+}
+
+.exec-node-header {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.exec-children {
+  margin-left: 1.5rem;
+  border-left: 1px solid var(--dark-border);
+  padding-left: 0.5rem;
+}
+
+.exec-error {
+  margin-left: 0.5rem;
+  font-size: 0.8rem;
+}
+
+.exec-type {
+  font-weight: 600;
+}
+
+.exec-blocks {
+  margin-left: 0.5rem;
+}
+
+.exec-blocks table {
+  margin-bottom: 0;
+}
+
+.exec-blocks code {
+  font-size: 0.75rem;
+}
+
+/* Diagnostics List Page Styles */
+.diagnostics-list-page {
+  --dark-bg: #1a1a1a;
+  --dark-bg-secondary: #252525;
+  --dark-bg-tertiary: #2d2d2d;
+  --dark-border: #3a3a3a;
+  --dark-text: #e0e0e0;
+  --dark-text-muted: #999;
+  --dark-accent-blue: #58a6ff;
+  --dark-accent-green: #3fb950;
+  --dark-accent-yellow: #d29922;
+  --dark-accent-cyan: #39c5cf;
+  --dark-accent-red: #f85149;
+
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+  background: var(--dark-bg);
+  color: var(--dark-text);
+}
+
+.diagnostics-list-page .page-header {
+  flex-shrink: 0;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--dark-border);
+  background: var(--dark-bg-secondary);
+}
+
+.diagnostics-list-page .page-content {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.diagnostics-list-page .tenants-panel {
+  width: 220px;
+  flex-shrink: 0;
+  padding: 1rem;
+  overflow-y: auto;
+  border-right: 1px solid var(--dark-border);
+  background: var(--dark-bg-secondary);
+}
+
+.diagnostics-list-page .diagnostics-panel {
+  flex: 1;
+  min-width: 0;
+  padding: 1rem;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.diagnostics-list-page .card {
+  background: var(--dark-bg-tertiary);
+  border-color: var(--dark-border);
+  color: var(--dark-text);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.diagnostics-list-page .card-header {
+  background: var(--dark-bg-secondary);
+  border-color: var(--dark-border);
+  color: var(--dark-text);
+  flex-shrink: 0;
+}
+
+.diagnostics-list-page .card-header code {
+  color: var(--dark-accent-cyan);
+}
+
+.diagnostics-list-page .card-body {
+  background: var(--dark-bg-tertiary);
+  flex: 1;
+  overflow: auto;
+}
+
+.diagnostics-list-page .form-control,
+.diagnostics-list-page .form-select {
+  background: var(--dark-bg);
+  border-color: var(--dark-border);
+  color: var(--dark-text);
+}
+
+.diagnostics-list-page .form-control:focus,
+.diagnostics-list-page .form-select:focus {
+  background: var(--dark-bg);
+  border-color: var(--dark-accent-blue);
+  color: var(--dark-text);
+  box-shadow: 0 0 0 0.2rem rgba(88, 166, 255, 0.25);
+}
+
+.diagnostics-list-page .form-control::placeholder {
+  color: var(--dark-text-muted);
+}
+
+.diagnostics-list-page .btn-primary {
+  background: var(--dark-accent-blue);
+  border-color: var(--dark-accent-blue);
+  color: #fff;
+}
+
+.diagnostics-list-page .btn-outline-primary {
+  border-color: var(--dark-accent-blue);
+  color: var(--dark-accent-blue);
+}
+
+.diagnostics-list-page .btn-outline-primary:hover {
+  background: var(--dark-accent-blue);
+  color: #fff;
+}
+
+.diagnostics-list-page .btn-outline-secondary {
+  border-color: var(--dark-border);
+  color: var(--dark-text-muted);
+}
+
+.diagnostics-list-page .btn-outline-secondary:hover {
+  background: var(--dark-bg-tertiary);
+  color: var(--dark-text);
+}
+
+.diagnostics-list-page .btn-link {
+  color: var(--dark-accent-blue);
+}
+
+.diagnostics-list-page .alert-danger {
+  background: rgba(248, 81, 73, 0.15);
+  border-color: var(--dark-accent-red);
+  color: var(--dark-accent-red);
+}
+
+.tenant-list {
+  max-height: calc(100vh - 250px);
+  overflow-y: auto;
+}
+
+.tenant-item {
+  cursor: pointer;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--dark-border);
+  display: block;
+  text-decoration: none;
+  color: var(--dark-text);
+}
+
+.tenant-item:hover {
+  background-color: var(--dark-bg-tertiary);
+  color: var(--dark-text);
+}
+
+.tenant-item.active {
+  background-color: var(--dark-accent-blue);
+  color: white;
+}
+
+/* Filters Row */
+.filters-row {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.filter-group {
+  flex: 1;
+  max-width: 300px;
+}
+
+/* Sortable Table Headers */
+.diagnostics-table th.sortable {
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.15s;
+}
+
+.diagnostics-table th.sortable:hover {
+  background-color: var(--dark-bg-tertiary);
+}
+
+.sort-icon {
+  margin-left: 0.25rem;
+  font-size: 0.75rem;
+}
+
+.sort-icon.active {
+  color: var(--dark-accent-blue);
+}
+
+.diagnostics-table {
+  font-size: 0.875rem;
+  color: var(--dark-text);
+}
+
+.diagnostics-table thead th {
+  background: var(--dark-bg-secondary);
+  border-color: var(--dark-border);
+  color: var(--dark-text);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.diagnostics-table td {
+  border-color: var(--dark-border);
+  vertical-align: middle;
+}
+
+.diagnostics-table tbody tr:hover {
+  background-color: var(--dark-bg) !important;
+}
+
+.diagnostics-table .col-narrow {
+  white-space: nowrap;
+  width: 1px;
+}
+
+.diagnostics-table .col-payload {
+  width: 100%;
+  max-width: 0;
+}
+
+.query-type-badge {
+  font-family: monospace;
+  font-size: 0.75rem;
+}
+
+.payload-json {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.75rem;
+  color: var(--dark-text-muted);
+}
+
+/* Badge overrides for diagnostics list page */
+.diagnostics-list-page .badge.bg-info {
+  background: rgba(57, 197, 207, 0.2) !important;
+  color: var(--dark-accent-cyan) !important;
+}
+
+.diagnostics-list-page .badge.bg-success {
+  background: rgba(63, 185, 80, 0.2) !important;
+  color: var(--dark-accent-green);
+}
+
+.diagnostics-list-page .badge.bg-secondary {
+  background: var(--dark-bg) !important;
+  color: var(--dark-text-muted);
+}
+
+.diagnostics-list-page .text-muted {
+  color: var(--dark-text-muted) !important;
+}
+
+.diagnostics-list-page .spinner-border {
+  color: var(--dark-accent-blue);
+}
+
+/* Diff parameters section */
+.diff-params {
+  background-color: var(--dark-bg);
+  border-radius: 0.375rem;
+  padding: 1rem;
+  margin-top: 0.5rem;
+  border: 1px solid var(--dark-border);
+}
+
+/* Execution Trace Container */
+.execution-trace-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.execution-trace-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  background: var(--dark-bg);
+  color: var(--dark-text-muted);
+}
+
+.execution-trace-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--dark-border);
+  background: var(--dark-bg-secondary);
+  flex-shrink: 0;
+  color: var(--dark-text);
+}
+
+.execution-trace-header h5 {
+  color: var(--dark-text);
+  margin: 0;
+}
+
+.execution-trace-body {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* Execution Flow Graph Styles */
+.execution-flow-container {
+  display: flex;
+  height: 100%;
+  background-color: var(--dark-bg);
+}
+
+.flow-wrapper {
+  flex: 1;
+  transition: flex 0.2s ease;
+}
+
+.flow-wrapper.with-panel {
+  flex: 0 0 65%;
+}
+
+.execution-flow-node {
+  padding: 6px 10px;
+  border-radius: 6px;
+  background: var(--dark-bg-tertiary);
+  border: 1px solid var(--dark-border);
+  width: 140px;
+  font-family: monospace;
+  font-size: 0.75rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  transition: all 0.15s ease;
+}
+
+.execution-flow-node:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  border-color: #555;
+}
+
+.execution-flow-node.selected {
+  border-color: var(--dark-accent-blue);
+  box-shadow: 0 0 0 2px rgba(88, 166, 255, 0.3);
+}
+
+.execution-flow-node.merge {
+  background: rgba(88, 166, 255, 0.15);
+  border-color: rgba(88, 166, 255, 0.4);
+}
+
+.execution-flow-node.read {
+  background: var(--dark-bg-tertiary);
+}
+
+.execution-flow-node.frontend {
+  background: rgba(57, 197, 207, 0.15);
+  border-color: rgba(57, 197, 207, 0.4);
+  width: auto;
+  min-width: 140px;
+}
+
+.execution-flow-node .node-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 4px;
+  min-width: 0;
+}
+
+.execution-flow-node .node-executor {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--dark-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.execution-flow-node .node-timing {
+  display: flex;
+  gap: 4px;
+  font-size: 0.65rem;
+}
+
+.execution-flow-node .node-start {
+  color: var(--dark-accent-yellow);
+  background: rgba(210, 153, 34, 0.2);
+  padding: 1px 4px;
+  border-radius: 2px;
+}
+
+.execution-flow-node .node-duration {
+  color: var(--dark-accent-cyan);
+  background: rgba(57, 197, 207, 0.2);
+  padding: 1px 4px;
+  border-radius: 2px;
+}
+
+.execution-flow-node .node-error {
+  margin-top: 4px;
+  color: var(--dark-accent-red);
+  font-size: 0.65rem;
+  font-weight: 600;
+}
+
+/* Group Node Styles */
+.execution-flow-node.group-node {
+  min-width: 180px;
+  text-align: center;
+  border-style: dashed;
+}
+
+.execution-flow-node.group-node .node-header {
+  justify-content: center;
+}
+
+.execution-flow-node.group-node .node-type {
+  font-size: 0.8rem;
+}
+
+.execution-flow-node.group-node .node-timing {
+  justify-content: center;
+}
+
+/* Grouped nodes list in details panel */
+.grouped-nodes-list h6 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 10px;
+  color: var(--dark-text);
+  border-top: 1px solid var(--dark-border);
+  padding-top: 12px;
+}
+
+.grouped-nodes-table {
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.grouped-nodes-table table {
+  font-size: 0.75rem;
+}
+
+.grouped-nodes-table th {
+  position: sticky;
+  top: 0;
+  background: var(--dark-bg-tertiary);
+  z-index: 1;
+}
+
+/* Node Details Panel */
+.node-details-panel {
+  flex: 0 0 35%;
+  border-left: 1px solid var(--dark-border);
+  background: var(--dark-bg-secondary);
+  overflow-y: auto;
+  font-size: 0.875rem;
+  color: var(--dark-text);
+}
+
+.node-details-panel .panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--dark-border);
+  background: var(--dark-bg-tertiary);
+  position: sticky;
+  top: 0;
+}
+
+.node-details-panel .panel-header h6 {
+  margin: 0;
+  font-weight: 600;
+  color: var(--dark-text);
+}
+
+.node-details-panel .btn-close {
+  filter: invert(1);
+}
+
+.node-details-panel .panel-body {
+  padding: 16px;
+}
+
+.node-details-panel .detail-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+  align-items: center;
+}
+
+.node-details-panel .detail-row label {
+  font-weight: 500;
+  color: var(--dark-text-muted);
+  min-width: 100px;
+  margin: 0;
+}
+
+.node-details-panel .detail-row code {
+  font-size: 0.8rem;
+  background: var(--dark-bg);
+  padding: 2px 6px;
+  border-radius: 4px;
+  color: var(--dark-accent-cyan);
+}
+
+.node-details-panel .error-row {
+  background: rgba(248, 81, 73, 0.15);
+  padding: 8px;
+  border-radius: 4px;
+  margin: 8px 0;
+  border: 1px solid var(--dark-accent-red);
+}
+
+.node-details-panel .block-executions {
+  margin-top: 16px;
+  border-top: 1px solid var(--dark-border);
+  padding-top: 12px;
+}
+
+.node-details-panel .block-executions h6 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 10px;
+  color: var(--dark-text);
+}
+
+.node-details-panel .block-table-wrapper {
+  overflow-x: auto;
+}
+
+.node-details-panel .block-table-wrapper table {
+  font-size: 0.75rem;
+  color: var(--dark-text);
+}
+
+.node-details-panel .block-table-wrapper th {
+  white-space: nowrap;
+  font-weight: 600;
+  background: var(--dark-bg-tertiary);
+  color: var(--dark-text);
+  border-color: var(--dark-border);
+}
+
+.node-details-panel .block-table-wrapper td {
+  border-color: var(--dark-border);
+}
+
+.node-details-panel .block-table-wrapper code {
+  font-size: 0.7rem;
+  color: var(--dark-accent-cyan);
+}
+
+/* Badge overrides for dark theme */
+.query-diagnostics-page .badge.bg-primary {
+  background: rgba(88, 166, 255, 0.2) !important;
+  color: var(--dark-accent-blue);
+}
+
+.query-diagnostics-page .badge.bg-success {
+  background: rgba(63, 185, 80, 0.2) !important;
+  color: var(--dark-accent-green);
+}
+
+.query-diagnostics-page .badge.bg-warning {
+  background: rgba(210, 153, 34, 0.2) !important;
+  color: var(--dark-accent-yellow) !important;
+}
+
+.query-diagnostics-page .badge.bg-info {
+  background: rgba(57, 197, 207, 0.2) !important;
+  color: var(--dark-accent-cyan) !important;
+}
+
+.query-diagnostics-page .badge.bg-secondary {
+  background: var(--dark-bg) !important;
+  color: var(--dark-text-muted);
+}
+
+.query-diagnostics-page .badge.bg-light {
+  background: var(--dark-bg) !important;
+  color: var(--dark-text);
+}
+
+/* Table styles for dark theme */
+.query-diagnostics-page .table {
+  color: var(--dark-text);
+  border-color: var(--dark-border);
+}
+
+.query-diagnostics-page .table > :not(caption) > * > * {
+  background-color: transparent;
+  border-color: var(--dark-border);
+}
+
+.query-diagnostics-page .table-hover > tbody > tr:hover > * {
+  background-color: var(--dark-bg-tertiary);
+}
+
+/* React Flow overrides for dark theme */
+.react-flow__node {
+  cursor: pointer;
+}
+
+.react-flow__controls {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+  background: var(--dark-bg-secondary);
+  border: 1px solid var(--dark-border);
+  border-radius: 8px;
+}
+
+.react-flow__controls-button {
+  background: var(--dark-bg-secondary);
+  border-color: var(--dark-border);
+  fill: var(--dark-text);
+}
+
+.react-flow__controls-button:hover {
+  background: var(--dark-bg-tertiary);
+}
+
+.react-flow__minimap {
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+  background: var(--dark-bg-secondary) !important;
+}
+
+.react-flow__edge-path {
+  stroke: #666;
+}
+
+/* Animation States for Execution Flow Nodes */
+@keyframes borderRotate {
+  0% {
+    border-color: var(--dark-accent-yellow);
+    box-shadow: 0 0 8px rgba(210, 153, 34, 0.5), 0 2px 8px rgba(0, 0, 0, 0.3);
+  }
+  50% {
+    border-color: var(--dark-accent-cyan);
+    box-shadow: 0 0 12px rgba(57, 197, 207, 0.6), 0 2px 8px rgba(0, 0, 0, 0.3);
+  }
+  100% {
+    border-color: var(--dark-accent-yellow);
+    box-shadow: 0 0 8px rgba(210, 153, 34, 0.5), 0 2px 8px rgba(0, 0, 0, 0.3);
+  }
+}
+
+@keyframes pulseGlow {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.9;
+    transform: scale(1.01);
+  }
+}
+
+.execution-flow-node.pending {
+  opacity: 0.4;
+  filter: grayscale(0.5);
+}
+
+.execution-flow-node.active {
+  animation: borderRotate 1s ease-in-out infinite,
+    pulseGlow 1s ease-in-out infinite;
+  border-width: 2px;
+}
+
+.execution-flow-node.active.merge {
+  background: rgba(88, 166, 255, 0.3);
+  border-color: var(--dark-accent-blue);
+}
+
+.execution-flow-node.active.read {
+  background: rgba(63, 185, 80, 0.2);
+  border-color: var(--dark-accent-green);
+}
+
+.execution-flow-node.active.frontend {
+  background: rgba(57, 197, 207, 0.3);
+  border-color: var(--dark-accent-cyan);
+}
+
+.execution-flow-node.completed {
+  opacity: 1;
+  box-shadow: 0 0 4px rgba(63, 185, 80, 0.3), 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+.execution-flow-node.completed.merge {
+  border-color: rgba(88, 166, 255, 0.5);
+}
+
+.execution-flow-node.completed.read {
+  border-color: var(--dark-accent-green);
+}
+
+.execution-flow-node.completed.frontend {
+  border-color: rgba(57, 197, 207, 0.5);
+}
+
+/* Playback Controls */
+.playback-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--dark-bg-secondary);
+  border: 1px solid var(--dark-border);
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+}
+
+.playback-btn {
+  background: var(--dark-bg-tertiary);
+  border: 1px solid var(--dark-border);
+  color: var(--dark-text);
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  transition: all 0.15s ease;
+}
+
+.playback-btn:hover {
+  background: var(--dark-bg);
+  border-color: var(--dark-accent-blue);
+}
+
+.playback-btn.play-pause {
+  width: 32px;
+  height: 32px;
+  font-size: 14px;
+  background: var(--dark-accent-blue);
+  border-color: var(--dark-accent-blue);
+}
+
+.playback-btn.play-pause:hover {
+  background: #4a90e0;
+  border-color: #4a90e0;
+}
+
+.playback-progress {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 200px;
+}
+
+.progress-slider {
+  width: 120px;
+  height: 4px;
+  -webkit-appearance: none;
+  appearance: none;
+  background: var(--dark-bg);
+  border-radius: 2px;
+  cursor: pointer;
+}
+
+.progress-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 12px;
+  height: 12px;
+  background: var(--dark-accent-blue);
+  border-radius: 50%;
+  cursor: pointer;
+  transition: transform 0.1s ease;
+}
+
+.progress-slider::-webkit-slider-thumb:hover {
+  transform: scale(1.2);
+}
+
+.progress-slider::-moz-range-thumb {
+  width: 12px;
+  height: 12px;
+  background: var(--dark-accent-blue);
+  border-radius: 50%;
+  cursor: pointer;
+  border: none;
+}
+
+.time-display {
+  font-family: monospace;
+  font-size: 0.7rem;
+  color: var(--dark-text-muted);
+  white-space: nowrap;
+}
+
+.speed-select {
+  background: var(--dark-bg);
+  border: 1px solid var(--dark-border);
+  color: var(--dark-text);
+  padding: 4px 6px;
+  border-radius: 4px;
+  font-size: 0.7rem;
+  cursor: pointer;
+}
+
+.speed-select:focus {
+  outline: none;
+  border-color: var(--dark-accent-blue);
+}

--- a/ui/src/admin/styles.css
+++ b/ui/src/admin/styles.css
@@ -926,15 +926,21 @@
 @keyframes borderRotate {
   0% {
     border-color: var(--dark-accent-yellow);
-    box-shadow: 0 0 8px rgba(210, 153, 34, 0.5), 0 2px 8px rgba(0, 0, 0, 0.3);
+    box-shadow:
+      0 0 8px rgba(210, 153, 34, 0.5),
+      0 2px 8px rgba(0, 0, 0, 0.3);
   }
   50% {
     border-color: var(--dark-accent-cyan);
-    box-shadow: 0 0 12px rgba(57, 197, 207, 0.6), 0 2px 8px rgba(0, 0, 0, 0.3);
+    box-shadow:
+      0 0 12px rgba(57, 197, 207, 0.6),
+      0 2px 8px rgba(0, 0, 0, 0.3);
   }
   100% {
     border-color: var(--dark-accent-yellow);
-    box-shadow: 0 0 8px rgba(210, 153, 34, 0.5), 0 2px 8px rgba(0, 0, 0, 0.3);
+    box-shadow:
+      0 0 8px rgba(210, 153, 34, 0.5),
+      0 2px 8px rgba(0, 0, 0, 0.3);
   }
 }
 
@@ -956,7 +962,8 @@
 }
 
 .execution-flow-node.active {
-  animation: borderRotate 1s ease-in-out infinite,
+  animation:
+    borderRotate 1s ease-in-out infinite,
     pulseGlow 1s ease-in-out infinite;
   border-width: 2px;
 }
@@ -978,7 +985,9 @@
 
 .execution-flow-node.completed {
   opacity: 1;
-  box-shadow: 0 0 4px rgba(63, 185, 80, 0.3), 0 2px 6px rgba(0, 0, 0, 0.3);
+  box-shadow:
+    0 0 4px rgba(63, 185, 80, 0.3),
+    0 2px 6px rgba(0, 0, 0, 0.3);
 }
 
 .execution-flow-node.completed.merge {

--- a/ui/src/admin/types.ts
+++ b/ui/src/admin/types.ts
@@ -1,0 +1,182 @@
+export type QueryMethod =
+  | 'SelectMergeStacktraces'
+  | 'SelectMergeProfile'
+  | 'SelectMergeSpanProfile'
+  | 'SelectSeries'
+  | 'SelectHeatmap'
+  | 'Diff'
+  | 'LabelNames'
+  | 'LabelValues'
+  | 'Series'
+  | 'ProfileTypes';
+
+export const QUERY_METHODS: QueryMethod[] = [
+  'SelectMergeStacktraces',
+  'SelectMergeProfile',
+  'SelectMergeSpanProfile',
+  'SelectSeries',
+  'SelectHeatmap',
+  'Diff',
+  'LabelNames',
+  'LabelValues',
+  'Series',
+  'ProfileTypes',
+];
+
+export interface QueryParams {
+  tenantId: string;
+  method: QueryMethod;
+  startTime: string;
+  endTime: string;
+  labelSelector: string;
+  profileTypeId: string;
+  maxNodes: string;
+  format: string;
+  spanSelector: string;
+  labelName: string;
+  labelNames: string;
+  step: string;
+  groupBy: string;
+  aggregation: string;
+  limit: string;
+  heatmapQueryType: string;
+  exemplarType: string;
+  diffLeftSelector: string;
+  diffLeftProfileType: string;
+  diffLeftStart: string;
+  diffLeftEnd: string;
+  diffRightSelector: string;
+  diffRightProfileType: string;
+  diffRightStart: string;
+  diffRightEnd: string;
+}
+
+export interface DiagnosticSummary {
+  id: string;
+  created_at: string;
+  method: string;
+  response_time_ms: number;
+  response_size_bytes: number;
+  request?: unknown;
+}
+
+// Raw diagnostic from API - uses snake_case JSON field names
+export interface RawDiagnostic {
+  id: string;
+  tenant_id: string;
+  created_at: string;
+  method: string;
+  response_time_ms: number;
+  response_size_bytes: number;
+  request?: unknown;
+  plan?: RawQueryPlan;
+  execution?: RawExecutionNode;
+}
+
+export interface RawQueryPlan {
+  root?: RawQueryNode;
+}
+
+export interface RawQueryNode {
+  type: number; // Protobuf enum: 0=MERGE, 1=READ
+  children?: RawQueryNode[];
+  blocks?: RawBlockMeta[];
+}
+
+export interface RawBlockMeta {
+  id: string;
+  shard: number;
+  size: number;
+  compaction_level: number;
+  datasets?: RawDataset[];
+  string_table?: string[];
+}
+
+export interface RawDataset {
+  name: number;
+  size: number;
+}
+
+export interface RawExecutionNode {
+  type: number; // Protobuf enum
+  executor: string;
+  start_time_ns: number;
+  end_time_ns: number;
+  children?: RawExecutionNode[];
+  stats?: RawExecutionStats;
+  error?: string;
+}
+
+export interface RawExecutionStats {
+  blocks_read: number;
+  datasets_processed: number;
+  block_executions?: RawBlockExecution[];
+}
+
+export interface RawBlockExecution {
+  block_id: string;
+  start_time_ns: number;
+  end_time_ns: number;
+  datasets_processed: number;
+  size: number;
+  shard: number;
+  compaction_level: number;
+}
+
+// Processed types for display
+export interface PlanTreeNode {
+  type: 'MERGE' | 'READ';
+  children?: PlanTreeNode[];
+  blockCount: number;
+  blocks: PlanTreeBlock[];
+  totalBlocks: number;
+}
+
+export interface PlanTreeBlock {
+  id: string;
+  shard: number;
+  size: string;
+  compactionLevel: number;
+}
+
+export interface ExecutionTreeNode {
+  type: string;
+  executor: string;
+  duration: number;
+  durationStr: string;
+  relativeStart: number;
+  relativeStartStr: string;
+  children?: ExecutionTreeNode[];
+  stats?: ExecutionTreeStats;
+  error?: string;
+}
+
+export interface ExecutionTreeStats {
+  blocksRead: number;
+  datasetsProcessed: number;
+  blockExecutions?: BlockExecutionInfo[];
+}
+
+export interface BlockExecutionInfo {
+  blockId: string;
+  duration: number;
+  durationStr: string;
+  relativeStart: number;
+  relativeStartStr: string;
+  relativeEnd: number;
+  relativeEndStr: string;
+  datasetsProcessed: number;
+  size: string;
+  shard: number;
+  compactionLevel: number;
+}
+
+// BlockMeta for metadata stats calculation
+export interface BlockMeta {
+  id: string;
+  shard: number;
+  size: number;
+  compaction_level: number;
+  datasets?: RawDataset[];
+  string_table?: string[];
+}

--- a/ui/src/admin/utils.ts
+++ b/ui/src/admin/utils.ts
@@ -1,0 +1,365 @@
+import type {
+  BlockExecutionInfo,
+  BlockMeta,
+  ExecutionTreeNode,
+  ExecutionTreeStats,
+  PlanTreeNode,
+  RawBlockMeta,
+  RawExecutionNode,
+  RawQueryNode,
+  RawQueryPlan,
+} from './types';
+
+export function getBasePath(): string {
+  const path = window.location.pathname;
+  const match = path.match(/^(.*\/admin)\//);
+  if (match) {
+    return match[1];
+  }
+  return '';
+}
+
+export function getQueryFrontendBasePath(): string {
+  const basePath = getBasePath();
+  if (basePath.endsWith('/admin')) {
+    return basePath.slice(0, -6) + '/query-frontend';
+  }
+  return basePath;
+}
+
+// Protobuf enums are serialized as numbers by Go's json.Marshal
+// QueryNode_UNKNOWN = 0, QueryNode_MERGE = 1, QueryNode_READ = 2
+const QUERY_NODE_TYPE_MAP: Record<number | string, 'MERGE' | 'READ'> = {
+  1: 'MERGE',
+  2: 'READ',
+  MERGE: 'MERGE',
+  READ: 'READ',
+};
+
+function getNodeType(type: number | string): 'MERGE' | 'READ' {
+  return QUERY_NODE_TYPE_MAP[type] || 'MERGE';
+}
+
+export function formatDuration(ns: number): string {
+  const ms = ns / 1e6;
+  if (ms < 1) {
+    return `${ms.toFixed(2)}ms`;
+  }
+  if (ms < 1000) {
+    return `${ms.toFixed(2)}ms`;
+  }
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+export function formatMs(ms: number): string {
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes === 0) {
+    return '-';
+  }
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+  let unitIndex = 0;
+  let size = bytes;
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex++;
+  }
+  return `${size.toFixed(1)} ${units[unitIndex]}`;
+}
+
+export function formatTime(isoString: string): string {
+  const d = new Date(isoString);
+  return d.toISOString().replace('T', ' ').substring(0, 19);
+}
+
+export function convertQueryPlanToTree(
+  plan: RawQueryPlan
+): PlanTreeNode | null {
+  if (!plan || !plan.root) {
+    return null;
+  }
+  return convertQueryNodeToTree(plan.root);
+}
+
+function convertQueryNodeToTree(node: RawQueryNode): PlanTreeNode | null {
+  if (!node) {
+    return null;
+  }
+
+  const nodeType = getNodeType(node.type);
+
+  const treeNode: PlanTreeNode = {
+    type: nodeType,
+    children: [],
+    blockCount: 0,
+    blocks: [],
+    totalBlocks: 0,
+  };
+
+  if (nodeType === 'MERGE') {
+    treeNode.children = (node.children || [])
+      .map(convertQueryNodeToTree)
+      .filter((n): n is PlanTreeNode => n !== null);
+    treeNode.totalBlocks = treeNode.children.reduce(
+      (sum, child) => sum + child.totalBlocks,
+      0
+    );
+  } else {
+    treeNode.blockCount = node.blocks?.length || 0;
+    treeNode.totalBlocks = treeNode.blockCount;
+    treeNode.blocks = (node.blocks || []).map((block: RawBlockMeta) => ({
+      id: block.id,
+      shard: block.shard ?? 0,
+      size: formatBytes(block.size),
+      compactionLevel: block.compaction_level ?? 0,
+    }));
+  }
+
+  return treeNode;
+}
+
+export function extractBlocksFromPlan(plan: RawQueryPlan): BlockMeta[] {
+  if (!plan || !plan.root) {
+    return [];
+  }
+  const blocks: BlockMeta[] = [];
+  extractBlocksFromNode(plan.root, blocks);
+  return blocks;
+}
+
+function extractBlocksFromNode(node: RawQueryNode, blocks: BlockMeta[]): void {
+  if (!node) {
+    return;
+  }
+  const nodeType = getNodeType(node.type);
+  if (nodeType === 'READ' && node.blocks) {
+    for (const rawBlock of node.blocks) {
+      blocks.push({
+        id: rawBlock.id,
+        shard: rawBlock.shard,
+        size: rawBlock.size,
+        compaction_level: rawBlock.compaction_level,
+        datasets: rawBlock.datasets,
+        string_table: rawBlock.string_table,
+      });
+    }
+  }
+  for (const child of node.children || []) {
+    extractBlocksFromNode(child, blocks);
+  }
+}
+
+export function buildMetadataStats(
+  blocks: BlockMeta[],
+  startTime: Date,
+  endTime: Date
+): string {
+  let result = `Blocks found: ${blocks.length}\n`;
+  result += `Time range: ${startTime.toISOString()} to ${endTime.toISOString()}`;
+
+  if (blocks.length === 0) {
+    return result;
+  }
+
+  let totalBlockSize = 0;
+  let totalDatasetSize = 0;
+  let totalDatasets = 0;
+
+  let largestBlock: BlockMeta | null = null;
+  let smallestBlock: BlockMeta | null = null;
+
+  interface DatasetInfo {
+    dataset: { name: number; size: number };
+    block: BlockMeta;
+  }
+  let largestDataset: DatasetInfo | null = null;
+  let smallestDataset: DatasetInfo | null = null;
+
+  for (const block of blocks) {
+    totalBlockSize += block.size;
+
+    if (!largestBlock || block.size > largestBlock.size) {
+      largestBlock = block;
+    }
+    if (!smallestBlock || block.size < smallestBlock.size) {
+      smallestBlock = block;
+    }
+
+    for (const ds of block.datasets || []) {
+      totalDatasetSize += ds.size;
+      totalDatasets++;
+
+      if (!largestDataset || ds.size > largestDataset.dataset.size) {
+        largestDataset = { dataset: ds, block };
+      }
+      if (!smallestDataset || ds.size < smallestDataset.dataset.size) {
+        smallestDataset = { dataset: ds, block };
+      }
+    }
+  }
+
+  result += '\n\nBlock Statistics:\n';
+  result += `  Total size: ${formatBytes(totalBlockSize)}\n`;
+  if (blocks.length > 0) {
+    const avgBlockSize = Math.floor(totalBlockSize / blocks.length);
+    result += `  Average size: ${formatBytes(avgBlockSize)}\n`;
+  }
+  if (largestBlock) {
+    result += `  Largest: ${formatBytes(largestBlock.size)} (${
+      largestBlock.id
+    }, shard ${largestBlock.shard}, L${largestBlock.compaction_level ?? 0})\n`;
+  }
+  if (smallestBlock) {
+    result += `  Smallest: ${formatBytes(smallestBlock.size)} (${
+      smallestBlock.id
+    }, shard ${smallestBlock.shard}, L${smallestBlock.compaction_level ?? 0})`;
+  }
+
+  if (totalDatasets > 0) {
+    result += '\n\nDataset Statistics:\n';
+    result += `  Total datasets: ${totalDatasets}\n`;
+    result += `  Total size: ${formatBytes(totalDatasetSize)}\n`;
+    const avgDatasetSize = Math.floor(totalDatasetSize / totalDatasets);
+    result += `  Average size: ${formatBytes(avgDatasetSize)}\n`;
+    if (largestDataset) {
+      const dsName = getDatasetName(
+        largestDataset.dataset,
+        largestDataset.block
+      );
+      result += `  Largest: ${formatBytes(
+        largestDataset.dataset.size
+      )} (${dsName} in ${largestDataset.block.id}, shard ${
+        largestDataset.block.shard
+      }, L${largestDataset.block.compaction_level ?? 0})\n`;
+    }
+    if (smallestDataset) {
+      const dsName = getDatasetName(
+        smallestDataset.dataset,
+        smallestDataset.block
+      );
+      result += `  Smallest: ${formatBytes(
+        smallestDataset.dataset.size
+      )} (${dsName} in ${smallestDataset.block.id}, shard ${
+        smallestDataset.block.shard
+      }, L${smallestDataset.block.compaction_level ?? 0})`;
+    }
+  }
+
+  return result;
+}
+
+function getDatasetName(
+  ds: { name: number; size: number },
+  block: BlockMeta
+): string {
+  if (
+    ds.name >= 0 &&
+    block.string_table &&
+    ds.name < block.string_table.length
+  ) {
+    return block.string_table[ds.name];
+  }
+  return `dataset-${ds.name}`;
+}
+
+export function convertExecutionNodeToTree(
+  node: RawExecutionNode
+): ExecutionTreeNode | null {
+  if (!node) {
+    return null;
+  }
+
+  const queryStartNs = findEarliestStartTime(node);
+  return convertExecutionNodeToTreeWithBase(node, queryStartNs);
+}
+
+function findEarliestStartTime(node: RawExecutionNode): number {
+  if (!node) {
+    return 0;
+  }
+
+  let earliest = node.start_time_ns;
+
+  if (node.stats?.block_executions) {
+    for (const blockExec of node.stats.block_executions) {
+      if (blockExec.start_time_ns < earliest) {
+        earliest = blockExec.start_time_ns;
+      }
+    }
+  }
+
+  for (const child of node.children || []) {
+    const childEarliest = findEarliestStartTime(child);
+    if (childEarliest > 0 && childEarliest < earliest) {
+      earliest = childEarliest;
+    }
+  }
+
+  return earliest;
+}
+
+function convertExecutionNodeToTreeWithBase(
+  node: RawExecutionNode,
+  queryStartNs: number
+): ExecutionTreeNode | null {
+  if (!node) {
+    return null;
+  }
+
+  const durationNs = node.end_time_ns - node.start_time_ns;
+  const relativeStartNs = node.start_time_ns - queryStartNs;
+
+  const nodeType = getNodeType(node.type);
+
+  const tree: ExecutionTreeNode = {
+    type: nodeType,
+    executor: node.executor,
+    duration: durationNs,
+    durationStr: formatDuration(durationNs),
+    relativeStart: relativeStartNs,
+    relativeStartStr: formatDuration(relativeStartNs),
+    error: node.error,
+  };
+
+  if (node.stats) {
+    const stats: ExecutionTreeStats = {
+      blocksRead: node.stats.blocks_read,
+      datasetsProcessed: node.stats.datasets_processed,
+      blockExecutions: [],
+    };
+
+    for (const blockExec of node.stats.block_executions || []) {
+      const blockDurationNs = blockExec.end_time_ns - blockExec.start_time_ns;
+      const blockRelStartNs = blockExec.start_time_ns - queryStartNs;
+      const blockRelEndNs = blockExec.end_time_ns - queryStartNs;
+
+      const blockInfo: BlockExecutionInfo = {
+        blockId: blockExec.block_id,
+        duration: blockDurationNs,
+        durationStr: formatDuration(blockDurationNs),
+        relativeStart: blockRelStartNs,
+        relativeStartStr: formatDuration(blockRelStartNs),
+        relativeEnd: blockRelEndNs,
+        relativeEndStr: formatDuration(blockRelEndNs),
+        datasetsProcessed: blockExec.datasets_processed ?? 0,
+        size: formatBytes(blockExec.size),
+        shard: blockExec.shard ?? 0,
+        compactionLevel: blockExec.compaction_level ?? 0,
+      };
+      stats.blockExecutions!.push(blockInfo);
+    }
+
+    tree.stats = stats;
+  }
+
+  tree.children = (node.children || [])
+    .map((child) => convertExecutionNodeToTreeWithBase(child, queryStartNs))
+    .filter((n): n is ExecutionTreeNode => n !== null);
+
+  return tree;
+}

--- a/ui/src/admin/utils.ts
+++ b/ui/src/admin/utils.ts
@@ -78,7 +78,7 @@ export function formatTime(isoString: string): string {
 }
 
 export function convertQueryPlanToTree(
-  plan: RawQueryPlan
+  plan: RawQueryPlan,
 ): PlanTreeNode | null {
   if (!plan || !plan.root) {
     return null;
@@ -107,7 +107,7 @@ function convertQueryNodeToTree(node: RawQueryNode): PlanTreeNode | null {
       .filter((n): n is PlanTreeNode => n !== null);
     treeNode.totalBlocks = treeNode.children.reduce(
       (sum, child) => sum + child.totalBlocks,
-      0
+      0,
     );
   } else {
     treeNode.blockCount = node.blocks?.length || 0;
@@ -157,7 +157,7 @@ function extractBlocksFromNode(node: RawQueryNode, blocks: BlockMeta[]): void {
 export function buildMetadataStats(
   blocks: BlockMeta[],
   startTime: Date,
-  endTime: Date
+  endTime: Date,
 ): string {
   let result = `Blocks found: ${blocks.length}\n`;
   result += `Time range: ${startTime.toISOString()} to ${endTime.toISOString()}`;
@@ -229,10 +229,10 @@ export function buildMetadataStats(
     if (largestDataset) {
       const dsName = getDatasetName(
         largestDataset.dataset,
-        largestDataset.block
+        largestDataset.block,
       );
       result += `  Largest: ${formatBytes(
-        largestDataset.dataset.size
+        largestDataset.dataset.size,
       )} (${dsName} in ${largestDataset.block.id}, shard ${
         largestDataset.block.shard
       }, L${largestDataset.block.compaction_level ?? 0})\n`;
@@ -240,10 +240,10 @@ export function buildMetadataStats(
     if (smallestDataset) {
       const dsName = getDatasetName(
         smallestDataset.dataset,
-        smallestDataset.block
+        smallestDataset.block,
       );
       result += `  Smallest: ${formatBytes(
-        smallestDataset.dataset.size
+        smallestDataset.dataset.size,
       )} (${dsName} in ${smallestDataset.block.id}, shard ${
         smallestDataset.block.shard
       }, L${smallestDataset.block.compaction_level ?? 0})`;
@@ -255,7 +255,7 @@ export function buildMetadataStats(
 
 function getDatasetName(
   ds: { name: number; size: number },
-  block: BlockMeta
+  block: BlockMeta,
 ): string {
   if (
     ds.name >= 0 &&
@@ -268,7 +268,7 @@ function getDatasetName(
 }
 
 export function convertExecutionNodeToTree(
-  node: RawExecutionNode
+  node: RawExecutionNode,
 ): ExecutionTreeNode | null {
   if (!node) {
     return null;
@@ -305,7 +305,7 @@ function findEarliestStartTime(node: RawExecutionNode): number {
 
 function convertExecutionNodeToTreeWithBase(
   node: RawExecutionNode,
-  queryStartNs: number
+  queryStartNs: number,
 ): ExecutionTreeNode | null {
   if (!node) {
     return null;

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -56,7 +56,9 @@ export default defineConfig({
           const names = [asset.name, ...(asset.names ?? [])].filter(
             (n): n is string => typeof n === 'string',
           );
-          if (names.some((n) => n === 'admin.css' || n.endsWith('/admin.css'))) {
+          if (
+            names.some((n) => n === 'admin.css' || n.endsWith('/admin.css'))
+          ) {
             return 'assets/admin.css';
           }
           return 'assets/[name]-[hash][extname]';

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -39,6 +39,30 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        index: fileURLToPath(new URL('./index.html', import.meta.url)),
+        admin: fileURLToPath(new URL('./src/admin/admin.tsx', import.meta.url)),
+      },
+      output: {
+        // Admin bundle is loaded by name from Go-rendered HTML templates
+        // (pkg/operations/v2/querydiagnostics/*.gohtml), so its filename must
+        // be stable. Other entries keep content hashes for cache busting.
+        entryFileNames: (chunk) =>
+          chunk.name === 'admin'
+            ? 'assets/admin.js'
+            : 'assets/[name]-[hash].js',
+        assetFileNames: (asset) => {
+          const names = [asset.name, ...(asset.names ?? [])].filter(
+            (n): n is string => typeof n === 'string',
+          );
+          if (names.some((n) => n === 'admin.css' || n.endsWith('/admin.css'))) {
+            return 'assets/admin.css';
+          }
+          return 'assets/[name]-[hash][extname]';
+        },
+      },
+    },
   },
   server: {
     proxy: {

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2021,12 +2021,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-interpolate@npm:^3.0.0":
+"@types/d3-drag@npm:^3.0.7":
+  version: 3.0.7
+  resolution: "@types/d3-drag@npm:3.0.7"
+  dependencies:
+    "@types/d3-selection": "npm:*"
+  checksum: 10c0/65e29fa32a87c72d26c44b5e2df3bf15af21cd128386bcc05bcacca255927c0397d0cd7e6062aed5f0abd623490544a9d061c195f5ed9f018fe0b698d99c079d
+  languageName: node
+  linkType: hard
+
+"@types/d3-interpolate@npm:*, @types/d3-interpolate@npm:^3.0.0, @types/d3-interpolate@npm:^3.0.4":
   version: 3.0.4
   resolution: "@types/d3-interpolate@npm:3.0.4"
   dependencies:
     "@types/d3-color": "npm:*"
   checksum: 10c0/066ebb8da570b518dd332df6b12ae3b1eaa0a7f4f0c702e3c57f812cf529cc3500ec2aac8dc094f31897790346c6b1ebd8cd7a077176727f4860c2b181a65ca4
+  languageName: node
+  linkType: hard
+
+"@types/d3-selection@npm:*, @types/d3-selection@npm:^3.0.10":
+  version: 3.0.11
+  resolution: "@types/d3-selection@npm:3.0.11"
+  checksum: 10c0/0c512956c7503ff5def4bb32e0c568cc757b9a2cc400a104fc0f4cfe5e56d83ebde2a97821b6f2cb26a7148079d3b86a2f28e11d68324ed311cf35c2ed980d1d
+  languageName: node
+  linkType: hard
+
+"@types/d3-transition@npm:^3.0.8":
+  version: 3.0.9
+  resolution: "@types/d3-transition@npm:3.0.9"
+  dependencies:
+    "@types/d3-selection": "npm:*"
+  checksum: 10c0/4f68b9df7ac745b3491216c54203cbbfa0f117ae4c60e2609cdef2db963582152035407fdff995b10ee383bae2f05b7743493f48e1b8e46df54faa836a8fb7b5
+  languageName: node
+  linkType: hard
+
+"@types/d3-zoom@npm:^3.0.8":
+  version: 3.0.8
+  resolution: "@types/d3-zoom@npm:3.0.8"
+  dependencies:
+    "@types/d3-interpolate": "npm:*"
+    "@types/d3-selection": "npm:*"
+  checksum: 10c0/1dbdbcafddcae12efb5beb6948546963f29599e18bc7f2a91fb69cc617c2299a65354f2d47e282dfb86fec0968406cd4fb7f76ba2d2fb67baa8e8d146eb4a547
   languageName: node
   linkType: hard
 
@@ -2426,6 +2461,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xyflow/react@npm:^12.10.0":
+  version: 12.10.2
+  resolution: "@xyflow/react@npm:12.10.2"
+  dependencies:
+    "@xyflow/system": "npm:0.0.76"
+    classcat: "npm:^5.0.3"
+    zustand: "npm:^4.4.0"
+  peerDependencies:
+    react: ">=17"
+    react-dom: ">=17"
+  checksum: 10c0/e6706bfd85c294c4b475851d4aa14f00a76e33106e67b620c349275c33f1bc46895a2daf75323630d049d6094b9f70d5fb940b823ac34dbf696449df4def1a94
+  languageName: node
+  linkType: hard
+
+"@xyflow/system@npm:0.0.76":
+  version: 0.0.76
+  resolution: "@xyflow/system@npm:0.0.76"
+  dependencies:
+    "@types/d3-drag": "npm:^3.0.7"
+    "@types/d3-interpolate": "npm:^3.0.4"
+    "@types/d3-selection": "npm:^3.0.10"
+    "@types/d3-transition": "npm:^3.0.8"
+    "@types/d3-zoom": "npm:^3.0.8"
+    d3-drag: "npm:^3.0.0"
+    d3-interpolate: "npm:^3.0.1"
+    d3-selection: "npm:^3.0.0"
+    d3-zoom: "npm:^3.0.0"
+  checksum: 10c0/49c78f7e7d1015bfd990011030d9375e237b7fd6bdbb3908f2b0cdb9cc7baddd49f104c0e75bf3a218ce9258845956293b62d81ff6df02db920c4ba3cabb3cfb
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:^4.0.0":
   version: 4.0.0
   resolution: "abbrev@npm:4.0.0"
@@ -2635,6 +2701,13 @@ __metadata:
   version: 3.0.0
   resolution: "chownr@npm:3.0.0"
   checksum: 10c0/43925b87700f7e3893296c8e9c56cc58f926411cce3a6e5898136daaf08f08b9a8eb76d37d3267e707d0dcc17aed2e2ebdf5848c0c3ce95cf910a919935c1b10
+  languageName: node
+  linkType: hard
+
+"classcat@npm:^5.0.3":
+  version: 5.0.5
+  resolution: "classcat@npm:5.0.5"
+  checksum: 10c0/ff8d273055ef9b518529cfe80fd0486f7057a9917373807ff802d75ceb46e8f8e148f41fa094ee7625c8f34642cfaa98395ff182d9519898da7cbf383d4a210d
   languageName: node
   linkType: hard
 
@@ -2855,7 +2928,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-drag@npm:2 - 3, d3-drag@npm:3":
+"d3-drag@npm:2 - 3, d3-drag@npm:3, d3-drag@npm:^3.0.0":
   version: 3.0.0
   resolution: "d3-drag@npm:3.0.0"
   dependencies:
@@ -2936,7 +3009,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-interpolate@npm:1 - 3, d3-interpolate@npm:1.2.0 - 3, d3-interpolate@npm:3, d3-interpolate@npm:3.0.1":
+"d3-interpolate@npm:1 - 3, d3-interpolate@npm:1.2.0 - 3, d3-interpolate@npm:3, d3-interpolate@npm:3.0.1, d3-interpolate@npm:^3.0.1":
   version: 3.0.1
   resolution: "d3-interpolate@npm:3.0.1"
   dependencies:
@@ -2996,7 +3069,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-selection@npm:2 - 3, d3-selection@npm:3":
+"d3-selection@npm:2 - 3, d3-selection@npm:3, d3-selection@npm:^3.0.0":
   version: 3.0.0
   resolution: "d3-selection@npm:3.0.0"
   checksum: 10c0/e59096bbe8f0cb0daa1001d9bdd6dbc93a688019abc97d1d8b37f85cd3c286a6875b22adea0931b0c88410d025563e1643019161a883c516acf50c190a11b56b
@@ -3052,7 +3125,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-zoom@npm:3":
+"d3-zoom@npm:3, d3-zoom@npm:^3.0.0":
   version: 3.0.0
   resolution: "d3-zoom@npm:3.0.0"
   dependencies:
@@ -6211,6 +6284,7 @@ __metadata:
     "@types/react": "npm:^19.2.14"
     "@types/react-dom": "npm:^19.2.3"
     "@vitejs/plugin-react": "npm:^6.0.1"
+    "@xyflow/react": "npm:^12.10.0"
     eslint: "npm:^9.39.4"
     eslint-config-prettier: "npm:^10.1.8"
     eslint-plugin-react-hooks: "npm:^7.0.1"
@@ -6282,7 +6356,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.4.0":
+"use-sync-external-store@npm:^1.2.2, use-sync-external-store@npm:^1.4.0":
   version: 1.6.0
   resolution: "use-sync-external-store@npm:1.6.0"
   peerDependencies:
@@ -6641,5 +6715,25 @@ __metadata:
   version: 0.1.0
   resolution: "zstddec@npm:0.1.0"
   checksum: 10c0/13601cc53211af491cf3a28a49239405e44129c7aba6a0211401d7bf79ee96b4679016a4d3c5e9c01f753e6da806eb40550f12c469580548b695b146a6d8fe1a
+  languageName: node
+  linkType: hard
+
+"zustand@npm:^4.4.0":
+  version: 4.5.7
+  resolution: "zustand@npm:4.5.7"
+  dependencies:
+    use-sync-external-store: "npm:^1.2.2"
+  peerDependencies:
+    "@types/react": ">=16.8"
+    immer: ">=9.0.6"
+    react: ">=16.8"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    immer:
+      optional: true
+    react:
+      optional: true
+  checksum: 10c0/55559e37a82f0c06cadc61cb08f08314c0fe05d6a93815e41e3376130c13db22a5017cbb0cd1f018c82f2dad0051afe3592561d40f980bd4082e32005e8a950c
   languageName: node
   linkType: hard


### PR DESCRIPTION
#4948 inadvertently removed files needed for #4806. This brings them back in the new `ui` folder. 

Tested locally at http://localhost:4040/query-diagnostics

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large front-end addition and build-output change (stable `admin.js`/module loading) could break admin pages or asset loading if bundling or paths differ across environments, but it is scoped to the query diagnostics admin UI.
> 
> **Overview**
> Restores the **Query Diagnostics** admin UI under `ui/src/admin`, including a query runner that loads tenants, executes querier methods with diagnostics collection, and can reload previously-stored diagnostics via URL params.
> 
> Adds a stored diagnostics browser with tenant selection, filtering/sorting, and zip import/export flows, plus a richer query plan and execution trace experience (visual plan tree + JSON view, and an animated execution trace graph via `@xyflow/react` with playback controls and per-node detail panel).
> 
> Updates the build/runtime wiring so Go-rendered templates load `assets/admin.js` as an ES module, and Vite is configured for a multi-entry build that outputs **stable** `assets/admin.js`/`assets/admin.css` filenames for the admin pages (while keeping hashed filenames for other entries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 115f1e2f73873873c77ce40aefb271e9006dd7bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->