### PR TITLE
compactionworker: default job concurrency to 1

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -54,7 +54,7 @@ Usage of ./pyroscope:
   -compaction-worker.cleanup-max-duration duration
     	Maximum duration of the cleanup operations. (default 15s)
   -compaction-worker.job-concurrency int
-    	Number of concurrent jobs compaction worker will run. Defaults to the number of CPU cores.
+    	Number of concurrent jobs compaction worker will run. Values less than 1 are treated as 1.
   -compaction-worker.job-poll-interval duration
     	Interval between job requests (default 5s)
   -compaction-worker.metrics-exporter.enabled

--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -54,7 +54,7 @@ Usage of ./pyroscope:
   -compaction-worker.cleanup-max-duration duration
     	Maximum duration of the cleanup operations. (default 15s)
   -compaction-worker.job-concurrency int
-    	Number of concurrent jobs compaction worker will run. Values less than 1 are treated as 1.
+    	Number of concurrent jobs compaction worker will run. Values less than 1 are treated as 1. (default 1)
   -compaction-worker.job-poll-interval duration
     	Interval between job requests (default 5s)
   -compaction-worker.metrics-exporter.enabled

--- a/pkg/compactionworker/worker.go
+++ b/pkg/compactionworker/worker.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -46,13 +45,20 @@ type Config struct {
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	const prefix = "compaction-worker."
-	f.IntVar(&cfg.JobConcurrency, prefix+"job-concurrency", 0, "Number of concurrent jobs compaction worker will run. Defaults to the number of CPU cores.")
+	f.IntVar(&cfg.JobConcurrency, prefix+"job-concurrency", 1, "Number of concurrent jobs compaction worker will run. Values less than 1 are treated as 1.")
 	f.DurationVar(&cfg.JobPollInterval, prefix+"job-poll-interval", 5*time.Second, "Interval between job requests")
 	f.DurationVar(&cfg.RequestTimeout, prefix+"request-timeout", 5*time.Second, "Job request timeout.")
 	f.DurationVar(&cfg.CleanupMaxDuration, prefix+"cleanup-max-duration", 15*time.Second, "Maximum duration of the cleanup operations.")
 	f.IntVar(&cfg.SmallObjectSize, prefix+"small-object-size-bytes", 8<<20, "Size of the object that can be loaded in memory.")
 	f.StringVar(&cfg.TempDir, prefix+"temp-dir", os.TempDir(), "Temporary directory for compaction jobs.")
 	cfg.MetricsExporter.RegisterFlags(f)
+}
+
+func effectiveJobConcurrency(configured int) int {
+	if configured < 1 {
+		return 1
+	}
+	return configured
 }
 
 type Worker struct {
@@ -123,10 +129,7 @@ func New(
 		ruler:     ruler,
 		exporter:  exporter,
 	}
-	w.threads = config.JobConcurrency
-	if w.threads < 1 {
-		w.threads = runtime.GOMAXPROCS(-1)
-	}
+	w.threads = effectiveJobConcurrency(config.JobConcurrency)
 	w.queue = make(chan *compactionJob, 2*w.threads)
 	w.jobs = make(map[string]*compactionJob, 2*w.threads)
 	w.capacity.Store(int32(w.threads))

--- a/pkg/compactionworker/worker_test.go
+++ b/pkg/compactionworker/worker_test.go
@@ -525,3 +525,9 @@ func TestWorker_CleanupMaxDurationAtShutdown(t *testing.T) {
 
 	require.Equal(t, 2, int(blocksDeleted.Load()))
 }
+
+func TestEffectiveJobConcurrency(t *testing.T) {
+	require.Equal(t, 1, effectiveJobConcurrency(0))
+	require.Equal(t, 1, effectiveJobConcurrency(-1))
+	require.Equal(t, 3, effectiveJobConcurrency(3))
+}


### PR DESCRIPTION
Summary
- default compaction-worker.job-concurrency to 1
- treat values below 1 as 1
- update help text and add a focused unit test

Why
compaction-worker currently defaults job-concurrency to 0, which resolves to runtime.GOMAXPROCS(-1).

For a memory-bound worker, CPU count is not a safe default for concurrency. On large nodes this can cause the worker to advertise a very large job capacity and run too many compactions in parallel by default.

Using 1 as the default makes the worker conservative and predictable, while still allowing operators to explicitly raise concurrency when they have enough memory headroom.

Changes
- change the flag default for -compaction-worker.job-concurrency from 0 to 1
- add effectiveJobConcurrency() so values below 1 resolve to 1
- remove the GOMAXPROCS fallback from worker initialization
- update CLI help text
- add a unit test for the fallback behavior

Validation
- go test ./pkg/compactionworker

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default `compaction-worker.job-concurrency` behavior, reducing parallelism by default and clamping misconfigured values, which can affect compaction throughput and job scheduling capacity in production deployments.
> 
> **Overview**
> Updates `compaction-worker.job-concurrency` to default to **1** (instead of deriving from CPU count) and introduces `effectiveJobConcurrency()` to clamp configured values `<1` up to 1.
> 
> This removes the previous `GOMAXPROCS` fallback during worker initialization, updates the CLI help text, and adds a focused unit test covering the new clamping behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b38eeffeba7783d68cae0835124760e95b2ed6d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->