### PR TITLE
docs(dotnet): update supported .NET versions to 8/9/10

### DIFF
--- a/docs/sources/configure-client/language-sdks/dotnet.md
+++ b/docs/sources/configure-client/language-sdks/dotnet.md
@@ -24,13 +24,18 @@ The .NET Profiler supports the following profiling types:
 * Allocations
 * Lock contention
 * Exceptions
-* Live heap (requires .NET 7+)
+* Live heap
 
 ### Compatibility
 
 The only compatible operating system and architecture combination is Linux running on amd64 architecture.
 
-Our .NET profiler works with .NET 6 and later versions.
+Our .NET profiler works with the following .NET versions:
+
+* .NET 8
+* .NET 9
+* .NET 10
+
 
 ## Before you begin
 
@@ -175,7 +180,7 @@ Here is a simple [example](https://github.com/grafana/pyroscope/blob/main/exampl
 | PYROSCOPE_PROFILING_EXCEPTION_ENABLED  | Boolean      | If set to true, enables the Exceptions profiling. Defaults to false.                                                              |
 | PYROSCOPE_PROFILING_ALLOCATION_ENABLED | Boolean      | If set to true, enables the Allocations profiling. Defaults to false.                                                             |
 | PYROSCOPE_PROFILING_LOCK_ENABLED       | Boolean      | If set to true, enables the Lock Contention profiling. Defaults to false.                                                         |
-| PYROSCOPE_PROFILING_HEAP_ENABLED       | Boolean      | If set to true, enables the Live heap profiling. Requires .NET 7+. Defaults to false.                                             |
+| PYROSCOPE_PROFILING_HEAP_ENABLED       | Boolean      | If set to true, enables the Live heap profiling. Defaults to false.                                                               |
 | PYROSCOPE_BASIC_AUTH_USER              | String       | For HTTP Basic Authentication, use this to send profiles to authenticated server, for example Grafana Cloud                       |
 | PYROSCOPE_BASIC_AUTH_PASSWORD          | String       | For HTTP Basic Authentication, use this to send profiles to authenticated server, for example Grafana Cloud                       |
 | PYROSCOPE_TENANT_ID                    | String       | Only needed if using multi-tenancy in Pyroscope.                                                                                  |


### PR DESCRIPTION
## Summary

- Replaces the ambiguous "".NET 6 and later versions"" with an explicit list of supported runtimes.
- Drops .NET 6 (no longer supported by the profiler) and .NET 7 (EOL); documents .NET 9 and .NET 10 as supported. Both already work per https://github.com/grafana/pyroscope-dotnet/issues/117.
- Removes the now-redundant "requires .NET 7+"" qualifiers on the Live heap bullet and the `PYROSCOPE_PROFILING_HEAP_ENABLED` env var description, since every supported version is .NET 8+.

Fixes grafana/pyroscope-dotnet#117.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that adjust stated runtime compatibility and remove outdated version requirements; no code or runtime behavior changes.
> 
> **Overview**
> Updates the .NET client docs to **replace the vague “.NET 6+” compatibility statement with an explicit supported runtime list** (`.NET 8`, `.NET 9`, `.NET 10`).
> 
> Also removes the `.NET 7+` requirement wording from *Live heap* profiling and `PYROSCOPE_PROFILING_HEAP_ENABLED`, since all documented supported versions are now `.NET 8+`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ab0be72d7f1a6d68d0e07d04fbff7ca3eb1c6db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->