### PR TITLE
chore: Release helm chart for v2.0.1

### DIFF
--- a/operations/pyroscope/helm/pyroscope/Chart.yaml
+++ b/operations/pyroscope/helm/pyroscope/Chart.yaml
@@ -3,7 +3,7 @@ name: pyroscope
 description: horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 home: https://grafana.com/oss/pyroscope/
 type: application
-version: 2.0.0
+version: 2.0.1
 appVersion: 2.0.1
 dependencies:
   - name: grafana-agent

--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -1,6 +1,6 @@
 # pyroscope
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
+![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
 
 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -27,7 +27,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -48,7 +48,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -69,7 +69,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -90,7 +90,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -111,7 +111,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -132,7 +132,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -176,7 +176,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -523,7 +523,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1381,7 +1381,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1398,7 +1398,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1683,7 +1683,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1710,7 +1710,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1735,7 +1735,7 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1761,7 +1761,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1786,7 +1786,7 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1812,7 +1812,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1837,7 +1837,7 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1863,7 +1863,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1888,7 +1888,7 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1914,7 +1914,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1939,7 +1939,7 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1965,7 +1965,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1990,7 +1990,7 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2016,7 +2016,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2041,7 +2041,7 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2067,7 +2067,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2082,7 +2082,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2171,7 +2171,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2186,7 +2186,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2275,7 +2275,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2290,7 +2290,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2379,7 +2379,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2394,7 +2394,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2483,7 +2483,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2511,7 +2511,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2542,7 +2542,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2570,7 +2570,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2781,7 +2781,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2799,7 +2799,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2893,7 +2893,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2911,7 +2911,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3001,7 +3001,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -3019,7 +3019,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -27,7 +27,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -48,7 +48,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -69,7 +69,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -90,7 +90,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -111,7 +111,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -132,7 +132,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -153,7 +153,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -174,7 +174,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -218,7 +218,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -565,7 +565,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1423,7 +1423,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1440,7 +1440,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1725,7 +1725,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1752,7 +1752,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1777,7 +1777,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1803,7 +1803,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1828,7 +1828,7 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1854,7 +1854,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1879,7 +1879,7 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1905,7 +1905,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1930,7 +1930,7 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1956,7 +1956,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1981,7 +1981,7 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2007,7 +2007,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2032,7 +2032,7 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2058,7 +2058,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2083,7 +2083,7 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2109,7 +2109,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2134,7 +2134,7 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2160,7 +2160,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2185,7 +2185,7 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2211,7 +2211,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2227,7 +2227,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2316,7 +2316,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2332,7 +2332,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2421,7 +2421,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2437,7 +2437,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2526,7 +2526,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2542,7 +2542,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2631,7 +2631,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2647,7 +2647,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2736,7 +2736,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2752,7 +2752,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3024,7 +3024,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -3042,7 +3042,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3136,7 +3136,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -3154,7 +3154,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3244,7 +3244,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -3262,7 +3262,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -27,7 +27,7 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -48,7 +48,7 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -69,7 +69,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -90,7 +90,7 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -111,7 +111,7 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -132,7 +132,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -153,7 +153,7 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -174,7 +174,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -218,7 +218,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -565,7 +565,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1423,7 +1423,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1440,7 +1440,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1598,7 +1598,7 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1623,7 +1623,7 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1770,7 +1770,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1797,7 +1797,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1826,7 +1826,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1856,7 +1856,7 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1885,7 +1885,7 @@ metadata:
   name: pyroscope-dev-admin-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1915,7 +1915,7 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1944,7 +1944,7 @@ metadata:
   name: pyroscope-dev-compaction-worker-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1974,7 +1974,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2003,7 +2003,7 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2033,7 +2033,7 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2066,7 +2066,7 @@ metadata:
   name: pyroscope-dev-metastore-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2101,7 +2101,7 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2130,7 +2130,7 @@ metadata:
   name: pyroscope-dev-query-backend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2160,7 +2160,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2189,7 +2189,7 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2219,7 +2219,7 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2248,7 +2248,7 @@ metadata:
   name: pyroscope-dev-segment-writer-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2278,7 +2278,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2307,7 +2307,7 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2337,7 +2337,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2353,7 +2353,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2447,7 +2447,7 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2463,7 +2463,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2557,7 +2557,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2573,7 +2573,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2667,7 +2667,7 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2683,7 +2683,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2777,7 +2777,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2793,7 +2793,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2887,7 +2887,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2903,7 +2903,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3180,7 +3180,7 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -3198,7 +3198,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3293,7 +3293,7 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -3311,7 +3311,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3422,7 +3422,7 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -3440,7 +3440,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -27,7 +27,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -48,7 +48,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -69,7 +69,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -90,7 +90,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -111,7 +111,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -132,7 +132,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -153,7 +153,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -174,7 +174,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -218,7 +218,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -565,7 +565,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1423,7 +1423,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1440,7 +1440,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1725,7 +1725,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1752,7 +1752,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1777,7 +1777,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1803,7 +1803,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1828,7 +1828,7 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1854,7 +1854,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1879,7 +1879,7 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1905,7 +1905,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1930,7 +1930,7 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1956,7 +1956,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1981,7 +1981,7 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2007,7 +2007,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2032,7 +2032,7 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2058,7 +2058,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2083,7 +2083,7 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2109,7 +2109,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2134,7 +2134,7 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2160,7 +2160,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2185,7 +2185,7 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2211,7 +2211,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2227,7 +2227,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2315,7 +2315,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2331,7 +2331,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2419,7 +2419,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2435,7 +2435,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2524,7 +2524,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2540,7 +2540,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2628,7 +2628,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2644,7 +2644,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2732,7 +2732,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -2748,7 +2748,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3019,7 +3019,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -3037,7 +3037,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3130,7 +3130,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -3148,7 +3148,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3237,7 +3237,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -3255,7 +3255,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 170fde6443d1286d330ec3d042168876af6584025a541f76a279a8f325c5a2d8
+        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -43,7 +43,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -56,7 +56,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -914,7 +914,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -931,7 +931,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1082,7 +1082,7 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1107,7 +1107,7 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1186,7 +1186,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1213,7 +1213,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1246,7 +1246,7 @@ metadata:
   name: pyroscope-dev-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1371,7 +1371,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1389,7 +1389,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7ec43b2c81007176b25964b78dbdde4d205aaab411747d7d1f527d2570dcf3ca
+        checksum/config: ac9201897d9e0c615be86351df4d32ec53b636b9683bf9c99e86002ff9d55362
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -43,7 +43,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -56,7 +56,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -914,7 +914,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -931,7 +931,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1141,7 +1141,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1168,7 +1168,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1193,7 +1193,7 @@ metadata:
   name: pyroscope-dev-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1309,7 +1309,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.0
+    helm.sh/chart: pyroscope-2.0.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.0.1"
@@ -1327,7 +1327,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7ec43b2c81007176b25964b78dbdde4d205aaab411747d7d1f527d2570dcf3ca
+        checksum/config: ac9201897d9e0c615be86351df4d32ec53b636b9683bf9c99e86002ff9d55362
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.0.1"
         profiles.grafana.com/cpu.port_name: http2


### PR DESCRIPTION
## Summary

Chart patch bump `2.0.0` → `2.0.1` to republish the chart after the description fix in #5099 (the 🔥 emoji broke uploads on stricter registries like Artifactory). Without a version bump, the fix never reaches users — registries reject re-pushes of an existing version.

- `appVersion` stays at `2.0.1` — no Pyroscope binary change
- Rendered manifests regenerated via `make helm/check`; only `helm.sh/chart` labels changed
- README regenerated via `make helm/docs`

## Test plan

- [x] `make helm/docs` — README badge updated to `Version: 2.0.1`
- [x] `make helm/check` — all 298 resources across single-binary / single-binary-v2 / micro-services / micro-services-v2 / legacy-micro-services / legacy-micro-services-hpa pass `kubeconform --strict`
- [ ] Verify chart `2.0.1` publishes to the Grafana helm repo after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a Helm chart patch/version republish with regenerated manifests; no runtime/appVersion change, but it will trigger rollout due to updated `helm.sh/chart` labels and config checksums in rendered outputs.
> 
> **Overview**
> Bumps the `pyroscope` Helm chart version from `2.0.0` to `2.0.1` (keeping `appVersion` at `2.0.1`) to republish the chart.
> 
> Regenerates Helm docs and rendered manifests so embedded `helm.sh/chart` labels (and associated `checksum/config` annotations in the rendered YAML) reflect the new chart version across single-binary and microservices variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c66f693a6eb905ba6fc34df4eb8b0dafdf826d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->