### PR TITLE
ci: use shared dockerhub-login action for Docker Hub auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,18 +163,8 @@ jobs:
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version: 1.25.9
-      # login to docker hub
-      - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@c2f1df59dba624b3fd509e5181aa8da5217120c0
-        with:
-          common_secrets: |
-            DOCKERHUB_USERNAME=dockerhub:username
-            DOCKERHUB_PASSWORD=dockerhub:password
-      - uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
-        name: Login to Docker Hub
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_PASSWORD }}
+      - name: Login to DockerHub (from vault)
+        uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
       - name: Pyroscope Build & push multi-arch image
         id: build-push
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,13 +43,11 @@ jobs:
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      # login to docker hub
+      - name: Login to DockerHub (from vault)
+        uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
       - id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@c2f1df59dba624b3fd509e5181aa8da5217120c0
         with:
-          common_secrets: |
-            DOCKERHUB_USERNAME=dockerhub:username
-            DOCKERHUB_PASSWORD=dockerhub:password
           repo_secrets: |
             GRAFANA_PYROSCOPE_BOT_APP_APP_ID=grafana-pyroscope-bot:app-id
             GRAFANA_PYROSCOPE_BOT_APP_PRIVATE_KEY=grafana-pyroscope-bot:app-private-key
@@ -61,11 +59,6 @@ jobs:
           private-key: ${{ env.GRAFANA_PYROSCOPE_BOT_APP_PRIVATE_KEY }}
           owner: pyroscope-io
           repositories: homebrew-brew
-      - uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
-        name: Login to Docker Hub
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_PASSWORD }}
       - run: make frontend/build
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -46,18 +46,8 @@ jobs:
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
-      # login to docker hub
-      - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@c2f1df59dba624b3fd509e5181aa8da5217120c0
-        with:
-          common_secrets: |
-            DOCKERHUB_USERNAME=dockerhub:username
-            DOCKERHUB_PASSWORD=dockerhub:password
-      - uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
-        name: Login to Docker Hub
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_PASSWORD }}
+      - name: Login to DockerHub (from vault)
+        uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20


### PR DESCRIPTION
## Summary
- Replaces the hand-rolled `get-vault-secrets` + `docker/login-action` pair with `grafana/shared-workflows/actions/dockerhub-login` across `ci.yml`, `release.yml`, and `weekly-release.yml`.
- Same pattern as grafana/pyroscope-dotnet#312, pinned at `dockerhub-login/v1.0.3`.
- `release.yml` keeps a `get-vault-secrets` step for the `grafana-pyroscope-bot` app credentials used for the Homebrew push; only the dockerhub entries were dropped from its `common_secrets`.

## Test plan
- [ ] Push to a `weekly/f*` branch and confirm `goreleaser-weekly` authenticates and pushes images.
- [ ] On the next tag, confirm `goreleaser` (release.yml) and the `build-push` job in `ci.yml` log in via vault and push successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Docker image publishing for CI and release workflows; a misconfiguration or behavior difference in the shared login action could break pushes to Docker Hub.
> 
> **Overview**
> Replaces the inlined Docker Hub authentication steps in `ci.yml`, `release.yml`, and `weekly-release.yml` (Vault secret fetch + `docker/login-action`) with the shared `grafana/shared-workflows/actions/dockerhub-login` action pinned to `v1.0.3`.
> 
> In `release.yml`, removes the Docker Hub entries from Vault `common_secrets` while keeping the remaining Vault fetch for Homebrew GitHub App credentials unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ef2d54e7ca9d20f95d9aa173a4f6d03be710b73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->