### PR TITLE
feat(distributor): add parse duration histogram metric for /ingest

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -373,6 +373,10 @@ func (d *Distributor) PushBatch(ctx context.Context, req *distributormodel.PushR
 		)
 	}
 
+	if req.ParseDuration > 0 {
+		d.metrics.parseDuration.WithLabelValues(string(req.RawProfileType), tenantID).Observe(req.ParseDuration.Seconds())
+	}
+
 	res := multierror.New()
 	errorsMutex := new(sync.Mutex)
 	wg := new(sync.WaitGroup)
@@ -381,7 +385,7 @@ func (d *Distributor) PushBatch(ctx context.Context, req *distributormodel.PushR
 		go func() {
 			defer wg.Done()
 			itErr := util.RecoverPanic(func() error {
-				return d.pushSeries(ctx, s, req.RawProfileType, tenantID)
+				return d.pushSeries(ctx, s, req.RawProfileType, tenantID, req.ParseDuration)
 			})()
 
 			if itErr != nil {
@@ -451,14 +455,14 @@ func (p *pushLog) log(logger log.Logger, err error) {
 	p.lvl(logger).Log(p.fields...)
 }
 
-func (d *Distributor) pushSeries(ctx context.Context, req *distributormodel.ProfileSeries, origin distributormodel.RawProfileType, tenantID string) (err error) {
+func (d *Distributor) pushSeries(ctx context.Context, req *distributormodel.ProfileSeries, origin distributormodel.RawProfileType, tenantID string, parseDuration time.Duration) (err error) {
 	if req.Profile == nil {
 		return noNewProfilesReceivedError()
 	}
 	now := model.Now()
 
 	logger := spanlogger.FromContext(ctx, log.With(d.logger, "tenant", tenantID))
-	finalLog := newPushLog(10)
+	finalLog := newPushLog(13)
 	defer func() {
 		finalLog.log(logger, err)
 	}()
@@ -544,6 +548,7 @@ func (d *Distributor) pushSeries(ctx context.Context, req *distributormodel.Prof
 		"ingestion_delay", now.Time().Sub(profTime),
 		"decompressed_size", decompressedSize,
 		"sample_count", len(p.Sample),
+		"parse_duration", parseDuration,
 	)
 	d.metrics.observeProfileSize(tenantID, StageSampled, int64(decompressedSize))                              //todo use req.TotalBytesUncompressed to include labels siz
 	d.metrics.receivedDecompressedBytes.WithLabelValues(profName, tenantID).Observe(float64(decompressedSize)) // deprecated TODO remove

--- a/pkg/distributor/metrics.go
+++ b/pkg/distributor/metrics.go
@@ -39,6 +39,7 @@ type metrics struct {
 	receivedSymbolsBytes           *prometheus.HistogramVec
 	replicationFactor              prometheus.Gauge
 	receivedDecompressedBytesTotal *prometheus.HistogramVec
+	parseDuration                  *prometheus.HistogramVec
 }
 
 func newMetrics(reg prometheus.Registerer) *metrics {
@@ -126,6 +127,18 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 				"stage",
 			},
 		),
+		parseDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace:                       "pyroscope",
+				Name:                            "distributor_parse_duration_seconds",
+				Help:                            "Duration of profile parsing (JFR or pprof) per ingest request in the distributor.",
+				Buckets:                         prometheus.ExponentialBucketsRange(0.001, 10, 30),
+				NativeHistogramBucketFactor:     1.1,
+				NativeHistogramMaxBucketNumber:  50,
+				NativeHistogramMinResetDuration: time.Hour,
+			},
+			[]string{"type", "tenant"},
+		),
 	}
 	if reg != nil {
 		reg.MustRegister(
@@ -136,6 +149,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			m.receivedSymbolsBytes,
 			m.replicationFactor,
 			m.receivedDecompressedBytesTotal,
+			m.parseDuration,
 		)
 	}
 	return m

--- a/pkg/distributor/model/push.go
+++ b/pkg/distributor/model/push.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"time"
+
 	v1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	"github.com/grafana/pyroscope/v2/pkg/distributor/annotation"
 	"github.com/grafana/pyroscope/v2/pkg/distributor/ingestlimits"
@@ -21,6 +23,7 @@ type PushRequest struct {
 	ReceivedCompressedProfileSize   int
 	ReceivedDecompressedProfileSize int
 	RawProfileType                  RawProfileType
+	ParseDuration                   time.Duration
 }
 
 // todo better name

--- a/pkg/ingester/pyroscope/ingest_adapter.go
+++ b/pkg/ingester/pyroscope/ingest_adapter.go
@@ -185,10 +185,12 @@ func (p *pyroscopeIngesterAdapter) parseToPprof(
 	in *ingestion.IngestInput,
 	pprofable ingestion.ParseableToPprof,
 ) error {
+	parseStart := time.Now()
 	plainReq, err := pprofable.ParseToPprof(ctx, in.Metadata, p.limits)
 	if err != nil {
 		return fmt.Errorf("parsing IngestInput-pprof failed %w", err)
 	}
+	plainReq.ParseDuration = time.Since(parseStart)
 	if len(plainReq.Series) == 0 {
 		tenantID, _ := tenant.ExtractTenantIDFromContext(ctx)
 		_ = level.Debug(p.log).Log("msg", "empty profile",


### PR DESCRIPTION
Track how long JFR/pprof profile parsing takes per `/ingest` HTTP request.

- New histogram `pyroscope_distributor_parse_duration_seconds` with labels `type` (jfr/pprof) and `tenant`. Buckets span 1ms–10s with native histogram support.
- Duration is measured in `parseToPprof()` in the ingest adapter and carried on `model.PushRequest.ParseDuration`.
- Observed once per `PushBatch` call (not per series — JFR produces multiple series from a single parse), guarded by `> 0` so direct gRPC `Push` requests are not counted.
- `parse_duration` field added to the per-series push log alongside `ingestion_delay` and `decompressed_size`.
- Push log capacity bumped from 10 to 13 to accommodate the new field without reallocation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the `PushRequest`/`pushSeries` call chain across ingester and distributor and adds new metric/log fields on the hot ingest path, which could affect labeling/cardinality or performance if misused.
> 
> **Overview**
> Adds end-to-end tracking of profile parse latency for `/ingest` by timing `parseToPprof()` and propagating the duration via `model.PushRequest.ParseDuration`.
> 
> The distributor now records a new histogram `pyroscope_distributor_parse_duration_seconds` (labels: `type`, `tenant`) once per `PushBatch` request (guarded by `ParseDuration > 0`), and includes `parse_duration` in the per-series push log (with `pushSeries` signature updated and push log capacity increased to avoid reallocations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c2f884431411ad86e49c25138e86cb45ad00a6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->