### PR TITLE
chore: disable npm/yarn lifecycle scripts

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,0 @@
-#!/usr/bin/env sh
-
-# Lint staged UI files (TypeScript / TSX) before committing.
-staged_ui_files=$(git diff --cached --name-only --diff-filter=ACM -- 'ui/*.ts' 'ui/*.tsx')
-if [ -n "$staged_ui_files" ]; then
-  cd ui && yarn lint
-fi

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-ignore-scripts=true

--- a/cmd/pyroscope/frontend.Dockerfile
+++ b/cmd/pyroscope/frontend.Dockerfile
@@ -1,7 +1,7 @@
 FROM node:24@sha256:bb20cf73b3ad7212834ec48e2174cdcb5775f6550510a5336b842ae32741ce6c AS builder
 
 WORKDIR /pyroscope/ui
-COPY ui/package.json ui/yarn.lock ui/.yarnrc.yml ./
+COPY ui/package.json ui/yarn.lock ui/.yarnrc.yml ui/.npmrc ./
 COPY ui/.yarn ./.yarn
 RUN corepack enable && yarn install --immutable
 COPY ui/index.html ui/vite.config.ts ./

--- a/examples/language-sdk-instrumentation/nodejs/express-pull/.npmrc
+++ b/examples/language-sdk-instrumentation/nodejs/express-pull/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/examples/language-sdk-instrumentation/nodejs/express-pull/.yarnrc
+++ b/examples/language-sdk-instrumentation/nodejs/express-pull/.yarnrc
@@ -1,0 +1,1 @@
+--install.ignore-scripts true

--- a/examples/language-sdk-instrumentation/nodejs/express-pull/Dockerfile
+++ b/examples/language-sdk-instrumentation/nodejs/express-pull/Dockerfile
@@ -2,7 +2,7 @@ FROM node:25
 
 WORKDIR /app
 
-COPY package.json yarn.lock .
+COPY package.json yarn.lock .npmrc .
 RUN yarn install
 COPY index.js .
 

--- a/examples/language-sdk-instrumentation/nodejs/express-pull/Dockerfile
+++ b/examples/language-sdk-instrumentation/nodejs/express-pull/Dockerfile
@@ -2,7 +2,7 @@ FROM node:25
 
 WORKDIR /app
 
-COPY package.json yarn.lock .npmrc .
+COPY package.json yarn.lock .npmrc .yarnrc .
 RUN yarn install
 COPY index.js .
 

--- a/examples/language-sdk-instrumentation/nodejs/express-ts-inline/.npmrc
+++ b/examples/language-sdk-instrumentation/nodejs/express-ts-inline/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/examples/language-sdk-instrumentation/nodejs/express-ts-inline/.yarnrc
+++ b/examples/language-sdk-instrumentation/nodejs/express-ts-inline/.yarnrc
@@ -1,0 +1,1 @@
+--install.ignore-scripts true

--- a/examples/language-sdk-instrumentation/nodejs/express-ts-inline/Dockerfile
+++ b/examples/language-sdk-instrumentation/nodejs/express-ts-inline/Dockerfile
@@ -2,7 +2,7 @@ FROM node:25
 
 WORKDIR /app
 
-COPY package.json yarn.lock .
+COPY package.json yarn.lock .npmrc .
 RUN yarn
 
 COPY tsconfig.json .

--- a/examples/language-sdk-instrumentation/nodejs/express-ts-inline/Dockerfile
+++ b/examples/language-sdk-instrumentation/nodejs/express-ts-inline/Dockerfile
@@ -2,7 +2,7 @@ FROM node:25
 
 WORKDIR /app
 
-COPY package.json yarn.lock .npmrc .
+COPY package.json yarn.lock .npmrc .yarnrc .
 RUN yarn
 
 COPY tsconfig.json .

--- a/examples/language-sdk-instrumentation/nodejs/express-ts/.npmrc
+++ b/examples/language-sdk-instrumentation/nodejs/express-ts/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/examples/language-sdk-instrumentation/nodejs/express-ts/.yarnrc
+++ b/examples/language-sdk-instrumentation/nodejs/express-ts/.yarnrc
@@ -1,0 +1,1 @@
+--install.ignore-scripts true

--- a/examples/language-sdk-instrumentation/nodejs/express-ts/Dockerfile
+++ b/examples/language-sdk-instrumentation/nodejs/express-ts/Dockerfile
@@ -2,7 +2,7 @@ FROM node:25
 
 WORKDIR /app
 
-COPY package.json yarn.lock .
+COPY package.json yarn.lock .npmrc .
 RUN yarn
 
 COPY tsconfig.json .

--- a/examples/language-sdk-instrumentation/nodejs/express-ts/Dockerfile
+++ b/examples/language-sdk-instrumentation/nodejs/express-ts/Dockerfile
@@ -2,7 +2,7 @@ FROM node:25
 
 WORKDIR /app
 
-COPY package.json yarn.lock .npmrc .
+COPY package.json yarn.lock .npmrc .yarnrc .
 RUN yarn
 
 COPY tsconfig.json .

--- a/examples/language-sdk-instrumentation/nodejs/express/.npmrc
+++ b/examples/language-sdk-instrumentation/nodejs/express/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/examples/language-sdk-instrumentation/nodejs/express/.yarnrc
+++ b/examples/language-sdk-instrumentation/nodejs/express/.yarnrc
@@ -1,0 +1,1 @@
+--install.ignore-scripts true

--- a/examples/language-sdk-instrumentation/nodejs/express/Dockerfile
+++ b/examples/language-sdk-instrumentation/nodejs/express/Dockerfile
@@ -2,7 +2,7 @@ FROM node:25
 
 WORKDIR /app
 
-COPY package.json yarn.lock .
+COPY package.json yarn.lock .npmrc .
 RUN yarn install
 COPY index.js .
 

--- a/examples/language-sdk-instrumentation/nodejs/express/Dockerfile
+++ b/examples/language-sdk-instrumentation/nodejs/express/Dockerfile
@@ -2,7 +2,7 @@ FROM node:25
 
 WORKDIR /app
 
-COPY package.json yarn.lock .npmrc .
+COPY package.json yarn.lock .npmrc .yarnrc .
 RUN yarn install
 COPY index.js .
 

--- a/examples/language-sdk-instrumentation/nodejs/tinyhttp/.npmrc
+++ b/examples/language-sdk-instrumentation/nodejs/tinyhttp/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/examples/language-sdk-instrumentation/nodejs/tinyhttp/.yarnrc
+++ b/examples/language-sdk-instrumentation/nodejs/tinyhttp/.yarnrc
@@ -1,0 +1,1 @@
+--install.ignore-scripts true

--- a/examples/language-sdk-instrumentation/nodejs/tinyhttp/Dockerfile
+++ b/examples/language-sdk-instrumentation/nodejs/tinyhttp/Dockerfile
@@ -2,7 +2,7 @@ FROM node:25
 
 WORKDIR /app
 
-COPY package.json yarn.lock .npmrc .
+COPY package.json yarn.lock .npmrc .yarnrc .
 RUN yarn install
 
 COPY index.js .

--- a/examples/language-sdk-instrumentation/nodejs/tinyhttp/Dockerfile
+++ b/examples/language-sdk-instrumentation/nodejs/tinyhttp/Dockerfile
@@ -2,7 +2,7 @@ FROM node:25
 
 WORKDIR /app
 
-COPY package.json yarn.lock .
+COPY package.json yarn.lock .npmrc .
 RUN yarn install
 
 COPY index.js .

--- a/ui/.npmrc
+++ b/ui/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/ui/.yarnrc.yml
+++ b/ui/.yarnrc.yml
@@ -1,1 +1,2 @@
+enableScripts: false
 nodeLinker: node-modules


### PR DESCRIPTION
Mitigates supply-chain risk from postinstall/preinstall scripts of transitive dependencies, per Grafana security guidance for CyberGrot week. See the security thread: https://raintank-corp.slack.com/archives/CKF4X4H1D/p1777883086472259

Changes:

- Yarn Berry workspace (ui/) gets enableScripts: false in .yarnrc.yml.
- Yarn Classic v1 demos (the five examples/language-sdk-instrumentation/nodejs/*) get a .yarnrc with --install.ignore-scripts true. Required because Yarn Classic does NOT honor .npmrc's ignore-scripts setting — verified empirically with an A/B test inside the express demo's docker image: without .yarnrc, a planted preinstall/postinstall produces a marker file; with .yarnrc, yarn logs "Ignored scripts due to flag." and the marker is absent.
- npm side is covered by ignore-scripts=true in .npmrc, placed in ui/ and in each of the five example demos (the workspaces where someone could plausibly run npm). No root .npmrc — the repo root has no package.json and nothing runs npm there.
- Dockerfiles updated to copy the new .npmrc / .yarnrc into the build context: cmd/pyroscope/frontend.Dockerfile and the five example Dockerfiles.
- Removed the orphaned .husky/pre-commit hook. No husky package is declared in any package.json and no prepare script wires it up; the hook only fired for developers who manually set core.hooksPath = .husky. UI lint already runs in CI (.github/workflows/frontend.yml) and Go/proto checks are covered by .pre-commit-config.yaml. Removed alongside the lifecycle-script ban so nobody assumes a future husky dep would auto-install hooks under the new ignore-scripts policy.

Verified locally:

- ui/: clean yarn install --immutable, then yarn lint, yarn test, yarn build all green. yarn config get enableScripts returns false. yarn now logs that protobufjs build scripts are disabled, confirming the policy is active.
- cmd/pyroscope/frontend.Dockerfile: image build succeeds end-to-end and produces ui/dist.
- All five Node example demos: docker build, run, and a curl GET / returns HTTP 200 with the expected payload, confirming @pyroscope/nodejs (which wraps @datadog/pprof) loads its native binding from the prebuilds/ shipped inside the npm tarball without needing a postinstall. Each yarn install also prints "Ignored scripts due to flag." confirming Yarn Classic enforced the policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build/install behavior changes across the UI and NodeJS example images by disabling lifecycle scripts, which can break dependencies that rely on `postinstall`/native builds. Changes are mostly config/Dockerfile updates, but they affect reproducibility and supply-chain posture.
> 
> **Overview**
> Disables npm/yarn lifecycle scripts to reduce supply-chain risk by adding `ui/.npmrc` (`ignore-scripts=true`) and setting `enableScripts: false` in `ui/.yarnrc.yml`.
> 
> Updates the UI and NodeJS example Dockerfiles to copy the new npm/yarn config files into the build context so installs inside containers also skip scripts, and adds `.npmrc`/`.yarnrc` to the NodeJS instrumentation examples to enforce the same policy.
> 
> Removes the unused `.husky/pre-commit` hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ae9f6e8fccc688b08793a857f808751993d86df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->