### PR TITLE
docs: remove outdated v2 note

### DIFF
--- a/docs/sources/reference-pyroscope-v2-architecture/about-pyroscope-v2-architecture/index.md
+++ b/docs/sources/reference-pyroscope-v2-architecture/about-pyroscope-v2-architecture/index.md
@@ -12,10 +12,6 @@ keywords:
 
 # About the Pyroscope v2 architecture
 
-{{< admonition type="note" >}}
-The Pyroscope v2 architecture is production-ready and powers Grafana Cloud Profiles exclusively. However, until it's released by default as part of Pyroscope v2.0, there are no API stability guarantees.
-{{< /admonition >}}
-
 Pyroscope v2 is a complete architectural redesign focused on improving scalability, performance, and cost-efficiency. The architecture is built around the following goals:
 
 - Deliver high write throughput


### PR DESCRIPTION
Now that v2 is released, this note is no longer accurate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that removes an outdated note and does not affect runtime behavior or APIs.
> 
> **Overview**
> Removes the introductory admonition in `about-pyroscope-v2-architecture/index.md` that warned Pyroscope v2 had no API stability guarantees until being released by default, reflecting that the note is no longer accurate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c761f5f46cc4326008cdf54b924615e167cdf1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->