### PR TITLE
docs: remove outdated v2 note (#5109)

### DIFF
--- a/docs/sources/reference-pyroscope-v2-architecture/about-pyroscope-v2-architecture/index.md
+++ b/docs/sources/reference-pyroscope-v2-architecture/about-pyroscope-v2-architecture/index.md
@@ -12,10 +12,6 @@ keywords:
 
 # About the Pyroscope v2 architecture
 
-{{< admonition type="note" >}}
-The Pyroscope v2 architecture is production-ready and powers Grafana Cloud Profiles exclusively. However, until it's released by default as part of Pyroscope v2.0, there are no API stability guarantees.
-{{< /admonition >}}
-
 Pyroscope v2 is a complete architectural redesign focused on improving scalability, performance, and cost-efficiency. The architecture is built around the following goals:
 
 - Deliver high write throughput


### PR DESCRIPTION
backports #5109 to the latest release

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that removes an outdated warning; no functional code or APIs are modified.
> 
> **Overview**
> Removes the admonition note from the Pyroscope v2 architecture docs that warned about being production-ready but lacking API stability guarantees until default v2.0 release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc2a5349dde767f3b9ac39ab91a6861abcd8fbfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->