### PR TITLE
feat(segmentwriter): build dataset index in segments

### DIFF
--- a/pkg/block/compaction.go
+++ b/pkg/block/compaction.go
@@ -177,7 +177,7 @@ type CompactionPlan struct {
 	datasets     []*datasetCompaction
 	meta         *metastorev1.BlockMeta
 	strings      *metadata.StringTable
-	datasetIndex *datasetIndexWriter
+	datasetIndex *DatasetIndexWriter
 }
 
 func newBlockCompaction(
@@ -190,7 +190,7 @@ func newBlockCompaction(
 		tenant:       tenant,
 		datasetMap:   make(map[int32]*datasetCompaction),
 		strings:      metadata.NewStringTable(),
-		datasetIndex: newDatasetIndexWriter(),
+		datasetIndex: NewDatasetIndexWriter(),
 	}
 	p.path = BuildObjectPath(tenant, shard, compactionLevel, id)
 	p.meta = &metastorev1.BlockMeta{
@@ -219,7 +219,7 @@ func (b *CompactionPlan) Compact(
 
 	// Datasets are compacted in a strict order.
 	for i, s := range b.datasets {
-		b.datasetIndex.setIndex(uint32(i))
+		b.datasetIndex.SetIndex(uint32(i))
 		s.registerSampleObserver(observer)
 		if err = s.compact(ctx, w); err != nil {
 			return nil, fmt.Errorf("compacting block: %w", err)
@@ -246,7 +246,7 @@ func (b *CompactionPlan) writeDatasetIndex(w *Writer) error {
 		return err
 	}
 	off := w.Offset()
-	n, err := io.Copy(w, bytes.NewReader(b.datasetIndex.buf))
+	n, err := io.Copy(w, bytes.NewReader(b.datasetIndex.Buf()))
 	if err != nil {
 		return err
 	}
@@ -438,7 +438,7 @@ func (m *datasetCompaction) writeRow(r ProfileEntry) (err error) {
 		observe := m.observer.Evaluate(r)
 		defer observe()
 	}
-	m.parent.datasetIndex.writeRow(r)
+	m.parent.datasetIndex.WriteRow(r)
 	m.indexRewriter.rewriteRow(r)
 	if err = m.symbolsRewriter.rewriteRow(r); err != nil {
 		return err
@@ -609,75 +609,3 @@ func (s *symbolsRewriter) loadStacktraceIDs(values []parquet.Value) {
 }
 
 func (s *symbolsRewriter) Flush() error { return s.w.Flush() }
-
-// datasetIndexWriter is identical with indexRewriter,
-// except it writes dataset ID instead of series ID.
-type datasetIndexWriter struct {
-	series   []seriesLabels
-	chunks   []index.ChunkMeta
-	previous model.Fingerprint
-	symbols  map[string]struct{}
-	idx      uint32
-	buf      []byte
-}
-
-func newDatasetIndexWriter() *datasetIndexWriter {
-	return &datasetIndexWriter{
-		symbols: make(map[string]struct{}),
-	}
-}
-
-func (rw *datasetIndexWriter) setIndex(i uint32) { rw.idx = i }
-
-func (rw *datasetIndexWriter) writeRow(e ProfileEntry) {
-	if rw.previous != e.Fingerprint || len(rw.series) == 0 {
-		series := e.Labels.Clone()
-		for _, l := range series {
-			rw.symbols[l.Name] = struct{}{}
-			rw.symbols[l.Value] = struct{}{}
-		}
-		rw.series = append(rw.series, seriesLabels{
-			labels:      series,
-			fingerprint: e.Fingerprint,
-		})
-		rw.chunks = append(rw.chunks, index.ChunkMeta{
-			SeriesIndex: rw.idx,
-		})
-		rw.previous = e.Fingerprint
-	}
-}
-
-func (rw *datasetIndexWriter) Flush() error {
-	// TODO(kolesnikovae):
-	//  * Estimate size.
-	//  * Use buffer pool.
-	w, err := memindex.NewWriter(context.Background(), 1<<20)
-	if err != nil {
-		return err
-	}
-
-	// Sort symbols
-	symbols := make([]string, 0, len(rw.symbols))
-	for s := range rw.symbols {
-		symbols = append(symbols, s)
-	}
-	sort.Strings(symbols)
-
-	// Add symbols
-	for _, symbol := range symbols {
-		if err = w.AddSymbol(symbol); err != nil {
-			return err
-		}
-	}
-
-	// Add Series
-	for i, series := range rw.series {
-		if err = w.AddSeries(storage.SeriesRef(i), series.labels, series.fingerprint, rw.chunks[i]); err != nil {
-			return err
-		}
-	}
-
-	err = w.Close()
-	rw.buf = w.ReleaseIndex()
-	return err
-}

--- a/pkg/block/compaction.go
+++ b/pkg/block/compaction.go
@@ -242,11 +242,12 @@ func (b *CompactionPlan) Compact(
 }
 
 func (b *CompactionPlan) writeDatasetIndex(w *Writer) error {
-	if err := b.datasetIndex.Flush(); err != nil {
-		return err
+	defer b.datasetIndex.Close()
+	if b.datasetIndex.Empty() {
+		return nil
 	}
 	off := w.Offset()
-	n, err := io.Copy(w, bytes.NewReader(b.datasetIndex.Buf()))
+	n, err := b.datasetIndex.WriteTo(w)
 	if err != nil {
 		return err
 	}

--- a/pkg/block/compaction.go
+++ b/pkg/block/compaction.go
@@ -258,7 +258,7 @@ func (b *CompactionPlan) writeDatasetIndex(w *Writer) error {
 		WithLabelSet(metadata.LabelNameTenantDataset, metadata.LabelValueDatasetTSDBIndex).
 		Build()
 	b.meta.Datasets = append(b.meta.Datasets, &metastorev1.Dataset{
-		Format:          1,
+		Format:          uint32(DatasetFormat1),
 		Tenant:          b.meta.Tenant,
 		Name:            0, // Anonymous.
 		MinTime:         b.meta.MinTime,

--- a/pkg/block/compaction.go
+++ b/pkg/block/compaction.go
@@ -178,6 +178,14 @@ type CompactionPlan struct {
 	meta         *metastorev1.BlockMeta
 	strings      *metadata.StringTable
 	datasetIndex *DatasetIndexWriter
+
+	// datasetIndex state for the compaction-time dedup of consecutive
+	// rows that share a fingerprint. The DatasetIndexWriter itself
+	// expects callers to add already-deduplicated series; compaction
+	// observes rows in series order, so we collapse runs of equal
+	// fingerprints here.
+	currentDatasetIdx  uint32
+	lastDatasetIndexFP model.Fingerprint
 }
 
 func newBlockCompaction(
@@ -219,7 +227,7 @@ func (b *CompactionPlan) Compact(
 
 	// Datasets are compacted in a strict order.
 	for i, s := range b.datasets {
-		b.datasetIndex.SetIndex(uint32(i))
+		b.currentDatasetIdx = uint32(i)
 		s.registerSampleObserver(observer)
 		if err = s.compact(ctx, w); err != nil {
 			return nil, fmt.Errorf("compacting block: %w", err)
@@ -239,6 +247,17 @@ func (b *CompactionPlan) Compact(
 		return nil, fmt.Errorf("uploading block: %w", err)
 	}
 	return b.meta, nil
+}
+
+// addRowToDatasetIndex appends the row's series to the per-tenant
+// dataset index, deduplicating runs of consecutive rows that share a
+// fingerprint. Compaction iterates rows in series order, so runs of
+// matching fingerprints belong to the same series.
+func (b *CompactionPlan) addRowToDatasetIndex(r ProfileEntry) {
+	if b.lastDatasetIndexFP != r.Fingerprint || b.datasetIndex.Empty() {
+		b.datasetIndex.AddSeries(b.currentDatasetIdx, r.Labels, r.Fingerprint)
+		b.lastDatasetIndexFP = r.Fingerprint
+	}
 }
 
 func (b *CompactionPlan) writeDatasetIndex(w *Writer) error {
@@ -439,7 +458,7 @@ func (m *datasetCompaction) writeRow(r ProfileEntry) (err error) {
 		observe := m.observer.Evaluate(r)
 		defer observe()
 	}
-	m.parent.datasetIndex.WriteRow(r)
+	m.parent.addRowToDatasetIndex(r)
 	m.indexRewriter.rewriteRow(r)
 	if err = m.symbolsRewriter.rewriteRow(r); err != nil {
 		return err

--- a/pkg/block/dataset_index.go
+++ b/pkg/block/dataset_index.go
@@ -2,7 +2,9 @@ package block
 
 import (
 	"context"
+	"io"
 	"sort"
+	"sync"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/storage"
@@ -11,6 +13,12 @@ import (
 	"github.com/grafana/pyroscope/v2/pkg/phlaredb/tsdb/index"
 	memindex "github.com/grafana/pyroscope/v2/pkg/segmentwriter/memdb/index"
 )
+
+// datasetIndexEncBufferSize is the initial capacity hint for the
+// underlying TSDB index writer's scratch encoding buffers. Dataset
+// indexes have one entry per dataset within a tenant block, so a small
+// hint is plenty; the buffers grow if needed.
+const datasetIndexEncBufferSize = 1 << 14
 
 // DatasetIndexWriter builds the per-tenant dataset TSDB index.
 //
@@ -23,19 +31,43 @@ import (
 // It is used both at compaction time (where series labels are discovered
 // row-by-row via WriteRow) and at segment flush time (where series are
 // already known and added in bulk via AddSeries).
+//
+// Writers are pooled. Obtain one with NewDatasetIndexWriter and return
+// it with Close once WriteTo has been called.
 type DatasetIndexWriter struct {
 	series   []seriesLabels
 	chunks   []index.ChunkMeta
 	previous model.Fingerprint
 	symbols  map[string]struct{}
 	idx      uint32
-	buf      []byte
 }
 
+var datasetIndexWriterPool = sync.Pool{
+	New: func() any {
+		return &DatasetIndexWriter{symbols: make(map[string]struct{})}
+	},
+}
+
+// NewDatasetIndexWriter returns a DatasetIndexWriter ready for use,
+// reusing one from a pool when possible. Callers must call Close to
+// return it once they are done.
 func NewDatasetIndexWriter() *DatasetIndexWriter {
-	return &DatasetIndexWriter{
-		symbols: make(map[string]struct{}),
-	}
+	return datasetIndexWriterPool.Get().(*DatasetIndexWriter)
+}
+
+// Close returns the writer to the pool. After Close, the writer must
+// not be used.
+func (rw *DatasetIndexWriter) Close() {
+	rw.reset()
+	datasetIndexWriterPool.Put(rw)
+}
+
+func (rw *DatasetIndexWriter) reset() {
+	rw.series = rw.series[:0]
+	rw.chunks = rw.chunks[:0]
+	clear(rw.symbols)
+	rw.previous = 0
+	rw.idx = 0
 }
 
 // SetIndex sets the dataset index assigned to subsequent series added
@@ -77,40 +109,47 @@ func (rw *DatasetIndexWriter) addSeries(labels phlaremodel.Labels, fp model.Fing
 // Empty reports whether the writer has no series.
 func (rw *DatasetIndexWriter) Empty() bool { return len(rw.series) == 0 }
 
-// Buf returns the serialised index bytes. Only valid after Flush.
-func (rw *DatasetIndexWriter) Buf() []byte { return rw.buf }
-
-func (rw *DatasetIndexWriter) Flush() error {
-	// TODO(kolesnikovae):
-	//  * Estimate size.
-	//  * Use buffer pool.
-	w, err := memindex.NewWriter(context.Background(), 1<<20)
-	if err != nil {
-		return err
+// WriteTo encodes the accumulated series into a TSDB index and writes
+// the encoded bytes directly to dst, returning the number of bytes
+// written. After WriteTo, the accumulated state is reset; the writer
+// can be reused for another tenant or returned to the pool via Close.
+func (rw *DatasetIndexWriter) WriteTo(dst io.Writer) (int64, error) {
+	if len(rw.series) == 0 {
+		return 0, nil
 	}
 
-	// Sort symbols
+	w, err := memindex.NewWriter(context.Background(), datasetIndexEncBufferSize)
+	if err != nil {
+		return 0, err
+	}
+
 	symbols := make([]string, 0, len(rw.symbols))
 	for s := range rw.symbols {
 		symbols = append(symbols, s)
 	}
 	sort.Strings(symbols)
 
-	// Add symbols
 	for _, symbol := range symbols {
 		if err = w.AddSymbol(symbol); err != nil {
-			return err
+			return 0, err
 		}
 	}
 
-	// Add Series
 	for i, series := range rw.series {
 		if err = w.AddSeries(storage.SeriesRef(i), series.labels, series.fingerprint, rw.chunks[i]); err != nil {
-			return err
+			return 0, err
 		}
 	}
 
-	err = w.Close()
-	rw.buf = w.ReleaseIndex()
-	return err
+	if err = w.Close(); err != nil {
+		return 0, err
+	}
+
+	bw := w.ReleaseIndexBuffer()
+	defer memindex.PutBufferWriterToPool(bw)
+	rw.reset()
+
+	buf, _, _ := bw.Buffer()
+	n, err := dst.Write(buf)
+	return int64(n), err
 }

--- a/pkg/block/dataset_index.go
+++ b/pkg/block/dataset_index.go
@@ -28,18 +28,16 @@ const datasetIndexEncBufferSize = 1 << 14
 // datasets within a block match a given label selector without opening
 // each dataset's TSDB index individually.
 //
-// It is used both at compaction time (where series labels are discovered
-// row-by-row via WriteRow) and at segment flush time (where series are
-// already known and added in bulk via AddSeries).
+// Series are added one-at-a-time via AddSeries with an explicit dataset
+// index. Callers that observe series row-by-row (e.g. compaction) are
+// expected to deduplicate by fingerprint before calling AddSeries.
 //
 // Writers are pooled. Obtain one with NewDatasetIndexWriter and return
 // it with Close once WriteTo has been called.
 type DatasetIndexWriter struct {
-	series   []seriesLabels
-	chunks   []index.ChunkMeta
-	previous model.Fingerprint
-	symbols  map[string]struct{}
-	idx      uint32
+	series  []seriesLabels
+	chunks  []index.ChunkMeta
+	symbols map[string]struct{}
 }
 
 var datasetIndexWriterPool = sync.Pool{
@@ -66,32 +64,13 @@ func (rw *DatasetIndexWriter) reset() {
 	rw.series = rw.series[:0]
 	rw.chunks = rw.chunks[:0]
 	clear(rw.symbols)
-	rw.previous = 0
-	rw.idx = 0
 }
 
-// SetIndex sets the dataset index assigned to subsequent series added
-// via WriteRow or AddSeries.
-func (rw *DatasetIndexWriter) SetIndex(i uint32) { rw.idx = i }
-
-// WriteRow ingests a profile row, deduplicating series by fingerprint.
-// It is used by compaction, which iterates rows in series order.
-func (rw *DatasetIndexWriter) WriteRow(e ProfileEntry) {
-	if rw.previous != e.Fingerprint || len(rw.series) == 0 {
-		rw.addSeries(e.Labels, e.Fingerprint)
-		rw.previous = e.Fingerprint
-	}
-}
-
-// AddSeries adds a single series at the current dataset index. The caller
-// is responsible for ensuring fingerprints are unique within the dataset.
-// It is used by the segment writer, where heads already provide a
-// deduplicated series list.
-func (rw *DatasetIndexWriter) AddSeries(labels phlaremodel.Labels, fp model.Fingerprint) {
-	rw.addSeries(labels, fp)
-}
-
-func (rw *DatasetIndexWriter) addSeries(labels phlaremodel.Labels, fp model.Fingerprint) {
+// AddSeries adds a single series at the given dataset index. The caller
+// is responsible for ensuring fingerprints are unique within the
+// writer (e.g. by deduplicating consecutive rows with the same
+// fingerprint at compaction time).
+func (rw *DatasetIndexWriter) AddSeries(idx uint32, labels phlaremodel.Labels, fp model.Fingerprint) {
 	cloned := labels.Clone()
 	for _, l := range cloned {
 		rw.symbols[l.Name] = struct{}{}
@@ -102,7 +81,7 @@ func (rw *DatasetIndexWriter) addSeries(labels phlaremodel.Labels, fp model.Fing
 		fingerprint: fp,
 	})
 	rw.chunks = append(rw.chunks, index.ChunkMeta{
-		SeriesIndex: rw.idx,
+		SeriesIndex: idx,
 	})
 }
 

--- a/pkg/block/dataset_index.go
+++ b/pkg/block/dataset_index.go
@@ -1,0 +1,116 @@
+package block
+
+import (
+	"context"
+	"sort"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/storage"
+
+	phlaremodel "github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/phlaredb/tsdb/index"
+	memindex "github.com/grafana/pyroscope/v2/pkg/segmentwriter/memdb/index"
+)
+
+// DatasetIndexWriter builds the per-tenant dataset TSDB index.
+//
+// The dataset index resembles the dataset (series) TSDB index, but uses
+// the dataset position within the block (instead of the series ID) as the
+// chunk SeriesIndex. The query backend uses this index to identify which
+// datasets within a block match a given label selector without opening
+// each dataset's TSDB index individually.
+//
+// It is used both at compaction time (where series labels are discovered
+// row-by-row via WriteRow) and at segment flush time (where series are
+// already known and added in bulk via AddSeries).
+type DatasetIndexWriter struct {
+	series   []seriesLabels
+	chunks   []index.ChunkMeta
+	previous model.Fingerprint
+	symbols  map[string]struct{}
+	idx      uint32
+	buf      []byte
+}
+
+func NewDatasetIndexWriter() *DatasetIndexWriter {
+	return &DatasetIndexWriter{
+		symbols: make(map[string]struct{}),
+	}
+}
+
+// SetIndex sets the dataset index assigned to subsequent series added
+// via WriteRow or AddSeries.
+func (rw *DatasetIndexWriter) SetIndex(i uint32) { rw.idx = i }
+
+// WriteRow ingests a profile row, deduplicating series by fingerprint.
+// It is used by compaction, which iterates rows in series order.
+func (rw *DatasetIndexWriter) WriteRow(e ProfileEntry) {
+	if rw.previous != e.Fingerprint || len(rw.series) == 0 {
+		rw.addSeries(e.Labels, e.Fingerprint)
+		rw.previous = e.Fingerprint
+	}
+}
+
+// AddSeries adds a single series at the current dataset index. The caller
+// is responsible for ensuring fingerprints are unique within the dataset.
+// It is used by the segment writer, where heads already provide a
+// deduplicated series list.
+func (rw *DatasetIndexWriter) AddSeries(labels phlaremodel.Labels, fp model.Fingerprint) {
+	rw.addSeries(labels, fp)
+}
+
+func (rw *DatasetIndexWriter) addSeries(labels phlaremodel.Labels, fp model.Fingerprint) {
+	cloned := labels.Clone()
+	for _, l := range cloned {
+		rw.symbols[l.Name] = struct{}{}
+		rw.symbols[l.Value] = struct{}{}
+	}
+	rw.series = append(rw.series, seriesLabels{
+		labels:      cloned,
+		fingerprint: fp,
+	})
+	rw.chunks = append(rw.chunks, index.ChunkMeta{
+		SeriesIndex: rw.idx,
+	})
+}
+
+// Empty reports whether the writer has no series.
+func (rw *DatasetIndexWriter) Empty() bool { return len(rw.series) == 0 }
+
+// Buf returns the serialised index bytes. Only valid after Flush.
+func (rw *DatasetIndexWriter) Buf() []byte { return rw.buf }
+
+func (rw *DatasetIndexWriter) Flush() error {
+	// TODO(kolesnikovae):
+	//  * Estimate size.
+	//  * Use buffer pool.
+	w, err := memindex.NewWriter(context.Background(), 1<<20)
+	if err != nil {
+		return err
+	}
+
+	// Sort symbols
+	symbols := make([]string, 0, len(rw.symbols))
+	for s := range rw.symbols {
+		symbols = append(symbols, s)
+	}
+	sort.Strings(symbols)
+
+	// Add symbols
+	for _, symbol := range symbols {
+		if err = w.AddSymbol(symbol); err != nil {
+			return err
+		}
+	}
+
+	// Add Series
+	for i, series := range rw.series {
+		if err = w.AddSeries(storage.SeriesRef(i), series.labels, series.fingerprint, rw.chunks[i]); err != nil {
+			return err
+		}
+	}
+
+	err = w.Close()
+	rw.buf = w.ReleaseIndex()
+	return err
+}

--- a/pkg/block/dataset_index_test.go
+++ b/pkg/block/dataset_index_test.go
@@ -1,0 +1,44 @@
+package block
+
+import (
+	"io"
+	"strconv"
+	"testing"
+
+	"github.com/prometheus/common/model"
+
+	phlaremodel "github.com/grafana/pyroscope/v2/pkg/model"
+)
+
+func benchSeries(n int) []phlaremodel.Labels {
+	out := make([]phlaremodel.Labels, n)
+	for i := range out {
+		out[i] = phlaremodel.LabelsFromStrings(
+			phlaremodel.LabelNameServiceName, "svc",
+			"__name__", "process_cpu",
+			"pod", "pod-"+strconv.Itoa(i),
+		)
+	}
+	return out
+}
+
+func BenchmarkDatasetIndexWriter_WriteTo(b *testing.B) {
+	const datasetsPerTenant = 4
+	const seriesPerDataset = 100
+	series := benchSeries(seriesPerDataset)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		w := NewDatasetIndexWriter()
+		for d := range datasetsPerTenant {
+			w.SetIndex(uint32(d))
+			for j, lbs := range series {
+				w.AddSeries(lbs, model.Fingerprint(uint64(d)<<32|uint64(j)))
+			}
+		}
+		if _, err := w.WriteTo(io.Discard); err != nil {
+			b.Fatal(err)
+		}
+		w.Close()
+	}
+}

--- a/pkg/block/dataset_index_test.go
+++ b/pkg/block/dataset_index_test.go
@@ -31,9 +31,8 @@ func BenchmarkDatasetIndexWriter_WriteTo(b *testing.B) {
 	for b.Loop() {
 		w := NewDatasetIndexWriter()
 		for d := range datasetsPerTenant {
-			w.SetIndex(uint32(d))
 			for j, lbs := range series {
-				w.AddSeries(lbs, model.Fingerprint(uint64(d)<<32|uint64(j)))
+				w.AddSeries(uint32(d), lbs, model.Fingerprint(uint64(d)<<32|uint64(j)))
 			}
 		}
 		if _, err := w.WriteTo(io.Discard); err != nil {

--- a/pkg/querybackend/query.go
+++ b/pkg/querybackend/query.go
@@ -101,8 +101,8 @@ func (b *blockContext) execute() error {
 	span, b.ctx = tracing.StartSpanFromContext(b.ctx, "blockContext.execute")
 	defer span.Finish()
 
-	if idx := b.datasetIndex(); idx != nil {
-		if err := b.lookupDatasets(idx); err != nil {
+	if idxs := b.datasetIndices(); len(idxs) > 0 {
+		if err := b.lookupDatasets(idxs); err != nil {
 			if b.obj.IsNotExists(err) {
 				level.Warn(b.log).Log("msg", "object not found", "err", err)
 				return nil
@@ -142,21 +142,43 @@ func (b *blockContext) execute() error {
 	return nil
 }
 
-// datasetIndex returns the dataset index if it is present in
-// the metadata and the query needs to lookup datasets.
-func (b *blockContext) datasetIndex() *metastorev1.Dataset {
+// datasetIndices returns the Format1 (dataset_tsdb_index) pseudo-datasets
+// in the block metadata that need to be resolved into concrete datasets
+// before the query can be executed. It returns nil when no resolution
+// is needed: either the metadata already lists explicit (Format0)
+// datasets, or the query is index-only and can be served directly from
+// the dataset_index TSDB section.
+//
+// Multiple Format1 datasets may be present in a single block when a
+// segment writer covers more than one tenant: it emits a per-tenant
+// dataset_index pseudo-dataset, and the metastore returns all matching
+// pseudo-datasets to the query backend. In that case all of their
+// indices must be looked up so the union of resolved datasets is
+// considered.
+func (b *blockContext) datasetIndices() []*metastorev1.Dataset {
 	md := b.obj.Metadata()
-	if len(md.Datasets) != 1 {
-		// The blocks metadata explicitly lists datasets to be queried.
+	var indices []*metastorev1.Dataset
+	for _, ds := range md.Datasets {
+		if block.DatasetFormat(ds.Format) == block.DatasetFormat1 {
+			indices = append(indices, ds)
+		}
+	}
+	if len(indices) == 0 {
+		// The block's metadata explicitly lists datasets to be queried.
 		return nil
 	}
-	ds := md.Datasets[0]
-	if block.DatasetFormat(ds.Format) != block.DatasetFormat1 {
+	if len(indices) != len(md.Datasets) {
+		// The metastore is expected to return a uniform set of datasets
+		// (either all Format0 explicit datasets matched by service_name,
+		// or all Format1 pseudo-datasets matched by __tenant_dataset__).
+		// A mixed set is not expected; bail on the lookup so the query
+		// runs against the explicitly-listed datasets only.
 		return nil
 	}
 
-	// If the query only requires TSDB data, we can serve
-	// it using the dataset index.
+	// If the query only requires TSDB data, we can serve it directly
+	// from each Format1 dataset's TSDB section (which is aliased to the
+	// dataset_index) without resolving real datasets.
 	s := (&queryContext{blockContext: b}).sections()
 	indexOnly := len(s) == 1 && s[0] == block.SectionTSDB
 	if indexOnly {
@@ -164,17 +186,23 @@ func (b *blockContext) datasetIndex() *metastorev1.Dataset {
 		return nil
 	}
 
-	return ds
+	return indices
 }
 
-func (b *blockContext) lookupDatasets(ds *metastorev1.Dataset) error {
+func (b *blockContext) lookupDatasets(indices []*metastorev1.Dataset) error {
 	oteltrace.SpanFromContext(b.ctx).SetAttributes(attribute.Bool("dataset_index_query", true))
+	oteltrace.SpanFromContext(b.ctx).SetAttributes(attribute.Int("dataset_index_count", len(indices)))
 
 	// As query execution has not started yet,
 	// we can safely open datasets.
-	idx := block.NewDataset(ds, b.obj)
+	datasets := make([]*block.Dataset, len(indices))
+	for i, ds := range indices {
+		datasets[i] = block.NewDataset(ds, b.obj)
+	}
 	defer func() {
-		_ = idx.Close()
+		for _, d := range datasets {
+			_ = d.Close()
+		}
 	}()
 
 	g, ctx := errgroup.WithContext(b.ctx)
@@ -183,16 +211,29 @@ func (b *blockContext) lookupDatasets(ds *metastorev1.Dataset) error {
 		md, err = b.obj.ReadMetadata(ctx)
 		return err
 	})
-	g.Go(func() error {
-		return idx.Open(ctx, block.SectionDatasetIndex)
-	})
+	for _, d := range datasets {
+		g.Go(func() error {
+			return d.Open(ctx, block.SectionDatasetIndex)
+		})
+	}
 	if err := g.Wait(); err != nil {
 		return err
 	}
 
-	datasetIDs, err := getSeriesIDs(idx.Index(), b.req.matchers...)
-	if err != nil {
-		return err
+	// Each per-tenant dataset_index encodes its tenant's real datasets
+	// using their global position within the block as the chunk
+	// SeriesIndex (see segment writer and compaction). Therefore IDs
+	// from different per-tenant indices are disjoint and a simple union
+	// across tenants is correct.
+	datasetIDs := make(map[uint32]struct{})
+	for _, d := range datasets {
+		ids, err := getSeriesIDs(d.Index(), b.req.matchers...)
+		if err != nil {
+			return err
+		}
+		for id := range ids {
+			datasetIDs[id] = struct{}{}
+		}
 	}
 
 	var j int

--- a/pkg/segmentwriter/memdb/head.go
+++ b/pkg/segmentwriter/memdb/head.go
@@ -34,21 +34,22 @@ type FlushedHead struct {
 		NumSeries        uint64
 	}
 
-	datasetIndexSeries []flushedSeries
+	datasetIndexSeries []*profileSeries
 }
 
 type datasetIndexWriter interface {
-	AddSeries(phlaremodel.Labels, model.Fingerprint)
+	AddSeries(idx uint32, labels phlaremodel.Labels, fp model.Fingerprint)
 }
 
-// WriteDatasetIndex feeds the flushed head's series (labels + fingerprint) into
-// the given dataset index writer at its current dataset position. It is
-// safe to call concurrently with other heads' writes only if the writer
-// itself is externally synchronised; segment flushes call it serially in
-// dataset (tenant+service) order.
-func (f *FlushedHead) WriteDatasetIndex(w datasetIndexWriter) {
-	for _, series := range f.datasetIndexSeries {
-		w.AddSeries(series.Labels, series.Fingerprint)
+// WriteDatasetIndex feeds the flushed head's series (labels + fingerprint)
+// into the given dataset index writer, attributing every series to the
+// supplied dataset index (the dataset's global position in the block).
+// It is safe to call concurrently with other heads' writes only if the
+// writer itself is externally synchronised; segment flushes call it
+// serially in dataset (tenant+service) order.
+func (f *FlushedHead) WriteDatasetIndex(w datasetIndexWriter, idx uint32) {
+	for _, s := range f.datasetIndexSeries {
+		w.AddSeries(idx, s.lbs, s.fp)
 	}
 }
 

--- a/pkg/segmentwriter/memdb/head.go
+++ b/pkg/segmentwriter/memdb/head.go
@@ -24,6 +24,12 @@ type FlushedHead struct {
 	Index        []byte
 	Profiles     []byte
 	Symbols      []byte
+	// Series contains the series of the flushed head, sorted in the same
+	// order as they appear in the TSDB Index. The segment writer uses it
+	// to build the per-tenant dataset index without having to re-read the
+	// index. It only contains label sets and fingerprints; chunk metadata
+	// is omitted as the dataset index does not need it.
+	Series       []FlushedSeries
 	Unsymbolized bool
 	Meta         struct {
 		ProfileTypeNames []string
@@ -33,6 +39,13 @@ type FlushedHead struct {
 		NumProfiles      uint64
 		NumSeries        uint64
 	}
+}
+
+// FlushedSeries is a single series labels with its fingerprint, captured
+// at the time of flushing the head.
+type FlushedSeries struct {
+	Labels      phlaremodel.Labels
+	Fingerprint model.Fingerprint
 }
 
 type Head struct {
@@ -173,7 +186,7 @@ func (h *Head) flush(ctx context.Context) (*FlushedHead, error) {
 		return nil, fmt.Errorf("failed to get profile type names: %w", err)
 	}
 
-	if res.Index, profiles, err = h.profiles.Flush(ctx); err != nil {
+	if res.Index, profiles, res.Series, err = h.profiles.Flush(ctx); err != nil {
 		return nil, fmt.Errorf("failed to flush profiles: %w", err)
 	}
 	res.Meta.NumProfiles = uint64(len(profiles))

--- a/pkg/segmentwriter/memdb/head.go
+++ b/pkg/segmentwriter/memdb/head.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"sync"
 
+
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -24,12 +25,6 @@ type FlushedHead struct {
 	Index        []byte
 	Profiles     []byte
 	Symbols      []byte
-	// Series contains the series of the flushed head, sorted in the same
-	// order as they appear in the TSDB Index. The segment writer uses it
-	// to build the per-tenant dataset index without having to re-read the
-	// index. It only contains label sets and fingerprints; chunk metadata
-	// is omitted as the dataset index does not need it.
-	Series       []FlushedSeries
 	Unsymbolized bool
 	Meta         struct {
 		ProfileTypeNames []string
@@ -39,13 +34,23 @@ type FlushedHead struct {
 		NumProfiles      uint64
 		NumSeries        uint64
 	}
+
+	datasetIndexSeries []flushedSeries
 }
 
-// FlushedSeries is a single series labels with its fingerprint, captured
-// at the time of flushing the head.
-type FlushedSeries struct {
-	Labels      phlaremodel.Labels
-	Fingerprint model.Fingerprint
+type datasetIndexWriter interface {
+	AddSeries(phlaremodel.Labels, model.Fingerprint)
+}
+
+// WriteDatasetIndex feeds the flushed head's series (labels + fingerprint) into
+// the given dataset index writer at its current dataset position. It is
+// safe to call concurrently with other heads' writes only if the writer
+// itself is externally synchronised; segment flushes call it serially in
+// dataset (tenant+service) order.
+func (f *FlushedHead) WriteDatasetIndex(w datasetIndexWriter) {
+	for _, series := range f.datasetIndexSeries {
+		w.AddSeries(series.Labels, series.Fingerprint)
+	}
 }
 
 type Head struct {
@@ -186,7 +191,7 @@ func (h *Head) flush(ctx context.Context) (*FlushedHead, error) {
 		return nil, fmt.Errorf("failed to get profile type names: %w", err)
 	}
 
-	if res.Index, profiles, res.Series, err = h.profiles.Flush(ctx); err != nil {
+	if res.Index, profiles, res.datasetIndexSeries, err = h.profiles.Flush(ctx); err != nil {
 		return nil, fmt.Errorf("failed to flush profiles: %w", err)
 	}
 	res.Meta.NumProfiles = uint64(len(profiles))

--- a/pkg/segmentwriter/memdb/head.go
+++ b/pkg/segmentwriter/memdb/head.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"sync"
 
-
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"

--- a/pkg/segmentwriter/memdb/profile_index.go
+++ b/pkg/segmentwriter/memdb/profile_index.go
@@ -31,11 +31,6 @@ type profilesIndex struct {
 	totalSeries   *atomic.Int64
 }
 
-type flushedSeries struct {
-	Labels      phlaremodel.Labels
-	Fingerprint model.Fingerprint
-}
-
 func newProfileIndex(metrics *HeadMetrics) *profilesIndex {
 	ix, err := tsdb.NewBitPrefixWithShards(32)
 	if err != nil {
@@ -96,7 +91,7 @@ func (pi *profilesIndex) Add(ps *schemav1.InMemoryProfile, lbs phlaremodel.Label
 	pi.metrics.profilesCreated.WithLabelValues(profileName).Inc()
 }
 
-func (pi *profilesIndex) Flush(ctx context.Context) ([]byte, []schemav1.InMemoryProfile, []flushedSeries, error) {
+func (pi *profilesIndex) Flush(ctx context.Context) ([]byte, []schemav1.InMemoryProfile, []*profileSeries, error) {
 	writer, err := memindex.NewWriter(ctx, memindex.SegmentsIndexWriterBufSize)
 	if err != nil {
 		return nil, nil, nil, err
@@ -139,7 +134,6 @@ func (pi *profilesIndex) Flush(ctx context.Context) ([]byte, []schemav1.InMemory
 	}
 
 	profiles := make([]schemav1.InMemoryProfile, 0, profilesSize)
-	series := make([]flushedSeries, 0, len(pfs))
 
 	// Add series
 	for i, s := range pfs {
@@ -151,10 +145,6 @@ func (pi *profilesIndex) Flush(ctx context.Context) ([]byte, []schemav1.InMemory
 		}); err != nil {
 			return nil, nil, nil, err
 		}
-		series = append(series, flushedSeries{
-			Labels:      s.lbs,
-			Fingerprint: s.fp,
-		})
 		// store series index
 		for j := range s.profiles {
 			s.profiles[j].SeriesIndex = uint32(i)
@@ -173,7 +163,7 @@ func (pi *profilesIndex) Flush(ctx context.Context) ([]byte, []schemav1.InMemory
 	//todo maybe return the bufferWriter to avoid copy, it is copied again anyway
 	tsdbIndex := writer.ReleaseIndex()
 
-	return tsdbIndex, profiles, series, err
+	return tsdbIndex, profiles, pfs, err
 }
 
 func (pi *profilesIndex) profileTypeNames() ([]string, error) {

--- a/pkg/segmentwriter/memdb/profile_index.go
+++ b/pkg/segmentwriter/memdb/profile_index.go
@@ -31,6 +31,11 @@ type profilesIndex struct {
 	totalSeries   *atomic.Int64
 }
 
+type flushedSeries struct {
+	Labels      phlaremodel.Labels
+	Fingerprint model.Fingerprint
+}
+
 func newProfileIndex(metrics *HeadMetrics) *profilesIndex {
 	ix, err := tsdb.NewBitPrefixWithShards(32)
 	if err != nil {
@@ -91,7 +96,7 @@ func (pi *profilesIndex) Add(ps *schemav1.InMemoryProfile, lbs phlaremodel.Label
 	pi.metrics.profilesCreated.WithLabelValues(profileName).Inc()
 }
 
-func (pi *profilesIndex) Flush(ctx context.Context) ([]byte, []schemav1.InMemoryProfile, []FlushedSeries, error) {
+func (pi *profilesIndex) Flush(ctx context.Context) ([]byte, []schemav1.InMemoryProfile, []flushedSeries, error) {
 	writer, err := memindex.NewWriter(ctx, memindex.SegmentsIndexWriterBufSize)
 	if err != nil {
 		return nil, nil, nil, err
@@ -101,7 +106,6 @@ func (pi *profilesIndex) Flush(ctx context.Context) ([]byte, []schemav1.InMemory
 
 	pfs := make([]*profileSeries, 0, len(pi.profilesPerFP))
 	profilesSize := 0
-
 	for _, p := range pi.profilesPerFP {
 		pfs = append(pfs, p)
 		profilesSize += len(p.profiles)
@@ -135,7 +139,7 @@ func (pi *profilesIndex) Flush(ctx context.Context) ([]byte, []schemav1.InMemory
 	}
 
 	profiles := make([]schemav1.InMemoryProfile, 0, profilesSize)
-	series := make([]FlushedSeries, 0, len(pfs))
+	series := make([]flushedSeries, 0, len(pfs))
 
 	// Add series
 	for i, s := range pfs {
@@ -147,7 +151,7 @@ func (pi *profilesIndex) Flush(ctx context.Context) ([]byte, []schemav1.InMemory
 		}); err != nil {
 			return nil, nil, nil, err
 		}
-		series = append(series, FlushedSeries{
+		series = append(series, flushedSeries{
 			Labels:      s.lbs,
 			Fingerprint: s.fp,
 		})

--- a/pkg/segmentwriter/memdb/profile_index.go
+++ b/pkg/segmentwriter/memdb/profile_index.go
@@ -91,16 +91,14 @@ func (pi *profilesIndex) Add(ps *schemav1.InMemoryProfile, lbs phlaremodel.Label
 	pi.metrics.profilesCreated.WithLabelValues(profileName).Inc()
 }
 
-func (pi *profilesIndex) Flush(ctx context.Context) ([]byte, []schemav1.InMemoryProfile, error) {
+func (pi *profilesIndex) Flush(ctx context.Context) ([]byte, []schemav1.InMemoryProfile, []FlushedSeries, error) {
 	writer, err := memindex.NewWriter(ctx, memindex.SegmentsIndexWriterBufSize)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	pi.mutex.RLock()
 	defer pi.mutex.RUnlock()
 
-	// TODO(kolesnikovae): We should reuse these series
-	//   when building dataset index.
 	pfs := make([]*profileSeries, 0, len(pi.profilesPerFP))
 	profilesSize := 0
 
@@ -132,11 +130,12 @@ func (pi *profilesIndex) Flush(ctx context.Context) ([]byte, []schemav1.InMemory
 	// Add symbols
 	for _, symbol := range symbols {
 		if err := writer.AddSymbol(symbol); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 	}
 
 	profiles := make([]schemav1.InMemoryProfile, 0, profilesSize)
+	series := make([]FlushedSeries, 0, len(pfs))
 
 	// Add series
 	for i, s := range pfs {
@@ -146,8 +145,12 @@ func (pi *profilesIndex) Flush(ctx context.Context) ([]byte, []schemav1.InMemory
 			// We store the series Index from the head with the series to use when retrieving data from parquet.
 			SeriesIndex: uint32(i),
 		}); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
+		series = append(series, FlushedSeries{
+			Labels:      s.lbs,
+			Fingerprint: s.fp,
+		})
 		// store series index
 		for j := range s.profiles {
 			s.profiles[j].SeriesIndex = uint32(i)
@@ -160,13 +163,13 @@ func (pi *profilesIndex) Flush(ctx context.Context) ([]byte, []schemav1.InMemory
 
 	err = writer.Close()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	//todo maybe return the bufferWriter to avoid copy, it is copied again anyway
 	tsdbIndex := writer.ReleaseIndex()
 
-	return tsdbIndex, profiles, err
+	return tsdbIndex, profiles, series, err
 }
 
 func (pi *profilesIndex) profileTypeNames() ([]string, error) {

--- a/pkg/segmentwriter/memdb/profile_index_test.go
+++ b/pkg/segmentwriter/memdb/profile_index_test.go
@@ -161,7 +161,7 @@ func TestWriteRead(t *testing.T) {
 		}
 	}
 
-	indexData, _, err := a.Flush(context.Background())
+	indexData, _, _, err := a.Flush(context.Background())
 	require.NoError(t, err)
 
 	r, err := index.NewReader(index.RealByteSlice(indexData))
@@ -226,7 +226,7 @@ func TestQueryIndex(t *testing.T) {
 		}
 	}
 
-	indexData, _, err := a.Flush(context.Background())
+	indexData, _, _, err := a.Flush(context.Background())
 	require.NoError(t, err)
 
 	r, err := index.NewReader(index.RealByteSlice(indexData))
@@ -311,7 +311,7 @@ func TestIndexAddOutOfOrder(t *testing.T) {
 		SeriesFingerprint: model.Fingerprint(lb2.Hash()),
 	}, lb2, "memory")
 
-	_, profiles, err := a.Flush(context.Background())
+	_, profiles, _, err := a.Flush(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 5, len(profiles))
 	expectedTS := []int64{0, 10, 20, 238, 239}

--- a/pkg/segmentwriter/segment.go
+++ b/pkg/segmentwriter/segment.go
@@ -303,8 +303,7 @@ func (s *segment) flushBlock(stream flushStream) ([]byte, *metastorev1.BlockMeta
 			dsIndex = block.NewDatasetIndexWriter()
 		}
 		ds := concatSegmentHead(f, w, stringTable)
-		dsIndex.SetIndex(uint32(len(meta.Datasets)))
-		f.flushed.WriteDatasetIndex(dsIndex)
+		f.flushed.WriteDatasetIndex(dsIndex, uint32(len(meta.Datasets)))
 		meta.MinTime = min(meta.MinTime, ds.MinTime)
 		meta.MaxTime = max(meta.MaxTime, ds.MaxTime)
 		meta.Datasets = append(meta.Datasets, ds)

--- a/pkg/segmentwriter/segment.go
+++ b/pkg/segmentwriter/segment.go
@@ -367,7 +367,7 @@ func writeTenantDatasetIndex(
 		WithLabelSet(metadata.LabelNameTenantDataset, metadata.LabelValueDatasetTSDBIndex).
 		Build()
 	meta.Datasets = append(meta.Datasets, &metastorev1.Dataset{
-		Format:          1,
+		Format:          uint32(block.DatasetFormat1),
 		Tenant:          stringTable.Put(tenant),
 		Name:            0, // Anonymous.
 		MinTime:         minT,

--- a/pkg/segmentwriter/segment.go
+++ b/pkg/segmentwriter/segment.go
@@ -346,15 +346,12 @@ func writeTenantDatasetIndex(
 	firstDatasetIdx int,
 	dsIndex *block.DatasetIndexWriter,
 ) error {
+	defer dsIndex.Close()
 	if dsIndex.Empty() {
 		return nil
 	}
-	if err := dsIndex.Flush(); err != nil {
-		return fmt.Errorf("failed to flush dataset index: %w", err)
-	}
-	buf := dsIndex.Buf()
 	off := uint64(w.offset)
-	n, err := w.Write(buf)
+	n, err := dsIndex.WriteTo(w)
 	if err != nil {
 		return fmt.Errorf("failed to write dataset index: %w", err)
 	}

--- a/pkg/segmentwriter/segment.go
+++ b/pkg/segmentwriter/segment.go
@@ -273,20 +273,41 @@ func (s *segment) flushBlock(stream flushStream) ([]byte, *metastorev1.BlockMeta
 	blockFile := bytes.NewBuffer(nil)
 
 	w := &writerOffset{Writer: blockFile}
+	// Datasets are flushed in tenant+service order, so all datasets of a
+	// given tenant are contiguous. We accumulate series of each tenant in
+	// a DatasetIndexWriter and emit a per-tenant dataset index pseudo-
+	// dataset once we observe the tenant boundary (or after the last head).
+	var (
+		curTenant    string
+		curTenantIdx int
+		dsIndex      *block.DatasetIndexWriter
+	)
 	for stream.Next() {
 		f := stream.At()
-		// TODO(kolesnikovae): Build dataset index for the tenant.
-		//   Note that the heads are flushed concurrently, so we cannot build
-		//   during head flush. I'd prefer to delegate it to the head itself:
-		//      WriteDatasetIndex(w *memindex.Writer, idx uint32)
-		//   Tenant datasets follow sequentially; when all tenant datasets
-		//   are flushed, we can build the index and create a metadata
-		//   entry for it.
+		if dsIndex == nil || f.dataset.key.tenant != curTenant {
+			if dsIndex != nil {
+				if err := writeTenantDatasetIndex(w, meta, stringTable, curTenant, curTenantIdx, dsIndex); err != nil {
+					return nil, nil, err
+				}
+			}
+			curTenant = f.dataset.key.tenant
+			curTenantIdx = len(meta.Datasets)
+			dsIndex = block.NewDatasetIndexWriter()
+		}
 		ds := concatSegmentHead(f, w, stringTable)
+		dsIndex.SetIndex(uint32(len(meta.Datasets)))
+		for _, series := range f.flushed.Series {
+			dsIndex.AddSeries(series.Labels, series.Fingerprint)
+		}
 		meta.MinTime = min(meta.MinTime, ds.MinTime)
 		meta.MaxTime = max(meta.MaxTime, ds.MaxTime)
 		meta.Datasets = append(meta.Datasets, ds)
 		s.sw.metrics.headSizeBytes.WithLabelValues(s.sshard, f.dataset.key.tenant).Observe(float64(ds.Size))
+	}
+	if dsIndex != nil {
+		if err := writeTenantDatasetIndex(w, meta, stringTable, curTenant, curTenantIdx, dsIndex); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	meta.StringTable = stringTable.Strings
@@ -308,6 +329,59 @@ func (w *writerOffset) Write(p []byte) (n int, err error) {
 	n, err = w.Writer.Write(p)
 	w.offset += int64(n)
 	return n, err
+}
+
+// writeTenantDatasetIndex flushes a per-tenant dataset index built from
+// the series of all datasets of the tenant in the segment, writes it to
+// the block file, and appends a pseudo-dataset entry to the block
+// metadata, annotated with the __tenant_dataset__ = dataset_tsdb_index
+// label.
+//
+// firstDatasetIdx is the index of the tenant's first real dataset within
+// meta.Datasets and is used to derive the time range covered by the
+// tenant in the segment.
+func writeTenantDatasetIndex(
+	w *writerOffset,
+	meta *metastorev1.BlockMeta,
+	stringTable *metadata.StringTable,
+	tenant string,
+	firstDatasetIdx int,
+	dsIndex *block.DatasetIndexWriter,
+) error {
+	if dsIndex.Empty() {
+		return nil
+	}
+	if err := dsIndex.Flush(); err != nil {
+		return fmt.Errorf("failed to flush dataset index: %w", err)
+	}
+	buf := dsIndex.Buf()
+	off := uint64(w.offset)
+	n, err := w.Write(buf)
+	if err != nil {
+		return fmt.Errorf("failed to write dataset index: %w", err)
+	}
+	var minT, maxT int64 = math.MaxInt64, 0
+	for _, ds := range meta.Datasets[firstDatasetIdx:] {
+		minT = min(minT, ds.MinTime)
+		maxT = max(maxT, ds.MaxTime)
+	}
+	// We annotate the dataset with the
+	// __tenant_dataset__ = "dataset_tsdb_index" label,
+	// so the dataset index metadata can be queried.
+	labels := metadata.NewLabelBuilder(stringTable).
+		WithLabelSet(metadata.LabelNameTenantDataset, metadata.LabelValueDatasetTSDBIndex).
+		Build()
+	meta.Datasets = append(meta.Datasets, &metastorev1.Dataset{
+		Format:          1,
+		Tenant:          stringTable.Put(tenant),
+		Name:            0, // Anonymous.
+		MinTime:         minT,
+		MaxTime:         maxT,
+		TableOfContents: []uint64{off},
+		Size:            uint64(n),
+		Labels:          labels,
+	})
+	return nil
 }
 
 func concatSegmentHead(f *datasetFlush, w *writerOffset, s *metadata.StringTable) *metastorev1.Dataset {

--- a/pkg/segmentwriter/segment.go
+++ b/pkg/segmentwriter/segment.go
@@ -118,6 +118,8 @@ func (sh *shard) flushSegment(ctx context.Context, wg *sync.WaitGroup) {
 				"writing segment block done",
 				"heads-count", len(s.datasets),
 				"heads-moved-count", s.debuginfo.movedHeads,
+				"tenant-indexes", s.debuginfo.tenantIndexes,
+				"tenant-index-bytes", s.debuginfo.tenantIndexBytes,
 				"inflight-duration", s.debuginfo.waitInflight,
 				"flush-heads-duration", s.debuginfo.flushHeadsDuration,
 				"flush-block-duration", s.debuginfo.flushBlockDuration,
@@ -286,8 +288,14 @@ func (s *segment) flushBlock(stream flushStream) ([]byte, *metastorev1.BlockMeta
 		f := stream.At()
 		if dsIndex == nil || f.dataset.key.tenant != curTenant {
 			if dsIndex != nil {
-				if err := writeTenantDatasetIndex(w, meta, stringTable, curTenant, curTenantIdx, dsIndex); err != nil {
+				n, err := writeTenantDatasetIndex(w, meta, stringTable, curTenant, curTenantIdx, dsIndex)
+				if err != nil {
 					return nil, nil, err
+				}
+				if n > 0 {
+					s.debuginfo.tenantIndexes++
+					s.debuginfo.tenantIndexBytes += n
+					s.sw.metrics.tenantIndexBytes.WithLabelValues(s.sshard, curTenant).Observe(float64(n))
 				}
 			}
 			curTenant = f.dataset.key.tenant
@@ -303,8 +311,14 @@ func (s *segment) flushBlock(stream flushStream) ([]byte, *metastorev1.BlockMeta
 		s.sw.metrics.headSizeBytes.WithLabelValues(s.sshard, f.dataset.key.tenant).Observe(float64(ds.Size))
 	}
 	if dsIndex != nil {
-		if err := writeTenantDatasetIndex(w, meta, stringTable, curTenant, curTenantIdx, dsIndex); err != nil {
+		n, err := writeTenantDatasetIndex(w, meta, stringTable, curTenant, curTenantIdx, dsIndex)
+		if err != nil {
 			return nil, nil, err
+		}
+		if n > 0 {
+			s.debuginfo.tenantIndexes++
+			s.debuginfo.tenantIndexBytes += n
+			s.sw.metrics.tenantIndexBytes.WithLabelValues(s.sshard, curTenant).Observe(float64(n))
 		}
 	}
 
@@ -338,6 +352,9 @@ func (w *writerOffset) Write(p []byte) (n int, err error) {
 // firstDatasetIdx is the index of the tenant's first real dataset within
 // meta.Datasets and is used to derive the time range covered by the
 // tenant in the segment.
+// writeTenantDatasetIndex returns the number of bytes written for the
+// dataset index payload (0 if the index is empty and no pseudo-dataset
+// was emitted).
 func writeTenantDatasetIndex(
 	w *writerOffset,
 	meta *metastorev1.BlockMeta,
@@ -345,15 +362,15 @@ func writeTenantDatasetIndex(
 	tenant string,
 	firstDatasetIdx int,
 	dsIndex *block.DatasetIndexWriter,
-) error {
+) (int64, error) {
 	defer dsIndex.Close()
 	if dsIndex.Empty() {
-		return nil
+		return 0, nil
 	}
 	off := uint64(w.offset)
 	n, err := dsIndex.WriteTo(w)
 	if err != nil {
-		return fmt.Errorf("failed to write dataset index: %w", err)
+		return 0, fmt.Errorf("failed to write dataset index: %w", err)
 	}
 	var minT, maxT int64 = math.MaxInt64, 0
 	for _, ds := range meta.Datasets[firstDatasetIdx:] {
@@ -376,7 +393,7 @@ func writeTenantDatasetIndex(
 		Size:            uint64(n),
 		Labels:          labels,
 	})
-	return nil
+	return n, nil
 }
 
 func concatSegmentHead(f *datasetFlush, w *writerOffset, s *metadata.StringTable) *metastorev1.Dataset {
@@ -561,6 +578,8 @@ type segment struct {
 		flushHeadsDuration time.Duration
 		flushBlockDuration time.Duration
 		storeMetaDuration  time.Duration
+		tenantIndexes      int
+		tenantIndexBytes   int64
 	}
 
 	// TODO(kolesnikovae): Naming.

--- a/pkg/segmentwriter/segment.go
+++ b/pkg/segmentwriter/segment.go
@@ -296,9 +296,7 @@ func (s *segment) flushBlock(stream flushStream) ([]byte, *metastorev1.BlockMeta
 		}
 		ds := concatSegmentHead(f, w, stringTable)
 		dsIndex.SetIndex(uint32(len(meta.Datasets)))
-		for _, series := range f.flushed.Series {
-			dsIndex.AddSeries(series.Labels, series.Fingerprint)
-		}
+		f.flushed.WriteDatasetIndex(dsIndex)
 		meta.MinTime = min(meta.MinTime, ds.MinTime)
 		meta.MaxTime = max(meta.MaxTime, ds.MaxTime)
 		meta.Datasets = append(meta.Datasets, ds)

--- a/pkg/segmentwriter/segment_metrics.go
+++ b/pkg/segmentwriter/segment_metrics.go
@@ -10,6 +10,7 @@ type segmentMetrics struct {
 	segmentIngestBytes          *prometheus.HistogramVec
 	segmentSizeBytes            *prometheus.HistogramVec
 	headSizeBytes               *prometheus.HistogramVec
+	tenantIndexBytes            *prometheus.HistogramVec
 	segmentFlushWaitDuration    *prometheus.HistogramVec
 	segmentFlushTimeouts        *prometheus.CounterVec
 	storeMetadataDuration       *prometheus.HistogramVec
@@ -151,6 +152,16 @@ func newSegmentMetrics(reg prometheus.Registerer) *segmentMetrics {
 				NativeHistogramMaxBucketNumber:  32,
 				NativeHistogramMinResetDuration: time.Minute * 15,
 			}, []string{"shard", "tenant"}),
+		tenantIndexBytes: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace:                       "pyroscope",
+				Name:                            "segment_tenant_index_bytes",
+				Help:                            "Size of the per-tenant dataset index emitted into a flushed segment block.",
+				Buckets:                         prometheus.ExponentialBucketsRange(1024, 100*1024*1024, 20),
+				NativeHistogramBucketFactor:     1.1,
+				NativeHistogramMaxBucketNumber:  32,
+				NativeHistogramMinResetDuration: time.Minute * 15,
+			}, []string{"shard", "tenant"}),
 	}
 
 	if reg != nil {
@@ -167,6 +178,7 @@ func newSegmentMetrics(reg prometheus.Registerer) *segmentMetrics {
 		reg.MustRegister(m.flushServiceHeadError)
 		reg.MustRegister(m.flushSegmentDuration)
 		reg.MustRegister(m.headSizeBytes)
+		reg.MustRegister(m.tenantIndexBytes)
 	}
 	return m
 }

--- a/pkg/segmentwriter/segment_test.go
+++ b/pkg/segmentwriter/segment_test.go
@@ -308,10 +308,15 @@ func TestDatasetMinMaxTime(t *testing.T) {
 
 	block := <-metas
 
+	// Datasets in the block: real datasets are sorted by tenant+service; a
+	// per-tenant dataset index pseudo-dataset is appended after the last
+	// real dataset of each tenant.
 	expected := [][2]int{
-		{10, 1337},
-		{239, 420},
-		{420, 421},
+		{10, 1337},   // ta/svc1
+		{10, 1337},   // ta dataset index
+		{239, 420},   // tb/svc1
+		{420, 421},   // tb/svc2
+		{239, 421},   // tb dataset index
 	}
 
 	require.Equal(t, len(expected), len(block.Datasets))
@@ -552,6 +557,10 @@ func (sw *sw) createBlocksFromMetas(blocks []*metastorev1.BlockMeta) tenantClien
 		require.NoError(sw.t, err)
 
 		for _, ds := range meta.Datasets {
+			if block.DatasetFormat(ds.Format) != block.DatasetFormat0 {
+				// Skip pseudo-datasets such as the per-tenant dataset index.
+				continue
+			}
 			tenant := meta.StringTable[ds.Tenant]
 			profiles := blob[ds.TableOfContents[0]:ds.TableOfContents[1]]
 			tsdb := blob[ds.TableOfContents[1]:ds.TableOfContents[2]]
@@ -570,6 +579,9 @@ func (sw *sw) createBlocksFromMetas(blocks []*metastorev1.BlockMeta) tenantClien
 	res := make(tenantClients)
 	for _, meta := range blocks {
 		for _, ds := range meta.Datasets {
+			if block.DatasetFormat(ds.Format) != block.DatasetFormat0 {
+				continue
+			}
 			tenant := meta.StringTable[ds.Tenant]
 			if _, ok := res[tenant]; !ok {
 				// todo consider not using BlockQuerier for tests

--- a/pkg/segmentwriter/segment_test.go
+++ b/pkg/segmentwriter/segment_test.go
@@ -39,7 +39,9 @@ import (
 	"github.com/grafana/pyroscope/v2/pkg/objstore/providers/filesystem"
 	"github.com/grafana/pyroscope/v2/pkg/objstore/providers/memory"
 	"github.com/grafana/pyroscope/v2/pkg/og/convert/pprof/bench"
+	phlareobj "github.com/grafana/pyroscope/v2/pkg/objstore"
 	"github.com/grafana/pyroscope/v2/pkg/phlaredb"
+	tsdbindex "github.com/grafana/pyroscope/v2/pkg/phlaredb/tsdb/index"
 	testutil3 "github.com/grafana/pyroscope/v2/pkg/phlaredb/block/testutil"
 	pprofth "github.com/grafana/pyroscope/v2/pkg/pprof/testhelper"
 	"github.com/grafana/pyroscope/v2/pkg/segmentwriter/memdb"
@@ -326,6 +328,100 @@ func TestDatasetMinMaxTime(t *testing.T) {
 	}
 	assert.Equal(t, int64(10), block.MinTime)
 	assert.Equal(t, int64(1337), block.MaxTime)
+}
+
+// TestSegmentTenantDatasetIndexes flushes a multi-tenant segment and
+// inspects the per-tenant Format1 dataset_index pseudo-datasets in the
+// resulting block. For each tenant it verifies that the dataset_index
+// encodes one entry per real dataset of the tenant, and that each
+// entry's chunk SeriesIndex is the global position of the real dataset
+// within meta.Datasets (this is what the query backend uses to resolve
+// datasets from a Format1 lookup).
+func TestSegmentTenantDatasetIndexes(t *testing.T) {
+	l := test.NewTestingLogger(t)
+	bucket := memory.NewInMemBucket()
+	metas := make(chan *metastorev1.BlockMeta, 1)
+	client := mockmetastorev1.NewMockIndexServiceClient(t)
+	client.On("AddBlock", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			metas <- args.Get(1).(*metastorev1.AddBlockRequest).Block
+		}).Return(new(metastorev1.AddBlockResponse), nil)
+	sw := newSegmentWriter(
+		l,
+		newSegmentMetrics(nil),
+		memdb.NewHeadMetricsWithPrefix(nil, ""),
+		defaultTestConfig(),
+		validation.MockDefaultOverrides(),
+		bucket,
+		client,
+	)
+	defer sw.stop()
+
+	// Two tenants on the same shard so they share the segment block.
+	data := []input{
+		{shard: 1, tenant: "ta", profile: cpuProfile(13, 100, "svc1", "foo", "bar")},
+		{shard: 1, tenant: "ta", profile: cpuProfile(13, 110, "svc2", "foo", "bar")},
+		{shard: 1, tenant: "tb", profile: cpuProfile(13, 120, "svc1", "foo", "bar")},
+	}
+	_ = sw.ingest(1, func(head segmentIngest) {
+		for _, p := range data {
+			head.ingest(p.tenant, p.profile.Profile, p.profile.UUID, p.profile.Labels, p.profile.Annotations)
+		}
+	})
+
+	meta := <-metas
+
+	// Group real datasets by tenant; record their global positions in
+	// meta.Datasets and find each tenant's Format1 pseudo-dataset.
+	realByTenant := map[string][]int{}
+	indexByTenant := map[string]*metastorev1.Dataset{}
+	for i, ds := range meta.Datasets {
+		tenantName := meta.StringTable[ds.Tenant]
+		switch block.DatasetFormat(ds.Format) {
+		case block.DatasetFormat0:
+			realByTenant[tenantName] = append(realByTenant[tenantName], i)
+		case block.DatasetFormat1:
+			require.Nil(t, indexByTenant[tenantName], "more than one Format1 dataset for tenant %s", tenantName)
+			indexByTenant[tenantName] = ds
+		}
+	}
+	require.Equal(t, []int{0, 1}, realByTenant["ta"], "expected ta to have two real datasets")
+	require.Len(t, realByTenant["tb"], 1, "expected tb to have one real dataset")
+	require.Len(t, indexByTenant, 2, "expected one Format1 dataset per tenant")
+
+	// Open the block and inspect each tenant's dataset_index.
+	obj := block.NewObject(phlareobj.NewBucket(bucket), meta)
+	t.Cleanup(func() { _ = obj.Close() })
+	require.NoError(t, obj.Open(context.Background()))
+
+	for tenantName, indexDS := range indexByTenant {
+		t.Run(tenantName, func(t *testing.T) {
+			ds := block.NewDataset(indexDS, obj)
+			t.Cleanup(func() { _ = ds.Close() })
+			require.NoError(t, ds.Open(context.Background(), block.SectionDatasetIndex))
+
+			// Walk every series in the index and collect chunk
+			// SeriesIndex values; they must equal the global
+			// positions of the tenant's real datasets within
+			// meta.Datasets.
+			indexReader := ds.Index()
+			n, v := tsdbindex.AllPostingsKey()
+			postings, err := indexReader.Postings(n, nil, v)
+			require.NoError(t, err)
+			var seriesIndices []int
+			chunks := make([]tsdbindex.ChunkMeta, 1)
+			for postings.Next() {
+				_, err := indexReader.Series(postings.At(), nil, &chunks)
+				require.NoError(t, err)
+				require.Len(t, chunks, 1, "each series in the dataset_index should map to exactly one chunk")
+				seriesIndices = append(seriesIndices, int(chunks[0].SeriesIndex))
+			}
+			require.NoError(t, postings.Err())
+			slices.Sort(seriesIndices)
+			assert.Equal(t, realByTenant[tenantName], seriesIndices,
+				"dataset_index series must point to the tenant's real datasets via global positions")
+		})
+	}
 }
 
 func TestQueryMultipleSeriesSingleTenant(t *testing.T) {

--- a/pkg/segmentwriter/segment_test.go
+++ b/pkg/segmentwriter/segment_test.go
@@ -36,13 +36,13 @@ import (
 	"github.com/grafana/pyroscope/v2/pkg/metastore/index/dlq"
 	metastoretest "github.com/grafana/pyroscope/v2/pkg/metastore/test"
 	"github.com/grafana/pyroscope/v2/pkg/model"
+	phlareobj "github.com/grafana/pyroscope/v2/pkg/objstore"
 	"github.com/grafana/pyroscope/v2/pkg/objstore/providers/filesystem"
 	"github.com/grafana/pyroscope/v2/pkg/objstore/providers/memory"
 	"github.com/grafana/pyroscope/v2/pkg/og/convert/pprof/bench"
-	phlareobj "github.com/grafana/pyroscope/v2/pkg/objstore"
 	"github.com/grafana/pyroscope/v2/pkg/phlaredb"
-	tsdbindex "github.com/grafana/pyroscope/v2/pkg/phlaredb/tsdb/index"
 	testutil3 "github.com/grafana/pyroscope/v2/pkg/phlaredb/block/testutil"
+	tsdbindex "github.com/grafana/pyroscope/v2/pkg/phlaredb/tsdb/index"
 	pprofth "github.com/grafana/pyroscope/v2/pkg/pprof/testhelper"
 	"github.com/grafana/pyroscope/v2/pkg/segmentwriter/memdb"
 	memdbtest "github.com/grafana/pyroscope/v2/pkg/segmentwriter/memdb/testutil"
@@ -314,11 +314,11 @@ func TestDatasetMinMaxTime(t *testing.T) {
 	// per-tenant dataset index pseudo-dataset is appended after the last
 	// real dataset of each tenant.
 	expected := [][2]int{
-		{10, 1337},   // ta/svc1
-		{10, 1337},   // ta dataset index
-		{239, 420},   // tb/svc1
-		{420, 421},   // tb/svc2
-		{239, 421},   // tb dataset index
+		{10, 1337}, // ta/svc1
+		{10, 1337}, // ta dataset index
+		{239, 420}, // tb/svc1
+		{420, 421}, // tb/svc2
+		{239, 421}, // tb dataset index
 	}
 
 	require.Equal(t, len(expected), len(block.Datasets))

--- a/pkg/test/integration/cluster/cluster_v2.go
+++ b/pkg/test/integration/cluster/cluster_v2.go
@@ -30,6 +30,34 @@ func WithV2() ClusterOption {
 	}
 }
 
+// WithV2Federated configures a V2 cluster suitable for exercising the
+// federated (multi-tenant) query path. It mirrors the V2 cluster but
+// without a compaction-worker: L0 segment blocks therefore remain
+// Format1 (per-tenant dataset_index pseudo-datasets) for the duration
+// of the test, which is what the multi-Format1 resolution path in the
+// query backend handles.
+//
+// With two segment-writers and adaptive placement defaults, profiles
+// from each tenant are spread across both writers, so each flushed L0
+// segment is a multi-tenant block and naturally exercises the
+// multi-Format1 resolution path.
+func WithV2Federated() ClusterOption {
+	return func(c *Cluster) {
+		c.v2 = true
+		c.expectedComponents = []string{
+			"distributor",
+			"distributor",
+			"segment-writer",
+			"segment-writer",
+			"metastore",
+			"metastore",
+			"metastore",
+			"query-frontend",
+			"query-backend",
+		}
+	}
+}
+
 func (c *Cluster) metastoreConfig() (string, error) {
 	cfgPath := filepath.Join(c.tmpDir, "metastore.yaml")
 

--- a/pkg/test/integration/microservices_test.go
+++ b/pkg/test/integration/microservices_test.go
@@ -126,6 +126,68 @@ func TestMicroServicesIntegrationV2(t *testing.T) {
 
 }
 
+// TestMicroServicesIntegrationV2_Federated boots a V2 cluster with a
+// single segment-writer and no compaction-worker, ingests profiles for
+// multiple tenants and runs federated (multi-tenant) queries against
+// them. The single-writer / no-compaction setup deterministically
+// produces L0 blocks containing one Format1 dataset_index pseudo-dataset
+// per tenant, which is what the multi-Format1 resolution path in the
+// query backend handles.
+func TestMicroServicesIntegrationV2_Federated(t *testing.T) {
+	c := cluster.NewMicroServiceCluster(cluster.WithV2Federated())
+	ctx := context.Background()
+
+	require.NoError(t, c.Prepare(ctx))
+	for _, comp := range c.Components {
+		t.Log(comp.String())
+	}
+
+	require.NoError(t, c.Start(ctx))
+	t.Log("Cluster ready")
+	defer func() {
+		waitStopped := c.Stop()
+		require.NoError(t, waitStopped(ctx))
+	}()
+
+	tc := newTestCtx(c)
+	// Use a small fixed dataset for this test: federated correctness does
+	// not depend on dataset size, and this keeps the test fast.
+	tc.perTenantData = map[string]tenantParams{
+		"tenant-a": {serviceCount: 3, samples: 2},
+		"tenant-b": {serviceCount: 2, samples: 2},
+	}
+
+	t.Run("PushProfiles", func(t *testing.T) {
+		tc.pushProfiles(ctx, t)
+	})
+
+	// Wait for all per-tenant services to be visible via the dataset
+	// index. Without a compaction-worker the L0 segments are the only
+	// queryable blocks, so a positive answer here also confirms that
+	// multi-tenant L0 blocks have been flushed and indexed.
+	require.Eventually(t, func() bool {
+		for tenantID := range tc.perTenantData {
+			ctx := tenant.InjectTenantID(ctx, tenantID)
+			resp, err := tc.querier.LabelValues(ctx, connect.NewRequest(&typesv1.LabelValuesRequest{
+				Start: tc.now.Add(-time.Hour).UnixMilli(),
+				End:   tc.now.Add(time.Hour).UnixMilli(),
+				Name:  "service_name",
+			}))
+			if err != nil {
+				return false
+			}
+			if len(resp.Msg.Names) != tc.perTenantData[tenantID].serviceCount {
+				return false
+			}
+		}
+		return true
+	}, time.Minute, time.Second)
+
+	t.Run("QueryFederatedMultiTenant", func(t *testing.T) {
+		tc.runFederatedQueryTest(ctx, t)
+	})
+}
+
 // TestMetastoreAutoJoin tests that a new metastore node can join an existing cluster
 // using the auto-join feature without requiring bootstrap configuration.
 func TestMetastoreAutoJoin(t *testing.T) {
@@ -474,4 +536,79 @@ func (tc *testCtx) runQueryTest(ctx context.Context, t *testing.T) {
 			})
 		}
 	})
+
+}
+
+// runFederatedQueryTest exercises queries that span multiple tenants by
+// passing a pipe-separated tenant ID in X-Scope-OrgID. It is intended to
+// be driven against a cluster that produces multi-tenant L0 blocks (see
+// cluster.WithV2Federated), so that the query backend's multi-Format1
+// dataset_index resolution path is exercised.
+func (tc *testCtx) runFederatedQueryTest(ctx context.Context, t *testing.T) {
+	tenants := make([]string, 0, len(tc.perTenantData))
+	expectedServices := 0
+	expectedServiceNames := make([]string, 0)
+	// expectedTotalSampleValue mirrors the per-tenant ingest pattern in
+	// pushProfiles: each service emits one foo/bar/baz sample with
+	// value=1, plus a foo/bar/boz sample with value=3 for every (i,j)
+	// where (i+j)%3 == 0. The merged federated profile sums all those
+	// values across every service of every tenant.
+	expectedTotalSampleValue := int64(0)
+	for tenantID, params := range tc.perTenantData {
+		tenants = append(tenants, tenantID)
+		expectedServices += params.serviceCount
+		for i := 0; i < params.serviceCount; i++ {
+			expectedServiceNames = append(expectedServiceNames, fmt.Sprintf("%s/test-service-%d", tenantID, i))
+			expectedTotalSampleValue++ // foo/bar/baz, value=1
+			for j := 0; j < params.samples; j++ {
+				if (i+j)%3 == 0 {
+					expectedTotalSampleValue += 3 // foo/bar/boz, value=3
+				}
+			}
+		}
+	}
+	sort.Strings(tenants)
+	sort.Strings(expectedServiceNames)
+	orgID := strings.Join(tenants, "|")
+	// The connect tenant interceptor on the client side calls the
+	// single-tenant resolver, which rejects multi-tenant IDs, so
+	// we set the X-Scope-OrgID header explicitly to bypass it.
+
+	// LabelValues without a service_name matcher takes the
+	// dataset_index lookup path (index-only branch). Asserting the
+	// exact set of service names confirms that every tenant's data is
+	// reachable through the federated query, not just one of them.
+	lvReq := connect.NewRequest(&typesv1.LabelValuesRequest{
+		Start: tc.now.Add(-time.Hour).UnixMilli(),
+		End:   tc.now.Add(time.Hour).UnixMilli(),
+		Name:  "service_name",
+	})
+	lvReq.Header().Set("X-Scope-OrgID", orgID)
+	lv, err := tc.querier.LabelValues(ctx, lvReq)
+	require.NoError(t, err)
+	assert.Equal(t, expectedServiceNames, lv.Msg.Names, "federated label values must include every tenant's services")
+
+	// SelectMergeProfile without a service_name matcher needs
+	// SectionProfiles+SectionSymbols, exercising the resolve path
+	// where each per-tenant dataset_index is opened. Summing the
+	// merged sample values lets us check that data from every
+	// tenant ended up in the merged profile.
+	smpReq := connect.NewRequest(&querierv1.SelectMergeProfileRequest{
+		ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+		LabelSelector: "{}",
+		Start:         tc.now.Add(-time.Hour).UnixMilli(),
+		End:           tc.now.Add(time.Hour).UnixMilli(),
+	})
+	smpReq.Header().Set("X-Scope-OrgID", orgID)
+	resp, err := tc.querier.SelectMergeProfile(ctx, smpReq)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Msg)
+	assert.NotEmpty(t, resp.Msg.Sample, "federated profile must contain samples")
+	var totalSampleValue int64
+	for _, s := range resp.Msg.Sample {
+		for _, v := range s.Value {
+			totalSampleValue += v
+		}
+	}
+	assert.Equal(t, expectedTotalSampleValue, totalSampleValue, "federated profile must merge sample values from every tenant")
 }

--- a/pkg/test/integration/microservices_test.go
+++ b/pkg/test/integration/microservices_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -102,49 +101,8 @@ func TestMicroServicesIntegrationV2(t *testing.T) {
 		tc.pushProfiles(ctx, t)
 	})
 
-	// ingest some more data to compact the rest of the data we care about
-	// TODO: This shouldn't be necessary see https://github.com/grafana/pyroscope/issues/4193.
-	pushCtx, pushCancel := context.WithCancel(ctx)
-	g, gctx := errgroup.WithContext(pushCtx)
-	g.SetLimit(4)
-	for i := 0; i < 200; i++ {
-		g.Go(func() error {
-			p, err := testhelper.NewProfileBuilder(tc.now.UnixNano()).
-				CPUProfile().
-				ForStacktraceString("foo", "bar", "baz").AddSamples(1).
-				MarshalVT()
-			require.NoError(t, err)
-
-			pctx := tenant.InjectTenantID(gctx, fmt.Sprintf("dummy-tenant-%d", i))
-			_, err = tc.pusher.Push(pctx, connect.NewRequest(&pushv1.PushRequest{
-				Series: []*pushv1.RawProfileSeries{{
-					Labels: []*typesv1.LabelPair{
-						{Name: "service_name", Value: fmt.Sprintf("dummy-service/%d", i)},
-						{Name: "__name__", Value: "process_cpu"},
-					},
-					Samples: []*pushv1.RawSample{{RawProfile: p}},
-				}},
-			}))
-			return err
-		})
-	}
-	defer func() {
-		pushCancel()
-		err := g.Wait()
-		if !errors.Is(err, context.Canceled) {
-			require.NoError(t, g.Wait())
-		}
-	}()
-
-	// await compaction so tenant wide index is available
-	require.Eventually(t, func() bool {
-		jobs, err := c.CompactionJobsFinished(ctx)
-		return err == nil && jobs > 0
-	}, time.Minute, time.Second)
-	t.Log("Compaction worker finished")
-
-	// await until all tenants have all expected labelValues available
-	// TODO: This shouldn't be necessary see https://github.com/grafana/pyroscope/issues/4193.
+	// Segments contain a per-tenant dataset index, so queries that do not
+	// match a service_name can find data without waiting for compaction.
 	require.Eventually(t, func() bool {
 		for tenantID := range tc.perTenantData {
 			ctx := tenant.InjectTenantID(ctx, tenantID)
@@ -250,7 +208,7 @@ func (tc *testCtx) pushProfiles(ctx context.Context, t *testing.T) {
 			var i = i
 			g.Go(func() error {
 				serviceName := fmt.Sprintf("%s/test-service-%d", tenantID, i)
-				builder := testhelper.NewProfileBuilder(int64(1)).
+				builder := testhelper.NewProfileBuilder(tc.now.UnixNano()).
 					CPUProfile().
 					WithLabels(
 						"job", "test",
@@ -258,7 +216,6 @@ func (tc *testCtx) pushProfiles(ctx context.Context, t *testing.T) {
 					)
 				builder.ForStacktraceString("foo", "bar", "baz").AddSamples(1)
 				for j := 0; j < params.samples; j++ {
-					builder.TimeNanos = tc.now.Add(time.Duration(j) * 5 * time.Second).UnixNano()
 					if (i+j)%3 == 0 {
 						builder.ForStacktraceString("foo", "bar", "boz").AddSamples(3)
 					}


### PR DESCRIPTION
Currently, the per-tenant dataset TSDB index is only built at compaction time. Queries that do not include a `service_name` label rely on the dataset index to identify which datasets within a block match the query. As a result, freshly ingested data is effectively invisible to such queries until compaction completes.

This change extends the segment writer to build a per-tenant dataset index for each tenant present in a segment. The index is appended as a `Format1` pseudo-dataset to the block metadata, annotated with the `__tenant_dataset__ = dataset_tsdb_index` label, mirroring the layout produced by the compactor.

The implementation:

- Preserves the series labels and fingerprints captured by the in-memory profile index so that we can build the dataset index without re-reading the TSDB.
- Promotes the dataset index writer used by compaction to a public block.DatasetIndexWriter and adds an AddSeries entry point (compaction continues to use the row-by-row path).
- Groups contiguous tenant heads in a segment, builds an index per tenant and writes a pseudo-dataset entry on each tenant boundary.

The integration test workaround that pushed extra profiles to force compaction so a tenant-wide index would become available is no longer necessary and is removed (closes the TODO referencing pyroscope#4193).

The `pushProfiles` helper is also adjusted to stamp profiles at the test's reference time instead of the (overwritten) future timestamps, so queries with default time ranges can find the data without depending on wall-clock progress.

TODO:
- [x] test in a dev environment
- [x] simplify tests for federated (multi-tenant) queries

Performance impact (after 447b0d1):

```
  ┌──────────────────────┬────────────────┬───────────────┬────────┐                               
  │     Profile type     │ New-code total │ Service total │ Share  │                               
  ├──────────────────────┼────────────────┼───────────────┼────────┤                               
  │ CPU (process_cpu)    │ 4.19 s         │ 109.51 s      │ 3.83%  │                               
  ├──────────────────────┼────────────────┼───────────────┼────────┤                             
  │ Memory alloc_space   │ 793 MB         │ 53.86 GB      │ 1.47%  │                               
  ├──────────────────────┼────────────────┼───────────────┼────────┤                               
  │ Memory alloc_objects │ 2.82 M         │ 211 M         │ 1.34%  │                               
  ├──────────────────────┼────────────────┼───────────────┼────────┤                               
  │ Memory inuse_space   │ 538 KB         │ 236 MB        │ 0.23%  │                               
  ├──────────────────────┼────────────────┼───────────────┼────────┤                               
  │ Mutex delay          │ 5.5 µs         │ 221 ms        │ <0.01% │                               
  ├──────────────────────┼────────────────┼───────────────┼────────┤                               
  │ Block delay          │ not present    │ —             │ 0%     │                               
  └──────────────────────┴────────────────┴───────────────┴────────┘                               
```

Fixes #4193



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes block layout/metadata by adding per-tenant `DatasetFormat1` pseudo-datasets at segment flush time and updates query resolution logic to union results across multiple indices, which can affect dataset selection for queries. Risk is moderated by added unit/integration coverage but touches critical query/compaction paths.
> 
> **Overview**
> Freshly-flushed segment (L0) blocks now include a **per-tenant `DatasetFormat1` `dataset_tsdb_index` pseudo-dataset** appended at each tenant boundary, so queries without `service_name` can discover datasets without waiting for compaction.
> 
> This introduces a pooled `block.DatasetIndexWriter` (used by both compaction and segment flush), preserves series labels/fingerprints from `memdb` flush to feed the index, and adds segment-writer metrics/debug counters for emitted tenant indexes.
> 
> The query backend now supports **resolving multiple Format1 indices in a single block** (multi-tenant segments) by opening each index, unioning matched dataset IDs, and rewriting block metadata accordingly; tests/integration were updated to skip pseudo-datasets, add federated coverage, and remove the prior “force compaction” workaround.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eef33f5caa2820b0e2909374e1c6a0c39e9084a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->