### PR TITLE
fix: correct ingest aggregationType docs

### DIFF
--- a/docs/sources/reference-server-api/index.md
+++ b/docs/sources/reference-server-api/index.md
@@ -662,7 +662,7 @@ The following query parameters are accepted:
 | `sampleRate`       | sample rate used in Hz                  | optional (default is `100` Hz) |
 | `spyName`          | name of the spy used                    | optional                       |
 | `units`            | name of the profiling data unit         | optional (default is `samples` |
-| `aggregrationType` | type of aggregation to merge profiles   | optional (default is `sum`)    |
+| `aggregationType`  | type of aggregation to merge profiles   | optional (default is `sum`)    |
 
 
 `name` specifies application name. For example:

--- a/docs/sources/reference-server-api/index.template
+++ b/docs/sources/reference-server-api/index.template
@@ -63,7 +63,7 @@ The following query parameters are accepted:
 | `sampleRate`       | sample rate used in Hz                  | optional (default is `100` Hz) |
 | `spyName`          | name of the spy used                    | optional                       |
 | `units`            | name of the profiling data unit         | optional (default is `samples` |
-| `aggregrationType` | type of aggregation to merge profiles   | optional (default is `sum`)    |
+| `aggregationType`  | type of aggregation to merge profiles   | optional (default is `sum`)    |
 
 
 `name` specifies application name. For example:


### PR DESCRIPTION
Summary:
- Fixes the /ingest query parameter name from aggregrationType to aggregationType in the API docs.
- Regenerates docs/sources/reference-server-api/index.md from the template.

How to reproduce:
1. Open docs/sources/reference-server-api/index.md and check the /ingest query parameter table.
2. Compare it with pkg/ingester/pyroscope/ingest_handler.go, where the handler reads aggregationType.
3. The docs had the misspelled name, so copy-pasting from them could send users down the wrong path.

Tiny docs papercut, imo, but worth fixing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it only corrects a query parameter name in generated API docs.
> 
> **Overview**
> Corrects the legacy `POST /ingest` query parameter name in the Server API docs from the misspelled `aggregrationType` to `aggregationType`.
> 
> Regenerates `docs/sources/reference-server-api/index.md` from `index.template` so the published reference matches the actual handler parameter name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 884ecb11c0f938fc4db6c650bed8ddb1e21a5b0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->