### PR TITLE
fix: skip TestGoPclntabSelfExe on non-Linux platforms

### DIFF
--- a/lidia/lidia_test.go
+++ b/lidia/lidia_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -203,6 +204,9 @@ func (b *bufferCloser) Close() error {
 // TestGoPclntabSelfExe tests creating a lidia table from /proc/self/exe using only gopclntab
 // (no symtab) and resolving the test function's address.
 func TestGoPclntabSelfExe(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("skipping: /proc/self/exe is only available on Linux")
+	}
 	// Get the address of this test function using reflect
 	testFuncAddr := reflect.ValueOf(TestGoPclntabSelfExe).Pointer()
 


### PR DESCRIPTION
TestGoPclntabSelfExe reads /proc/self/exe which is a Linux-only procfs symlink. The test fails on macOS and other non-Linux platforms. This adds a runtime.GOOS guard to skip the test on non-Linux systems.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only affects test execution by gating a Linux-specific `/proc/self/exe` dependency, reducing cross-platform CI failures without touching production code.
> 
> **Overview**
> Makes `TestGoPclntabSelfExe` in `lidia/lidia_test.go` Linux-only by adding a `runtime.GOOS` guard and skipping the test on non-Linux platforms.
> 
> Adds the `runtime` import to support the OS check; no functional changes to `lidia` behavior outside tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af3fdb58164e5ced98314082663238100280a777. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->