### PR TITLE
fix(deps): bump uuid from 11.1.0 to 11.1.1 in /ui [security]

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -42,6 +42,7 @@
     "react-custom-scrollbars-2@npm:4.5.0": "patch:react-custom-scrollbars-2@npm%3A4.5.0#~/.yarn/patches/react-custom-scrollbars-2-npm-4.5.0-420f40d266.patch",
     "brace-expansion@npm:^1.1.7": "npm:1.1.13",
     "dompurify": "npm:^3.4.0",
-    "immutable": "npm:5.1.5"
+    "immutable": "npm:5.1.5",
+    "uuid": "npm:^11.1.1"
   }
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6365,12 +6365,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:11.1.0":
-  version: 11.1.0
-  resolution: "uuid@npm:11.1.0"
+"uuid@npm:^11.1.1":
+  version: 11.1.1
+  resolution: "uuid@npm:11.1.1"
   bin:
     uuid: dist/esm/bin/uuid
-  checksum: 10c0/34aa51b9874ae398c2b799c88a127701408cd581ee89ec3baa53509dd8728cbb25826f2a038f9465f8b7be446f0fbf11558862965b18d21c993684297628d4d3
+  checksum: 10c0/9e3af58eba872ece5a5e76f4773a94fc78a0ef2c2444c38dbe6b42f41dadf76c01850fd783604f27986f6195e6286aef064d45987d401b2a33127b98ddf7c0c5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bumps `uuid` from 11.1.0 to 11.1.1 in `ui/`
- Adds a yarn resolution override to force the patched version (uuid is a transitive dependency of `@grafana/ui`)
- Fixes CVE-2026-41907 (MEDIUM severity)

## Test plan

- [x] `nix run sys#trivy -- fs ui/yarn.lock` reports 0 vulnerabilities after this change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change limited to Yarn `resolutions` and `yarn.lock`; primary risk is unexpected transitive dependency behavior if another package required `uuid@11.1.0`.
> 
> **Overview**
> Updates `ui` dependency resolution to **force `uuid@^11.1.1`** via `package.json` `resolutions` and refreshes `ui/yarn.lock` to lock `uuid` to `11.1.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6b7de8f18c8f96f5863aa5f6705b5db008d956c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->