### PR TITLE
Add release notes for v1.21.1

### DIFF
--- a/docs/sources/release-notes/v1-21.md
+++ b/docs/sources/release-notes/v1-21.md
@@ -5,6 +5,17 @@ description: Release notes for Grafana Pyroscope 1.21
 weight: 690
 ---
 
+## Version 1.21.1 release notes
+
+### Fixes
+* **querier**: Clone label values to prevent buffer reuse-after-free in concurrent `LabelValues` queries ([#5116](https://github.com/grafana/pyroscope/pull/5116))
+
+### Security fixes
+* Update `github.com/prometheus/prometheus` to v0.311.3 (security) ([#5113](https://github.com/grafana/pyroscope/pull/5113))
+* Bump `postcss` from 8.5.8 to 8.5.13 in `/ui` (security) ([#5105](https://github.com/grafana/pyroscope/pull/5105))
+* Bump `ip-address` from 10.1.0 to 10.2.0 in `/ui` (security) ([#5114](https://github.com/grafana/pyroscope/pull/5114))
+* Bump `uuid` from 11.1.0 to 11.1.1 in `/ui` (security) ([#5123](https://github.com/grafana/pyroscope/pull/5123))
+
 ## Version 1.21.0 release notes
 
 The Pyroscope team is excited to present Grafana Pyroscope 1.21.0.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates release notes; no runtime code paths are modified.
> 
> **Overview**
> Adds a new **v1.21.1** section to the `v1-21.md` release notes, documenting one querier fix (preventing buffer reuse-after-free in concurrent `LabelValues` queries) and several dependency security updates (Prometheus, plus `postcss`, `ip-address`, and `uuid` in `/ui`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e47bf817bb93b0b35db9c3d89df5a65f63c401df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->