### PR TITLE
Add release notes for v2.0.2

### DIFF
--- a/docs/sources/release-notes/v2-0.md
+++ b/docs/sources/release-notes/v2-0.md
@@ -5,6 +5,17 @@ description: Release notes for Grafana Pyroscope 2.0
 weight: 680
 ---
 
+## Version 2.0.2 release notes
+
+### Fixes
+* **querier**: Clone label values to prevent buffer reuse-after-free in concurrent `LabelValues` queries ([#5116](https://github.com/grafana/pyroscope/pull/5116))
+
+### Security fixes
+* Update `github.com/prometheus/prometheus` to v0.311.3 (security) ([#5113](https://github.com/grafana/pyroscope/pull/5113))
+* Bump `postcss` from 8.5.8 to 8.5.13 in `/ui` (security) ([#5105](https://github.com/grafana/pyroscope/pull/5105))
+* Bump `ip-address` from 10.1.0 to 10.2.0 in `/ui` (security) ([#5114](https://github.com/grafana/pyroscope/pull/5114))
+* Bump `uuid` from 11.1.0 to 11.1.1 in `/ui` (security) ([#5123](https://github.com/grafana/pyroscope/pull/5123))
+
 ## Version 2.0.1 release notes
 
 ### Fixes


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change with no runtime or build logic modifications.
> 
> **Overview**
> Adds a new **v2.0.2** section to `docs/sources/release-notes/v2-0.md`, documenting a querier fix for concurrent `LabelValues` buffer reuse-after-free and listing dependency security updates (Prometheus, `postcss`, `ip-address`, `uuid`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7097c1a606b061552bf4d3d0dfd2c663aa538af5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->