### PR TITLE
fix(store-gateway): Ring info route was set to /tenants, changing it back to /ring

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -270,7 +270,7 @@ func (a *API) RegisterStoreGateway(svc *storegateway.StoreGateway) {
 		{Desc: "Ring status", Path: "/store-gateway/ring"},
 		{Desc: "Tenants & Blocks", Path: "/store-gateway/tenants"},
 	})
-	a.RegisterRoute("/store-gateway/tenants", http.HandlerFunc(svc.RingHandler), a.registerOptionsRingPage()...)
+	a.RegisterRoute("/store-gateway/ring", http.HandlerFunc(svc.RingHandler), a.registerOptionsRingPage()...)
 	a.RegisterRoute("/store-gateway/tenants", http.HandlerFunc(svc.TenantsHandler), a.registerOptionsPublicAccess()...)
 	a.RegisterRoute("/store-gateway/tenant/{tenant}/blocks", http.HandlerFunc(svc.BlocksHandler), a.registerOptionsPublicAccess()...)
 }


### PR DESCRIPTION
A bug was introduced by https://github.com/grafana/pyroscope/commit/1f263141880a1b01b8132c081eecc22ff41dae7c. Causing the ring handler for store gateway to be registered on the wrong /tenants route. 
This PR rollback this and fix the bug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small routing change that restores the intended endpoint mapping for the store-gateway ring page.
> 
> **Overview**
> Restores the store-gateway ring status HTTP route by registering `svc.RingHandler` on `/store-gateway/ring` (instead of mistakenly wiring it to `/store-gateway/tenants`).
> 
> The tenants and blocks routes remain mapped to their respective handlers, so the ring page and tenants page no longer conflict.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44498fb056fb74b9d56a48a5d66f9a0570dd3456. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->