### PR TITLE
fix: Nil check invalid matchers for recording rules Upsert

### DIFF
--- a/pkg/settings/recording/recording.go
+++ b/pkg/settings/recording/recording.go
@@ -275,6 +275,9 @@ func validateUpsert(req *settingsv1.UpsertRecordingRuleRequest) error {
 			errs = append(errs, fmt.Errorf("matcher %q is invalid: %v", m, err))
 		}
 		for _, matcher := range matchers {
+			if matcher == nil {
+				continue
+			}
 			if matcher.Name == model.LabelNameProfileType {
 				if matcher.Type != labels.MatchEqual {
 					errs = append(errs, fmt.Errorf("matcher %q must have type %q", matcher.Name, labels.MatchEqual))

--- a/pkg/settings/recording/recording_test.go
+++ b/pkg/settings/recording/recording_test.go
@@ -177,6 +177,19 @@ func Test_validateUpsert(t *testing.T) {
 			WantErr: `matcher "" is invalid: unknown position: parse error: unexpected end of input`,
 		},
 		{
+			Name: "mixed_invalid_matchers",
+			Req: &settingsv1.UpsertRecordingRuleRequest{
+				MetricName: "profiles_recorded_my_metric",
+				Matchers: []string{
+					"",
+					`{ __profile_type__ = "any-type", INVALID }`,
+				},
+				GroupBy:        []string{},
+				ExternalLabels: []*typesv1.LabelPair{},
+			},
+			WantErr: "matcher \"\" is invalid: unknown position: parse error: unexpected end of input\nmatcher \"{ __profile_type__ = \\\"any-type\\\", INVALID }\" is invalid: 1:42: parse error: unexpected \"}\" in label matching, expected label matching operator",
+		},
+		{
 			Name: "missing __profile_type__ matcher",
 			Req: &settingsv1.UpsertRecordingRuleRequest{
 				MetricName:     "profiles_recorded_my_metric",


### PR DESCRIPTION
The matchers parser could return a non-nil list of parsed matchers that can include both correct parsed matchers and nils for invalid ones. This PR checks the second case where parser return nils as well.

Solves https://github.com/grafana/pyroscope-squad/issues/772

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 09a19b7320785ebdcab43cbe69f2277a7715b42a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->