### PR TITLE
feat(symbolizer): add opt-in in-memory cache for lidia bytes

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -1587,6 +1587,8 @@ Usage of ./pyroscope:
     	URL of the debuginfod server (default "https://debuginfod.elfutils.org")
   -symbolizer.enabled
     	[experimental] Enable symbolization for tenants by default.
+  -symbolizer.lidia-cache-size-bytes int
+    	Maximum size in bytes of the in-memory lidia cache. The cache is per-process: each query-frontend replica holds its own copy. Items larger than this value are silently rejected; watch the cache_operations{cache_type="lidia_inmem",status="rejected"} metric.
   -symbolizer.max-debuginfod-concurrency int
     	Maximum number of concurrent symbolization requests to debuginfod server. (default 10)
   -target comma-separated-list-of-strings

--- a/pkg/symbolizer/lidia_cache.go
+++ b/pkg/symbolizer/lidia_cache.go
@@ -1,0 +1,94 @@
+package symbolizer
+
+import (
+	"fmt"
+
+	"github.com/dgraph-io/ristretto/v2"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"golang.org/x/sync/singleflight"
+)
+
+const cacheTypeLidiaInmem = "lidia_inmem"
+
+// Sizes ristretto's TinyLFU sketch (~10x expected items per ristretto docs).
+// Multi-MiB lidia files keep practical item counts well under this.
+const lidiaCacheNumCounters = 10000
+
+// In-memory cache of lidia bytes keyed by tenant+buildID, with singleflight
+// on fill. A nil receiver acts as a disabled cache (passthrough to fetch).
+type lidiaCache struct {
+	cache  *ristretto.Cache[string, []byte]
+	sf     singleflight.Group
+	m      *metrics
+	logger log.Logger
+}
+
+func newLidiaCache(maxBytes int64, m *metrics, logger log.Logger) (*lidiaCache, error) {
+	if maxBytes <= 0 {
+		return nil, nil
+	}
+	c, err := ristretto.NewCache(&ristretto.Config[string, []byte]{
+		NumCounters: lidiaCacheNumCounters,
+		MaxCost:     maxBytes,
+		BufferItems: 64,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create lidia cache: %w", err)
+	}
+	return &lidiaCache{cache: c, m: m, logger: logger}, nil
+}
+
+// getOrFetch returns the cached bytes for key, or invokes fetch on miss.
+// Concurrent callers requesting the same key share a single fetch.
+func (c *lidiaCache) getOrFetch(key string, fetch func() ([]byte, error)) ([]byte, error) {
+	if c == nil {
+		return fetch()
+	}
+	if data, ok := c.cache.Get(key); ok {
+		c.m.cacheOperations.WithLabelValues(cacheTypeLidiaInmem, "get", statusSuccess).Inc()
+		return data, nil
+	}
+	c.m.cacheOperations.WithLabelValues(cacheTypeLidiaInmem, "get", "miss").Inc()
+
+	v, err, _ := c.sf.Do(key, func() (any, error) {
+		// Re-check: a concurrent caller may have populated the cache.
+		if data, ok := c.cache.Get(key); ok {
+			return data, nil
+		}
+		data, err := fetch()
+		if err != nil {
+			return nil, err
+		}
+		c.set(key, data)
+		return data, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.([]byte), nil
+}
+
+func (c *lidiaCache) set(key string, data []byte) {
+	if !c.cache.Set(key, data, int64(len(data))) {
+		c.m.cacheOperations.WithLabelValues(cacheTypeLidiaInmem, "set", "rejected").Inc()
+		// Most likely cause: item size exceeds the configured cache MaxCost.
+		level.Warn(c.logger).Log(
+			"msg", "lidia cache rejected entry; item likely exceeds cache size",
+			"key", key,
+			"item_bytes", len(data),
+		)
+		return
+	}
+	c.cache.Wait()
+	c.m.cacheOperations.WithLabelValues(cacheTypeLidiaInmem, "set", statusSuccess).Inc()
+	c.m.cacheSizeBytes.WithLabelValues(cacheTypeLidiaInmem).
+		Set(float64(c.cache.Metrics.CostAdded() - c.cache.Metrics.CostEvicted()))
+}
+
+func (c *lidiaCache) close() {
+	if c == nil {
+		return
+	}
+	c.cache.Close()
+}

--- a/pkg/symbolizer/lidia_cache_test.go
+++ b/pkg/symbolizer/lidia_cache_test.go
@@ -1,0 +1,81 @@
+package symbolizer
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/pyroscope/v2/pkg/tenant"
+)
+
+func TestLidiaCache_HitOnRepeatedBuildID(t *testing.T) {
+	const buildID = "ffcf60c240417166980a43fbbfde486e0b3718e5"
+	lidiaData, err := extractGzipFile(t, "testdata/test_lidia_file.gz")
+	require.NoError(t, err)
+
+	s, _, mockBucket := newSymbolizerTest(t, &symbolizerInputs{LidiaCacheSizeBytes: 128 << 20})
+
+	// One Get for the cache fill; subsequent calls must be served from cache.
+	mockBucket.On("Get", mock.Anything, lidiaObjectPath("tenant", buildID)).
+		Return(io.NopCloser(bytes.NewReader(lidiaData)), nil).Once()
+
+	ctx := tenant.InjectTenantID(context.Background(), "tenant")
+
+	for i := 0; i < 5; i++ {
+		req := &request{
+			buildID:    buildID,
+			binaryName: "test-binary",
+			locations:  []*location{{address: 0x1b743d6}},
+		}
+		s.symbolize(ctx, req)
+		require.NotEmpty(t, req.locations[0].lines, "iteration %d returned no symbols", i)
+	}
+
+	mockBucket.AssertExpectations(t)
+}
+
+func TestLidiaCache_ConcurrentMissesShareOneFetch(t *testing.T) {
+	const buildID = "ffcf60c240417166980a43fbbfde486e0b3718e5"
+	lidiaData, err := extractGzipFile(t, "testdata/test_lidia_file.gz")
+	require.NoError(t, err)
+
+	s, _, mockBucket := newSymbolizerTest(t, &symbolizerInputs{LidiaCacheSizeBytes: 128 << 20})
+
+	var gets atomic.Int64
+	// Hold the first Get briefly so concurrent callers all observe the cache
+	// miss and queue behind singleflight, rather than serializing naturally.
+	mockBucket.On("Get", mock.Anything, lidiaObjectPath("tenant", buildID)).
+		Return(func(_ context.Context, _ string) (io.ReadCloser, error) {
+			gets.Add(1)
+			time.Sleep(10 * time.Millisecond)
+			return io.NopCloser(bytes.NewReader(lidiaData)), nil
+		}, nil)
+
+	ctx := tenant.InjectTenantID(context.Background(), "tenant")
+
+	const concurrency = 16
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			defer wg.Done()
+			req := &request{
+				buildID:    buildID,
+				binaryName: "test-binary",
+				locations:  []*location{{address: 0x1b743d6}},
+			}
+			s.symbolize(ctx, req)
+			require.NotEmpty(t, req.locations[0].lines)
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, int64(1), gets.Load(), "singleflight should coalesce all concurrent misses to one fetch")
+}

--- a/pkg/symbolizer/symbolizer.go
+++ b/pkg/symbolizer/symbolizer.go
@@ -35,16 +35,26 @@ type DebuginfodClient interface {
 type Config struct {
 	DebuginfodURL            string `yaml:"debuginfod_url" category:"advanced"`
 	MaxDebuginfodConcurrency int    `yaml:"max_debuginfod_concurrency" category:"advanced"`
+	LidiaCacheSizeBytes      int64  `yaml:"lidia_cache_size_bytes" category:"advanced"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
-	f.StringVar(&cfg.DebuginfodURL, "symbolizer.debuginfod-url", "https://debuginfod.elfutils.org", "URL of the debuginfod server")
-	f.IntVar(&cfg.MaxDebuginfodConcurrency, "symbolizer.max-debuginfod-concurrency", 10, "Maximum number of concurrent symbolization requests to debuginfod server.")
+	f.StringVar(&cfg.DebuginfodURL, "symbolizer.debuginfod-url", "https://debuginfod.elfutils.org",
+		"URL of the debuginfod server")
+	f.IntVar(&cfg.MaxDebuginfodConcurrency, "symbolizer.max-debuginfod-concurrency", 10, "Maximum "+
+		"number of concurrent symbolization requests to debuginfod server.")
+	f.Int64Var(&cfg.LidiaCacheSizeBytes, "symbolizer.lidia-cache-size-bytes", 0, "Maximum size in "+
+		"bytes of the in-memory lidia cache. The cache is per-process: each query-frontend replica holds its own "+
+		"copy. Items larger than this value are silently rejected; watch the "+
+		"cache_operations{cache_type=\"lidia_inmem\",status=\"rejected\"} metric.")
 }
 
 func (cfg *Config) Validate() error {
 	if cfg.MaxDebuginfodConcurrency < 1 {
 		return fmt.Errorf("invalid max-debuginfod-concurrency value, must be positive")
+	}
+	if cfg.LidiaCacheSizeBytes < 0 {
+		return fmt.Errorf("invalid lidia-cache-size-bytes value, must be non-negative")
 	}
 	return nil
 }
@@ -56,6 +66,7 @@ type Symbolizer struct {
 	metrics *metrics
 	cfg     Config
 	limits  Limits
+	cache   *lidiaCache
 }
 
 type ErrSymbolSizeBytesExceedsLimit struct {
@@ -81,6 +92,11 @@ func New(logger log.Logger, cfg Config, reg prometheus.Registerer, storageBucket
 		return nil, err
 	}
 
+	cache, err := newLidiaCache(cfg.LidiaCacheSizeBytes, m, logger)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Symbolizer{
 		logger:  logger,
 		client:  client,
@@ -88,7 +104,13 @@ func New(logger log.Logger, cfg Config, reg prometheus.Registerer, storageBucket
 		metrics: m,
 		cfg:     cfg,
 		limits:  limits,
+		cache:   cache,
 	}, nil
+}
+
+// Close releases resources held by the Symbolizer. After Close, the Symbolizer must not be used.
+func (s *Symbolizer) Close() {
+	s.cache.close()
 }
 
 func (s *Symbolizer) SymbolizePprof(ctx context.Context, profile *googlev1.Profile) error {
@@ -426,6 +448,14 @@ func (s *Symbolizer) getLidiaBytes(ctx context.Context, buildID string) ([]byte,
 		return nil, err
 	}
 
+	return s.cache.getOrFetch(tenantID+"/"+buildID, func() ([]byte, error) {
+		return s.fetchLidiaFromBackends(ctx, tenantID, buildID)
+	})
+}
+
+// Fill function for lidiaCache: object storage first, debuginfod on miss
+// (uploading the converted lidia back to object storage on success).
+func (s *Symbolizer) fetchLidiaFromBackends(ctx context.Context, tenantID, buildID string) ([]byte, error) {
 	lidiaBytes, err := s.fetchLidiaFromObjectStore(ctx, tenantID, buildID)
 	if err == nil {
 		s.metrics.cacheOperations.WithLabelValues("object_storage", "get", statusSuccess).Inc()

--- a/pkg/symbolizer/symbolizer_bench_test.go
+++ b/pkg/symbolizer/symbolizer_bench_test.go
@@ -1,0 +1,98 @@
+package symbolizer
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/pyroscope/v2/pkg/tenant"
+	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockobjstore"
+	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mocksymbolizer"
+	"github.com/grafana/pyroscope/v2/pkg/validation"
+)
+
+// Microbenchmark: same buildID symbolized repeatedly. Synthetic best case,
+// production numbers will be smaller. Sub-benchmarks A/B cache off vs on.
+func BenchmarkSymbolizeRepeatedBuildID(b *testing.B) {
+	cases := []struct {
+		name      string
+		cacheSize int64
+	}{
+		{"off", 0},
+		{"on_512MiB", 512 << 20},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			runRepeatedBuildIDBench(b, tc.cacheSize)
+		})
+	}
+}
+
+func runRepeatedBuildIDBench(b *testing.B, cacheSize int64) {
+	const buildID = "ffcf60c240417166980a43fbbfde486e0b3718e5"
+	const addr = 0x1b743d6
+
+	lidiaData := mustReadGzip(b, "testdata/test_lidia_file.gz")
+
+	bucket := mockobjstore.NewMockBucket(b)
+	// Match every Get call; return a fresh reader each time so the benchmark
+	// reflects the io.ReadAll cost per call accurately.
+	var bucketGets atomic.Int64
+	bucket.On("Get", mock.Anything, lidiaObjectPath("tenant", buildID)).
+		Return(func(_ context.Context, _ string) (io.ReadCloser, error) {
+			bucketGets.Add(1)
+			return io.NopCloser(bytes.NewReader(lidiaData)), nil
+		}, nil)
+
+	s, err := New(
+		log.NewNopLogger(),
+		Config{
+			MaxDebuginfodConcurrency: 1,
+			LidiaCacheSizeBytes:      cacheSize,
+		},
+		prometheus.NewRegistry(),
+		bucket,
+		validation.MockDefaultOverrides(),
+	)
+	require.NoError(b, err)
+	s.client = mocksymbolizer.NewMockDebuginfodClient(b)
+	b.Cleanup(s.Close)
+
+	ctx := tenant.InjectTenantID(context.Background(), "tenant")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := &request{
+			buildID:    buildID,
+			binaryName: "test-binary",
+			locations:  []*location{{address: addr}},
+		}
+		s.symbolize(ctx, req)
+	}
+	b.StopTimer()
+
+	b.ReportMetric(float64(bucketGets.Load())/float64(b.N), "bucket_gets/op")
+}
+
+func mustReadGzip(b *testing.B, path string) []byte {
+	b.Helper()
+	f, err := os.Open(path)
+	require.NoError(b, err)
+	defer f.Close()
+	gz, err := gzip.NewReader(f)
+	require.NoError(b, err)
+	defer gz.Close()
+	data, err := io.ReadAll(gz)
+	require.NoError(b, err)
+	return data
+}

--- a/pkg/symbolizer/symbolizer_test.go
+++ b/pkg/symbolizer/symbolizer_test.go
@@ -26,8 +26,9 @@ import (
 )
 
 type symbolizerInputs struct {
-	Registry *prometheus.Registry
-	Limits   Limits
+	Registry            *prometheus.Registry
+	Limits              Limits
+	LidiaCacheSizeBytes int64 // 0 disables the in-memory lidia cache.
 }
 
 func newSymbolizerTest(t *testing.T, inp *symbolizerInputs) (*Symbolizer, *mocksymbolizer.MockDebuginfodClient, *mockobjstore.MockBucket) {
@@ -49,13 +50,17 @@ func newSymbolizerTest(t *testing.T, inp *symbolizerInputs) (*Symbolizer, *mocks
 
 	s, err := New(
 		log.NewNopLogger(),
-		Config{MaxDebuginfodConcurrency: 1},
+		Config{
+			MaxDebuginfodConcurrency: 1,
+			LidiaCacheSizeBytes:      inp.LidiaCacheSizeBytes,
+		},
 		inp.Registry,
 		lidiaBucket,
 		inp.Limits,
 	)
 	require.NoError(t, err)
 	s.client = mockClient
+	t.Cleanup(s.Close)
 
 	return s, mockClient, lidiaBucket
 }


### PR DESCRIPTION
## Summary

Opt-in, per-process in-memory cache for lidia bytes in the symbolizer. Default is **off** (`-symbolizer.lidia-cache-size-bytes=0`). Sits in front of object storage as an L1; on cache hits, callers receive bytes by reference without re-running `io.ReadAll`.
                                                                                                          
Addresses the flamegraph pattern where `symbolizer.symbolizeMappingsConcurrently → io.ReadAll` accounts for ~90% of  `alloc_space` (≈30 GiB / scrape) in the query-frontend. 

<img width="1552" height="465" alt="Screenshot 2026-05-07 at 16 35 33" src="https://github.com/user-attachments/assets/30398079-df8e-45ba-98bd-bb2f41baa255" /><br>

## How it works (three-tier lookup)

```
L1: in-memory ristretto cache (this PR) — per-pod
   ↓ miss
L2: object storage at symbolizer/{tenant}/{buildID} — cluster-shared, persistent
   ↓ miss
L3: debuginfod — slowest, with ELF→lidia conversion + upload to L2 on success
```

## Cache invalidation

Lidia bytes are content-addressed by buildID and immutable by construction; no TTL or explicit invalidation needed. Three mechanisms:
- size-based eviction (ristretto TinyLFU) 
- pod restart (in-memory; dies with the process)
- operator disabling the flag. 

Lidia format changes require a `go.mod` bump and redeploy, which restarts pods and clears caches so the cache cannot hold bytes the running binary can't parse.

### Why this is safe under format evolution

Any lidia format change requires:
1. Bumping the lidia pseudo-version in pyroscope's `go.mod`.
2. Rebuilding the pyroscope binary.
3. Redeploying.

A redeploy restarts pods, which clears the cache. Therefore the cache cannot end up holding bytes that the running binary doesn't know how to parse, because the lidia code IN that running binary is fixed at build time. The deployment lifecycle invalidates the cache "for free" on any format change.

## ⚠️ Memory cost

The cache is **per-process**: each query-frontend replica holds its own copy. **If you enable this, plan to provision ~`MaxCost` extra memory per QF replica.** Recommended starting size: 256 MiB. Total cluster cost: `N_replicas × min(working_set, MaxCost)`. Items larger than `MaxCost` are silently rejected by ristretto (logged at `level.Warn` and counted in the `rejected` metric).


## Microbenchmark

`go test -bench=BenchmarkSymbolizeRepeatedBuildID -benchmem -count=5 -benchtime=5s ./pkg/symbolizer/`:

| Metric | OFF | ON (512 MiB) | Δ |
|---|---|---|---|
| time/op | ~15.4 ms | ~6.4 ms | **2.4× faster** |
| bytes/op | ~316.7 MB | ~2.3 MB | **~136× less allocated** |
| allocs/op | ~154 | 22 | **~7× fewer** |
| bucket Gets/op | 1.000 | 0.001 | **~1000× fewer fetches** |

**These are synthetic best-case numbers** (single process, one buildID, repeated calls — the cache always hits after warmup). They prove the **mechanism** works as intended; they do **not** project production performance. Production effect depends on routing, working set vs `MaxCost`, and request shape.

## Test plan

- [x] Unit tests pass: `go test ./pkg/symbolizer/...`
- [x] Race detector clean: `go test ./pkg/symbolizer/... -race -count=3`
- [x] Whole-repo build: `go build ./...`
- [x] Long-run benchmark stable (no allocation drift, no goroutine leak over 5,500+ iterations per run)
- [ ] **Test in dev**

