### PR TITLE
fix(read-path): do not allow sub-ms step parameter

### DIFF
--- a/pkg/frontend/readpath/queryfrontend/query_heatmap.go
+++ b/pkg/frontend/readpath/queryfrontend/query_heatmap.go
@@ -25,9 +25,11 @@ func (q *QueryFrontend) SelectHeatmap(
 	ctx context.Context,
 	c *connect.Request[querierv1.SelectHeatmapRequest],
 ) (*connect.Response[querierv1.SelectHeatmapResponse], error) {
-	// Validate step
-	if c.Msg.Step <= 0 {
-		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("step must be greater than 0, got %f", c.Msg.Step))
+	// Sub-millisecond step values truncate to 0 in the backend's millisecond
+	// arithmetic and would cause divide-by-zero / unbounded loop downstream;
+	// reject anything below 1ms.
+	if c.Msg.Step < 0.001 {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("step must be >= 1ms, got %f", c.Msg.Step))
 	}
 
 	// Validate limit if provided

--- a/pkg/frontend/readpath/queryfrontend/query_select_time_series.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_time_series.go
@@ -38,8 +38,11 @@ func (q *QueryFrontend) SelectSeries(
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
-	if c.Msg.Step == 0 {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("step must be non-zero"))
+	// Sub-millisecond step values truncate to 0 in the backend's millisecond
+	// arithmetic and would cause an unbounded loop in RangeSeries; reject
+	// anything below 1ms.
+	if c.Msg.Step < 0.001 {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("step must be >= 1ms"))
 	}
 
 	stepMs := time.Duration(c.Msg.Step * float64(time.Second)).Milliseconds()

--- a/pkg/frontend/readpath/queryfrontend/query_select_time_series_test.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_time_series_test.go
@@ -1,0 +1,72 @@
+package queryfrontend
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/grafana/pyroscope/v2/pkg/tenant"
+	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockfrontend"
+)
+
+// Sub-millisecond step values truncate to 0 in the backend's millisecond
+// arithmetic and would cause an unbounded loop in RangeSeries; the frontend
+// must reject them with InvalidArgument before they reach the backend.
+func TestSelectSeries_RejectsSubMillisecondStep(t *testing.T) {
+	for _, step := range []float64{0, 0.0001, 0.0005, 0.0009999} {
+		t.Run("step="+formatStep(step), func(t *testing.T) {
+			limits := mockfrontend.NewMockLimits(t)
+			limits.On("MaxQueryLookback", "test-tenant").Return(time.Duration(0)).Maybe()
+			limits.On("MaxQueryLength", "test-tenant").Return(time.Duration(0)).Maybe()
+
+			qf := NewQueryFrontend(log.NewNopLogger(), limits, nil, nil, nil, nil, nil)
+			ctx := tenant.InjectTenantID(context.Background(), "test-tenant")
+
+			_, err := qf.SelectSeries(ctx, connect.NewRequest(&querierv1.SelectSeriesRequest{
+				ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+				LabelSelector: "{}",
+				Start:         1000,
+				End:           2000,
+				Step:          step,
+			}))
+
+			require.Error(t, err)
+			require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+			require.Contains(t, err.Error(), "step must be >= 1ms")
+		})
+	}
+}
+
+func TestSelectHeatmap_RejectsSubMillisecondStep(t *testing.T) {
+	for _, step := range []float64{0, 0.0001, 0.0005, 0.0009999} {
+		t.Run("step="+formatStep(step), func(t *testing.T) {
+			limits := mockfrontend.NewMockLimits(t)
+			qf := NewQueryFrontend(log.NewNopLogger(), limits, nil, nil, nil, nil, nil)
+			ctx := tenant.InjectTenantID(context.Background(), "test-tenant")
+
+			_, err := qf.SelectHeatmap(ctx, connect.NewRequest(&querierv1.SelectHeatmapRequest{
+				ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+				LabelSelector: "{}",
+				Start:         1000,
+				End:           2000,
+				Step:          step,
+			}))
+
+			require.Error(t, err)
+			require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+			require.Contains(t, err.Error(), "step must be >= 1ms")
+		})
+	}
+}
+
+func formatStep(s float64) string {
+	if s == 0 {
+		return "0"
+	}
+	return time.Duration(s * float64(time.Second)).String()
+}

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -1004,8 +1004,10 @@ func (q *Querier) SelectSeries(ctx context.Context, req *connect.Request[querier
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("start must be before end"))
 	}
 
-	if req.Msg.Step == 0 {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("step must be non-zero"))
+	// Sub-millisecond step values truncate to 0 in stepMs and would cause an
+	// unbounded loop in RangeSeries; reject anything below 1ms.
+	if req.Msg.Step < 0.001 {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("step must be >= 1ms"))
 	}
 
 	// SelectSeries (v1 API) does not support exemplars


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk input-validation change that tightens API parameter constraints to prevent divide-by-zero/unbounded loops; behavior changes only for requests with `step < 1ms`.
> 
> **Overview**
> Prevents `SelectSeries`/`SelectHeatmap` queries from accepting *sub-millisecond* `step` values by rejecting any `step < 0.001` with `InvalidArgument` (protecting downstream millisecond arithmetic from truncating to 0 and causing divide-by-zero/unbounded loops).
> 
> Adds frontend unit tests to ensure both endpoints consistently reject `step` values below 1ms (including `0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d00a37c1af0c62adaa2e1c69ae738610e7110a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->