### PR TITLE
Update golang version to 1.25.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: 1.25.9
+          go-version: 1.25.10
       - name: Format
         run: make fmt check/unstaged-changes
   check-generated:
@@ -40,7 +40,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: 1.25.9
+          go-version: 1.25.10
       - name: Check generated files
         run: make generate check/unstaged-changes
   test:
@@ -66,7 +66,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: 1.25.9
+          go-version: 1.25.10
       - name: Go Mod
         run: make check/go/mod
       - name: Test
@@ -92,7 +92,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: 1.25.9
+          go-version: 1.25.10
       - name: Integration Test
         run: make go/test-integration GO_TEST_FLAGS="${{ matrix.go_test_flags }}"
   lint:
@@ -105,7 +105,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: 1.25.9
+          go-version: 1.25.10
       - name: Run linter
         run: make lint
       - name: Check helm manifests
@@ -136,7 +136,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: 1.25.9
+          go-version: 1.25.10
       - name: Build image Pyroscope
         run: make docker-image/pyroscope/build-multiarch "BUILDX_ARGS=--cache-from=type=gha --cache-to=type=gha"
 
@@ -162,7 +162,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: 1.25.9
+          go-version: 1.25.10
       - name: Login to DockerHub (from vault)
         uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
       - name: Pyroscope Build & push multi-arch image

--- a/.github/workflows/fuzzer.yml
+++ b/.github/workflows/fuzzer.yml
@@ -16,6 +16,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: 1.25.9
+          go-version: 1.25.10
       - name: Run Fuzz_Merge_Single
         run: go test -fuzz=Fuzz_Merge_Single --fuzztime 1h -run '^$' -v ./pkg/pprof/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: false
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: 1.25.9
+          go-version: 1.25.10
       - name: Run tests
         run: make examples/test

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -47,7 +47,7 @@ jobs:
           echo "user-id=$(gh api "/users/${APP_BOT}" --jq .id)" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version: 1.25.9
+          go-version: 1.25.10
       - name: Update contributors
         run: make update-contributors
 

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -39,7 +39,7 @@ jobs:
           git tag "$IMAGE_TAG"
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: false
       # setup docker buildx
       - name: Set up QEMU

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,7 +3,7 @@ version: 2
 before:
   hooks:
     # This hook ensures that goreleaser uses the correct go version for a Pyroscope release
-    - sh -euc 'go version | grep "go version go1.25.9 " || { echo "Unexpected go version"; exit 1; }'
+    - sh -euc 'go version | grep "go version go1.25.10 " || { echo "Unexpected go version"; exit 1; }'
 env:
   # Strip debug information from the binary by default, weekly builds will have debug information
   - GORELEASER_DEBUG_INFO_FLAGS={{ if and (index .Env "GORELEASER_STRIP_DEBUG_INFO") (eq .Env.GORELEASER_STRIP_DEBUG_INFO "false")  }}{{ else }}-s -w{{ end }}

--- a/.pyroscope.yaml
+++ b/.pyroscope.yaml
@@ -8,5 +8,5 @@ source_code:
        github:
         owner: golang
         repo: go
-        ref: go1.25.9
+        ref: go1.25.10
         path: src

--- a/api/go.mod
+++ b/api/go.mod
@@ -2,7 +2,7 @@ module github.com/grafana/pyroscope/api
 
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	connectrpc.com/connect v1.19.1

--- a/examples/golang-pgo/Dockerfile
+++ b/examples/golang-pgo/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.9
+FROM golang:1.25.10
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/golang-pgo/go.mod
+++ b/examples/golang-pgo/go.mod
@@ -2,7 +2,7 @@ module rideshare
 
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	github.com/agoda-com/opentelemetry-logs-go v0.5.1

--- a/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/Dockerfile
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.9
+FROM golang:1.25.10
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/Dockerfile.load-generator
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/Dockerfile.load-generator
@@ -1,4 +1,4 @@
-FROM golang:1.25.9
+FROM golang:1.25.10
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/go.mod
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/go.mod
@@ -2,7 +2,7 @@ module rideshare
 
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	github.com/agoda-com/opentelemetry-logs-go v0.4.1

--- a/examples/language-sdk-instrumentation/golang-push/rideshare-k6/Dockerfile
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare-k6/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.9
+FROM golang:1.25.10
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/language-sdk-instrumentation/golang-push/rideshare-k6/Dockerfile.load-generator
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare-k6/Dockerfile.load-generator
@@ -1,4 +1,4 @@
-FROM golang:1.25.9
+FROM golang:1.25.10
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/language-sdk-instrumentation/golang-push/rideshare-k6/go.mod
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare-k6/go.mod
@@ -2,7 +2,7 @@ module rideshare
 
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	github.com/agoda-com/opentelemetry-logs-go v0.4.1

--- a/examples/language-sdk-instrumentation/golang-push/rideshare/Dockerfile
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.9
+FROM golang:1.25.10
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/language-sdk-instrumentation/golang-push/rideshare/Dockerfile.load-generator
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare/Dockerfile.load-generator
@@ -1,4 +1,4 @@
-FROM golang:1.25.9
+FROM golang:1.25.10
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/language-sdk-instrumentation/golang-push/rideshare/go.mod
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare/go.mod
@@ -2,7 +2,7 @@ module rideshare
 
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	github.com/agoda-com/opentelemetry-logs-go v0.5.1

--- a/examples/language-sdk-instrumentation/golang-push/simple/Dockerfile
+++ b/examples/language-sdk-instrumentation/golang-push/simple/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.9
+FROM golang:1.25.10
 
 WORKDIR /go/src/app
 

--- a/examples/language-sdk-instrumentation/golang-push/simple/go.mod
+++ b/examples/language-sdk-instrumentation/golang-push/simple/go.mod
@@ -2,7 +2,7 @@ module pushsimple
 
 go 1.24.6
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require github.com/grafana/pyroscope-go v1.2.7
 

--- a/examples/tracing/golang-push/Dockerfile
+++ b/examples/tracing/golang-push/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.9
+FROM golang:1.25.10
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/tracing/golang-push/Dockerfile.load-generator
+++ b/examples/tracing/golang-push/Dockerfile.load-generator
@@ -1,4 +1,4 @@
-FROM golang:1.25.9
+FROM golang:1.25.10
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/tracing/golang-push/go.mod
+++ b/examples/tracing/golang-push/go.mod
@@ -2,7 +2,7 @@ module rideshare
 
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	github.com/agoda-com/opentelemetry-logs-go v0.5.1

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/grafana/pyroscope/v2
 
 go 1.25.7
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	connectrpc.com/connect v1.19.1

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.25.7
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 use (
 	.

--- a/lidia/go.mod
+++ b/lidia/go.mod
@@ -2,7 +2,7 @@ module github.com/grafana/pyroscope/lidia
 
 go 1.24.6
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require github.com/stretchr/testify v1.11.1
 

--- a/tools/update_examples.Dockerfile
+++ b/tools/update_examples.Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get -y install wget git build-essential libssl-dev lib
     gawk autoconf automake bison libffi-dev libgdbm-dev libsqlite3-dev libtool pkg-config sqlite3 libncurses5-dev \
     libreadline-dev gnupg
 
-ARG GO_VERSION=1.25.9
+ARG GO_VERSION=1.25.10
 RUN wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk version bump: updates Go patch version references across CI/release tooling and example build images; main risk is CI/release breakage if any workflow still expects the old toolchain.
> 
> **Overview**
> Updates the project’s pinned Go toolchain from **1.25.9 to 1.25.10** across GitHub Actions workflows (CI, fuzzing, releases), Go module `toolchain` directives (`go.mod`, `go.work`, `api`, `lidia`, and example modules), and the example/build Docker images.
> 
> Release tooling is kept in sync by updating the `.goreleaser.yaml` Go version check and the `.pyroscope.yaml` Go source mapping ref, plus the `tools/update_examples.Dockerfile` Go download arg.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2896fc42326f98f958a33668f1ff503543eee74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->