### PR TITLE
Fix TLS support in distributor-to-ingester connections

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -323,6 +323,8 @@ Usage of ./pyroscope:
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
   -distributor.sample-type-relabeling-rules value
     	List of sample type relabel configurations. Rules are applied to sample types with __type__ and __unit__ labels, along with all series labels.
+  -distributor.tls-enabled
+    	Enable TLS for ingester client connections.
   -distributor.zone-awareness-enabled
     	True to enable the zone-awareness and replicate ingested samples across different availability zones.
   -embedded-grafana.data-path string
@@ -805,6 +807,8 @@ Usage of ./pyroscope:
     	Whether profiles should be sanitized when merging. (default true)
   -querier.split-queries-by-interval duration
     	Split queries by a time interval and execute in parallel. The value 0 disables splitting by time
+  -querier.tls-enabled
+    	Enable TLS for ingester client connections.
   -query-backend.address string
     	 (default "localhost:9095")
   -query-backend.client-timeout duration

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -77,6 +77,8 @@ Usage of ./pyroscope:
     	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -distributor.ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
+  -distributor.tls-enabled
+    	Enable TLS for ingester client connections.
   -distributor.zone-awareness-enabled
     	True to enable the zone-awareness and replicate ingested samples across different availability zones.
   -embedded-grafana.data-path string
@@ -185,6 +187,8 @@ Usage of ./pyroscope:
     	Whether profiles should be sanitized when merging. (default true)
   -querier.split-queries-by-interval duration
     	Split queries by a time interval and execute in parallel. The value 0 disables splitting by time
+  -querier.tls-enabled
+    	Enable TLS for ingester client connections.
   -query-scheduler.max-outstanding-requests-per-tenant int
     	Maximum number of outstanding requests per tenant per query-scheduler. In-flight requests above this limit will fail with HTTP response status code 429. (default 100)
   -query-scheduler.ring.consul.hostname string

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -671,6 +671,10 @@ pool_config:
   # CLI flag: -distributor.health-check-timeout
   [remote_timeout: <duration> | default = 5s]
 
+  # Enable TLS for ingester client connections.
+  # CLI flag: -distributor.tls-enabled
+  [tls_enabled: <boolean> | default = false]
+
 ring:
   # The key-value store used to share the hash ring across multiple instances.
   kvstore:
@@ -1115,6 +1119,10 @@ pool_config:
   # Timeout for ingester client healthcheck RPCs.
   # CLI flag: -querier.health-check-timeout
   [remote_timeout: <duration> | default = 5s]
+
+  # Enable TLS for ingester client connections.
+  # CLI flag: -querier.tls-enabled
+  [tls_enabled: <boolean> | default = false]
 
 # The time after which a metric should be queried from storage and not just
 # ingesters. 0 means all queries are sent to store. If this option is enabled,

--- a/pkg/clientpool/ingester_client_pool.go
+++ b/pkg/clientpool/ingester_client_pool.go
@@ -2,6 +2,7 @@ package clientpool
 
 import (
 	"context"
+	"crypto/tls"
 	"flag"
 	"io"
 	"time"
@@ -12,6 +13,7 @@ import (
 	ring_client "github.com/grafana/dskit/ring/client"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
@@ -24,6 +26,7 @@ type PoolConfig struct {
 	ClientCleanupPeriod  time.Duration `yaml:"client_cleanup_period"`
 	HealthCheckIngesters bool          `yaml:"health_check_ingesters"`
 	RemoteTimeout        time.Duration `yaml:"remote_timeout"`
+	TLSEnabled           bool          `yaml:"tls_enabled"`
 }
 
 // RegisterFlagsWithPrefix adds the flags required to config this to the given FlagSet.
@@ -31,11 +34,12 @@ func (cfg *PoolConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.DurationVar(&cfg.ClientCleanupPeriod, prefix+".client-cleanup-period", 15*time.Second, "How frequently to clean up clients for ingesters that have gone away.")
 	f.BoolVar(&cfg.HealthCheckIngesters, prefix+".health-check-ingesters", true, "Run a health check on each ingester client during periodic cleanup.")
 	f.DurationVar(&cfg.RemoteTimeout, prefix+".health-check-timeout", 5*time.Second, "Timeout for ingester client healthcheck RPCs.")
+	f.BoolVar(&cfg.TLSEnabled, prefix+".tls-enabled", false, "Enable TLS for ingester client connections.")
 }
 
 func NewIngesterPool(cfg PoolConfig, ring ring.ReadRing, factory ring_client.PoolFactory, clientsMetric prometheus.Gauge, logger log.Logger, options ...connect.ClientOption) *ring_client.Pool {
 	if factory == nil {
-		factory = newIngesterPoolFactory(options...)
+		factory = newIngesterPoolFactory(cfg.TLSEnabled, options...)
 	}
 	poolCfg := ring_client.PoolConfig{
 		CheckInterval:      cfg.ClientCleanupPeriod,
@@ -47,22 +51,37 @@ func NewIngesterPool(cfg PoolConfig, ring ring.ReadRing, factory ring_client.Poo
 }
 
 type ingesterPoolFactory struct {
-	options []connect.ClientOption
+	tlsEnabled bool
+	options    []connect.ClientOption
 }
 
-func newIngesterPoolFactory(options ...connect.ClientOption) ring_client.PoolFactory {
-	return &ingesterPoolFactory{options: options}
+func newIngesterPoolFactory(tlsEnabled bool, options ...connect.ClientOption) ring_client.PoolFactory {
+	return &ingesterPoolFactory{
+		tlsEnabled: tlsEnabled,
+		options:    options,
+	}
 }
 
 func (f *ingesterPoolFactory) FromInstance(inst ring.InstanceDesc) (ring_client.PoolClient, error) {
-	conn, err := grpc.Dial(inst.Addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	var dialOpts []grpc.DialOption
+	var scheme string
+
+	if f.tlsEnabled {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
+		scheme = "https://"
+	} else {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		scheme = "http://"
+	}
+
+	conn, err := grpc.Dial(inst.Addr, dialOpts...)
 	if err != nil {
 		return nil, err
 	}
 
 	httpClient := util.InstrumentedDefaultHTTPClient(util.WithTracingTransport(), util.WithBaggageTransport())
 	return &ingesterPoolClient{
-		IngesterServiceClient: ingesterv1connect.NewIngesterServiceClient(httpClient, "http://"+inst.Addr, f.options...),
+		IngesterServiceClient: ingesterv1connect.NewIngesterServiceClient(httpClient, scheme+inst.Addr, f.options...),
 		HealthClient:          grpc_health_v1.NewHealthClient(conn),
 		Closer:                conn,
 	}, nil


### PR DESCRIPTION
Fixes #4585.

The ingester client pool hardcodes `insecure.NewCredentials()` for gRPC transport and `http://` for the Connect HTTP client. When TLS is configured between distributor and ingester, the distributor still connects over plaintext.

This adds a `TLSEnabled` field to `PoolConfig` (flag: `--tls-enabled`, default `false`). When enabled, the pool factory uses `credentials.NewTLS` for gRPC and `https://` for the Connect client URL scheme. The default behavior is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how distributor ingester clients dial gRPC and Connect endpoints when `--tls-enabled` is set, which can affect inter-service connectivity if misconfigured. Default behavior remains plaintext and should be unchanged for existing deployments.
> 
> **Overview**
> Adds an optional `tls_enabled`/`--tls-enabled` switch to the ingester client pool configuration.
> 
> When enabled, ingester pool clients use TLS credentials for gRPC dialing and switch the Connect client base URL from `http://` to `https://`, instead of always forcing insecure transport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93de26e22f7247c366cd510abde19045c9116fa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->