### PR TITLE
fix(ci): ignore shared-workflows checkout dir so goreleaser doesn't see a dirty tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ tools/k6/.env
 
 # grafana/shared-workflows composite action dockerhub-login check itself out
 # into the working tree, which trips goreleaser's dirty-state check.
-_shared-workflows-dockerhub-login
+/_shared-workflows-dockerhub-login/

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ pyroscope.sln
 /.tmp
 tools/k6/.env
 .claude/worktrees/
+
+# grafana/shared-workflows composite action dockerhub-login check itself out
+# into the working tree, which trips goreleaser's dirty-state check.
+_shared-workflows-dockerhub-login


### PR DESCRIPTION
Goreleaser has been failing on weekly releases with:

``` 
git is in a dirty state
Please check in your pipeline what can be changing the following files:
?? _shared-workflows-dockerhub-login/
```

The `grafana/shared-workflows/actions/dockerhub-login` action (introduced in f1fdf94dc) is a composite action that checks itself out into `_shared-workflows-dockerhub-login` in the workspace

This adds `_shared-workflows-dockerhub-login` to gitignore so the working tree stays clean from goreleaser's perspective.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single `.gitignore` entry to prevent CI-created workspace artifacts from causing goreleaser dirty-tree failures.
> 
> **Overview**
> Prevents goreleaser release jobs from failing due to a “dirty” git state by adding `/_shared-workflows-dockerhub-login/` to `.gitignore`.
> 
> This ignores the checkout directory created by the `grafana/shared-workflows` `dockerhub-login` composite action so CI doesn’t introduce untracked files during releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34e94ff5393550266da33511654eea2bd70e8c53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->