### PR TITLE
fix(ci): ignore shared-workflows checkout dir so goreleaser doesn't see a dirty tree (#5140)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ pyroscope.sln
 /.tmp
 tools/k6/.env
 .claude/worktrees/
+
+# grafana/shared-workflows composite action dockerhub-login check itself out
+# into the working tree, which trips goreleaser's dirty-state check.
+/_shared-workflows-dockerhub-login/


### PR DESCRIPTION
backport

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `.gitignore` to exclude a CI-created checkout directory, with no runtime or build logic changes beyond preventing false dirty-state detection.
> 
> **Overview**
> Prevents `goreleaser` from detecting a dirty working tree in CI by adding `/_shared-workflows-dockerhub-login/` to `.gitignore`, ignoring the directory created when the `grafana/shared-workflows` `dockerhub-login` composite action checks itself out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d082c514098a6becc2e244b09d8d5755aeb0d4a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->