### PR TITLE
fix(speedscope): replace panic with error return for unknown unit values

### DIFF
--- a/pkg/og/convert/speedscope/parser.go
+++ b/pkg/og/convert/speedscope/parser.go
@@ -125,7 +125,11 @@ func parseOne(prof *profile, putInput storage.PutInput, frames []frame, multi bo
 	// TODO(petethepig): We need a way to tell if it's a default or a value set by user
 	//   See https://github.com/pyroscope-io/pyroscope/issues/1598
 	if putInput.SampleRate == 100 {
-		putInput.SampleRate = uint32(prof.Unit.defaultSampleRate())
+		rate, err := prof.Unit.defaultSampleRate()
+		if err != nil {
+			return nil, fmt.Errorf("invalid profile unit: %w", err)
+		}
+		putInput.SampleRate = rate
 	}
 
 	var err error
@@ -150,7 +154,10 @@ func parseEvented(tr *tree.Tree, prof *profile, frames []frame) error {
 	last := prof.StartValue
 	indexStack := []int{}
 	nameStack := []string{}
-	precisionMultiplier := prof.Unit.precisionMultiplier()
+	precisionMultiplier, err := prof.Unit.precisionMultiplier()
+	if err != nil {
+		return fmt.Errorf("invalid profile unit: %w", err)
+	}
 
 	for _, ev := range prof.Events {
 		if ev.At < last {
@@ -198,7 +205,10 @@ func parseSampled(tr *tree.Tree, prof *profile, frames []frame) error {
 		return fmt.Errorf("Unequal lengths of samples and weights: %d != %d", len(prof.Samples), len(prof.Weights))
 	}
 
-	precisionMultiplier := prof.Unit.precisionMultiplier()
+	precisionMultiplier, err := prof.Unit.precisionMultiplier()
+	if err != nil {
+		return fmt.Errorf("invalid profile unit: %w", err)
+	}
 	stack := []string{}
 	for i, samp := range prof.Samples {
 		weight := prof.Weights[i]

--- a/pkg/og/convert/speedscope/speedscope_test.go
+++ b/pkg/og/convert/speedscope/speedscope_test.go
@@ -93,6 +93,50 @@ a;b;d 400
 		Expect(input2.SampleRate).To(Equal(uint32(100)))
 	})
 
+	It("Returns error for unknown unit in defaultSampleRate", func() {
+		u := unit("UNKNOWN_UNIT")
+		_, err := u.defaultSampleRate()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("unknown unit"))
+	})
+
+	It("Returns error for unknown unit in precisionMultiplier", func() {
+		u := unit("UNKNOWN_UNIT")
+		_, err := u.precisionMultiplier()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("unknown unit"))
+	})
+
+	It("Returns error instead of panicking for unknown unit in sampled profile", func() {
+		data := []byte(`{"$schema":"https://www.speedscope.app/file-format-schema.json","shared":{"frames":[{"name":"main"}]},"profiles":[{"type":"sampled","unit":"TRIGGER_PANIC_UNKNOWN_UNIT","name":"poc","startValue":0,"endValue":1,"samples":[[0]],"weights":[1]}]}`)
+
+		key, err := labelset.Parse("foo")
+		Expect(err).ToNot(HaveOccurred())
+
+		ingester := new(mockIngester)
+		profile := &RawProfile{RawData: data}
+
+		md := ingestion.Metadata{LabelSet: key, SampleRate: 100}
+		err = profile.Parse(context.Background(), ingester, nil, md)
+		Expect(err).To(HaveOccurred())
+		Expect(ingester.actual).To(BeEmpty())
+	})
+
+	It("Returns error instead of panicking for unknown unit in evented profile", func() {
+		data := []byte(`{"$schema":"https://www.speedscope.app/file-format-schema.json","shared":{"frames":[{"name":"a"}]},"profiles":[{"type":"evented","unit":"TRIGGER_PANIC_UNKNOWN_UNIT","name":"poc","startValue":0,"endValue":1,"events":[{"type":"O","frame":0,"at":0},{"type":"C","frame":0,"at":1}]}]}`)
+
+		key, err := labelset.Parse("foo")
+		Expect(err).ToNot(HaveOccurred())
+
+		ingester := new(mockIngester)
+		profile := &RawProfile{RawData: data}
+
+		md := ingestion.Metadata{LabelSet: key, SampleRate: 100}
+		err = profile.Parse(context.Background(), ingester, nil, md)
+		Expect(err).To(HaveOccurred())
+		Expect(ingester.actual).To(BeEmpty())
+	})
+
 	It("Merges duplicate profiles", func() {
 		data, err := os.ReadFile("testdata/duplicates.speedscope.json")
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/og/convert/speedscope/units.go
+++ b/pkg/og/convert/speedscope/units.go
@@ -22,42 +22,34 @@ const (
 // from doubles to integers
 var timePrecisionMultiplier = 100
 
-func (u unit) defaultSampleRate() uint32 {
+func (u unit) defaultSampleRate() (uint32, error) {
 	switch u {
 	case unitNanoseconds:
-		return uint32(timePrecisionMultiplier) * 1000 * 1000 * 1000
+		return uint32(timePrecisionMultiplier) * 1000 * 1000 * 1000, nil
 	case unitMicroseconds:
-		return uint32(timePrecisionMultiplier) * 1000 * 1000
+		return uint32(timePrecisionMultiplier) * 1000 * 1000, nil
 	case unitMilliseconds:
-		return uint32(timePrecisionMultiplier) * 1000
+		return uint32(timePrecisionMultiplier) * 1000, nil
 	case unitSeconds:
-		return uint32(timePrecisionMultiplier)
+		return uint32(timePrecisionMultiplier), nil
 	case unitNone:
 		// 100 is a common default value for sample rate
-		return uint32(timePrecisionMultiplier) * 100
+		return uint32(timePrecisionMultiplier) * 100, nil
 	case unitBytes:
-		return 0
+		return 0, nil
 	default:
-		panic("unknown unit " + u)
+		return 0, fmt.Errorf("unknown unit: %s", u)
 	}
 }
 
-func (u unit) precisionMultiplier() uint64 {
+func (u unit) precisionMultiplier() (uint64, error) {
 	switch u {
-	case unitNanoseconds:
-		return uint64(timePrecisionMultiplier)
-	case unitMicroseconds:
-		return uint64(timePrecisionMultiplier)
-	case unitMilliseconds:
-		return uint64(timePrecisionMultiplier)
-	case unitSeconds:
-		return uint64(timePrecisionMultiplier)
-	case unitNone:
-		return uint64(timePrecisionMultiplier)
+	case unitNanoseconds, unitMicroseconds, unitMilliseconds, unitSeconds, unitNone:
+		return uint64(timePrecisionMultiplier), nil
 	case unitBytes:
-		return 1
+		return 1, nil
 	default:
-		panic("unknown unit " + u)
+		return 0, fmt.Errorf("unknown unit: %s", u)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `pkg/og/convert/speedscope/units.go`: `defaultSampleRate()` and `precisionMultiplier()` called `panic()` on unrecognised `unit` values that come directly from attacker-controlled JSON input
- Replaced both `panic()` calls with `fmt.Errorf()` returns and propagated the error up through all three call sites in `parser.go`
- Simplified `precisionMultiplier()` by collapsing five identical cases into one multi-value `case`
- Added four new tests covering both functions at the unit level and both profile types (`sampled`, `evented`) end-to-end through `Parse()`

## Impact

An write path caller could previously crash a handler goroutine by `POST /ingest?format=speedscope` with any non-standard `unit` string (e.g. `"INVALID"`). The panic propagated past the ingestion stack and was only recovered by Go's `net/http` top-level handler, producing a 500 response.

## Test plan

- [ ] `go test ./pkg/og/convert/speedscope/...` passes (7/7)
- [ ] `make lint` passes clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ingestion-time parsing behavior for attacker-controlled Speedscope JSON units from process panics to handled errors; low code churn but impacts error paths and profile rejection behavior.
> 
> **Overview**
> Prevents Speedscope ingestion from crashing on unrecognized `unit` values by changing `unit.defaultSampleRate()` and `unit.precisionMultiplier()` to return errors instead of `panic`.
> 
> Propagates these errors through `parser.go` so `Parse()` fails cleanly for both `sampled` and `evented` profiles when the unit is invalid, and adds tests asserting the new error behavior (including end-to-end parse cases that previously would have panicked).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0dc3e807cf06a8a6e03a0c690a42d4833d8224b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->