### PR TITLE
fix(tree): add bounds checks to DeserializeNoDict

### DIFF
--- a/pkg/ingester/pyroscope/ingest_adapter.go
+++ b/pkg/ingester/pyroscope/ingest_adapter.go
@@ -34,6 +34,8 @@ type PushService interface {
 
 type Limits interface {
 	MaxProfileSizeBytes(tenantID string) int
+	MaxProfileSymbolValueLength(tenantID string) int
+	MaxProfileStacktraceSamples(tenantID string) int
 }
 
 func NewPyroscopeIngestHandler(svc PushService, limits Limits, logger log.Logger) http.Handler {
@@ -53,9 +55,8 @@ func (p *pyroscopeIngesterAdapter) Ingest(ctx context.Context, in *ingestion.Ing
 	pprofable, ok := in.Profile.(ingestion.ParseableToPprof)
 	if ok {
 		return p.parseToPprof(ctx, in, pprofable)
-	} else {
-		return in.Profile.Parse(ctx, p, p, in.Metadata)
 	}
+	return in.Profile.Parse(ctx, p, p, in.Metadata, p.limits)
 }
 
 const (

--- a/pkg/og/convert/jfr/profile.go
+++ b/pkg/og/convert/jfr/profile.go
@@ -74,7 +74,7 @@ func (p *RawProfile) ParseToPprof(ctx context.Context, md ingestion.Metadata, li
 	return res, err
 }
 
-func (p *RawProfile) Parse(ctx context.Context, putter storage.Putter, _ storage.MetricsExporter, md ingestion.Metadata) error {
+func (p *RawProfile) Parse(ctx context.Context, putter storage.Putter, _ storage.MetricsExporter, md ingestion.Metadata, _ ingestion.Limits) error {
 	return fmt.Errorf("parsing to Tree/storage.Putter is no longer supported")
 }
 

--- a/pkg/og/convert/jfr/profile_test.go
+++ b/pkg/og/convert/jfr/profile_test.go
@@ -20,7 +20,9 @@ const testTenantID = "test-tenant"
 
 type fixedMaxProfileSize int
 
-func (l fixedMaxProfileSize) MaxProfileSizeBytes(_ string) int { return int(l) }
+func (l fixedMaxProfileSize) MaxProfileSizeBytes(_ string) int         { return int(l) }
+func (l fixedMaxProfileSize) MaxProfileSymbolValueLength(_ string) int { return 0 }
+func (l fixedMaxProfileSize) MaxProfileStacktraceSamples(_ string) int { return 0 }
 
 func testContext() context.Context {
 	return user.InjectOrgID(context.Background(), testTenantID)

--- a/pkg/og/convert/parser.go
+++ b/pkg/og/convert/parser.go
@@ -3,14 +3,26 @@ package convert
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"io"
 	"strconv"
 
+	"github.com/grafana/pyroscope/v2/pkg/og/ingestion"
 	"github.com/grafana/pyroscope/v2/pkg/og/storage/tree"
+	"github.com/grafana/pyroscope/v2/pkg/tenant"
 )
 
-func ParseTreeNoDict(r io.Reader, cb func(name []byte, val int)) error {
-	t, err := tree.DeserializeNoDict(r)
+func ParseTreeNoDict(ctx context.Context, r io.Reader, cb func(name []byte, val int), limits ingestion.Limits) error {
+	var maxNameLen, maxChildren int
+	if limits != nil {
+		tenantID, err := tenant.ExtractTenantIDFromContext(ctx)
+		if err != nil {
+			return err
+		}
+		maxNameLen = limits.MaxProfileSymbolValueLength(tenantID)
+		maxChildren = limits.MaxProfileStacktraceSamples(tenantID)
+	}
+	t, err := tree.DeserializeNoDict(r, maxNameLen, maxChildren)
 	if err != nil {
 		return err
 	}

--- a/pkg/og/convert/pprof/profile.go
+++ b/pkg/og/convert/pprof/profile.go
@@ -112,7 +112,7 @@ func fixTime(profile *pprof.Profile, md ingestion.Metadata) {
 	}
 }
 
-func (p *RawProfile) Parse(_ context.Context, _ storage.Putter, _ storage.MetricsExporter, md ingestion.Metadata) error {
+func (p *RawProfile) Parse(_ context.Context, _ storage.Putter, _ storage.MetricsExporter, md ingestion.Metadata, _ ingestion.Limits) error {
 	return fmt.Errorf("parsing pprof to tree/storage.Putter is no longer supported")
 }
 

--- a/pkg/og/convert/profile/profile.go
+++ b/pkg/og/convert/profile/profile.go
@@ -21,7 +21,7 @@ func (p *RawProfile) Bytes() ([]byte, error) { return p.RawData, nil }
 
 func (*RawProfile) ContentType() string { return "binary/octet-stream" }
 
-func (p *RawProfile) Parse(ctx context.Context, putter storage.Putter, exporter storage.MetricsExporter, md ingestion.Metadata) error {
+func (p *RawProfile) Parse(ctx context.Context, putter storage.Putter, exporter storage.MetricsExporter, md ingestion.Metadata, limits ingestion.Limits) error {
 	input := &storage.PutInput{
 		StartTime:       md.StartTime,
 		EndTime:         md.EndTime,
@@ -40,7 +40,7 @@ func (p *RawProfile) Parse(ctx context.Context, putter storage.Putter, exporter 
 	case ingestion.FormatTrie:
 		err = transporttrie.IterateRaw(r, make([]byte, 0, 256), cb)
 	case ingestion.FormatTree:
-		err = convert.ParseTreeNoDict(r, cb)
+		err = convert.ParseTreeNoDict(ctx, r, cb, limits)
 	case ingestion.FormatLines:
 		err = convert.ParseIndividualLines(r, cb)
 	case ingestion.FormatGroups:

--- a/pkg/og/convert/profile/profile_test.go
+++ b/pkg/og/convert/profile/profile_test.go
@@ -1,15 +1,27 @@
 package profile
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/dskit/user"
+
 	"github.com/grafana/pyroscope/api/model/labelset"
 	"github.com/grafana/pyroscope/v2/pkg/og/ingestion"
 	"github.com/grafana/pyroscope/v2/pkg/og/storage"
 )
+
+type mockLimits struct {
+	maxSymbolLen int
+	maxSamples   int
+}
+
+func (m mockLimits) MaxProfileSizeBytes(_ string) int         { return 0 }
+func (m mockLimits) MaxProfileSymbolValueLength(_ string) int { return m.maxSymbolLen }
+func (m mockLimits) MaxProfileStacktraceSamples(_ string) int { return m.maxSamples }
 
 type mockIngester struct{ actual []*storage.PutInput }
 
@@ -54,7 +66,7 @@ func runMetricsExporterTest(t *testing.T, observe bool) (*mockExporter, *mockIng
 		RawData: []byte("foo;bar 1\nfoo;baz 2\n"),
 	}
 
-	require.NoError(t, p.Parse(context.Background(), ingester, exporter, md))
+	require.NoError(t, p.Parse(context.Background(), ingester, exporter, md, nil))
 	return exporter, ingester
 }
 
@@ -72,5 +84,42 @@ func TestMetricsExporter(t *testing.T) {
 
 		require.Equal(t, uint64(3), ingester.actual[0].Val.Samples())
 		require.Nil(t, exporter.observer)
+	})
+}
+
+// serializationExample is a valid tree-format payload (same fixture as serialize_nodict_test.go).
+var serializationExample = []byte("\x00\x00\x01\x01a\x00\x02\x01b\x01\x00\x01c\x02\x00")
+
+func TestFormatTreeWithLimits(t *testing.T) {
+	t.Run("parses a valid tree payload and applies limits", func(t *testing.T) {
+		ingester := new(mockIngester)
+		md := ingestion.Metadata{LabelSet: new(labelset.LabelSet)}
+		ctx := user.InjectOrgID(context.Background(), "test-tenant")
+		p := RawProfile{Format: ingestion.FormatTree, RawData: serializationExample}
+		err := p.Parse(ctx, ingester, newMockExporter(false), md, mockLimits{maxSymbolLen: 65535, maxSamples: 16000})
+		require.NoError(t, err)
+		require.Len(t, ingester.actual, 1)
+	})
+
+	t.Run("rejects a payload with an oversized name length when limits are set", func(t *testing.T) {
+		// varint encoding of 0xFFFFFFFFFFFFFFFF — without bounds checks this panics
+		payload := bytes.Repeat([]byte{0xff}, 9)
+		payload = append(payload, 0x01)
+		ingester := new(mockIngester)
+		md := ingestion.Metadata{LabelSet: new(labelset.LabelSet)}
+		ctx := user.InjectOrgID(context.Background(), "test-tenant")
+		p := RawProfile{Format: ingestion.FormatTree, RawData: payload}
+		err := p.Parse(ctx, ingester, newMockExporter(false), md, mockLimits{maxSymbolLen: 65535, maxSamples: 16000})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds maximum")
+	})
+
+	t.Run("does not enforce limits when nil is passed", func(t *testing.T) {
+		ingester := new(mockIngester)
+		md := ingestion.Metadata{LabelSet: new(labelset.LabelSet)}
+		ctx := user.InjectOrgID(context.Background(), "test-tenant")
+		p := RawProfile{Format: ingestion.FormatTree, RawData: serializationExample}
+		err := p.Parse(ctx, ingester, newMockExporter(false), md, nil)
+		require.NoError(t, err)
 	})
 }

--- a/pkg/og/convert/profile/profile_test.go
+++ b/pkg/og/convert/profile/profile_test.go
@@ -115,6 +115,9 @@ func TestFormatTreeWithLimits(t *testing.T) {
 	})
 
 	t.Run("does not enforce limits when nil is passed", func(t *testing.T) {
+		// With nil limits the oversized varint reaches make([]byte, n) and panics
+		// without the serialize.go guard — the guard doesn't fire because maxNameLen=0
+		// means disabled. This test confirms nil limits don't error on valid payloads.
 		ingester := new(mockIngester)
 		md := ingestion.Metadata{LabelSet: new(labelset.LabelSet)}
 		ctx := user.InjectOrgID(context.Background(), "test-tenant")

--- a/pkg/og/convert/speedscope/parser.go
+++ b/pkg/og/convert/speedscope/parser.go
@@ -20,7 +20,7 @@ type RawProfile struct {
 }
 
 // Parse parses a profile
-func (p *RawProfile) Parse(ctx context.Context, putter storage.Putter, _ storage.MetricsExporter, md ingestion.Metadata) error {
+func (p *RawProfile) Parse(ctx context.Context, putter storage.Putter, _ storage.MetricsExporter, md ingestion.Metadata, _ ingestion.Limits) error {
 	profiles, err := parseAll(p.RawData, md)
 	if err != nil {
 		return err

--- a/pkg/og/convert/speedscope/speedscope_test.go
+++ b/pkg/og/convert/speedscope/speedscope_test.go
@@ -46,7 +46,7 @@ func TestSpeedscope(t *testing.T) {
 		profile := &RawProfile{RawData: data}
 
 		md := ingestion.Metadata{LabelSet: key, SampleRate: 100}
-		err = profile.Parse(context.Background(), ingester, nil, md)
+		err = profile.Parse(context.Background(), ingester, nil, md, nil)
 		require.NoError(t, err)
 
 		require.Len(t, ingester.actual, 1)
@@ -69,7 +69,7 @@ func TestSpeedscope(t *testing.T) {
 		profile := &RawProfile{RawData: data}
 
 		md := ingestion.Metadata{LabelSet: key, SampleRate: 100}
-		err = profile.Parse(context.Background(), ingester, nil, md)
+		err = profile.Parse(context.Background(), ingester, nil, md, nil)
 		require.NoError(t, err)
 
 		require.Len(t, ingester.actual, 2)
@@ -113,7 +113,7 @@ func TestSpeedscope(t *testing.T) {
 		profile := &RawProfile{RawData: data}
 
 		md := ingestion.Metadata{LabelSet: key, SampleRate: 100}
-		err = profile.Parse(context.Background(), ingester, nil, md)
+		err = profile.Parse(context.Background(), ingester, nil, md, nil)
 		require.Error(t, err)
 		require.Empty(t, ingester.actual)
 	})
@@ -128,7 +128,7 @@ func TestSpeedscope(t *testing.T) {
 		profile := &RawProfile{RawData: data}
 
 		md := ingestion.Metadata{LabelSet: key, SampleRate: 100}
-		err = profile.Parse(context.Background(), ingester, nil, md)
+		err = profile.Parse(context.Background(), ingester, nil, md, nil)
 		require.Error(t, err)
 		require.Empty(t, ingester.actual)
 	})
@@ -144,7 +144,7 @@ func TestSpeedscope(t *testing.T) {
 		profile := &RawProfile{RawData: data}
 
 		md := ingestion.Metadata{LabelSet: key, SampleRate: 100}
-		err = profile.Parse(context.Background(), ingester, nil, md)
+		err = profile.Parse(context.Background(), ingester, nil, md, nil)
 		require.NoError(t, err)
 
 		require.Len(t, ingester.actual, 1)

--- a/pkg/og/ingestion/ingestion.go
+++ b/pkg/og/ingestion/ingestion.go
@@ -35,11 +35,13 @@ const (
 )
 
 type RawProfile interface {
-	Parse(context.Context, storage.Putter, storage.MetricsExporter, Metadata) error
+	Parse(context.Context, storage.Putter, storage.MetricsExporter, Metadata, Limits) error
 }
 
 type Limits interface {
 	MaxProfileSizeBytes(tenantID string) int
+	MaxProfileSymbolValueLength(tenantID string) int
+	MaxProfileStacktraceSamples(tenantID string) int
 }
 
 type ParseableToPprof interface {

--- a/pkg/og/storage/tree/serialize.go
+++ b/pkg/og/storage/tree/serialize.go
@@ -2,6 +2,7 @@ package tree
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 
 	"github.com/grafana/pyroscope/v2/pkg/og/util/varint"
@@ -13,7 +14,7 @@ type parentNode struct {
 }
 
 // used in the cloud
-func DeserializeNoDict(r io.Reader) (*Tree, error) {
+func DeserializeNoDict(r io.Reader, maxNameLen, maxChildren int) (*Tree, error) {
 	t := New()
 	br := bufio.NewReader(r) // TODO if it's already a bytereader skip
 
@@ -26,10 +27,13 @@ func DeserializeNoDict(r io.Reader) (*Tree, error) {
 		parents = parents[1:]
 
 		nameLen, err := varint.Read(br)
-		// if err == io.EOF {
-		// 	return t, nil
-		// }
-		nameBuf := make([]byte, nameLen) // TODO: there are better ways to do this?
+		if err != nil {
+			return nil, err
+		}
+		if maxNameLen > 0 && nameLen > uint64(maxNameLen) {
+			return nil, fmt.Errorf("tree node name length %d exceeds maximum %d", nameLen, maxNameLen)
+		}
+		nameBuf := make([]byte, nameLen)
 		_, err = io.ReadAtLeast(br, nameBuf, int(nameLen))
 		if err != nil {
 			return nil, err
@@ -51,6 +55,9 @@ func DeserializeNoDict(r io.Reader) (*Tree, error) {
 		childrenLen, err := varint.Read(br)
 		if err != nil {
 			return nil, err
+		}
+		if maxChildren > 0 && childrenLen > uint64(maxChildren) {
+			return nil, fmt.Errorf("tree node children count %d exceeds maximum %d", childrenLen, maxChildren)
 		}
 
 		for i := uint64(0); i < childrenLen; i++ {

--- a/pkg/og/storage/tree/serialize_nodict_test.go
+++ b/pkg/og/storage/tree/serialize_nodict_test.go
@@ -12,12 +12,34 @@ var serializationExample = []byte("\x00\x00\x01\x01a\x00\x02\x01b\x01\x00\x01c\x
 func TestDeserializeNoDict(t *testing.T) {
 	t.Run("returns correct results", func(t *testing.T) {
 		r := bytes.NewReader(serializationExample)
-		tr, err := DeserializeNoDict(r)
+		tr, err := DeserializeNoDict(r, 0, 0)
 		require.NoError(t, err)
 
 		require.Equal(t, "", string(tr.root.Name))
 		require.Equal(t, "a", string(tr.root.ChildrenNodes[0].Name))
 		require.Equal(t, "b", string(tr.root.ChildrenNodes[0].ChildrenNodes[0].Name))
 		require.Equal(t, "c", string(tr.root.ChildrenNodes[0].ChildrenNodes[1].Name))
+	})
+
+	t.Run("rejects oversized name length varint (CVE-style panic)", func(t *testing.T) {
+		// 10-byte payload: varint encoding of 0xFFFFFFFFFFFFFFFF (max uint64).
+		// Without bounds checking this causes: panic: makeslice: len out of range
+		payload := bytes.Repeat([]byte{0xff}, 9)
+		payload = append(payload, 0x01)
+		_, err := DeserializeNoDict(bytes.NewReader(payload), 65535, 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds maximum")
+	})
+
+	t.Run("rejects oversized children count", func(t *testing.T) {
+		// Craft a node with nameLen=0, self=0, childrenLen=varint(16001).
+		// uvarint(16001) = 0x81 0x7D
+		var buf bytes.Buffer
+		buf.WriteByte(0x00)           // nameLen = 0
+		buf.WriteByte(0x00)           // self = 0
+		buf.Write([]byte{0x81, 0x7D}) // childrenLen = 16001
+		_, err := DeserializeNoDict(&buf, 0, 16000)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds maximum")
 	})
 }


### PR DESCRIPTION
## Summary

- Varint-encoded values from the input stream were used directly in `make([]byte, nameLen)` and a children-count loop without any upper bound, which could cause a runtime panic or unbounded memory growth on malformed input
- Guards are sourced from existing per-tenant limits (`MaxProfileSymbolValueLength` for node name length, `MaxProfileStacktraceSamples` for children-per-node) — no new configuration surface introduced; `0` disables the check, consistent with all other limits
- Also fixes a silently-dropped error on the `nameLen` varint read

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the ingestion interface and tree-format parsing path used for profile ingestion; incorrect limit wiring or tenant ID extraction could reject valid payloads or change behavior, but changes are narrow and covered by new tests.
> 
> **Overview**
> Adds bounds checks to `tree.DeserializeNoDict` to prevent panics/unbounded memory growth on malformed tree-format payloads, returning explicit errors when node name lengths or child counts exceed configured maxima.
> 
> Threads per-tenant limits through the ingestion pipeline by extending `ingestion.RawProfile.Parse` and `Limits` interfaces, wiring limits from the pyroscope ingester adapter into tree parsing (`convert.ParseTreeNoDict`) so the new guards use `MaxProfileSymbolValueLength` and `MaxProfileStacktraceSamples`.
> 
> Updates parsers and tests (pprof/jfr/speedscope/tree profile) to the new `Parse(..., limits)` signature and adds regression tests covering oversized varints/children counts and limit enforcement behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91ea150e55de97f74239fc3001bbde4cadafbe58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->