### PR TITLE
docs: update local V2 run command in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,12 +138,9 @@ go run ./cmd/pyroscope --target all,embedded-grafana
 # Grafana: http://localhost:4041
 
 # Run with V2 architecture (segment writers, query backend, symbolizer)
-PYROSCOPE_V2=1 go run ./cmd/pyroscope \
-  -target=all \
-  -storage.backend=filesystem \
-  -write-path=segment-writer \
-  -enable-query-backend=true \
-  -symbolizer.enabled=true
+# V2 is the default since the v2.0 release; only -storage.backend is required.
+# -symbolizer.enabled=true opts into symbolization (off by default).
+go run ./cmd/pyroscope -target=all -storage.backend=filesystem -symbolizer.enabled=true
 ```
 
 ## Code Style & Conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,9 +138,8 @@ go run ./cmd/pyroscope --target all,embedded-grafana
 # Grafana: http://localhost:4041
 
 # Run with V2 architecture (segment writers, query backend, symbolizer)
-# V2 is the default since the v2.0 release; only -storage.backend is required.
 # -symbolizer.enabled=true opts into symbolization (off by default).
-go run ./cmd/pyroscope -target=all -storage.backend=filesystem -symbolizer.enabled=true
+go run ./cmd/pyroscope -symbolizer.enabled=true
 ```
 
 ## Code Style & Conventions


### PR DESCRIPTION
## Summary
- `PYROSCOPE_V2` env var was removed in the v2.0 release (#5038) and V2 is now the default architecture.
- The flags `-write-path=segment-writer` and `-enable-query-backend=true` are already the defaults (`pkg/distributor/writepath/write_path.go:95`, `pkg/frontend/readpath/read_path.go:14`), and `architecture.storage` defaults to `v1-v2-dual` (`pkg/pyroscope/pyroscope.go:200`).
- Simplifies the "Running Locally" snippet so contributors don't copy stale flags. CLAUDE.md is a symlink to AGENTS.md so it inherits the change.

## Test plan
- [x] `go run ./cmd/pyroscope -target=all -storage.backend=filesystem` starts in V2 mode locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates local run instructions; no production code or behavior is modified.
> 
> **Overview**
> Updates `AGENTS.md` “Running Locally” guidance to reflect that V2 is now the default, removing the stale `PYROSCOPE_V2`/explicit V2 flags and replacing the snippet with a minimal `go run ./cmd/pyroscope -symbolizer.enabled=true` example (with a note that symbolization is opt-in).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1d99c31ed7fc83b1ac506548a45da751cdb01df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->