### PR TITLE
docs(config): add yaml-example doc-generator output and document V2 config blocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ generate: $(BIN)/buf $(BIN)/protoc-gen-go $(BIN)/protoc-gen-go-vtproto $(BIN)/pr
 	cd pkg && PATH=$(BIN) $(BIN)/buf generate
 	PATH="$(BIN):$(PATH)" ./tools/add-parquet-tags.sh
 	go run ./tools/doc-generator/ ./docs/sources/configure-server/reference-configuration-parameters/index.template > docs/sources/configure-server/reference-configuration-parameters/index.md
+	go run ./tools/doc-generator/ -format yaml-example -skip-blocks ingester,querier,query_scheduler,compactor,store_gateway > cmd/pyroscope/pyroscope.yaml
 	go run ./tools/api-docs-generator/
 
 .PHONY: buf/lint

--- a/cmd/pyroscope/pyroscope.yaml
+++ b/cmd/pyroscope/pyroscope.yaml
@@ -1,2 +1,803 @@
+# Pyroscope example configuration file.
+#
+# All fields are shown with their default values, commented out.
+# Uncomment and modify the ones you want to override.
+# For the full reference see:
+#   https://grafana.com/docs/pyroscope/latest/configure-server/reference-configuration-parameters/
+
+# Comma-separated list of Pyroscope modules to load. The alias 'all' can be used
+# in the list to load a number of core modules and will enable single-binary
+# mode.
+# target: "all"
+
+api:
+  # base URL for when the server is behind a reverse proxy with a different path
+  # base-url: ""
+
 server:
-  http_listen_port: 4040
+  # HTTP server listen network, default tcp
+  # http_listen_network: "tcp"
+
+  # HTTP server listen address.
+  # http_listen_address: ""
+
+  # HTTP server listen port.
+  # http_listen_port: 4040
+
+  # Maximum number of simultaneous http connections, <=0 to disable
+  # http_listen_conn_limit: 0
+
+  # gRPC server listen network
+  # grpc_listen_network: "tcp"
+
+  # gRPC server listen address.
+  # grpc_listen_address: ""
+
+  # gRPC server listen port.
+  # grpc_listen_port: 9095
+
+  # Maximum number of simultaneous grpc connections, <=0 to disable
+  # grpc_listen_conn_limit: 0
+
+  # If true, the max streams by connection gauge will be collected.
+  # grpc_collect_max_streams_by_conn: true
+
+  # Enables PROXY protocol.
+  # proxy_protocol_enabled: false
+
+  # Comma-separated list of cipher suites to use. If blank, the default Go
+  # cipher suites is used.
+  # tls_cipher_suites: ""
+
+  # Minimum TLS version to use. Allowed values: VersionTLS10, VersionTLS11,
+  # VersionTLS12, VersionTLS13. If blank, the Go TLS minimum version is used.
+  # tls_min_version: ""
+
+  http_tls_config:
+    # Server TLS certificate. This configuration parameter is YAML only.
+    # cert: ""
+
+    # Server TLS key. This configuration parameter is YAML only.
+    # key: ""
+
+    # Root certificate authority used to verify client certificates. This
+    # configuration parameter is YAML only.
+    # client_ca: ""
+
+    # HTTP server cert path.
+    # cert_file: ""
+
+    # HTTP server key path.
+    # key_file: ""
+
+    # HTTP TLS Client Auth type.
+    # client_auth_type: ""
+
+    # HTTP TLS Client CA path.
+    # client_ca_file: ""
+
+  grpc_tls_config:
+    # Server TLS certificate. This configuration parameter is YAML only.
+    # cert: ""
+
+    # Server TLS key. This configuration parameter is YAML only.
+    # key: ""
+
+    # Root certificate authority used to verify client certificates. This
+    # configuration parameter is YAML only.
+    # client_ca: ""
+
+    # GRPC TLS server cert path.
+    # cert_file: ""
+
+    # GRPC TLS server key path.
+    # key_file: ""
+
+    # GRPC TLS Client Auth type.
+    # client_auth_type: ""
+
+    # GRPC TLS Client CA path.
+    # client_ca_file: ""
+
+  # Register the intrumentation handlers (/metrics etc).
+  # register_instrumentation: true
+
+  # If set to true, gRPC statuses will be reported in instrumentation labels
+  # with their string representations. Otherwise, they will be reported as
+  # "error".
+  # report_grpc_codes_in_instrumentation_label_enabled: false
+
+  # Timeout for graceful shutdowns
+  # graceful_shutdown_timeout: 30s
+
+  # Read timeout for entire HTTP request, including headers and body.
+  # http_server_read_timeout: 30s
+
+  # Read timeout for HTTP request headers. If set to 0, value of
+  # -server.http-read-timeout is used.
+  # http_server_read_header_timeout: 0s
+
+  # Write timeout for HTTP server
+  # http_server_write_timeout: 30s
+
+  # Idle timeout for HTTP server
+  # http_server_idle_timeout: 2m
+
+  # Log closed connections that did not receive any response, most likely
+  # because client didn't send any request within timeout.
+  # http_log_closed_connections_without_response_enabled: false
+
+  # Limit on the size of a gRPC message this server can receive (bytes).
+  # grpc_server_max_recv_msg_size: 104857600
+
+  # Limit on the size of a gRPC message this server can send (bytes).
+  # grpc_server_max_send_msg_size: 104857600
+
+  # Limit on the number of concurrent streams for gRPC calls per client
+  # connection (0 = unlimited)
+  # grpc_server_max_concurrent_streams: 100
+
+  # The duration after which an idle connection should be closed. Default:
+  # infinity
+  # grpc_server_max_connection_idle: 2562047h47m16.854775807s
+
+  # The duration for the maximum amount of time a connection may exist before it
+  # will be closed. Default: infinity
+  # grpc_server_max_connection_age: 2562047h47m16.854775807s
+
+  # An additive period after max-connection-age after which the connection will
+  # be forcibly closed. Default: infinity
+  # grpc_server_max_connection_age_grace: 2562047h47m16.854775807s
+
+  # Duration after which a keepalive probe is sent in case of no activity over
+  # the connection., Default: 2h
+  # grpc_server_keepalive_time: 2h
+
+  # After having pinged for keepalive check, the duration after which an idle
+  # connection should be closed, Default: 20s
+  # grpc_server_keepalive_timeout: 20s
+
+  # Minimum amount of time a client should wait before sending a keepalive ping.
+  # If client sends keepalive ping more often, server will send GOAWAY and close
+  # the connection.
+  # grpc_server_min_time_between_pings: 1s
+
+  # If true, server allows keepalive pings even when there are no active
+  # streams(RPCs). If false, and client sends ping when there are no active
+  # streams, server will send GOAWAY and close the connection.
+  # grpc_server_ping_without_stream_allowed: false
+
+  # If non-zero, configures the amount of GRPC server workers used to serve the
+  # requests.
+  # grpc_server_num_workers: 0
+
+  # If true, the request_message_bytes, response_message_bytes, and
+  # inflight_requests metrics will be tracked. Enabling this option prevents the
+  # use of memory pools for parsing gRPC request bodies and may lead to more
+  # memory allocations.
+  # grpc_server_stats_tracking_enabled: true
+
+  # Deprecated option, has no effect and will be removed in a future version.
+  # grpc_server_recv_buffer_pools_enabled: false
+
+  # Size of the read buffer for each gRPC connection (bytes). A smaller buffer
+  # may reduce memory usage but may lead to more system calls.
+  # grpc_server_read_buffer_size: 32768
+
+  # Size of the write buffer for each gRPC connection (bytes). A smaller buffer
+  # may reduce memory usage but may lead to more system calls.
+  # grpc_server_write_buffer_size: 32768
+
+  # Output log messages in the given format. Valid formats: [logfmt, json]
+  # log_format: "logfmt"
+
+  # Only log messages with the given severity or above. Valid levels: [debug,
+  # info, warn, error]
+  # log_level: "info"
+
+  # Optionally log the source IPs.
+  # log_source_ips_enabled: false
+
+  # Log all source IPs instead of only the originating one. Only used if
+  # server.log-source-ips-enabled is true
+  # log_source_ips_full: false
+
+  # Header field storing the source IPs. Only used if
+  # server.log-source-ips-enabled is true. If not set the default Forwarded,
+  # X-Real-IP and X-Forwarded-For headers are used
+  # log_source_ips_header: ""
+
+  # Regex for matching the source IPs. Only used if
+  # server.log-source-ips-enabled is true. If not set the default Forwarded,
+  # X-Real-IP and X-Forwarded-For headers are used
+  # log_source_ips_regex: ""
+
+  # Optionally log request headers.
+  # log_request_headers: false
+
+  # Optionally log requests at info level instead of debug level. Applies to
+  # request headers as well if server.log-request-headers is enabled.
+  # log_request_at_info_level_enabled: false
+
+  # Comma separated list of headers to exclude from loggin. Only used if
+  # server.log-request-headers is true.
+  # log_request_exclude_headers_list: ""
+
+  # Optionally add request headers to tracing spans.
+  # trace_request_headers: false
+
+  # Comma separated list of headers to exclude from tracing spans. Only used if
+  # server.trace-request-headers is true. The following headers are always
+  # excluded: Authorization, Cookie, X-Access-Token, X-Csrf-Token, X-Grafana-Id.
+  # trace_request_exclude_headers_list: ""
+
+  # Base path to serve all API routes from (e.g. /v1/)
+  # http_path_prefix: ""
+
+  # Creates new traces for each call rather than continuing the existing trace.
+  # A span link is used to allow navigation to the parent trace. Only works when
+  # using Open-Telemetry tracing.
+  # create_new_traces: false
+
+metastore:
+  raft:
+    # Directory to store WAL and raft state. It must be a persistent directory,
+    # not a tmpfs or similar.
+    # dir: "./data/v2/metastore/raft"
+
+  # Directory to store the data.
+  # data_dir: "./data/v2/metastore/data"
+
+  # levels: 0
+
+  # cleanupbatchsize: 0
+
+  # cleanupdelay: 0s
+
+  # cleanupjobminlevel: 0
+
+  # cleanupjobmaxlevel: 0
+
+distributor:
+  # Timeout when pushing data to ingester.
+  # pushtimeout: 5s
+
+  pool_config:
+    # How frequently to clean up clients for ingesters that have gone away.
+    # client_cleanup_period: 15s
+
+    # Run a health check on each ingester client during periodic cleanup.
+    # health_check_ingesters: true
+
+    # Timeout for ingester client healthcheck RPCs.
+    # remote_timeout: 5s
+
+  ring:
+    kvstore:
+      # Backend storage to use for the ring. Supported values are: consul, etcd,
+      # inmemory, memberlist, multi.
+      # store: "memberlist"
+
+      consul:
+        # Hostname and port of Consul.
+        # host: "localhost:8500"
+
+      etcd:
+        # The etcd endpoints to connect to.
+        # endpoints: []
+
+        # Etcd username.
+        # username: ""
+
+        # Etcd password.
+        # password: ""
+
+    # List of network interface names to look up when finding the instance IP
+    # address.
+    # instance_interface_names: [<private network interfaces>]
+
+limits:
+  # Per-tenant ingestion rate limit in sample size per second. Units in MB.
+  # ingestion_rate_mb: 4
+
+  # Per-tenant allowed ingestion burst size (in sample size). Units in MB. The
+  # burst size refers to the per-distributor local rate limiter, and should be
+  # set at least to the maximum profile size expected in a single push request.
+  # ingestion_burst_size_mb: 2
+
+  # Maximum length accepted for label names.
+  # max_label_name_length: 1024
+
+  # Maximum length accepted for label value. This setting also applies to the
+  # metric name.
+  # max_label_value_length: 2048
+
+  # Maximum number of label names per series.
+  # max_label_names_per_series: 30
+
+  # Maximum number of sessions per series. 0 to disable.
+  # max_sessions_per_series: 0
+
+  # Enforce labels order optimization.
+  # enforce_labels_order: false
+
+  # Disable label name sanitization (converting dots to underscores). When
+  # disabled, labels with dots are accepted as-is using UTF-8 validation.
+  # disable_label_sanitization: true
+
+  # Maximum size of a profile in bytes. This is based off the uncompressed size.
+  # 0 to disable.
+  # max_profile_size_bytes: 4194304
+
+  # Maximum number of samples in a profile. 0 to disable.
+  # max_profile_stacktrace_samples: 16000
+
+  # Maximum number of labels in a profile sample. 0 to disable.
+  # max_profile_stacktrace_sample_labels: 100
+
+  # Maximum depth of a profile stacktrace. Profiles are not rejected instead
+  # stacktraces are truncated. 0 to disable.
+  # max_profile_stacktrace_depth: 1000
+
+  # Maximum length of a profile symbol value (labels, function names and
+  # filenames, etc...). Profiles are not rejected instead symbol values are
+  # truncated. 0 to disable.
+  # max_profile_symbol_value_length: 65535
+
+  # Duration of the distributor aggregation window. Requires aggregation period
+  # to be specified. 0 to disable.
+  # distributor_aggregation_window: 0s
+
+  # Duration of the distributor aggregation period. Requires aggregation window
+  # to be specified. 0 to disable.
+  # distributor_aggregation_period: 0s
+
+  # The tenant's shard size used by shuffle-sharding. Must be set both on
+  # ingesters and distributors. 0 disables shuffle sharding.
+  # ingestion_tenant_shard_size: 0
+
+  # Maximum number of active series of profiles per tenant, per ingester. 0 to
+  # disable.
+  # max_local_series_per_tenant: 0
+
+  # Maximum number of active series of profiles per tenant, across the cluster.
+  # 0 to disable. When the global limit is enabled, each ingester is configured
+  # with a dynamic local limit based on the replication factor and the current
+  # number of healthy ingesters, and is kept updated whenever the number of
+  # ingesters change.
+  # max_global_series_per_tenant: 5000
+
+  # Limit how far back in profiling data can be queried, up until lookback
+  # duration ago. This limit is enforced in the query frontend. If the requested
+  # time range is outside the allowed range, the request will not fail, but will
+  # be modified to only query data within the allowed time range. 0 to disable,
+  # default to 7d.
+  # max_query_lookback: 1w
+
+  # The limit to length of queries. 0 to disable.
+  # max_query_length: 1d
+
+  # Maximum number of queries that will be scheduled in parallel by the
+  # frontend.
+  # max_query_parallelism: 0
+
+  # Whether query analysis is enabled in the query frontend. If disabled, the
+  # /AnalyzeQuery endpoint will return an empty response.
+  # query_analysis_enabled: true
+
+  # Whether the series portion of query analysis is enabled. If disabled, no
+  # series data (e.g., series count) will be calculated by the /AnalyzeQuery
+  # endpoint.
+  # query_analysis_series_enabled: false
+
+  # Maximum number of flame graph nodes by default. 0 to disable.
+  # max_flamegraph_nodes_default: 8192
+
+  # Maximum number of flame graph nodes allowed. 0 to disable.
+  # max_flamegraph_nodes_max: 1048576
+
+  # The tenant's shard size, used when store-gateway sharding is enabled. Value
+  # of 0 disables shuffle sharding for the tenant, that is all tenant blocks are
+  # sharded across all store-gateway replicas.
+  # store_gateway_tenant_shard_size: 0
+
+  # Split queries by a time interval and execute in parallel. The value 0
+  # disables splitting by time
+  # split_queries_by_interval: 0s
+
+  # Whether profiles should be sanitized when merging.
+  # query_sanitize_on_merge: true
+
+  # Delete blocks containing samples older than the specified retention period.
+  # 0 to disable.
+  # compactor_blocks_retention_period: 0s
+
+  # The number of shards to use when splitting blocks. 0 to disable splitting.
+  # compactor_split_and_merge_shards: 0
+
+  # Number of stages split shards will be written to. Number of output split
+  # shards is controlled by -compactor.split-and-merge-shards.
+  # compactor_split_and_merge_stage_size: 0
+
+  # Number of groups that blocks for splitting should be grouped into. Each
+  # group of blocks is then split separately. Number of output split shards is
+  # controlled by -compactor.split-and-merge-shards.
+  # compactor_split_groups: 1
+
+  # Max number of compactors that can compact blocks for single tenant. 0 to
+  # disable the limit and use all compactors.
+  # compactor_tenant_shard_size: 0
+
+  # If a partial block (unfinished block without meta.json file) hasn't been
+  # modified for this time, it will be marked for deletion. The minimum accepted
+  # value is 4h0m0s: a lower value will be ignored and the feature disabled. 0
+  # to disable.
+  # compactor_partial_block_deletion_delay: 1d
+
+  # If enabled, the compactor will downsample profiles in blocks at compaction
+  # level 3 and above. The original profiles are also kept. Note: This set the
+  # default for the teanant overrides, in order to be effective it also requires
+  # compactor.downsampler-enabled to be set to true.
+  # compactor_downsampler_enabled: true
+
+  # S3 server-side encryption type. Required to enable server-side encryption
+  # overrides for a specific tenant. If not set, the default S3 client settings
+  # are used.
+  # s3_sse_type: ""
+
+  # S3 server-side encryption KMS Key ID. Ignored if the SSE type override is
+  # not set.
+  # s3_sse_kms_key_id: ""
+
+  # S3 server-side encryption KMS encryption context. If unset and the key ID
+  # override is set, the encryption context will not be provided to S3. Ignored
+  # if the SSE type override is not set.
+  # s3_sse_kms_encryption_context: ""
+
+  # This limits how far into the past profiling data can be ingested. This limit
+  # is enforced in the distributor. 0 to disable, defaults to 1h.
+  # reject_older_than: 1h
+
+  # This limits how far into the future profiling data can be ingested. This
+  # limit is enforced in the distributor. 0 to disable, defaults to 10m.
+  # reject_newer_than: 10m
+
+segment_writer:
+  lifecycler:
+    ring:
+      kvstore:
+        # Backend storage to use for the ring. Supported values are: consul,
+        # etcd, inmemory, memberlist, multi.
+        # store: "consul"
+
+        consul:
+          # Hostname and port of Consul.
+          # host: "localhost:8500"
+
+        etcd:
+          # The etcd endpoints to connect to.
+          # endpoints: []
+
+          # Etcd username.
+          # username: ""
+
+          # Etcd password.
+          # password: ""
+
+      # The number of ingesters to write to and read from.
+      # replication_factor: 3
+
+      # True to enable the zone-awareness and replicate ingested samples across
+      # different availability zones.
+      # zone_awareness_enabled: false
+
+    # Name of network interface to read address from.
+    # interface_names: [<private network interfaces>]
+
+    # File path where tokens are stored. If empty, tokens are not stored at
+    # shutdown and restored at startup.
+    # tokens_file_path: ""
+
+    # The availability zone where this instance is running.
+    # availability_zone: ""
+
+memberlist:
+  # Gossip address to advertise to other members in the cluster. Used for NAT
+  # traversal.
+  # advertise_addr: ""
+
+  # Gossip port to advertise to other members in the cluster. Used for NAT
+  # traversal.
+  # advertise_port: 7946
+
+  # Other cluster members to join. Can be specified multiple times or as a
+  # comma-separated list. It can be an IP, hostname or an entry specified in the
+  # DNS Service Discovery format.
+  # join_members: 0
+
+  # Abort if this node fails to join memberlist cluster at startup. When
+  # enabled, it's not guaranteed that other services are started only after the
+  # cluster state has been successfully updated; use 'abort-if-fast-join-fails'
+  # instead.
+  # abort_if_cluster_join_fails: false
+
+  # IP address to listen on for gossip messages. Multiple addresses may be
+  # specified. Defaults to 0.0.0.0
+  # bind_addr: []
+
+  # Port to listen on for gossip messages.
+  # bind_port: 7946
+
+pyroscopedb:
+  # Directory used for local storage.
+  # data_path: "./data"
+
+  # Upper limit to the duration of a Pyroscope block.
+  # max_block_duration: 1h
+
+  # How big should a single row group be uncompressed
+  # row_group_target_size: 1342177280
+
+  # Specifies the dimension by which symbols are partitioned. By default, the
+  # partitioning is determined automatically.
+  # symbols_partition_label: ""
+
+  # How much available disk space to keep in GiB
+  # min_free_disk_gb: 10
+
+  # Which percentage of free disk space to keep
+  # min_disk_available_percentage: 0.05
+
+  # How often to enforce disk retention
+  # enforcement_interval: 5m
+
+  # Disable retention policy enforcement
+  # disable_enforcement: false
+
+tracing:
+  # Set to false to disable tracing.
+  # enabled: true
+
+overrides_exporter:
+  ring:
+    kvstore:
+      # Backend storage to use for the ring. Supported values are: consul, etcd,
+      # inmemory, memberlist, multi.
+      # store: "memberlist"
+
+      consul:
+        # Hostname and port of Consul.
+        # host: "localhost:8500"
+
+      etcd:
+        # The etcd endpoints to connect to.
+        # endpoints: []
+
+        # Etcd username.
+        # username: ""
+
+        # Etcd password.
+        # password: ""
+
+    # List of network interface names to look up when finding the instance IP
+    # address.
+    # instance_interface_names: [<private network interfaces>]
+
+runtime_config:
+  # Comma separated list of yaml files or URLs with the configuration that can
+  # be updated at runtime. Runtime config files will be merged from left to
+  # right.
+  # file: ""
+
+storage:
+  # Backend storage to use. Supported backends are: s3, gcs, azure, swift,
+  # filesystem, cos.
+  # backend: "filesystem"
+
+  s3:
+    # The S3 bucket endpoint. It could be an AWS S3 endpoint listed at
+    # https://docs.aws.amazon.com/general/latest/gr/s3.html or the address of an
+    # S3-compatible service in hostname:port format.
+    # endpoint: ""
+
+    # S3 region. If unset, the client will issue a S3 GetBucketLocation API call
+    # to autodetect it.
+    # region: ""
+
+    # S3 bucket name
+    # bucket_name: ""
+
+    # S3 secret access key
+    # secret_access_key: ""
+
+    # S3 access key ID
+    # access_key_id: ""
+
+    sse:
+      # Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.
+      # type: ""
+
+      # KMS Key ID used to encrypt objects in S3
+      # kms_key_id: ""
+
+      # KMS Encryption Context used for object encryption. It expects JSON
+      # formatted string.
+      # kms_encryption_context: ""
+
+  gcs:
+    # GCS bucket name
+    # bucket_name: ""
+
+    # JSON either from a Google Developers Console client_credentials.json file,
+    # or a Google Developers service account key. Needs to be valid JSON, not a
+    # filesystem path. If empty, fallback to Google default logic:
+    # 1. A JSON file whose path is specified by the
+    # GOOGLE_APPLICATION_CREDENTIALS environment variable. For workload identity
+    # federation, refer to
+    # https://cloud.google.com/iam/docs/how-to#using-workload-identity-federation
+    # on how to generate the JSON configuration file for on-prem/non-Google
+    # cloud platforms.
+    # 2. A JSON file in a location known to the gcloud command-line tool:
+    # $HOME/.config/gcloud/application_default_credentials.json.
+    # 3. On Google Compute Engine it fetches credentials from the metadata
+    # server.
+    # service_account: ""
+
+  azure:
+    # Azure Active Directory tenant ID. If set alongside `client-id` and
+    # `client-secret`, these values will be used for authentication via a client
+    # secret credential.
+    # az_tenant_id: ""
+
+    # Azure Active Directory client ID. If set alongside `az-tenant-id` and
+    # `client-secret`, these values will be used for authentication via a client
+    # secret credential.
+    # client_id: ""
+
+    # Azure Active Directory client secret. If set alongside `az-tenant-id` and
+    # `client-id`, these values will be used for authentication via a client
+    # secret credential.
+    # client_secret: ""
+
+    # Azure storage account name
+    # account_name: ""
+
+    # Azure storage account key. If unset, Azure managed identities will be used
+    # for authentication instead.
+    # account_key: ""
+
+    # If `connection-string` is set, the value of `endpoint-suffix` will not be
+    # used. Use this method over `account-key` if you need to authenticate via a
+    # SAS token. Or if you use the Azurite emulator.
+    # connection_string: ""
+
+    # Azure storage container name
+    # container_name: ""
+
+    # Azure storage endpoint suffix without schema. The account name will be
+    # prefixed to this value to create the FQDN. If set to empty string, default
+    # endpoint suffix is used.
+    # endpoint_suffix: ""
+
+  swift:
+    # OpenStack Swift authentication API version. 0 to autodetect.
+    # auth_version: 0
+
+    # OpenStack Swift authentication URL
+    # auth_url: ""
+
+    # OpenStack Swift username.
+    # username: ""
+
+    # OpenStack Swift user's domain name.
+    # user_domain_name: ""
+
+    # OpenStack Swift user's domain ID.
+    # user_domain_id: ""
+
+    # OpenStack Swift user ID.
+    # user_id: ""
+
+    # OpenStack Swift API key.
+    # password: ""
+
+    # OpenStack Swift user's domain ID.
+    # domain_id: ""
+
+    # OpenStack Swift user's domain name.
+    # domain_name: ""
+
+    # OpenStack Swift project ID (v2,v3 auth only).
+    # project_id: ""
+
+    # OpenStack Swift project name (v2,v3 auth only).
+    # project_name: ""
+
+    # ID of the OpenStack Swift project's domain (v3 auth only), only needed if
+    # it differs the from user domain.
+    # project_domain_id: ""
+
+    # Name of the OpenStack Swift project's domain (v3 auth only), only needed
+    # if it differs from the user domain.
+    # project_domain_name: ""
+
+    # OpenStack Swift Region to use (v2,v3 auth only).
+    # region_name: ""
+
+    # Name of the OpenStack Swift container to put chunks in.
+    # container_name: ""
+
+  cos:
+    # COS bucket name
+    # bucket: ""
+
+    # COS region name
+    # region: ""
+
+    # COS app id
+    # app_id: ""
+
+    # COS storage endpoint
+    # endpoint: ""
+
+    # COS secret key
+    # secret_key: ""
+
+    # COS secret id
+    # secret_id: ""
+
+  filesystem:
+    # Local filesystem storage directory.
+    # dir: "./data/v2/shared"
+
+  # Prefix for all objects stored in the backend storage. For simplicity, it may
+  # only contain digits and English alphabet characters, hyphens, underscores,
+  # dots and forward slashes.
+  # prefix: ""
+
+self_profiling:
+  # When running in single binary (--target=all) Pyroscope will push (Go SDK)
+  # profiles to itself. Set to true to disable self-profiling.
+  # disable_push: false
+
+  # mutex_profile_fraction: 5
+
+  # block_profile_rate: 5
+
+  # Read k6 labels from request headers and set them as dynamic profile tags.
+  # use_k6_middleware: false
+
+  # Tenant ID for self-profiling data. If empty, no tenant header is sent
+  # (anonymous).
+  # tenant_id: ""
+
+# When set to true, incoming HTTP requests must specify tenant ID in HTTP
+# X-Scope-OrgId header. When set to false, tenant ID anonymous is used instead.
+# multitenancy_enabled: false
+
+analytics:
+  # Enable anonymous usage statistics collection. For more details about usage
+  # statistics, refer to
+  # https://grafana.com/docs/pyroscope/latest/configure-server/anonymous-usage-statistics-reporting/
+  # reporting_enabled: true
+
+# Prints the application banner at startup.
+# show_banner: true
+
+# Wait time before shutting down after a termination signal.
+# shutdown_delay: 0s
+
+# Storage architecture layer. Use 'v1' to use legacy ingester-based storage,
+# 'v2' for new storage, and 'v1-v2-dual' to use new storage while being able to
+# query old data.
+# architecture_storage: "v1-v2-dual"
+
+embedded_grafana:
+  # The directory where the Grafana data will be stored.
+  # data_path: "./data/__embedded_grafana/"
+
+  # The port on which the Grafana will listen.
+  # listen_port: 4041
+
+  # The URL of the Pyroscope instance to use for the Grafana datasources.
+  # pyroscope_url: "http://localhost:4040"

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -74,11 +74,24 @@ api:
 # service(s).
 [server: <server>]
 
+# The metastore block configures the metastore (V2).
+[metastore: <metastore>]
+
 # The distributor block configures the distributor.
 [distributor: <distributor>]
 
 # The query_frontend block configures the query-frontend.
 [frontend: <query_frontend>]
+
+# The query_backend block configures the query-backend (V2 read path).
+[query_backend: <query_backend>]
+
+# The adaptive_placement block configures adaptive placement for the
+# segment-writer (V2).
+[adaptive_placement: <adaptive_placement>]
+
+# The symbolizer block configures the symbolizer (V2).
+[symbolizer: <symbolizer>]
 
 # The frontend_worker block configures the frontend-worker.
 [frontend_worker: <frontend_worker>]
@@ -86,6 +99,9 @@ api:
 # The limits block configures default and per-tenant limits imposed by
 # components.
 [limits: <limits>]
+
+# The segment_writer block configures the segment-writer (V2 write path).
+[segment_writer: <segment_writer>]
 
 # The memberlist block configures the Gossip memberlist.
 [memberlist: <memberlist>]
@@ -129,8 +145,11 @@ tracing:
   # CLI flag: -tracing.enabled
   [enabled: <boolean> | default = true]
 
+# The overrides_exporter block configures the overrides exporter.
+[overrides_exporter: <overrides_exporter>]
+
 runtime_config:
-  # How often to check runtime config files.
+  # (advanced) How often to check runtime config files.
   # CLI flag: -runtime-config.reload-period
   [period: <duration> | default = 10s]
 
@@ -140,18 +159,21 @@ runtime_config:
   # CLI flag: -runtime-config.file
   [file: <string> | default = ""]
 
-  # HTTP client timeout when fetching runtime config from URLs.
+  # (advanced) HTTP client timeout when fetching runtime config from URLs.
   # CLI flag: -runtime-config.http-client-timeout
   [http_client_timeout: <duration> | default = 30s]
 
   http_client_cluster_validation:
-    # Primary cluster validation label.
+    # (experimental) Primary cluster validation label.
     # CLI flag: -runtime-config.http-client-cluster-validation.label
     [label: <string> | default = ""]
 
+# The compaction_worker block configures the compaction-worker (V2).
+[compaction_worker: <compaction_worker>]
+
 tenant_settings:
   recording_rules:
-    # Enable the storing of recording rules in tenant settings.
+    # (experimental) Enable the storing of recording rules in tenant settings.
     # CLI flag: -tenant-settings.recording-rules.enabled
     [enabled: <boolean> | default = false]
 
@@ -203,40 +225,41 @@ storage:
     [secret_id: <string> | default = ""]
 
     http:
-      # The time an idle connection will remain idle before closing.
+      # (advanced) The time an idle connection will remain idle before closing.
       # CLI flag: -storage.cos.http.idle-conn-timeout
       [idle_conn_timeout: <duration> | default = 1m30s]
 
-      # The amount of time the client will wait for a servers response headers.
+      # (advanced) The amount of time the client will wait for a servers
+      # response headers.
       # CLI flag: -storage.cos.http.response-header-timeout
       [response_header_timeout: <duration> | default = 2m]
 
-      # If the client connects to COS via HTTPS and this option is enabled, the
-      # client will accept any certificate and hostname.
+      # (advanced) If the client connects to COS via HTTPS and this option is
+      # enabled, the client will accept any certificate and hostname.
       # CLI flag: -storage.cos.http.insecure-skip-verify
       [insecure_skip_verify: <boolean> | default = false]
 
-      # Maximum time to wait for a TLS handshake. 0 means no limit.
+      # (advanced) Maximum time to wait for a TLS handshake. 0 means no limit.
       # CLI flag: -storage.cos.tls-handshake-timeout
       [tls_handshake_timeout: <duration> | default = 10s]
 
-      # The time to wait for a server's first response headers after fully
-      # writing the request headers if the request has an Expect header. 0 to
-      # send the request body immediately.
+      # (advanced) The time to wait for a server's first response headers after
+      # fully writing the request headers if the request has an Expect header. 0
+      # to send the request body immediately.
       # CLI flag: -storage.cos.expect-continue-timeout
       [expect_continue_timeout: <duration> | default = 1s]
 
-      # Maximum number of idle (keep-alive) connections across all hosts. 0
-      # means no limit.
+      # (advanced) Maximum number of idle (keep-alive) connections across all
+      # hosts. 0 means no limit.
       # CLI flag: -storage.cos.max-idle-connections
       [max_idle_connections: <int> | default = 100]
 
-      # Maximum number of idle (keep-alive) connections to keep per-host. If 0,
-      # a built-in default value is used.
+      # (advanced) Maximum number of idle (keep-alive) connections to keep
+      # per-host. If 0, a built-in default value is used.
       # CLI flag: -storage.cos.max-idle-connections-per-host
       [max_idle_connections_per_host: <int> | default = 100]
 
-      # Maximum number of connections per host. 0 means no limit.
+      # (advanced) Maximum number of connections per host. 0 means no limit.
       # CLI flag: -storage.cos.max-connections-per-host
       [max_connections_per_host: <int> | default = 0]
 
@@ -250,9 +273,10 @@ storage:
   # CLI flag: -storage.prefix
   [prefix: <string> | default = ""]
 
-  # Deprecated: Use 'storage..prefix' instead. Prefix for all objects stored in
-  # the backend storage. For simplicity, it may only contain digits and English
-  # alphabet characters, hyphens, underscores, dots and forward slashes.
+  # (experimental) Deprecated: Use 'storage..prefix' instead. Prefix for all
+  # objects stored in the backend storage. For simplicity, it may only contain
+  # digits and English alphabet characters, hyphens, underscores, dots and
+  # forward slashes.
   # CLI flag: -storage.storage-prefix
   [storage_prefix: <string> | default = ""]
 
@@ -609,46 +633,46 @@ grpc_tls_config:
 [http_path_prefix: <string> | default = ""]
 
 cluster_validation:
-  # Primary cluster validation label.
+  # (experimental) Primary cluster validation label.
   # CLI flag: -server.cluster-validation.label
   [label: <string> | default = ""]
 
-  # Comma-separated list of additional cluster validation labels that the server
-  # will accept from incoming requests.
+  # (experimental) Comma-separated list of additional cluster validation labels
+  # that the server will accept from incoming requests.
   # CLI flag: -server.cluster-validation.additional-labels
   [additional_labels: <string> | default = ""]
 
   grpc:
-    # When enabled, cluster label validation is executed: configured cluster
-    # validation label is compared with the cluster validation label received
-    # through the requests.
+    # (experimental) When enabled, cluster label validation is executed:
+    # configured cluster validation label is compared with the cluster
+    # validation label received through the requests.
     # CLI flag: -server.cluster-validation.grpc.enabled
     [enabled: <boolean> | default = false]
 
-    # When enabled, soft cluster label validation is executed. Can be enabled
-    # only together with server.cluster-validation.grpc.enabled
+    # (experimental) When enabled, soft cluster label validation is executed.
+    # Can be enabled only together with server.cluster-validation.grpc.enabled
     # CLI flag: -server.cluster-validation.grpc.soft-validation
     [soft_validation: <boolean> | default = false]
 
   http:
-    # When enabled, cluster label validation is executed: configured cluster
-    # validation label is compared with the cluster validation label received
-    # through the requests.
+    # (experimental) When enabled, cluster label validation is executed:
+    # configured cluster validation label is compared with the cluster
+    # validation label received through the requests.
     # CLI flag: -server.cluster-validation.http.enabled
     [enabled: <boolean> | default = false]
 
-    # When enabled, soft cluster label validation is executed. Can be enabled
-    # only together with server.cluster-validation.http.enabled
+    # (experimental) When enabled, soft cluster label validation is executed.
+    # Can be enabled only together with server.cluster-validation.http.enabled
     # CLI flag: -server.cluster-validation.http.soft-validation
     [soft_validation: <boolean> | default = false]
 
-    # Comma-separated list of url paths that are excluded from the cluster
-    # validation check.
+    # (experimental) Comma-separated list of url paths that are excluded from
+    # the cluster validation check.
     # CLI flag: -server.cluster-validation.http.excluded-paths
     [excluded_paths: <string> | default = ""]
 
-    # Comma-separated list of user agents that are excluded from the cluster
-    # validation check.
+    # (experimental) Comma-separated list of user agents that are excluded from
+    # the cluster validation check.
     # CLI flag: -server.cluster-validation.http.excluded-user-agents
     [excluded_user_agents: <string> | default = ""]
 
@@ -689,7 +713,7 @@ ring:
     # CLI flag: -distributor.ring.store
     [store: <string> | default = "memberlist"]
 
-    # The prefix for the keys in the store. Should end with a /.
+    # (advanced) The prefix for the keys in the store. Should end with a /.
     # CLI flag: -distributor.ring.prefix
     [prefix: <string> | default = "collectors/"]
 
@@ -698,29 +722,30 @@ ring:
       # CLI flag: -distributor.ring.consul.hostname
       [host: <string> | default = "localhost:8500"]
 
-      # ACL Token used to interact with Consul.
+      # (advanced) ACL Token used to interact with Consul.
       # CLI flag: -distributor.ring.consul.acl-token
       [acl_token: <string> | default = ""]
 
-      # HTTP timeout when talking to Consul
+      # (advanced) HTTP timeout when talking to Consul
       # CLI flag: -distributor.ring.consul.client-timeout
       [http_client_timeout: <duration> | default = 20s]
 
-      # Enable consistent reads to Consul.
+      # (advanced) Enable consistent reads to Consul.
       # CLI flag: -distributor.ring.consul.consistent-reads
       [consistent_reads: <boolean> | default = false]
 
-      # Rate limit when watching key or prefix in Consul, in requests per
-      # second. 0 disables the rate limit.
+      # (advanced) Rate limit when watching key or prefix in Consul, in requests
+      # per second. 0 disables the rate limit.
       # CLI flag: -distributor.ring.consul.watch-rate-limit
       [watch_rate_limit: <float> | default = 1]
 
-      # Burst size used in rate limit. Values less than 1 are treated as 1.
+      # (advanced) Burst size used in rate limit. Values less than 1 are treated
+      # as 1.
       # CLI flag: -distributor.ring.consul.watch-burst-size
       [watch_burst_size: <int> | default = 1]
 
-      # Maximum duration to wait before retrying a Compare And Swap (CAS)
-      # operation.
+      # (advanced) Maximum duration to wait before retrying a Compare And Swap
+      # (CAS) operation.
       # CLI flag: -distributor.ring.consul.cas-retry-delay
       [cas_retry_delay: <duration> | default = 1s]
 
@@ -729,43 +754,44 @@ ring:
       # CLI flag: -distributor.ring.etcd.endpoints
       [endpoints: <list of strings> | default = []]
 
-      # The dial timeout for the etcd connection.
+      # (advanced) The dial timeout for the etcd connection.
       # CLI flag: -distributor.ring.etcd.dial-timeout
       [dial_timeout: <duration> | default = 10s]
 
-      # The maximum number of retries to do for failed ops.
+      # (advanced) The maximum number of retries to do for failed ops.
       # CLI flag: -distributor.ring.etcd.max-retries
       [max_retries: <int> | default = 10]
 
-      # Enable TLS.
+      # (advanced) Enable TLS.
       # CLI flag: -distributor.ring.etcd.tls-enabled
       [tls_enabled: <boolean> | default = false]
 
-      # Path to the client certificate, which will be used for authenticating
-      # with the server. Also requires the key path to be configured.
+      # (advanced) Path to the client certificate, which will be used for
+      # authenticating with the server. Also requires the key path to be
+      # configured.
       # CLI flag: -distributor.ring.etcd.tls-cert-path
       [tls_cert_path: <string> | default = ""]
 
-      # Path to the key for the client certificate. Also requires the client
-      # certificate to be configured.
+      # (advanced) Path to the key for the client certificate. Also requires the
+      # client certificate to be configured.
       # CLI flag: -distributor.ring.etcd.tls-key-path
       [tls_key_path: <string> | default = ""]
 
-      # Path to the CA certificates to validate server certificate against. If
-      # not set, the host's root CA certificates are used.
+      # (advanced) Path to the CA certificates to validate server certificate
+      # against. If not set, the host's root CA certificates are used.
       # CLI flag: -distributor.ring.etcd.tls-ca-path
       [tls_ca_path: <string> | default = ""]
 
-      # Override the expected name on the server certificate.
+      # (advanced) Override the expected name on the server certificate.
       # CLI flag: -distributor.ring.etcd.tls-server-name
       [tls_server_name: <string> | default = ""]
 
-      # Skip validating server certificate.
+      # (advanced) Skip validating server certificate.
       # CLI flag: -distributor.ring.etcd.tls-insecure-skip-verify
       [tls_insecure_skip_verify: <boolean> | default = false]
 
-      # Override the default cipher suite list (separated by commas). Allowed
-      # values:
+      # (advanced) Override the default cipher suite list (separated by commas).
+      # Allowed values:
       # 
       # Secure Ciphers:
       # - TLS_AES_128_GCM_SHA256
@@ -798,8 +824,8 @@ ring:
       # CLI flag: -distributor.ring.etcd.tls-cipher-suites
       [tls_cipher_suites: <string> | default = ""]
 
-      # Override the default minimum TLS version. Allowed values: VersionTLS10,
-      # VersionTLS11, VersionTLS12, VersionTLS13
+      # (advanced) Override the default minimum TLS version. Allowed values:
+      # VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
       # CLI flag: -distributor.ring.etcd.tls-min-version
       [tls_min_version: <string> | default = ""]
 
@@ -812,32 +838,32 @@ ring:
       [password: <string> | default = ""]
 
     multi:
-      # Primary backend storage used by multi-client.
+      # (advanced) Primary backend storage used by multi-client.
       # CLI flag: -distributor.ring.multi.primary
       [primary: <string> | default = ""]
 
-      # Secondary backend storage used by multi-client.
+      # (advanced) Secondary backend storage used by multi-client.
       # CLI flag: -distributor.ring.multi.secondary
       [secondary: <string> | default = ""]
 
-      # Mirror writes to the secondary store.
+      # (advanced) Mirror writes to the secondary store.
       # CLI flag: -distributor.ring.multi.mirror-enabled
       [mirror_enabled: <boolean> | default = false]
 
-      # Timeout for storing a value to the secondary store.
+      # (advanced) Timeout for storing a value to the secondary store.
       # CLI flag: -distributor.ring.multi.mirror-timeout
       [mirror_timeout: <duration> | default = 2s]
 
-  # Period at which to heartbeat to the ring. 0 = disabled.
+  # (advanced) Period at which to heartbeat to the ring. 0 = disabled.
   # CLI flag: -distributor.ring.heartbeat-period
   [heartbeat_period: <duration> | default = 15s]
 
-  # The heartbeat timeout after which distributors are considered unhealthy
-  # within the ring. 0 = never (timeout disabled).
+  # (advanced) The heartbeat timeout after which distributors are considered
+  # unhealthy within the ring. 0 = never (timeout disabled).
   # CLI flag: -distributor.ring.heartbeat-timeout
   [heartbeat_timeout: <duration> | default = 1m]
 
-  # Instance ID to register in the ring.
+  # (advanced) Instance ID to register in the ring.
   # CLI flag: -distributor.ring.instance-id
   [instance_id: <string> | default = "<hostname>"]
 
@@ -846,17 +872,507 @@ ring:
   # CLI flag: -distributor.ring.instance-interface-names
   [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
 
-  # Port to advertise in the ring (defaults to -server.http-listen-port).
+  # (advanced) Port to advertise in the ring (defaults to
+  # -server.http-listen-port).
   # CLI flag: -distributor.ring.instance-port
   [instance_port: <int> | default = 0]
 
-  # IP address to advertise in the ring. Default is auto-detected.
+  # (advanced) IP address to advertise in the ring. Default is auto-detected.
   # CLI flag: -distributor.ring.instance-addr
   [instance_addr: <string> | default = ""]
 
-  # Enable using a IPv6 instance address. (default false)
+  # (advanced) Enable using a IPv6 instance address. (default false)
   # CLI flag: -distributor.ring.instance-enable-ipv6
   [instance_enable_ipv6: <boolean> | default = false]
+```
+
+### segment_writer
+
+The `segment_writer` block configures the segment-writer (V2 write path).
+
+```yaml
+# Configures the gRPC client used to communicate with the segment writer.
+# The CLI flags prefix for this block configuration is:
+# segment-writer.grpc-client-config
+[grpc_client_config: <grpc_client>]
+
+lifecycler:
+  ring:
+    kvstore:
+      # Backend storage to use for the ring. Supported values are: consul, etcd,
+      # inmemory, memberlist, multi.
+      # CLI flag: -segment-writer.store
+      [store: <string> | default = "consul"]
+
+      # (advanced) The prefix for the keys in the store. Should end with a /.
+      # CLI flag: -segment-writer.prefix
+      [prefix: <string> | default = "collectors/"]
+
+      consul:
+        # Hostname and port of Consul.
+        # CLI flag: -segment-writer.consul.hostname
+        [host: <string> | default = "localhost:8500"]
+
+        # (advanced) ACL Token used to interact with Consul.
+        # CLI flag: -segment-writer.consul.acl-token
+        [acl_token: <string> | default = ""]
+
+        # (advanced) HTTP timeout when talking to Consul
+        # CLI flag: -segment-writer.consul.client-timeout
+        [http_client_timeout: <duration> | default = 20s]
+
+        # (advanced) Enable consistent reads to Consul.
+        # CLI flag: -segment-writer.consul.consistent-reads
+        [consistent_reads: <boolean> | default = false]
+
+        # (advanced) Rate limit when watching key or prefix in Consul, in
+        # requests per second. 0 disables the rate limit.
+        # CLI flag: -segment-writer.consul.watch-rate-limit
+        [watch_rate_limit: <float> | default = 1]
+
+        # (advanced) Burst size used in rate limit. Values less than 1 are
+        # treated as 1.
+        # CLI flag: -segment-writer.consul.watch-burst-size
+        [watch_burst_size: <int> | default = 1]
+
+        # (advanced) Maximum duration to wait before retrying a Compare And Swap
+        # (CAS) operation.
+        # CLI flag: -segment-writer.consul.cas-retry-delay
+        [cas_retry_delay: <duration> | default = 1s]
+
+      etcd:
+        # The etcd endpoints to connect to.
+        # CLI flag: -segment-writer.etcd.endpoints
+        [endpoints: <list of strings> | default = []]
+
+        # (advanced) The dial timeout for the etcd connection.
+        # CLI flag: -segment-writer.etcd.dial-timeout
+        [dial_timeout: <duration> | default = 10s]
+
+        # (advanced) The maximum number of retries to do for failed ops.
+        # CLI flag: -segment-writer.etcd.max-retries
+        [max_retries: <int> | default = 10]
+
+        # (advanced) Enable TLS.
+        # CLI flag: -segment-writer.etcd.tls-enabled
+        [tls_enabled: <boolean> | default = false]
+
+        # (advanced) Path to the client certificate, which will be used for
+        # authenticating with the server. Also requires the key path to be
+        # configured.
+        # CLI flag: -segment-writer.etcd.tls-cert-path
+        [tls_cert_path: <string> | default = ""]
+
+        # (advanced) Path to the key for the client certificate. Also requires
+        # the client certificate to be configured.
+        # CLI flag: -segment-writer.etcd.tls-key-path
+        [tls_key_path: <string> | default = ""]
+
+        # (advanced) Path to the CA certificates to validate server certificate
+        # against. If not set, the host's root CA certificates are used.
+        # CLI flag: -segment-writer.etcd.tls-ca-path
+        [tls_ca_path: <string> | default = ""]
+
+        # (advanced) Override the expected name on the server certificate.
+        # CLI flag: -segment-writer.etcd.tls-server-name
+        [tls_server_name: <string> | default = ""]
+
+        # (advanced) Skip validating server certificate.
+        # CLI flag: -segment-writer.etcd.tls-insecure-skip-verify
+        [tls_insecure_skip_verify: <boolean> | default = false]
+
+        # (advanced) Override the default cipher suite list (separated by
+        # commas). Allowed values:
+        # 
+        # Secure Ciphers:
+        # - TLS_AES_128_GCM_SHA256
+        # - TLS_AES_256_GCM_SHA384
+        # - TLS_CHACHA20_POLY1305_SHA256
+        # - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+        # - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+        # - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+        # - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+        # - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        # - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+        # - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        # - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        # - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        # - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+        # 
+        # Insecure Ciphers:
+        # - TLS_RSA_WITH_RC4_128_SHA
+        # - TLS_RSA_WITH_3DES_EDE_CBC_SHA
+        # - TLS_RSA_WITH_AES_128_CBC_SHA
+        # - TLS_RSA_WITH_AES_256_CBC_SHA
+        # - TLS_RSA_WITH_AES_128_CBC_SHA256
+        # - TLS_RSA_WITH_AES_128_GCM_SHA256
+        # - TLS_RSA_WITH_AES_256_GCM_SHA384
+        # - TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
+        # - TLS_ECDHE_RSA_WITH_RC4_128_SHA
+        # - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
+        # - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+        # - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+        # CLI flag: -segment-writer.etcd.tls-cipher-suites
+        [tls_cipher_suites: <string> | default = ""]
+
+        # (advanced) Override the default minimum TLS version. Allowed values:
+        # VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
+        # CLI flag: -segment-writer.etcd.tls-min-version
+        [tls_min_version: <string> | default = ""]
+
+        # Etcd username.
+        # CLI flag: -segment-writer.etcd.username
+        [username: <string> | default = ""]
+
+        # Etcd password.
+        # CLI flag: -segment-writer.etcd.password
+        [password: <string> | default = ""]
+
+      multi:
+        # (advanced) Primary backend storage used by multi-client.
+        # CLI flag: -segment-writer.multi.primary
+        [primary: <string> | default = ""]
+
+        # (advanced) Secondary backend storage used by multi-client.
+        # CLI flag: -segment-writer.multi.secondary
+        [secondary: <string> | default = ""]
+
+        # (advanced) Mirror writes to the secondary store.
+        # CLI flag: -segment-writer.multi.mirror-enabled
+        [mirror_enabled: <boolean> | default = false]
+
+        # (advanced) Timeout for storing a value to the secondary store.
+        # CLI flag: -segment-writer.multi.mirror-timeout
+        [mirror_timeout: <duration> | default = 2s]
+
+    # (advanced) The heartbeat timeout after which ingesters are skipped for
+    # reads/writes.
+    # CLI flag: -segment-writer.ring.heartbeat-timeout
+    [heartbeat_timeout: <duration> | default = 1m]
+
+    # The number of ingesters to write to and read from.
+    # CLI flag: -segment-writer.distributor.replication-factor
+    [replication_factor: <int> | default = 3]
+
+    # True to enable the zone-awareness and replicate ingested samples across
+    # different availability zones.
+    # CLI flag: -segment-writer.distributor.zone-awareness-enabled
+    [zone_awareness_enabled: <boolean> | default = false]
+
+    # (advanced) Comma-separated list of zones to exclude from the ring.
+    # Instances in excluded zones will be filtered out from the ring.
+    # CLI flag: -segment-writer.distributor.excluded-zones
+    [excluded_zones: <string> | default = ""]
+
+  # (advanced) Number of tokens for each ingester.
+  # CLI flag: -segment-writer.num-tokens
+  [num_tokens: <int> | default = 4]
+
+  # (advanced) Period at which to heartbeat to consul.
+  # CLI flag: -segment-writer.heartbeat-period
+  [heartbeat_period: <duration> | default = 5s]
+
+  # (advanced) Heartbeat timeout after which instance is assumed to be
+  # unhealthy.
+  # CLI flag: -segment-writer.heartbeat-timeout
+  [heartbeat_timeout: <duration> | default = 1m]
+
+  # (advanced) Observe tokens after generating to resolve collisions. Useful
+  # when using gossiping ring.
+  # CLI flag: -segment-writer.observe-period
+  [observe_period: <duration> | default = 0s]
+
+  # (advanced) Period to wait for a claim from another member; will join
+  # automatically after this.
+  # CLI flag: -segment-writer.join-after
+  [join_after: <duration> | default = 0s]
+
+  # (advanced) Minimum duration to wait after the internal readiness checks have
+  # passed but before succeeding the readiness endpoint. This is used to
+  # slowdown deployment controllers (eg. Kubernetes) after an instance is ready
+  # and before they proceed with a rolling update, to give the rest of the
+  # cluster instances enough time to receive ring updates.
+  # CLI flag: -segment-writer.min-ready-duration
+  [min_ready_duration: <duration> | default = 30s]
+
+  # Name of network interface to read address from.
+  # CLI flag: -segment-writer.lifecycler.interface
+  [interface_names: <list of strings> | default = [<private network interfaces>]]
+
+  # (advanced) Enable IPv6 support. Required to make use of IP addresses from
+  # IPv6 interfaces.
+  # CLI flag: -segment-writer.enable-inet6
+  [enable_inet6: <boolean> | default = false]
+
+  # (advanced) Duration to sleep for before exiting, to ensure metrics are
+  # scraped.
+  # CLI flag: -segment-writer.final-sleep
+  [final_sleep: <duration> | default = 0s]
+
+  # File path where tokens are stored. If empty, tokens are not stored at
+  # shutdown and restored at startup.
+  # CLI flag: -segment-writer.tokens-file-path
+  [tokens_file_path: <string> | default = ""]
+
+  # The availability zone where this instance is running.
+  # CLI flag: -segment-writer.availability-zone
+  [availability_zone: <string> | default = ""]
+
+  # (advanced) Unregister from the ring upon clean shutdown. It can be useful to
+  # disable for rolling restarts with consistent naming in conjunction with
+  # -distributor.extend-writes=false.
+  # CLI flag: -segment-writer.unregister-on-shutdown
+  [unregister_on_shutdown: <boolean> | default = false]
+
+  # (advanced) When enabled the readiness probe succeeds only after all
+  # instances are ACTIVE and healthy in the ring, otherwise only the instance
+  # itself is checked. This option should be disabled if in your cluster
+  # multiple instances can be rolled out simultaneously, otherwise rolling
+  # updates may be slowed down.
+  # CLI flag: -segment-writer.readiness-check-ring-health
+  [readiness_check_ring_health: <boolean> | default = true]
+
+  # (advanced) IP address to advertise in the ring.
+  # CLI flag: -segment-writer.lifecycler.addr
+  [address: <string> | default = ""]
+
+  # (advanced) port to advertise in consul (defaults to
+  # server.grpc-listen-port).
+  # CLI flag: -segment-writer.lifecycler.port
+  [port: <int> | default = 0]
+
+  # (advanced) ID to register in the ring.
+  # CLI flag: -segment-writer.lifecycler.ID
+  [id: <string> | default = "<hostname>"]
+
+# (advanced) Timeout when flushing segments to bucket.
+# CLI flag: -segment-writer.segment-duration
+[segment_duration: <duration> | default = 500ms]
+
+# (advanced) Number of concurrent flushes. Defaults to the number of CPUs, but
+# not less than 8.
+# CLI flag: -segment-writer.flush-concurrency
+[flush_concurrency: <int> | default = 0]
+
+# (advanced) Timeout for upload requests, including retries.
+# CLI flag: -segment-writer.upload-timeout
+[upload-timeout: <duration> | default = 2s]
+
+# (advanced) Number of times to backoff and retry before failing.
+# CLI flag: -segment-writer.upload-max-retries
+[upload-retry_max_retries: <int> | default = 3]
+
+# (advanced) Minimum delay when backing off.
+# CLI flag: -segment-writer.upload-retry-min-period
+[upload-retry_min_period: <duration> | default = 50ms]
+
+# (advanced) Maximum delay when backing off.
+# CLI flag: -segment-writer.upload-retry-max-period
+[upload-retry_max_period: <duration> | default = 500ms]
+
+# (advanced) Time after which to hedge the upload request.
+# CLI flag: -segment-writer.upload-hedge-after
+[upload-hedge_upload_after: <duration> | default = 500ms]
+
+# (advanced) Maximum number of hedged requests per second. 0 disables rate
+# limiting.
+# CLI flag: -segment-writer.upload-hedge-rate-max
+[upload-hedge_rate_max: <float> | default = 2]
+
+# (advanced) Maximum number of hedged requests in a burst.
+# CLI flag: -segment-writer.upload-hedge-rate-burst
+[upload-hedge_rate_burst: <int> | default = 10]
+
+# (advanced) Enables dead letter queue (DLQ) for metadata. If the metadata
+# update fails, it will be stored and updated asynchronously.
+# CLI flag: -segment-writer.metadata-dlq-enabled
+[metadata_dlq_enabled: <boolean> | default = true]
+
+# (advanced) Timeout for metadata update requests.
+# CLI flag: -segment-writer.metadata-update-timeout
+[metadata_update_timeout: <duration> | default = 2s]
+
+# (advanced) Enables bucket health check on startup. This both validates
+# credentials and warms up the connection to reduce latency for the first write.
+# CLI flag: -segment-writer.bucket-health-check-enabled
+[bucket_health_check_enabled: <boolean> | default = true]
+
+# (advanced) Timeout for bucket health check operations.
+# CLI flag: -segment-writer.bucket-health-check-timeout
+[bucket_health_check_timeout: <duration> | default = 10s]
+```
+
+### metastore
+
+The `metastore` block configures the metastore (V2).
+
+```yaml
+# (advanced)
+# CLI flag: -metastore.address
+[address: <string> | default = "localhost:9095"]
+
+# Configures the gRPC client used to communicate with the metastore.
+# The CLI flags prefix for this block configuration is:
+# metastore.grpc-client-config
+[grpc_client_config: <grpc_client>]
+
+# (advanced) Minimum duration to wait after the internal readiness checks have
+# passed but before succeeding the readiness endpoint. This is used to slowdown
+# deployment controllers (eg. Kubernetes) after an instance is ready and before
+# they proceed with a rolling update, to give the rest of the cluster instances
+# enough time to receive some (DNS?) updates.
+# CLI flag: -metastore.min-ready-duration
+[min_ready_duration: <duration> | default = 15s]
+
+raft:
+  # Directory to store WAL and raft state. It must be a persistent directory,
+  # not a tmpfs or similar.
+  # CLI flag: -metastore.raft.dir
+  [dir: <string> | default = "./data/v2/metastore/raft"]
+
+  # (advanced)
+  # CLI flag: -metastore.raft.bootstrap-peers
+  [bootstrap_peers: <list of strings> | default = []]
+
+  # (advanced) Expected number of peers including the local node.
+  # CLI flag: -metastore.raft.bootstrap-expect-peers
+  [bootstrap_expect_peers: <int> | default = 1]
+
+  # (advanced) If enabled, new nodes (without a state) will try to join an
+  # existing cluster on startup.
+  # CLI flag: -metastore.raft.auto-join
+  [auto_join: <boolean> | default = false]
+
+  # (advanced)
+  # CLI flag: -metastore.raft.server-id
+  [server_id: <string> | default = "localhost:9099"]
+
+  # (advanced)
+  # CLI flag: -metastore.raft.bind-address
+  [bind_address: <string> | default = "localhost:9099"]
+
+  # (advanced)
+  # CLI flag: -metastore.raft.advertise-address
+  [advertise_address: <string> | default = "localhost:9099"]
+
+# (advanced) Compression algorithm to use for snapshots. Supported compressions:
+# zstd.
+# CLI flag: -metastore.snapshot-compression
+[snapshot_compression: <string> | default = "zstd"]
+
+# (advanced) Rate limit for snapshot writer in MB/s.
+# CLI flag: -metastore.snapshot-rate-limit
+[snapshot_rate_limit: <int> | default = 15]
+
+# (advanced) Compact the database on restore.
+# CLI flag: -metastore.snapshot-compact-on-restore
+[snapshot_compact_on_restore: <boolean> | default = false]
+
+# Directory to store the data.
+# CLI flag: -metastore.data-dir
+[data_dir: <string> | default = "./data/v2/metastore/data"]
+
+index:
+  # (advanced) Maximum number of shards to keep in memory
+  # CLI flag: -metastore.index.shard-cache-size
+  [shard_cache_size: <int> | default = 2000]
+
+  # (advanced) Maximum number of written blocks to keep in memory
+  # CLI flag: -metastore.index.block-write-cache-size
+  [block_write_cache_size: <int> | default = 10000]
+
+  # (advanced) Maximum number of read blocks to keep in memory
+  # CLI flag: -metastore.index.block-read-cache-size
+  [block_read_cache_size: <int> | default = 100000]
+
+  # (advanced) Maximum number of partitions to cleanup at once. A partition is
+  # qualified by partition key, tenant, and shard.
+  # CLI flag: -metastore.index.cleanup-max-partitions
+  [cleanup_max_partitions: <int> | default = 32]
+
+  # (advanced) After a partition is eligible for deletion, it will be kept for
+  # this period before actually being evaluated. The period should cover the
+  # time difference between the block creation time and the data timestamps.
+  # Blocks are only deleted if all data in the block has passed the retention
+  # period, and the grace period delays the moment when the partition is
+  # evaluated for deletion.
+  # CLI flag: -metastore.index.cleanup-grace-period
+  [cleanup_grace_period: <duration> | default = 6h]
+
+  # (advanced) Interval for index cleanup check. 0 to disable.
+  # CLI flag: -metastore.index.cleanup-interval
+  [cleanup_interval: <duration> | default = 0s]
+
+  # (advanced) Dead Letter Queue check interval. 0 to disable.
+  # CLI flag: -metastore.index.dlq-recovery-check-interval
+  [dlq_recovery_check_interval: <duration> | default = 15s]
+
+[levels: <list of LevelConfigs> | default = ]
+
+[cleanupbatchsize: <int> | default = ]
+
+[cleanupdelay: <duration> | default = ]
+
+[cleanupjobminlevel: <int> | default = ]
+
+[cleanupjobmaxlevel: <int> | default = ]
+
+# (advanced)
+# CLI flag: -metastore.compaction-max-failures
+[compaction_max_failures: <int> | default = 3]
+
+# (advanced)
+# CLI flag: -metastore.compaction-job-lease-duration
+[compaction_job_lease_duration: <duration> | default = 15s]
+
+# (advanced)
+# CLI flag: -metastore.compaction-max-job-queue-size
+[compaction_max_job_queue_size: <int> | default = 10000]
+```
+
+### compaction_worker
+
+The `compaction_worker` block configures the compaction-worker (V2).
+
+```yaml
+# (advanced) Number of concurrent jobs compaction worker will run. Defaults to
+# the number of CPU cores.
+# CLI flag: -compaction-worker.job-concurrency
+[job_capacity: <int> | default = 0]
+
+# (advanced) Interval between job requests
+# CLI flag: -compaction-worker.job-poll-interval
+[job_poll_interval: <duration> | default = 5s]
+
+# (advanced) Size of the object that can be loaded in memory.
+# CLI flag: -compaction-worker.small-object-size-bytes
+[small_object_size_bytes: <int> | default = 8388608]
+
+# (advanced) Temporary directory for compaction jobs.
+# CLI flag: -compaction-worker.temp-dir
+[temp_dir: <string> | default = "/tmp"]
+
+# (advanced) Job request timeout.
+# CLI flag: -compaction-worker.request-timeout
+[request_timeout: <duration> | default = 5s]
+
+# (advanced) Maximum duration of the cleanup operations.
+# CLI flag: -compaction-worker.cleanup-max-duration
+[cleanup_max_duration: <duration> | default = 15s]
+
+metrics_exporter:
+  # (advanced) This parameter specifies whether the metrics exporter is enabled.
+  # CLI flag: -compaction-worker.metrics-exporter.enabled
+  [enabled: <boolean> | default = false]
+
+  rules_source:
+    # (advanced) The address to use for the recording rules client connection.
+    # CLI flag: -compaction-worker.metrics-exporter.rules-source.client-address
+    [client_address: <string> | default = ""]
+
+  # (advanced) The address to use for metrics tenant.
+  # CLI flag: -compaction-worker.metrics-exporter.remote-write-address
+  [remote_write_address: <string> | default = ""]
 ```
 
 ### ingester
@@ -872,7 +1388,7 @@ lifecycler:
       # CLI flag: -ring.store
       [store: <string> | default = "consul"]
 
-      # The prefix for the keys in the store. Should end with a /.
+      # (advanced) The prefix for the keys in the store. Should end with a /.
       # CLI flag: -ring.prefix
       [prefix: <string> | default = "collectors/"]
 
@@ -881,29 +1397,30 @@ lifecycler:
         # CLI flag: -consul.hostname
         [host: <string> | default = "localhost:8500"]
 
-        # ACL Token used to interact with Consul.
+        # (advanced) ACL Token used to interact with Consul.
         # CLI flag: -consul.acl-token
         [acl_token: <string> | default = ""]
 
-        # HTTP timeout when talking to Consul
+        # (advanced) HTTP timeout when talking to Consul
         # CLI flag: -consul.client-timeout
         [http_client_timeout: <duration> | default = 20s]
 
-        # Enable consistent reads to Consul.
+        # (advanced) Enable consistent reads to Consul.
         # CLI flag: -consul.consistent-reads
         [consistent_reads: <boolean> | default = false]
 
-        # Rate limit when watching key or prefix in Consul, in requests per
-        # second. 0 disables the rate limit.
+        # (advanced) Rate limit when watching key or prefix in Consul, in
+        # requests per second. 0 disables the rate limit.
         # CLI flag: -consul.watch-rate-limit
         [watch_rate_limit: <float> | default = 1]
 
-        # Burst size used in rate limit. Values less than 1 are treated as 1.
+        # (advanced) Burst size used in rate limit. Values less than 1 are
+        # treated as 1.
         # CLI flag: -consul.watch-burst-size
         [watch_burst_size: <int> | default = 1]
 
-        # Maximum duration to wait before retrying a Compare And Swap (CAS)
-        # operation.
+        # (advanced) Maximum duration to wait before retrying a Compare And Swap
+        # (CAS) operation.
         # CLI flag: -consul.cas-retry-delay
         [cas_retry_delay: <duration> | default = 1s]
 
@@ -912,43 +1429,44 @@ lifecycler:
         # CLI flag: -etcd.endpoints
         [endpoints: <list of strings> | default = []]
 
-        # The dial timeout for the etcd connection.
+        # (advanced) The dial timeout for the etcd connection.
         # CLI flag: -etcd.dial-timeout
         [dial_timeout: <duration> | default = 10s]
 
-        # The maximum number of retries to do for failed ops.
+        # (advanced) The maximum number of retries to do for failed ops.
         # CLI flag: -etcd.max-retries
         [max_retries: <int> | default = 10]
 
-        # Enable TLS.
+        # (advanced) Enable TLS.
         # CLI flag: -etcd.tls-enabled
         [tls_enabled: <boolean> | default = false]
 
-        # Path to the client certificate, which will be used for authenticating
-        # with the server. Also requires the key path to be configured.
+        # (advanced) Path to the client certificate, which will be used for
+        # authenticating with the server. Also requires the key path to be
+        # configured.
         # CLI flag: -etcd.tls-cert-path
         [tls_cert_path: <string> | default = ""]
 
-        # Path to the key for the client certificate. Also requires the client
-        # certificate to be configured.
+        # (advanced) Path to the key for the client certificate. Also requires
+        # the client certificate to be configured.
         # CLI flag: -etcd.tls-key-path
         [tls_key_path: <string> | default = ""]
 
-        # Path to the CA certificates to validate server certificate against. If
-        # not set, the host's root CA certificates are used.
+        # (advanced) Path to the CA certificates to validate server certificate
+        # against. If not set, the host's root CA certificates are used.
         # CLI flag: -etcd.tls-ca-path
         [tls_ca_path: <string> | default = ""]
 
-        # Override the expected name on the server certificate.
+        # (advanced) Override the expected name on the server certificate.
         # CLI flag: -etcd.tls-server-name
         [tls_server_name: <string> | default = ""]
 
-        # Skip validating server certificate.
+        # (advanced) Skip validating server certificate.
         # CLI flag: -etcd.tls-insecure-skip-verify
         [tls_insecure_skip_verify: <boolean> | default = false]
 
-        # Override the default cipher suite list (separated by commas). Allowed
-        # values:
+        # (advanced) Override the default cipher suite list (separated by
+        # commas). Allowed values:
         # 
         # Secure Ciphers:
         # - TLS_AES_128_GCM_SHA256
@@ -981,7 +1499,7 @@ lifecycler:
         # CLI flag: -etcd.tls-cipher-suites
         [tls_cipher_suites: <string> | default = ""]
 
-        # Override the default minimum TLS version. Allowed values:
+        # (advanced) Override the default minimum TLS version. Allowed values:
         # VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
         # CLI flag: -etcd.tls-min-version
         [tls_min_version: <string> | default = ""]
@@ -995,23 +1513,24 @@ lifecycler:
         [password: <string> | default = ""]
 
       multi:
-        # Primary backend storage used by multi-client.
+        # (advanced) Primary backend storage used by multi-client.
         # CLI flag: -multi.primary
         [primary: <string> | default = ""]
 
-        # Secondary backend storage used by multi-client.
+        # (advanced) Secondary backend storage used by multi-client.
         # CLI flag: -multi.secondary
         [secondary: <string> | default = ""]
 
-        # Mirror writes to the secondary store.
+        # (advanced) Mirror writes to the secondary store.
         # CLI flag: -multi.mirror-enabled
         [mirror_enabled: <boolean> | default = false]
 
-        # Timeout for storing a value to the secondary store.
+        # (advanced) Timeout for storing a value to the secondary store.
         # CLI flag: -multi.mirror-timeout
         [mirror_timeout: <duration> | default = 2s]
 
-    # The heartbeat timeout after which ingesters are skipped for reads/writes.
+    # (advanced) The heartbeat timeout after which ingesters are skipped for
+    # reads/writes.
     # CLI flag: -ring.heartbeat-timeout
     [heartbeat_timeout: <duration> | default = 1m]
 
@@ -1024,38 +1543,39 @@ lifecycler:
     # CLI flag: -distributor.zone-awareness-enabled
     [zone_awareness_enabled: <boolean> | default = false]
 
-    # Comma-separated list of zones to exclude from the ring. Instances in
-    # excluded zones will be filtered out from the ring.
+    # (advanced) Comma-separated list of zones to exclude from the ring.
+    # Instances in excluded zones will be filtered out from the ring.
     # CLI flag: -distributor.excluded-zones
     [excluded_zones: <string> | default = ""]
 
-  # Number of tokens for each ingester.
+  # (advanced) Number of tokens for each ingester.
   # CLI flag: -ingester.num-tokens
   [num_tokens: <int> | default = 128]
 
-  # Period at which to heartbeat to consul.
+  # (advanced) Period at which to heartbeat to consul.
   # CLI flag: -ingester.heartbeat-period
   [heartbeat_period: <duration> | default = 5s]
 
-  # Heartbeat timeout after which instance is assumed to be unhealthy.
+  # (advanced) Heartbeat timeout after which instance is assumed to be
+  # unhealthy.
   # CLI flag: -ingester.heartbeat-timeout
   [heartbeat_timeout: <duration> | default = 1m]
 
-  # Observe tokens after generating to resolve collisions. Useful when using
-  # gossiping ring.
+  # (advanced) Observe tokens after generating to resolve collisions. Useful
+  # when using gossiping ring.
   # CLI flag: -ingester.observe-period
   [observe_period: <duration> | default = 0s]
 
-  # Period to wait for a claim from another member; will join automatically
-  # after this.
+  # (advanced) Period to wait for a claim from another member; will join
+  # automatically after this.
   # CLI flag: -ingester.join-after
   [join_after: <duration> | default = 0s]
 
-  # Minimum duration to wait after the internal readiness checks have passed but
-  # before succeeding the readiness endpoint. This is used to slowdown
-  # deployment controllers (eg. Kubernetes) after an instance is ready and
-  # before they proceed with a rolling update, to give the rest of the cluster
-  # instances enough time to receive ring updates.
+  # (advanced) Minimum duration to wait after the internal readiness checks have
+  # passed but before succeeding the readiness endpoint. This is used to
+  # slowdown deployment controllers (eg. Kubernetes) after an instance is ready
+  # and before they proceed with a rolling update, to give the rest of the
+  # cluster instances enough time to receive ring updates.
   # CLI flag: -ingester.min-ready-duration
   [min_ready_duration: <duration> | default = 15s]
 
@@ -1063,12 +1583,13 @@ lifecycler:
   # CLI flag: -ingester.lifecycler.interface
   [interface_names: <list of strings> | default = [<private network interfaces>]]
 
-  # Enable IPv6 support. Required to make use of IP addresses from IPv6
-  # interfaces.
+  # (advanced) Enable IPv6 support. Required to make use of IP addresses from
+  # IPv6 interfaces.
   # CLI flag: -ingester.enable-inet6
   [enable_inet6: <boolean> | default = false]
 
-  # Duration to sleep for before exiting, to ensure metrics are scraped.
+  # (advanced) Duration to sleep for before exiting, to ensure metrics are
+  # scraped.
   # CLI flag: -ingester.final-sleep
   [final_sleep: <duration> | default = 0s]
 
@@ -1081,29 +1602,30 @@ lifecycler:
   # CLI flag: -ingester.availability-zone
   [availability_zone: <string> | default = ""]
 
-  # Unregister from the ring upon clean shutdown. It can be useful to disable
-  # for rolling restarts with consistent naming in conjunction with
+  # (advanced) Unregister from the ring upon clean shutdown. It can be useful to
+  # disable for rolling restarts with consistent naming in conjunction with
   # -distributor.extend-writes=false.
   # CLI flag: -ingester.unregister-on-shutdown
   [unregister_on_shutdown: <boolean> | default = true]
 
-  # When enabled the readiness probe succeeds only after all instances are
-  # ACTIVE and healthy in the ring, otherwise only the instance itself is
-  # checked. This option should be disabled if in your cluster multiple
-  # instances can be rolled out simultaneously, otherwise rolling updates may be
-  # slowed down.
+  # (advanced) When enabled the readiness probe succeeds only after all
+  # instances are ACTIVE and healthy in the ring, otherwise only the instance
+  # itself is checked. This option should be disabled if in your cluster
+  # multiple instances can be rolled out simultaneously, otherwise rolling
+  # updates may be slowed down.
   # CLI flag: -ingester.readiness-check-ring-health
   [readiness_check_ring_health: <boolean> | default = true]
 
-  # IP address to advertise in the ring.
+  # (advanced) IP address to advertise in the ring.
   # CLI flag: -ingester.lifecycler.addr
   [address: <string> | default = ""]
 
-  # port to advertise in consul (defaults to server.grpc-listen-port).
+  # (advanced) port to advertise in consul (defaults to
+  # server.grpc-listen-port).
   # CLI flag: -ingester.lifecycler.port
   [port: <int> | default = 0]
 
-  # ID to register in the ring.
+  # (advanced) ID to register in the ring.
   # CLI flag: -ingester.lifecycler.ID
   [id: <string> | default = "<hostname>"]
 ```
@@ -1126,10 +1648,11 @@ pool_config:
   # CLI flag: -querier.health-check-timeout
   [remote_timeout: <duration> | default = 5s]
 
-# The time after which a metric should be queried from storage and not just
-# ingesters. 0 means all queries are sent to store. If this option is enabled,
-# the time range of the query sent to the store-gateway will be manipulated to
-# ensure the query end is not more recent than 'now - query-store-after'.
+# (advanced) The time after which a metric should be queried from storage and
+# not just ingesters. 0 means all queries are sent to store. If this option is
+# enabled, the time range of the query sent to the store-gateway will be
+# manipulated to ensure the query end is not more recent than 'now -
+# query-store-after'.
 # CLI flag: -querier.query-store-after
 [query_store_after: <duration> | default = 4h]
 ```
@@ -1139,7 +1662,8 @@ pool_config:
 The `query_frontend` block configures the query-frontend.
 
 ```yaml
-# Number of concurrent workers forwarding queries to single query-scheduler.
+# (advanced) Number of concurrent workers forwarding queries to single
+# query-scheduler.
 # CLI flag: -query-frontend.scheduler-worker-concurrency
 [scheduler_worker_concurrency: <int> | default = 5]
 
@@ -1149,25 +1673,45 @@ The `query_frontend` block configures the query-frontend.
 # query-frontend.grpc-client-config
 [grpc_client_config: <grpc_client>]
 
-# List of network interface names to look up when finding the instance IP
-# address. This address is sent to query-scheduler and querier, which uses it to
-# send the query response back to query-frontend.
+# (advanced) List of network interface names to look up when finding the
+# instance IP address. This address is sent to query-scheduler and querier,
+# which uses it to send the query response back to query-frontend.
 # CLI flag: -query-frontend.instance-interface-names
 [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
 
-# IP address to advertise to the querier (via scheduler) (default is
+# (advanced) IP address to advertise to the querier (via scheduler) (default is
 # auto-detected from network interfaces).
 # CLI flag: -query-frontend.instance-addr
 [instance_addr: <string> | default = ""]
 
-# Enable using a IPv6 instance address. (default false)
+# (advanced) Enable using a IPv6 instance address. (default false)
 # CLI flag: -query-frontend.instance-enable-ipv6
 [instance_enable_ipv6: <boolean> | default = false]
 
-# Port to advertise to query-scheduler and querier (defaults to
+# (advanced) Port to advertise to query-scheduler and querier (defaults to
 # -server.http-listen-port).
 # CLI flag: -query-frontend.instance-port
 [instance_port: <int> | default = 0]
+```
+
+### query_backend
+
+The `query_backend` block configures the query-backend (V2 read path).
+
+```yaml
+# (advanced)
+# CLI flag: -query-backend.address
+[address: <string> | default = "localhost:9095"]
+
+# Configures the gRPC client used to communicate between the query-frontends and
+# the query-schedulers.
+# The CLI flags prefix for this block configuration is:
+# query-backend.grpc-client-config
+[grpc_client_config: <grpc_client>]
+
+# (advanced) Timeout for query-backend client requests.
+# CLI flag: -query-backend.client-timeout
+[client_timeout: <duration> | default = 30s]
 ```
 
 ### frontend_worker
@@ -1175,8 +1719,8 @@ The `query_frontend` block configures the query-frontend.
 The `frontend_worker` block configures the frontend-worker.
 
 ```yaml
-# Querier ID, sent to the query-frontend to identify requests from the same
-# querier. Defaults to hostname.
+# (advanced) Querier ID, sent to the query-frontend to identify requests from
+# the same querier. Defaults to hostname.
 # CLI flag: -querier.id
 [id: <string> | default = ""]
 
@@ -1185,7 +1729,7 @@ The `frontend_worker` block configures the frontend-worker.
 # The CLI flags prefix for this block configuration is: querier.frontend-client
 [grpc_client_config: <grpc_client>]
 
-# The maximum number of concurrent queries allowed.
+# (advanced) The maximum number of concurrent queries allowed.
 # CLI flag: -querier.max-concurrent
 [max_concurrent: <int> | default = 4]
 ```
@@ -1201,10 +1745,10 @@ The `query_scheduler` block configures the query-scheduler.
 # CLI flag: -query-scheduler.max-outstanding-requests-per-tenant
 [max_outstanding_requests_per_tenant: <int> | default = 100]
 
-# If a querier disconnects without sending notification about graceful shutdown,
-# the query-scheduler will keep the querier in the tenant's shard until the
-# forget delay has passed. This feature is useful to reduce the blast radius
-# when shuffle-sharding is enabled.
+# (experimental) If a querier disconnects without sending notification about
+# graceful shutdown, the query-scheduler will keep the querier in the tenant's
+# shard until the forget delay has passed. This feature is useful to reduce the
+# blast radius when shuffle-sharding is enabled.
 # CLI flag: -query-scheduler.querier-forget-delay
 [querier_forget_delay: <duration> | default = 0s]
 
@@ -1214,8 +1758,8 @@ The `query_scheduler` block configures the query-scheduler.
 # query-scheduler.grpc-client-config
 [grpc_client_config: <grpc_client>]
 
-# The maximum number of query-scheduler instances to use, regardless how many
-# replicas are running. This option can be set only when
+# (experimental) The maximum number of query-scheduler instances to use,
+# regardless how many replicas are running. This option can be set only when
 # -query-scheduler.service-discovery-mode is set to 'ring'. 0 to use all
 # available query-scheduler instances.
 # CLI flag: -query-scheduler.max-used-instances
@@ -1236,7 +1780,7 @@ sharding_ring:
     # CLI flag: -store-gateway.sharding-ring.store
     [store: <string> | default = "memberlist"]
 
-    # The prefix for the keys in the store. Should end with a /.
+    # (advanced) The prefix for the keys in the store. Should end with a /.
     # CLI flag: -store-gateway.sharding-ring.prefix
     [prefix: <string> | default = "collectors/"]
 
@@ -1245,29 +1789,30 @@ sharding_ring:
       # CLI flag: -store-gateway.sharding-ring.consul.hostname
       [host: <string> | default = "localhost:8500"]
 
-      # ACL Token used to interact with Consul.
+      # (advanced) ACL Token used to interact with Consul.
       # CLI flag: -store-gateway.sharding-ring.consul.acl-token
       [acl_token: <string> | default = ""]
 
-      # HTTP timeout when talking to Consul
+      # (advanced) HTTP timeout when talking to Consul
       # CLI flag: -store-gateway.sharding-ring.consul.client-timeout
       [http_client_timeout: <duration> | default = 20s]
 
-      # Enable consistent reads to Consul.
+      # (advanced) Enable consistent reads to Consul.
       # CLI flag: -store-gateway.sharding-ring.consul.consistent-reads
       [consistent_reads: <boolean> | default = false]
 
-      # Rate limit when watching key or prefix in Consul, in requests per
-      # second. 0 disables the rate limit.
+      # (advanced) Rate limit when watching key or prefix in Consul, in requests
+      # per second. 0 disables the rate limit.
       # CLI flag: -store-gateway.sharding-ring.consul.watch-rate-limit
       [watch_rate_limit: <float> | default = 1]
 
-      # Burst size used in rate limit. Values less than 1 are treated as 1.
+      # (advanced) Burst size used in rate limit. Values less than 1 are treated
+      # as 1.
       # CLI flag: -store-gateway.sharding-ring.consul.watch-burst-size
       [watch_burst_size: <int> | default = 1]
 
-      # Maximum duration to wait before retrying a Compare And Swap (CAS)
-      # operation.
+      # (advanced) Maximum duration to wait before retrying a Compare And Swap
+      # (CAS) operation.
       # CLI flag: -store-gateway.sharding-ring.consul.cas-retry-delay
       [cas_retry_delay: <duration> | default = 1s]
 
@@ -1276,43 +1821,44 @@ sharding_ring:
       # CLI flag: -store-gateway.sharding-ring.etcd.endpoints
       [endpoints: <list of strings> | default = []]
 
-      # The dial timeout for the etcd connection.
+      # (advanced) The dial timeout for the etcd connection.
       # CLI flag: -store-gateway.sharding-ring.etcd.dial-timeout
       [dial_timeout: <duration> | default = 10s]
 
-      # The maximum number of retries to do for failed ops.
+      # (advanced) The maximum number of retries to do for failed ops.
       # CLI flag: -store-gateway.sharding-ring.etcd.max-retries
       [max_retries: <int> | default = 10]
 
-      # Enable TLS.
+      # (advanced) Enable TLS.
       # CLI flag: -store-gateway.sharding-ring.etcd.tls-enabled
       [tls_enabled: <boolean> | default = false]
 
-      # Path to the client certificate, which will be used for authenticating
-      # with the server. Also requires the key path to be configured.
+      # (advanced) Path to the client certificate, which will be used for
+      # authenticating with the server. Also requires the key path to be
+      # configured.
       # CLI flag: -store-gateway.sharding-ring.etcd.tls-cert-path
       [tls_cert_path: <string> | default = ""]
 
-      # Path to the key for the client certificate. Also requires the client
-      # certificate to be configured.
+      # (advanced) Path to the key for the client certificate. Also requires the
+      # client certificate to be configured.
       # CLI flag: -store-gateway.sharding-ring.etcd.tls-key-path
       [tls_key_path: <string> | default = ""]
 
-      # Path to the CA certificates to validate server certificate against. If
-      # not set, the host's root CA certificates are used.
+      # (advanced) Path to the CA certificates to validate server certificate
+      # against. If not set, the host's root CA certificates are used.
       # CLI flag: -store-gateway.sharding-ring.etcd.tls-ca-path
       [tls_ca_path: <string> | default = ""]
 
-      # Override the expected name on the server certificate.
+      # (advanced) Override the expected name on the server certificate.
       # CLI flag: -store-gateway.sharding-ring.etcd.tls-server-name
       [tls_server_name: <string> | default = ""]
 
-      # Skip validating server certificate.
+      # (advanced) Skip validating server certificate.
       # CLI flag: -store-gateway.sharding-ring.etcd.tls-insecure-skip-verify
       [tls_insecure_skip_verify: <boolean> | default = false]
 
-      # Override the default cipher suite list (separated by commas). Allowed
-      # values:
+      # (advanced) Override the default cipher suite list (separated by commas).
+      # Allowed values:
       # 
       # Secure Ciphers:
       # - TLS_AES_128_GCM_SHA256
@@ -1345,8 +1891,8 @@ sharding_ring:
       # CLI flag: -store-gateway.sharding-ring.etcd.tls-cipher-suites
       [tls_cipher_suites: <string> | default = ""]
 
-      # Override the default minimum TLS version. Allowed values: VersionTLS10,
-      # VersionTLS11, VersionTLS12, VersionTLS13
+      # (advanced) Override the default minimum TLS version. Allowed values:
+      # VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
       # CLI flag: -store-gateway.sharding-ring.etcd.tls-min-version
       [tls_min_version: <string> | default = ""]
 
@@ -1359,32 +1905,32 @@ sharding_ring:
       [password: <string> | default = ""]
 
     multi:
-      # Primary backend storage used by multi-client.
+      # (advanced) Primary backend storage used by multi-client.
       # CLI flag: -store-gateway.sharding-ring.multi.primary
       [primary: <string> | default = ""]
 
-      # Secondary backend storage used by multi-client.
+      # (advanced) Secondary backend storage used by multi-client.
       # CLI flag: -store-gateway.sharding-ring.multi.secondary
       [secondary: <string> | default = ""]
 
-      # Mirror writes to the secondary store.
+      # (advanced) Mirror writes to the secondary store.
       # CLI flag: -store-gateway.sharding-ring.multi.mirror-enabled
       [mirror_enabled: <boolean> | default = false]
 
-      # Timeout for storing a value to the secondary store.
+      # (advanced) Timeout for storing a value to the secondary store.
       # CLI flag: -store-gateway.sharding-ring.multi.mirror-timeout
       [mirror_timeout: <duration> | default = 2s]
 
-  # Period at which to heartbeat to the ring. 0 = disabled.
+  # (advanced) Period at which to heartbeat to the ring. 0 = disabled.
   # CLI flag: -store-gateway.sharding-ring.heartbeat-period
   [heartbeat_period: <duration> | default = 15s]
 
-  # The heartbeat timeout after which store-gateways are considered unhealthy
-  # within the ring. 0 = never (timeout disabled).
+  # (advanced) The heartbeat timeout after which store-gateways are considered
+  # unhealthy within the ring. 0 = never (timeout disabled).
   # CLI flag: -store-gateway.sharding-ring.heartbeat-timeout
   [heartbeat_timeout: <duration> | default = 1m]
 
-  # Instance ID to register in the ring.
+  # (advanced) Instance ID to register in the ring.
   # CLI flag: -store-gateway.sharding-ring.instance-id
   [instance_id: <string> | default = "<hostname>"]
 
@@ -1393,20 +1939,22 @@ sharding_ring:
   # CLI flag: -store-gateway.sharding-ring.instance-interface-names
   [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
 
-  # Port to advertise in the ring (defaults to -server.http-listen-port).
+  # (advanced) Port to advertise in the ring (defaults to
+  # -server.http-listen-port).
   # CLI flag: -store-gateway.sharding-ring.instance-port
   [instance_port: <int> | default = 0]
 
-  # IP address to advertise in the ring. Default is auto-detected.
+  # (advanced) IP address to advertise in the ring. Default is auto-detected.
   # CLI flag: -store-gateway.sharding-ring.instance-addr
   [instance_addr: <string> | default = ""]
 
-  # Enable using a IPv6 instance address. (default false)
+  # (advanced) Enable using a IPv6 instance address. (default false)
   # CLI flag: -store-gateway.sharding-ring.instance-enable-ipv6
   [instance_enable_ipv6: <boolean> | default = false]
 
-  # The replication factor to use when sharding blocks. This option needs be set
-  # both on the store-gateway and querier when running in microservices mode.
+  # (advanced) The replication factor to use when sharding blocks. This option
+  # needs be set both on the store-gateway and querier when running in
+  # microservices mode.
   # CLI flag: -store-gateway.sharding-ring.replication-factor
   [replication_factor: <int> | default = 1]
 
@@ -1421,14 +1969,14 @@ sharding_ring:
   # CLI flag: -store-gateway.sharding-ring.zone-awareness-enabled
   [zone_awareness_enabled: <boolean> | default = false]
 
-  # Minimum time to wait for ring stability at startup, if set to positive
-  # value.
+  # (advanced) Minimum time to wait for ring stability at startup, if set to
+  # positive value.
   # CLI flag: -store-gateway.sharding-ring.wait-stability-min-duration
   [wait_stability_min_duration: <duration> | default = 0s]
 
-  # Maximum time to wait for ring stability at startup. If the store-gateway
-  # ring keeps changing after this period of time, the store-gateway will start
-  # anyway.
+  # (advanced) Maximum time to wait for ring stability at startup. If the
+  # store-gateway ring keeps changing after this period of time, the
+  # store-gateway will start anyway.
   # CLI flag: -store-gateway.sharding-ring.wait-stability-max-duration
   [wait_stability_max_duration: <duration> | default = 5m]
 
@@ -1448,34 +1996,34 @@ bucket_store:
   # CLI flag: -blocks-storage.bucket-store.sync-dir
   [sync_dir: <string> | default = "./data/pyroscope-sync/"]
 
-  # How frequently to scan the bucket, or to refresh the bucket index (if
-  # enabled), in order to look for changes (new blocks shipped by ingesters and
-  # blocks deleted by retention or compaction).
+  # (advanced) How frequently to scan the bucket, or to refresh the bucket index
+  # (if enabled), in order to look for changes (new blocks shipped by ingesters
+  # and blocks deleted by retention or compaction).
   # CLI flag: -blocks-storage.bucket-store.sync-interval
   [sync_interval: <duration> | default = 15m]
 
-  # Maximum number of concurrent tenants synching blocks.
+  # (advanced) Maximum number of concurrent tenants synching blocks.
   # CLI flag: -blocks-storage.bucket-store.tenant-sync-concurrency
   [tenant_sync_concurrency: <int> | default = 10]
 
-  # Blocks with minimum time within this duration are ignored, and not loaded by
-  # store-gateway. Useful when used together with -querier.query-store-after to
-  # prevent loading young blocks, because there are usually many of them
-  # (depending on number of ingesters) and they are not yet compacted. Negative
-  # values or 0 disable the filter.
+  # (advanced) Blocks with minimum time within this duration are ignored, and
+  # not loaded by store-gateway. Useful when used together with
+  # -querier.query-store-after to prevent loading young blocks, because there
+  # are usually many of them (depending on number of ingesters) and they are not
+  # yet compacted. Negative values or 0 disable the filter.
   # CLI flag: -blocks-storage.bucket-store.ignore-blocks-within
   [ignore_blocks_within: <duration> | default = 3h]
 
-  # Number of Go routines to use when syncing block meta files from object
-  # storage per tenant.
+  # (advanced) Number of Go routines to use when syncing block meta files from
+  # object storage per tenant.
   # CLI flag: -blocks-storage.bucket-store.meta-sync-concurrency
   [meta_sync_concurrency: <int> | default = 20]
 
-  # Duration after which the blocks marked for deletion will be filtered out
-  # while fetching blocks. The idea of ignore-deletion-marks-delay is to ignore
-  # blocks that are marked for deletion with some delay. This ensures store can
-  # still serve blocks that are meant to be deleted but do not have a
-  # replacement yet.
+  # (advanced) Duration after which the blocks marked for deletion will be
+  # filtered out while fetching blocks. The idea of ignore-deletion-marks-delay
+  # is to ignore blocks that are marked for deletion with some delay. This
+  # ensures store can still serve blocks that are meant to be deleted but do not
+  # have a replacement yet.
   # CLI flag: -blocks-storage.bucket-store.ignore-deletion-marks-delay
   [ignore_deletion_mark_delay: <duration> | default = 30m]
 ```
@@ -1485,17 +2033,17 @@ bucket_store:
 The `compactor` block configures the compactor.
 
 ```yaml
-# List of compaction time ranges.
+# (advanced) List of compaction time ranges.
 # CLI flag: -compactor.block-ranges
 [block_ranges: <list of durations> | default = 1h0m0s,2h0m0s,8h0m0s]
 
-# Number of Go routines to use when downloading blocks for compaction and
-# uploading resulting blocks.
+# (advanced) Number of Go routines to use when downloading blocks for compaction
+# and uploading resulting blocks.
 # CLI flag: -compactor.block-sync-concurrency
 [block_sync_concurrency: <int> | default = 8]
 
-# Number of Go routines to use when syncing block meta files from the long term
-# storage.
+# (advanced) Number of Go routines to use when syncing block meta files from the
+# long term storage.
 # CLI flag: -compactor.meta-sync-concurrency
 [meta_sync_concurrency: <int> | default = 20]
 
@@ -1504,15 +2052,16 @@ The `compactor` block configures the compactor.
 # CLI flag: -compactor.data-dir
 [data_dir: <string> | default = "./data-compactor"]
 
-# The frequency at which the compaction runs
+# (advanced) The frequency at which the compaction runs
 # CLI flag: -compactor.compaction-interval
 [compaction_interval: <duration> | default = 30m]
 
-# How many times to retry a failed compaction within a single compaction run.
+# (advanced) How many times to retry a failed compaction within a single
+# compaction run.
 # CLI flag: -compactor.compaction-retries
 [compaction_retries: <int> | default = 3]
 
-# Max number of concurrent compactions running.
+# (advanced) Max number of concurrent compactions running.
 # CLI flag: -compactor.compaction-concurrency
 [compaction_concurrency: <int> | default = 1]
 
@@ -1523,63 +2072,65 @@ The `compactor` block configures the compactor.
 # CLI flag: -compactor.first-level-compaction-wait-period
 [first_level_compaction_wait_period: <duration> | default = 25m]
 
-# How frequently compactor should run blocks cleanup and maintenance, as well as
-# update the bucket index.
+# (advanced) How frequently compactor should run blocks cleanup and maintenance,
+# as well as update the bucket index.
 # CLI flag: -compactor.cleanup-interval
 [cleanup_interval: <duration> | default = 15m]
 
-# Max number of tenants for which blocks cleanup and maintenance should run
-# concurrently.
+# (advanced) Max number of tenants for which blocks cleanup and maintenance
+# should run concurrently.
 # CLI flag: -compactor.cleanup-concurrency
 [cleanup_concurrency: <int> | default = 20]
 
-# Time before a block marked for deletion is deleted from bucket. If not 0,
-# blocks will be marked for deletion and compactor component will permanently
-# delete blocks marked for deletion from the bucket. If 0, blocks will be
-# deleted straight away. Note that deleting blocks immediately can cause query
-# failures.
+# (advanced) Time before a block marked for deletion is deleted from bucket. If
+# not 0, blocks will be marked for deletion and compactor component will
+# permanently delete blocks marked for deletion from the bucket. If 0, blocks
+# will be deleted straight away. Note that deleting blocks immediately can cause
+# query failures.
 # CLI flag: -compactor.deletion-delay
 [deletion_delay: <duration> | default = 12h]
 
+# (advanced)
 [tenant_cleanup_delay: <duration> | default = ]
 
-# Max time for starting compactions for a single tenant. After this time no new
-# compactions for the tenant are started before next compaction cycle. This can
-# help in multi-tenant environments to avoid single tenant using all compaction
-# time, but also in single-tenant environments to force new discovery of blocks
-# more often. 0 = disabled.
+# (advanced) Max time for starting compactions for a single tenant. After this
+# time no new compactions for the tenant are started before next compaction
+# cycle. This can help in multi-tenant environments to avoid single tenant using
+# all compaction time, but also in single-tenant environments to force new
+# discovery of blocks more often. 0 = disabled.
 # CLI flag: -compactor.max-compaction-time
 [max_compaction_time: <duration> | default = 1h]
 
-# Maximum time to wait for in-flight cleanup and ring operations to finish
-# during shutdown. If the timeout is reached, the compactor will forcefully
-# stop. 0 = no timeout (wait indefinitely).
+# (advanced) Maximum time to wait for in-flight cleanup and ring operations to
+# finish during shutdown. If the timeout is reached, the compactor will
+# forcefully stop. 0 = no timeout (wait indefinitely).
 # CLI flag: -compactor.shutdown-timeout
 [shutdown_timeout: <duration> | default = 0s]
 
-# If enabled, will delete the bucket-index, markers and debug files in the
-# tenant bucket when there are no blocks left in the index.
+# (experimental) If enabled, will delete the bucket-index, markers and debug
+# files in the tenant bucket when there are no blocks left in the index.
 # CLI flag: -compactor.no-blocks-file-cleanup-enabled
 [no_blocks_file_cleanup_enabled: <boolean> | default = false]
 
-# If enabled, the compactor will downsample profiles in blocks at compaction
-# level 3 and above. The original profiles are also kept.
+# (advanced) If enabled, the compactor will downsample profiles in blocks at
+# compaction level 3 and above. The original profiles are also kept.
 # CLI flag: -compactor.downsampler-enabled
 [downsampler_enabled: <boolean> | default = false]
 
-# Number of goroutines opening blocks before compaction.
+# (advanced) Number of goroutines opening blocks before compaction.
 # CLI flag: -compactor.max-opening-blocks-concurrency
 [max_opening_blocks_concurrency: <int> | default = 16]
 
-# Comma separated list of tenants that can be compacted. If specified, only
-# these tenants will be compacted by compactor, otherwise all tenants can be
-# compacted. Subject to sharding.
+# (advanced) Comma separated list of tenants that can be compacted. If
+# specified, only these tenants will be compacted by compactor, otherwise all
+# tenants can be compacted. Subject to sharding.
 # CLI flag: -compactor.enabled-tenants
 [enabled_tenants: <string> | default = ""]
 
-# Comma separated list of tenants that cannot be compacted by this compactor. If
-# specified, and compactor would normally pick given tenant for compaction (via
-# -compactor.enabled-tenants or sharding), it will be ignored instead.
+# (advanced) Comma separated list of tenants that cannot be compacted by this
+# compactor. If specified, and compactor would normally pick given tenant for
+# compaction (via -compactor.enabled-tenants or sharding), it will be ignored
+# instead.
 # CLI flag: -compactor.disabled-tenants
 [disabled_tenants: <string> | default = ""]
 
@@ -1591,7 +2142,7 @@ sharding_ring:
     # CLI flag: -compactor.ring.store
     [store: <string> | default = "memberlist"]
 
-    # The prefix for the keys in the store. Should end with a /.
+    # (advanced) The prefix for the keys in the store. Should end with a /.
     # CLI flag: -compactor.ring.prefix
     [prefix: <string> | default = "collectors/"]
 
@@ -1600,29 +2151,30 @@ sharding_ring:
       # CLI flag: -compactor.ring.consul.hostname
       [host: <string> | default = "localhost:8500"]
 
-      # ACL Token used to interact with Consul.
+      # (advanced) ACL Token used to interact with Consul.
       # CLI flag: -compactor.ring.consul.acl-token
       [acl_token: <string> | default = ""]
 
-      # HTTP timeout when talking to Consul
+      # (advanced) HTTP timeout when talking to Consul
       # CLI flag: -compactor.ring.consul.client-timeout
       [http_client_timeout: <duration> | default = 20s]
 
-      # Enable consistent reads to Consul.
+      # (advanced) Enable consistent reads to Consul.
       # CLI flag: -compactor.ring.consul.consistent-reads
       [consistent_reads: <boolean> | default = false]
 
-      # Rate limit when watching key or prefix in Consul, in requests per
-      # second. 0 disables the rate limit.
+      # (advanced) Rate limit when watching key or prefix in Consul, in requests
+      # per second. 0 disables the rate limit.
       # CLI flag: -compactor.ring.consul.watch-rate-limit
       [watch_rate_limit: <float> | default = 1]
 
-      # Burst size used in rate limit. Values less than 1 are treated as 1.
+      # (advanced) Burst size used in rate limit. Values less than 1 are treated
+      # as 1.
       # CLI flag: -compactor.ring.consul.watch-burst-size
       [watch_burst_size: <int> | default = 1]
 
-      # Maximum duration to wait before retrying a Compare And Swap (CAS)
-      # operation.
+      # (advanced) Maximum duration to wait before retrying a Compare And Swap
+      # (CAS) operation.
       # CLI flag: -compactor.ring.consul.cas-retry-delay
       [cas_retry_delay: <duration> | default = 1s]
 
@@ -1631,43 +2183,44 @@ sharding_ring:
       # CLI flag: -compactor.ring.etcd.endpoints
       [endpoints: <list of strings> | default = []]
 
-      # The dial timeout for the etcd connection.
+      # (advanced) The dial timeout for the etcd connection.
       # CLI flag: -compactor.ring.etcd.dial-timeout
       [dial_timeout: <duration> | default = 10s]
 
-      # The maximum number of retries to do for failed ops.
+      # (advanced) The maximum number of retries to do for failed ops.
       # CLI flag: -compactor.ring.etcd.max-retries
       [max_retries: <int> | default = 10]
 
-      # Enable TLS.
+      # (advanced) Enable TLS.
       # CLI flag: -compactor.ring.etcd.tls-enabled
       [tls_enabled: <boolean> | default = false]
 
-      # Path to the client certificate, which will be used for authenticating
-      # with the server. Also requires the key path to be configured.
+      # (advanced) Path to the client certificate, which will be used for
+      # authenticating with the server. Also requires the key path to be
+      # configured.
       # CLI flag: -compactor.ring.etcd.tls-cert-path
       [tls_cert_path: <string> | default = ""]
 
-      # Path to the key for the client certificate. Also requires the client
-      # certificate to be configured.
+      # (advanced) Path to the key for the client certificate. Also requires the
+      # client certificate to be configured.
       # CLI flag: -compactor.ring.etcd.tls-key-path
       [tls_key_path: <string> | default = ""]
 
-      # Path to the CA certificates to validate server certificate against. If
-      # not set, the host's root CA certificates are used.
+      # (advanced) Path to the CA certificates to validate server certificate
+      # against. If not set, the host's root CA certificates are used.
       # CLI flag: -compactor.ring.etcd.tls-ca-path
       [tls_ca_path: <string> | default = ""]
 
-      # Override the expected name on the server certificate.
+      # (advanced) Override the expected name on the server certificate.
       # CLI flag: -compactor.ring.etcd.tls-server-name
       [tls_server_name: <string> | default = ""]
 
-      # Skip validating server certificate.
+      # (advanced) Skip validating server certificate.
       # CLI flag: -compactor.ring.etcd.tls-insecure-skip-verify
       [tls_insecure_skip_verify: <boolean> | default = false]
 
-      # Override the default cipher suite list (separated by commas). Allowed
-      # values:
+      # (advanced) Override the default cipher suite list (separated by commas).
+      # Allowed values:
       # 
       # Secure Ciphers:
       # - TLS_AES_128_GCM_SHA256
@@ -1700,8 +2253,8 @@ sharding_ring:
       # CLI flag: -compactor.ring.etcd.tls-cipher-suites
       [tls_cipher_suites: <string> | default = ""]
 
-      # Override the default minimum TLS version. Allowed values: VersionTLS10,
-      # VersionTLS11, VersionTLS12, VersionTLS13
+      # (advanced) Override the default minimum TLS version. Allowed values:
+      # VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
       # CLI flag: -compactor.ring.etcd.tls-min-version
       [tls_min_version: <string> | default = ""]
 
@@ -1714,32 +2267,32 @@ sharding_ring:
       [password: <string> | default = ""]
 
     multi:
-      # Primary backend storage used by multi-client.
+      # (advanced) Primary backend storage used by multi-client.
       # CLI flag: -compactor.ring.multi.primary
       [primary: <string> | default = ""]
 
-      # Secondary backend storage used by multi-client.
+      # (advanced) Secondary backend storage used by multi-client.
       # CLI flag: -compactor.ring.multi.secondary
       [secondary: <string> | default = ""]
 
-      # Mirror writes to the secondary store.
+      # (advanced) Mirror writes to the secondary store.
       # CLI flag: -compactor.ring.multi.mirror-enabled
       [mirror_enabled: <boolean> | default = false]
 
-      # Timeout for storing a value to the secondary store.
+      # (advanced) Timeout for storing a value to the secondary store.
       # CLI flag: -compactor.ring.multi.mirror-timeout
       [mirror_timeout: <duration> | default = 2s]
 
-  # Period at which to heartbeat to the ring. 0 = disabled.
+  # (advanced) Period at which to heartbeat to the ring. 0 = disabled.
   # CLI flag: -compactor.ring.heartbeat-period
   [heartbeat_period: <duration> | default = 15s]
 
-  # The heartbeat timeout after which compactors are considered unhealthy within
-  # the ring. 0 = never (timeout disabled).
+  # (advanced) The heartbeat timeout after which compactors are considered
+  # unhealthy within the ring. 0 = never (timeout disabled).
   # CLI flag: -compactor.ring.heartbeat-timeout
   [heartbeat_timeout: <duration> | default = 1m]
 
-  # Instance ID to register in the ring.
+  # (advanced) Instance ID to register in the ring.
   # CLI flag: -compactor.ring.instance-id
   [instance_id: <string> | default = "<hostname>"]
 
@@ -1748,134 +2301,393 @@ sharding_ring:
   # CLI flag: -compactor.ring.instance-interface-names
   [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
 
-  # Port to advertise in the ring (defaults to -server.http-listen-port).
+  # (advanced) Port to advertise in the ring (defaults to
+  # -server.http-listen-port).
   # CLI flag: -compactor.ring.instance-port
   [instance_port: <int> | default = 0]
 
-  # IP address to advertise in the ring. Default is auto-detected.
+  # (advanced) IP address to advertise in the ring. Default is auto-detected.
   # CLI flag: -compactor.ring.instance-addr
   [instance_addr: <string> | default = ""]
 
-  # Enable using a IPv6 instance address. (default false)
+  # (advanced) Enable using a IPv6 instance address. (default false)
   # CLI flag: -compactor.ring.instance-enable-ipv6
   [instance_enable_ipv6: <boolean> | default = false]
 
-  # Minimum time to wait for ring stability at startup. 0 to disable.
+  # (advanced) Minimum time to wait for ring stability at startup. 0 to disable.
   # CLI flag: -compactor.ring.wait-stability-min-duration
   [wait_stability_min_duration: <duration> | default = 0s]
 
-  # Maximum time to wait for ring stability at startup. If the compactor ring
-  # keeps changing after this period of time, the compactor will start anyway.
+  # (advanced) Maximum time to wait for ring stability at startup. If the
+  # compactor ring keeps changing after this period of time, the compactor will
+  # start anyway.
   # CLI flag: -compactor.ring.wait-stability-max-duration
   [wait_stability_max_duration: <duration> | default = 5m]
 
-  # Timeout for waiting on compactor to become ACTIVE in the ring.
+  # (advanced) Timeout for waiting on compactor to become ACTIVE in the ring.
   # CLI flag: -compactor.ring.wait-active-instance-timeout
   [wait_active_instance_timeout: <duration> | default = 10m]
 
-# The sorting to use when deciding which compaction jobs should run first for a
-# given tenant. Supported values are: smallest-range-oldest-blocks-first,
-# newest-blocks-first.
+# (advanced) The sorting to use when deciding which compaction jobs should run
+# first for a given tenant. Supported values are:
+# smallest-range-oldest-blocks-first, newest-blocks-first.
 # CLI flag: -compactor.compaction-jobs-order
 [compaction_jobs_order: <string> | default = "smallest-range-oldest-blocks-first"]
 
-# Experimental: The strategy to use when splitting blocks during compaction.
-# Supported values are: fingerprint, stacktracePartition.
+# (advanced) Experimental: The strategy to use when splitting blocks during
+# compaction. Supported values are: fingerprint, stacktracePartition.
 # CLI flag: -compactor.compaction-split-by
 [compaction_split_by: <string> | default = "fingerprint"]
+```
+
+### adaptive_placement
+
+The `adaptive_placement` block configures adaptive placement for the segment-writer (V2).
+
+```yaml
+# (advanced) Interval between updates to placement rules.
+# CLI flag: -adaptive-placement.placement-rules-update-interval
+[placement_rules_update_interval: <duration> | default = 15s]
+
+# (advanced) Retention period for inactive placement rules.
+# CLI flag: -adaptive-placement.placement-rules-retention-period
+[placement_rules_retention_period: <duration> | default = 15m]
+
+# (advanced) Confidence period for stats. During this period, placement rules
+# are not updated. If 0, placement rules may be applied using incomplete stats.
+# CLI flag: -adaptive-placement.stats-confidence-period
+[stats_confidence_period: <duration> | default = 0s]
+
+# (advanced) Time window for aggregating shard stats.
+# CLI flag: -adaptive-placement.stats-aggregation-window
+[stats_aggregation_window: <duration> | default = 3m]
+
+# (advanced) Retention period for stats that are no longer updated.
+# CLI flag: -adaptive-placement.stats-retention-period
+[stats_retention_period: <duration> | default = 15m]
+
+# (advanced) If enabled, shard limit metrics are exported as Prometheus metrics.
+# CLI flag: -adaptive-placement.export-shard-limit-metrics
+[export_shard_limit_metrics: <boolean> | default = true]
+
+# (advanced) If enabled, shard utilization metrics are exported as Prometheus
+# metrics.
+# CLI flag: -adaptive-placement.export-shard-usage-metrics
+[export_shard_usage_metrics: <boolean> | default = false]
+
+# (advanced) If enabled, shard utilization breakdown metrics, including shard
+# ownership, are exported as Prometheus metrics.
+# CLI flag: -adaptive-placement.export-shard-usage-breakdown-metrics
+[export_shard_usage_breakdown_metrics: <boolean> | default = false]
+```
+
+### symbolizer
+
+The `symbolizer` block configures the symbolizer (V2).
+
+```yaml
+# (advanced) URL of the debuginfod server
+# CLI flag: -symbolizer.debuginfod-url
+[debuginfod_url: <string> | default = "https://debuginfod.elfutils.org"]
+
+# (advanced) Maximum number of concurrent symbolization requests to debuginfod
+# server.
+# CLI flag: -symbolizer.max-debuginfod-concurrency
+[max_debuginfod_concurrency: <int> | default = 10]
+```
+
+### overrides_exporter
+
+The `overrides_exporter` block configures the overrides exporter.
+
+```yaml
+ring:
+  # The key-value store used to share the hash ring across multiple instances.
+  kvstore:
+    # Backend storage to use for the ring. Supported values are: consul, etcd,
+    # inmemory, memberlist, multi.
+    # CLI flag: -overrides-exporter.ring.store
+    [store: <string> | default = "memberlist"]
+
+    # (advanced) The prefix for the keys in the store. Should end with a /.
+    # CLI flag: -overrides-exporter.ring.prefix
+    [prefix: <string> | default = "collectors/"]
+
+    consul:
+      # Hostname and port of Consul.
+      # CLI flag: -overrides-exporter.ring.consul.hostname
+      [host: <string> | default = "localhost:8500"]
+
+      # (advanced) ACL Token used to interact with Consul.
+      # CLI flag: -overrides-exporter.ring.consul.acl-token
+      [acl_token: <string> | default = ""]
+
+      # (advanced) HTTP timeout when talking to Consul
+      # CLI flag: -overrides-exporter.ring.consul.client-timeout
+      [http_client_timeout: <duration> | default = 20s]
+
+      # (advanced) Enable consistent reads to Consul.
+      # CLI flag: -overrides-exporter.ring.consul.consistent-reads
+      [consistent_reads: <boolean> | default = false]
+
+      # (advanced) Rate limit when watching key or prefix in Consul, in requests
+      # per second. 0 disables the rate limit.
+      # CLI flag: -overrides-exporter.ring.consul.watch-rate-limit
+      [watch_rate_limit: <float> | default = 1]
+
+      # (advanced) Burst size used in rate limit. Values less than 1 are treated
+      # as 1.
+      # CLI flag: -overrides-exporter.ring.consul.watch-burst-size
+      [watch_burst_size: <int> | default = 1]
+
+      # (advanced) Maximum duration to wait before retrying a Compare And Swap
+      # (CAS) operation.
+      # CLI flag: -overrides-exporter.ring.consul.cas-retry-delay
+      [cas_retry_delay: <duration> | default = 1s]
+
+    etcd:
+      # The etcd endpoints to connect to.
+      # CLI flag: -overrides-exporter.ring.etcd.endpoints
+      [endpoints: <list of strings> | default = []]
+
+      # (advanced) The dial timeout for the etcd connection.
+      # CLI flag: -overrides-exporter.ring.etcd.dial-timeout
+      [dial_timeout: <duration> | default = 10s]
+
+      # (advanced) The maximum number of retries to do for failed ops.
+      # CLI flag: -overrides-exporter.ring.etcd.max-retries
+      [max_retries: <int> | default = 10]
+
+      # (advanced) Enable TLS.
+      # CLI flag: -overrides-exporter.ring.etcd.tls-enabled
+      [tls_enabled: <boolean> | default = false]
+
+      # (advanced) Path to the client certificate, which will be used for
+      # authenticating with the server. Also requires the key path to be
+      # configured.
+      # CLI flag: -overrides-exporter.ring.etcd.tls-cert-path
+      [tls_cert_path: <string> | default = ""]
+
+      # (advanced) Path to the key for the client certificate. Also requires the
+      # client certificate to be configured.
+      # CLI flag: -overrides-exporter.ring.etcd.tls-key-path
+      [tls_key_path: <string> | default = ""]
+
+      # (advanced) Path to the CA certificates to validate server certificate
+      # against. If not set, the host's root CA certificates are used.
+      # CLI flag: -overrides-exporter.ring.etcd.tls-ca-path
+      [tls_ca_path: <string> | default = ""]
+
+      # (advanced) Override the expected name on the server certificate.
+      # CLI flag: -overrides-exporter.ring.etcd.tls-server-name
+      [tls_server_name: <string> | default = ""]
+
+      # (advanced) Skip validating server certificate.
+      # CLI flag: -overrides-exporter.ring.etcd.tls-insecure-skip-verify
+      [tls_insecure_skip_verify: <boolean> | default = false]
+
+      # (advanced) Override the default cipher suite list (separated by commas).
+      # Allowed values:
+      # 
+      # Secure Ciphers:
+      # - TLS_AES_128_GCM_SHA256
+      # - TLS_AES_256_GCM_SHA384
+      # - TLS_CHACHA20_POLY1305_SHA256
+      # - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+      # - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+      # - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+      # - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+      # - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      # - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      # - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      # - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      # - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      # - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      # 
+      # Insecure Ciphers:
+      # - TLS_RSA_WITH_RC4_128_SHA
+      # - TLS_RSA_WITH_3DES_EDE_CBC_SHA
+      # - TLS_RSA_WITH_AES_128_CBC_SHA
+      # - TLS_RSA_WITH_AES_256_CBC_SHA
+      # - TLS_RSA_WITH_AES_128_CBC_SHA256
+      # - TLS_RSA_WITH_AES_128_GCM_SHA256
+      # - TLS_RSA_WITH_AES_256_GCM_SHA384
+      # - TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
+      # - TLS_ECDHE_RSA_WITH_RC4_128_SHA
+      # - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
+      # - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+      # - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+      # CLI flag: -overrides-exporter.ring.etcd.tls-cipher-suites
+      [tls_cipher_suites: <string> | default = ""]
+
+      # (advanced) Override the default minimum TLS version. Allowed values:
+      # VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
+      # CLI flag: -overrides-exporter.ring.etcd.tls-min-version
+      [tls_min_version: <string> | default = ""]
+
+      # Etcd username.
+      # CLI flag: -overrides-exporter.ring.etcd.username
+      [username: <string> | default = ""]
+
+      # Etcd password.
+      # CLI flag: -overrides-exporter.ring.etcd.password
+      [password: <string> | default = ""]
+
+    multi:
+      # (advanced) Primary backend storage used by multi-client.
+      # CLI flag: -overrides-exporter.ring.multi.primary
+      [primary: <string> | default = ""]
+
+      # (advanced) Secondary backend storage used by multi-client.
+      # CLI flag: -overrides-exporter.ring.multi.secondary
+      [secondary: <string> | default = ""]
+
+      # (advanced) Mirror writes to the secondary store.
+      # CLI flag: -overrides-exporter.ring.multi.mirror-enabled
+      [mirror_enabled: <boolean> | default = false]
+
+      # (advanced) Timeout for storing a value to the secondary store.
+      # CLI flag: -overrides-exporter.ring.multi.mirror-timeout
+      [mirror_timeout: <duration> | default = 2s]
+
+  # (advanced) Period at which to heartbeat to the ring. 0 = disabled.
+  # CLI flag: -overrides-exporter.ring.heartbeat-period
+  [heartbeat_period: <duration> | default = 15s]
+
+  # (advanced) The heartbeat timeout after which overrides-exporters are
+  # considered unhealthy within the ring. 0 = never (timeout disabled).
+  # CLI flag: -overrides-exporter.ring.heartbeat-timeout
+  [heartbeat_timeout: <duration> | default = 1m]
+
+  # (advanced) Instance ID to register in the ring.
+  # CLI flag: -overrides-exporter.ring.instance-id
+  [instance_id: <string> | default = "<hostname>"]
+
+  # List of network interface names to look up when finding the instance IP
+  # address.
+  # CLI flag: -overrides-exporter.ring.instance-interface-names
+  [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
+
+  # (advanced) Port to advertise in the ring (defaults to
+  # -server.http-listen-port).
+  # CLI flag: -overrides-exporter.ring.instance-port
+  [instance_port: <int> | default = 0]
+
+  # (advanced) IP address to advertise in the ring. Default is auto-detected.
+  # CLI flag: -overrides-exporter.ring.instance-addr
+  [instance_addr: <string> | default = ""]
+
+  # (advanced) Enable using a IPv6 instance address. (default false)
+  # CLI flag: -overrides-exporter.ring.instance-enable-ipv6
+  [instance_enable_ipv6: <boolean> | default = false]
+
+  # (advanced) Minimum time to wait for ring stability at startup, if set to
+  # positive value. Set to 0 to disable.
+  # CLI flag: -overrides-exporter.ring.wait-stability-min-duration
+  [wait_stability_min_duration: <duration> | default = 0s]
+
+  # (advanced) Maximum time to wait for ring stability at startup. If the
+  # overrides-exporter ring keeps changing after this period of time, it will
+  # start anyway.
+  # CLI flag: -overrides-exporter.ring.wait-stability-max-duration
+  [wait_stability_max_duration: <duration> | default = 5m]
 ```
 
 ### grpc_client
 
 The `grpc_client` block configures the gRPC client used to communicate between two Pyroscope components. The supported CLI flags `<prefix>` used to reference this configuration block are:
 
+- `metastore.grpc-client-config`
 - `querier.frontend-client`
+- `query-backend.grpc-client-config`
 - `query-frontend.grpc-client-config`
 - `query-scheduler.grpc-client-config`
+- `segment-writer.grpc-client-config`
 
 &nbsp;
 
 ```yaml
-# gRPC client max receive message size (bytes).
+# (advanced) gRPC client max receive message size (bytes).
 # CLI flag: -<prefix>.grpc-max-recv-msg-size
 [max_recv_msg_size: <int> | default = 104857600]
 
-# gRPC client max send message size (bytes).
+# (advanced) gRPC client max send message size (bytes).
 # CLI flag: -<prefix>.grpc-max-send-msg-size
 [max_send_msg_size: <int> | default = 104857600]
 
-# Use compression when sending messages. Supported values are: 'gzip', 'snappy'
-# and '' (disable compression)
+# (advanced) Use compression when sending messages. Supported values are:
+# 'gzip', 'snappy' and '' (disable compression)
 # CLI flag: -<prefix>.grpc-compression
 [grpc_compression: <string> | default = ""]
 
-# Rate limit for gRPC client; 0 means disabled.
+# (advanced) Rate limit for gRPC client; 0 means disabled.
 # CLI flag: -<prefix>.grpc-client-rate-limit
 [rate_limit: <float> | default = 0]
 
-# Rate limit burst for gRPC client.
+# (advanced) Rate limit burst for gRPC client.
 # CLI flag: -<prefix>.grpc-client-rate-limit-burst
 [rate_limit_burst: <int> | default = 0]
 
-# Enable backoff and retry when we hit rate limits.
+# (advanced) Enable backoff and retry when we hit rate limits.
 # CLI flag: -<prefix>.backoff-on-ratelimits
 [backoff_on_ratelimits: <boolean> | default = false]
 
 backoff_config:
-  # Minimum delay when backing off.
+  # (advanced) Minimum delay when backing off.
   # CLI flag: -<prefix>.backoff-min-period
   [min_period: <duration> | default = 100ms]
 
-  # Maximum delay when backing off.
+  # (advanced) Maximum delay when backing off.
   # CLI flag: -<prefix>.backoff-max-period
   [max_period: <duration> | default = 10s]
 
-  # Number of times to backoff and retry before failing.
+  # (advanced) Number of times to backoff and retry before failing.
   # CLI flag: -<prefix>.backoff-retries
   [max_retries: <int> | default = 10]
 
-# Initial stream window size. Values less than the default are not supported and
-# are ignored. Setting this to a value other than the default disables the BDP
-# estimator.
+# (experimental) Initial stream window size. Values less than the default are
+# not supported and are ignored. Setting this to a value other than the default
+# disables the BDP estimator.
 # CLI flag: -<prefix>.initial-stream-window-size
 [initial_stream_window_size: <int> | default = 63KiB1023B]
 
-# Initial connection window size. Values less than the default are not supported
-# and are ignored. Setting this to a value other than the default disables the
-# BDP estimator.
+# (experimental) Initial connection window size. Values less than the default
+# are not supported and are ignored. Setting this to a value other than the
+# default disables the BDP estimator.
 # CLI flag: -<prefix>.initial-connection-window-size
 [initial_connection_window_size: <int> | default = 63KiB1023B]
 
-# Enable TLS in the gRPC client. This flag needs to be enabled when any other
-# TLS flag is set. If set to false, insecure connection to gRPC server will be
-# used.
+# (advanced) Enable TLS in the gRPC client. This flag needs to be enabled when
+# any other TLS flag is set. If set to false, insecure connection to gRPC server
+# will be used.
 # CLI flag: -<prefix>.tls-enabled
 [tls_enabled: <boolean> | default = false]
 
-# Path to the client certificate, which will be used for authenticating with the
-# server. Also requires the key path to be configured.
+# (advanced) Path to the client certificate, which will be used for
+# authenticating with the server. Also requires the key path to be configured.
 # CLI flag: -<prefix>.tls-cert-path
 [tls_cert_path: <string> | default = ""]
 
-# Path to the key for the client certificate. Also requires the client
-# certificate to be configured.
+# (advanced) Path to the key for the client certificate. Also requires the
+# client certificate to be configured.
 # CLI flag: -<prefix>.tls-key-path
 [tls_key_path: <string> | default = ""]
 
-# Path to the CA certificates to validate server certificate against. If not
-# set, the host's root CA certificates are used.
+# (advanced) Path to the CA certificates to validate server certificate against.
+# If not set, the host's root CA certificates are used.
 # CLI flag: -<prefix>.tls-ca-path
 [tls_ca_path: <string> | default = ""]
 
-# Override the expected name on the server certificate.
+# (advanced) Override the expected name on the server certificate.
 # CLI flag: -<prefix>.tls-server-name
 [tls_server_name: <string> | default = ""]
 
-# Skip validating server certificate.
+# (advanced) Skip validating server certificate.
 # CLI flag: -<prefix>.tls-insecure-skip-verify
 [tls_insecure_skip_verify: <boolean> | default = false]
 
-# Override the default cipher suite list (separated by commas). Allowed values:
+# (advanced) Override the default cipher suite list (separated by commas).
+# Allowed values:
 # 
 # Secure Ciphers:
 # - TLS_AES_128_GCM_SHA256
@@ -1908,28 +2720,28 @@ backoff_config:
 # CLI flag: -<prefix>.tls-cipher-suites
 [tls_cipher_suites: <string> | default = ""]
 
-# Override the default minimum TLS version. Allowed values: VersionTLS10,
-# VersionTLS11, VersionTLS12, VersionTLS13
+# (advanced) Override the default minimum TLS version. Allowed values:
+# VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
 # CLI flag: -<prefix>.tls-min-version
 [tls_min_version: <string> | default = ""]
 
-# The maximum amount of time to establish a connection. A value of 0 means
-# default gRPC client connect timeout and backoff.
+# (advanced) The maximum amount of time to establish a connection. A value of 0
+# means default gRPC client connect timeout and backoff.
 # CLI flag: -<prefix>.connect-timeout
 [connect_timeout: <duration> | default = 5s]
 
-# Initial backoff delay after first connection failure. Only relevant if
-# ConnectTimeout > 0.
+# (advanced) Initial backoff delay after first connection failure. Only relevant
+# if ConnectTimeout > 0.
 # CLI flag: -<prefix>.connect-backoff-base-delay
 [connect_backoff_base_delay: <duration> | default = 1s]
 
-# Maximum backoff delay when establishing a connection. Only relevant if
-# ConnectTimeout > 0.
+# (advanced) Maximum backoff delay when establishing a connection. Only relevant
+# if ConnectTimeout > 0.
 # CLI flag: -<prefix>.connect-backoff-max-delay
 [connect_backoff_max_delay: <duration> | default = 5s]
 
 cluster_validation:
-  # Primary cluster validation label.
+  # (experimental) Primary cluster validation label.
   # CLI flag: -<prefix>.cluster-validation.label
   [label: <string> | default = ""]
 ```
@@ -1939,57 +2751,59 @@ cluster_validation:
 The `memberlist` block configures the Gossip memberlist.
 
 ```yaml
-# Name of the node in memberlist cluster. Defaults to hostname.
+# (advanced) Name of the node in memberlist cluster. Defaults to hostname.
 # CLI flag: -memberlist.nodename
 [node_name: <string> | default = ""]
 
-# Add random suffix to the node name.
+# (advanced) Add random suffix to the node name.
 # CLI flag: -memberlist.randomize-node-name
 [randomize_node_name: <boolean> | default = true]
 
-# The timeout for establishing a connection with a remote node, and for
-# read/write operations.
+# (advanced) The timeout for establishing a connection with a remote node, and
+# for read/write operations.
 # CLI flag: -memberlist.stream-timeout
 [stream_timeout: <duration> | default = 2s]
 
-# Multiplication factor used when sending out messages (factor * log(N+1)).
+# (advanced) Multiplication factor used when sending out messages (factor *
+# log(N+1)).
 # CLI flag: -memberlist.retransmit-factor
 [retransmit_factor: <int> | default = 4]
 
-# How often to use pull/push sync.
+# (advanced) How often to use pull/push sync.
 # CLI flag: -memberlist.pullpush-interval
 [pull_push_interval: <duration> | default = 30s]
 
-# How often to gossip.
+# (advanced) How often to gossip.
 # CLI flag: -memberlist.gossip-interval
 [gossip_interval: <duration> | default = 200ms]
 
-# How many nodes to gossip to.
+# (advanced) How many nodes to gossip to.
 # CLI flag: -memberlist.gossip-nodes
 [gossip_nodes: <int> | default = 3]
 
-# How long to keep gossiping to dead nodes, to give them chance to refute their
-# death.
+# (advanced) How long to keep gossiping to dead nodes, to give them chance to
+# refute their death.
 # CLI flag: -memberlist.gossip-to-dead-nodes-time
 [gossip_to_dead_nodes_time: <duration> | default = 30s]
 
-# How soon can dead node's name be reclaimed with new address. 0 to disable.
+# (advanced) How soon can dead node's name be reclaimed with new address. 0 to
+# disable.
 # CLI flag: -memberlist.dead-node-reclaim-time
 [dead_node_reclaim_time: <duration> | default = 0s]
 
-# Enable message compression. This can be used to reduce bandwidth usage at the
-# cost of slightly more CPU utilization.
+# (advanced) Enable message compression. This can be used to reduce bandwidth
+# usage at the cost of slightly more CPU utilization.
 # CLI flag: -memberlist.compression-enabled
 [compression_enabled: <boolean> | default = true]
 
-# How frequently to notify watchers when a key changes. Can reduce CPU activity
-# in large memberlist deployments. 0 to notify without delay.
+# (advanced) How frequently to notify watchers when a key changes. Can reduce
+# CPU activity in large memberlist deployments. 0 to notify without delay.
 # CLI flag: -memberlist.notify-interval
 [notify_interval: <duration> | default = 0s]
 
-# Size of the internal queue for messages received from other nodes. Increasing
-# this value may help to avoid dropping messages when the node is processing a
-# large number of messages from other nodes.
+# (advanced) Size of the internal queue for messages received from other nodes.
+# Increasing this value may help to avoid dropping messages when the node is
+# processing a large number of messages from other nodes.
 # CLI flag: -memberlist.received-messages-queue-size
 [received_messages_queue_size: <int> | default = 1024]
 
@@ -2003,17 +2817,17 @@ The `memberlist` block configures the Gossip memberlist.
 # CLI flag: -memberlist.advertise-port
 [advertise_port: <int> | default = 7946]
 
-# The cluster label is an optional string to include in outbound packets and
-# gossip streams. Other members in the memberlist cluster will discard any
-# message whose label doesn't match the configured one, unless the
+# (advanced) The cluster label is an optional string to include in outbound
+# packets and gossip streams. Other members in the memberlist cluster will
+# discard any message whose label doesn't match the configured one, unless the
 # 'cluster-label-verification-disabled' configuration option is set to true.
 # CLI flag: -memberlist.cluster-label
 [cluster_label: <string> | default = ""]
 
-# When true, memberlist doesn't verify that inbound packets and gossip streams
-# have the cluster label matching the configured one. This verification should
-# be disabled while rolling out the change to the configured cluster label in a
-# live memberlist cluster.
+# (advanced) When true, memberlist doesn't verify that inbound packets and
+# gossip streams have the cluster label matching the configured one. This
+# verification should be disabled while rolling out the change to the configured
+# cluster label in a live memberlist cluster.
 # CLI flag: -memberlist.cluster-label-verification-disabled
 [cluster_label_verification_disabled: <boolean> | default = false]
 
@@ -2023,27 +2837,28 @@ The `memberlist` block configures the Gossip memberlist.
 # CLI flag: -memberlist.join
 [join_members: <list of strings> | default = ]
 
-# Min backoff duration to join other cluster members.
+# (advanced) Min backoff duration to join other cluster members.
 # CLI flag: -memberlist.min-join-backoff
 [min_join_backoff: <duration> | default = 1s]
 
-# Max backoff duration to join other cluster members.
+# (advanced) Max backoff duration to join other cluster members.
 # CLI flag: -memberlist.max-join-backoff
 [max_join_backoff: <duration> | default = 1m]
 
-# Max number of retries to join other cluster members.
+# (advanced) Max number of retries to join other cluster members.
 # CLI flag: -memberlist.max-join-retries
 [max_join_retries: <int> | default = 10]
 
-# Abort if this node fails the fast memberlist cluster joining procedure at
-# startup. When enabled, it's guaranteed that other services, depending on
-# memberlist, have an updated view over the cluster state when they're started.
+# (advanced) Abort if this node fails the fast memberlist cluster joining
+# procedure at startup. When enabled, it's guaranteed that other services,
+# depending on memberlist, have an updated view over the cluster state when
+# they're started.
 # CLI flag: -memberlist.abort-if-fast-join-fails
 [abort_if_cluster_fast_join_fails: <boolean> | default = false]
 
-# Minimum number of seed nodes that must be successfully joined during fast-join
-# for it to succeed. Only applies when -memberlist.abort-if-fast-join-fails is
-# enabled.
+# (advanced) Minimum number of seed nodes that must be successfully joined
+# during fast-join for it to succeed. Only applies when
+# -memberlist.abort-if-fast-join-fails is enabled.
 # CLI flag: -memberlist.abort-if-fast-join-fails-min-nodes
 [abort_if_cluster_fast_join_fails_min_nodes: <int> | default = 1]
 
@@ -2053,48 +2868,48 @@ The `memberlist` block configures the Gossip memberlist.
 # CLI flag: -memberlist.abort-if-join-fails
 [abort_if_cluster_join_fails: <boolean> | default = false]
 
-# If not 0, how often to rejoin the cluster. Occasional rejoin can help to fix
-# the cluster split issue, and is harmless otherwise. For example when using
-# only few components as a seed nodes (via -memberlist.join), then it's
-# recommended to use rejoin. If -memberlist.join points to dynamic service that
-# resolves to all gossiping nodes (eg. Kubernetes headless service), then rejoin
-# is not needed.
+# (advanced) If not 0, how often to rejoin the cluster. Occasional rejoin can
+# help to fix the cluster split issue, and is harmless otherwise. For example
+# when using only few components as a seed nodes (via -memberlist.join), then
+# it's recommended to use rejoin. If -memberlist.join points to dynamic service
+# that resolves to all gossiping nodes (eg. Kubernetes headless service), then
+# rejoin is not needed.
 # CLI flag: -memberlist.rejoin-interval
 [rejoin_interval: <duration> | default = 0s]
 
-# Seed nodes to use for periodic rejoin. Takes precedence over -memberlist.join
-# for rejoining. If not specified, -memberlist.join is used. Can be specified
-# multiple times or as a comma-separated list. Supports IP, hostname, or DNS
-# Service Discovery format.
+# (experimental) Seed nodes to use for periodic rejoin. Takes precedence over
+# -memberlist.join for rejoining. If not specified, -memberlist.join is used.
+# Can be specified multiple times or as a comma-separated list. Supports IP,
+# hostname, or DNS Service Discovery format.
 # CLI flag: -memberlist.rejoin-seed-nodes
 [rejoin_seed_nodes: <list of strings> | default = ]
 
-# How long to keep LEFT ingesters in the ring.
+# (advanced) How long to keep LEFT ingesters in the ring.
 # CLI flag: -memberlist.left-ingesters-timeout
 [left_ingesters_timeout: <duration> | default = 5m]
 
-# How long to keep obsolete entries in the KV store.
+# (experimental) How long to keep obsolete entries in the KV store.
 # CLI flag: -memberlist.obsolete-entries-timeout
 [obsolete_entries_timeout: <duration> | default = 30s]
 
-# Timeout for leaving memberlist cluster.
+# (advanced) Timeout for leaving memberlist cluster.
 # CLI flag: -memberlist.leave-timeout
 [leave_timeout: <duration> | default = 20s]
 
-# Timeout for broadcasting all remaining locally-generated updates to other
-# nodes when shutting down. Only used if there are nodes left in the memberlist
-# cluster, and only applies to locally-generated updates, not to broadcast
-# messages that are result of incoming gossip updates. 0 = no timeout, wait
-# until all locally-generated updates are sent.
+# (advanced) Timeout for broadcasting all remaining locally-generated updates to
+# other nodes when shutting down. Only used if there are nodes left in the
+# memberlist cluster, and only applies to locally-generated updates, not to
+# broadcast messages that are result of incoming gossip updates. 0 = no timeout,
+# wait until all locally-generated updates are sent.
 # CLI flag: -memberlist.broadcast-timeout-for-local-updates-on-shutdown
 [broadcast_timeout_for_local_updates_on_shutdown: <duration> | default = 10s]
 
-# How much space to use for keeping received and sent messages in memory for
-# troubleshooting (two buffers). 0 to disable.
+# (advanced) How much space to use for keeping received and sent messages in
+# memory for troubleshooting (two buffers). 0 to disable.
 # CLI flag: -memberlist.message-history-buffer-bytes
 [message_history_buffer_bytes: <int> | default = 0]
 
-# Size of the buffered channel for the WatchPrefix function.
+# (advanced) Size of the buffered channel for the WatchPrefix function.
 # CLI flag: -memberlist.watch-prefix-buffer-size
 [watch_prefix_buffer_size: <int> | default = 128]
 
@@ -2107,51 +2922,52 @@ The `memberlist` block configures the Gossip memberlist.
 # CLI flag: -memberlist.bind-port
 [bind_port: <int> | default = 7946]
 
-# Timeout used when connecting to other nodes to send packet.
+# (advanced) Timeout used when connecting to other nodes to send packet.
 # CLI flag: -memberlist.packet-dial-timeout
 [packet_dial_timeout: <duration> | default = 2s]
 
-# Timeout for writing 'packet' data.
+# (advanced) Timeout for writing 'packet' data.
 # CLI flag: -memberlist.packet-write-timeout
 [packet_write_timeout: <duration> | default = 5s]
 
-# Maximum number of concurrent writes to other nodes.
+# (advanced) Maximum number of concurrent writes to other nodes.
 # CLI flag: -memberlist.max-concurrent-writes
 [max_concurrent_writes: <int> | default = 3]
 
-# Timeout for acquiring one of the concurrent write slots. After this time, the
-# message will be dropped.
+# (advanced) Timeout for acquiring one of the concurrent write slots. After this
+# time, the message will be dropped.
 # CLI flag: -memberlist.acquire-writer-timeout
 [acquire_writer_timeout: <duration> | default = 250ms]
 
-# Enable TLS on the memberlist transport layer.
+# (advanced) Enable TLS on the memberlist transport layer.
 # CLI flag: -memberlist.tls-enabled
 [tls_enabled: <boolean> | default = false]
 
-# Path to the client certificate, which will be used for authenticating with the
-# server. Also requires the key path to be configured.
+# (advanced) Path to the client certificate, which will be used for
+# authenticating with the server. Also requires the key path to be configured.
 # CLI flag: -memberlist.tls-cert-path
 [tls_cert_path: <string> | default = ""]
 
-# Path to the key for the client certificate. Also requires the client
-# certificate to be configured.
+# (advanced) Path to the key for the client certificate. Also requires the
+# client certificate to be configured.
 # CLI flag: -memberlist.tls-key-path
 [tls_key_path: <string> | default = ""]
 
-# Path to the CA certificates to validate server certificate against. If not
-# set, the host's root CA certificates are used.
+# (advanced) Path to the CA certificates to validate server certificate against.
+# If not set, the host's root CA certificates are used.
 # CLI flag: -memberlist.tls-ca-path
 [tls_ca_path: <string> | default = ""]
 
-# Override the expected name on the server certificate.
+# (advanced) Override the expected name on the server certificate.
 # CLI flag: -memberlist.tls-server-name
 [tls_server_name: <string> | default = ""]
 
-# Skip validating server certificate.
+# (advanced) Skip validating server certificate.
 # CLI flag: -memberlist.tls-insecure-skip-verify
 [tls_insecure_skip_verify: <boolean> | default = false]
 
-# Override the default cipher suite list (separated by commas). Allowed values:
+# (advanced) Override the default cipher suite list (separated by commas).
+# Allowed values:
 # 
 # Secure Ciphers:
 # - TLS_AES_128_GCM_SHA256
@@ -2184,39 +3000,41 @@ The `memberlist` block configures the Gossip memberlist.
 # CLI flag: -memberlist.tls-cipher-suites
 [tls_cipher_suites: <string> | default = ""]
 
-# Override the default minimum TLS version. Allowed values: VersionTLS10,
-# VersionTLS11, VersionTLS12, VersionTLS13
+# (advanced) Override the default minimum TLS version. Allowed values:
+# VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
 # CLI flag: -memberlist.tls-min-version
 [tls_min_version: <string> | default = ""]
 
 zone_aware_routing:
-  # Enable zone-aware routing for memberlist gossip.
+  # (experimental) Enable zone-aware routing for memberlist gossip.
   # CLI flag: -memberlist.zone-aware-routing.enabled
   [enabled: <boolean> | default = false]
 
-  # Availability zone where this node is running.
+  # (experimental) Availability zone where this node is running.
   # CLI flag: -memberlist.zone-aware-routing.instance-availability-zone
   [instance_availability_zone: <string> | default = ""]
 
-  # Role of this node in the cluster. Valid values: member, bridge.
+  # (experimental) Role of this node in the cluster. Valid values: member,
+  # bridge.
   # CLI flag: -memberlist.zone-aware-routing.role
   [role: <string> | default = "member"]
 
 propagation_delay_tracker:
-  # Enable the propagation delay tracker to measure gossip propagation delay.
+  # (experimental) Enable the propagation delay tracker to measure gossip
+  # propagation delay.
   # CLI flag: -memberlist.propagation-delay-tracker.enabled
   [enabled: <boolean> | default = false]
 
-  # How often to publish beacons for propagation tracking.
+  # (experimental) How often to publish beacons for propagation tracking.
   # CLI flag: -memberlist.propagation-delay-tracker.beacon-interval
   [beacon_interval: <duration> | default = 1m]
 
-  # How long a beacon lives before being garbage collected.
+  # (experimental) How long a beacon lives before being garbage collected.
   # CLI flag: -memberlist.propagation-delay-tracker.beacon-lifetime
   [beacon_lifetime: <duration> | default = 10m]
 
-  # Log warning when beacon propagation delay exceeds this threshold. 0 disables
-  # logging.
+  # (experimental) Log warning when beacon propagation delay exceeds this
+  # threshold. 0 disables logging.
   # CLI flag: -memberlist.propagation-delay-tracker.log-beacons-latency-longer-than
   [log_beacons_latency_longer_than: <duration> | default = 0s]
 ```
@@ -2298,8 +3116,8 @@ distributor_usage_groups:
 # CLI flag: -distributor.aggregation-period
 [distributor_aggregation_period: <duration> | default = 0s]
 
-# List of ingestion relabel configurations. The relabeling rules work the same
-# way, as those of
+# (advanced) List of ingestion relabel configurations. The relabeling rules work
+# the same way, as those of
 # [Prometheus](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config).
 # All rules are applied in the order they are specified. Note: In most
 # situations, it is more effective to use relabeling directly in Grafana Alloy.
@@ -2318,13 +3136,13 @@ distributor_usage_groups:
 # CLI flag: -distributor.ingestion-relabeling-rules
 [ingestion_relabeling_rules: <list of Configs> | default = []]
 
-# Position of the default ingestion relabeling rules in relation to relabel
-# rules from overrides. Valid values are 'first', 'last' or 'disabled'.
+# (advanced) Position of the default ingestion relabeling rules in relation to
+# relabel rules from overrides. Valid values are 'first', 'last' or 'disabled'.
 # CLI flag: -distributor.ingestion-relabeling-default-rules-position
 [ingestion_relabeling_default_rules_position: <string> | default = "first"]
 
-# List of sample type relabel configurations. Rules are applied to sample types
-# with __type__ and __unit__ labels, along with all series labels.
+# (advanced) List of sample type relabel configurations. Rules are applied to
+# sample types with __type__ and __unit__ labels, along with all series labels.
 # Example:
 #   This example shows sample type filtering rules. The first rule drops all
 #   allocation-related sample types (alloc_objects, alloc_space) from memory
@@ -2510,28 +3328,30 @@ The s3_backend block configures the connection to Amazon S3 object storage backe
 # CLI flag: -storage.s3.access-key-id
 [access_key_id: <string> | default = ""]
 
-# If enabled, use http:// for the S3 endpoint instead of https://. This could be
-# useful in local dev/test environments while using an S3-compatible backend
-# storage, like Minio.
+# (advanced) If enabled, use http:// for the S3 endpoint instead of https://.
+# This could be useful in local dev/test environments while using an
+# S3-compatible backend storage, like Minio.
 # CLI flag: -storage.s3.insecure
 [insecure: <boolean> | default = false]
 
-# The signature version to use for authenticating against S3. Supported values
-# are: v4, v2.
+# (advanced) The signature version to use for authenticating against S3.
+# Supported values are: v4, v2.
 # CLI flag: -storage.s3.signature-version
 [signature_version: <string> | default = "v4"]
 
-# Deprecated, use s3.bucket-lookup-type instead. Set this to `true` to force the
-# bucket lookup to be using path-style.
+# (advanced) Deprecated, use s3.bucket-lookup-type instead. Set this to `true`
+# to force the bucket lookup to be using path-style.
 # CLI flag: -storage.s3.force-path-style
 [force_path_style: <boolean> | default = false]
 
-# S3 bucket lookup style, use one of: [path-style virtual-hosted-style auto]
+# (advanced) S3 bucket lookup style, use one of: [path-style
+# virtual-hosted-style auto]
 # CLI flag: -storage.s3.bucket-lookup-type
 [bucket_lookup_type: <string> | default = "auto"]
 
-# If enabled, it will use the default authentication methods of the AWS SDK for
-# go based on known environment variables and known AWS config files.
+# (experimental) If enabled, it will use the default authentication methods of
+# the AWS SDK for go based on known environment variables and known AWS config
+# files.
 # CLI flag: -storage.s3.native-aws-auth-enabled
 [native_aws_auth_enabled: <boolean> | default = false]
 
@@ -2550,40 +3370,41 @@ sse:
   [kms_encryption_context: <string> | default = ""]
 
 http:
-  # The time an idle connection will remain idle before closing.
+  # (advanced) The time an idle connection will remain idle before closing.
   # CLI flag: -storage.s3.http.idle-conn-timeout
   [idle_conn_timeout: <duration> | default = 10m]
 
-  # The amount of time the client will wait for a servers response headers.
+  # (advanced) The amount of time the client will wait for a servers response
+  # headers.
   # CLI flag: -storage.s3.http.response-header-timeout
   [response_header_timeout: <duration> | default = 2m]
 
-  # If the client connects to S3 via HTTPS and this option is enabled, the
-  # client will accept any certificate and hostname.
+  # (advanced) If the client connects to S3 via HTTPS and this option is
+  # enabled, the client will accept any certificate and hostname.
   # CLI flag: -storage.s3.http.insecure-skip-verify
   [insecure_skip_verify: <boolean> | default = false]
 
-  # Maximum time to wait for a TLS handshake. 0 means no limit.
+  # (advanced) Maximum time to wait for a TLS handshake. 0 means no limit.
   # CLI flag: -storage.s3.tls-handshake-timeout
   [tls_handshake_timeout: <duration> | default = 10s]
 
-  # The time to wait for a server's first response headers after fully writing
-  # the request headers if the request has an Expect header. 0 to send the
-  # request body immediately.
+  # (advanced) The time to wait for a server's first response headers after
+  # fully writing the request headers if the request has an Expect header. 0 to
+  # send the request body immediately.
   # CLI flag: -storage.s3.expect-continue-timeout
   [expect_continue_timeout: <duration> | default = 1s]
 
-  # Maximum number of idle (keep-alive) connections across all hosts. 0 means no
-  # limit.
+  # (advanced) Maximum number of idle (keep-alive) connections across all hosts.
+  # 0 means no limit.
   # CLI flag: -storage.s3.max-idle-connections
   [max_idle_connections: <int> | default = 0]
 
-  # Maximum number of idle (keep-alive) connections to keep per-host. If 0, a
-  # built-in default value is used.
+  # (advanced) Maximum number of idle (keep-alive) connections to keep per-host.
+  # If 0, a built-in default value is used.
   # CLI flag: -storage.s3.max-idle-connections-per-host
   [max_idle_connections_per_host: <int> | default = 1000]
 
-  # Maximum number of connections per host. 0 means no limit.
+  # (advanced) Maximum number of connections per host. 0 means no limit.
   # CLI flag: -storage.s3.max-connections-per-host
   [max_connections_per_host: <int> | default = 0]
 ```
@@ -2612,40 +3433,41 @@ The gcs_backend block configures the connection to Google Cloud Storage object s
 [service_account: <string> | default = ""]
 
 http:
-  # The time an idle connection will remain idle before closing.
+  # (advanced) The time an idle connection will remain idle before closing.
   # CLI flag: -storage.gcs.http.idle-conn-timeout
   [idle_conn_timeout: <duration> | default = 10m]
 
-  # The amount of time the client will wait for a servers response headers.
+  # (advanced) The amount of time the client will wait for a servers response
+  # headers.
   # CLI flag: -storage.gcs.http.response-header-timeout
   [response_header_timeout: <duration> | default = 2m]
 
-  # If the client connects to GCS via HTTPS and this option is enabled, the
-  # client will accept any certificate and hostname.
+  # (advanced) If the client connects to GCS via HTTPS and this option is
+  # enabled, the client will accept any certificate and hostname.
   # CLI flag: -storage.gcs.http.insecure-skip-verify
   [insecure_skip_verify: <boolean> | default = false]
 
-  # Maximum time to wait for a TLS handshake. 0 means no limit.
+  # (advanced) Maximum time to wait for a TLS handshake. 0 means no limit.
   # CLI flag: -storage.gcs.tls-handshake-timeout
   [tls_handshake_timeout: <duration> | default = 10s]
 
-  # The time to wait for a server's first response headers after fully writing
-  # the request headers if the request has an Expect header. 0 to send the
-  # request body immediately.
+  # (advanced) The time to wait for a server's first response headers after
+  # fully writing the request headers if the request has an Expect header. 0 to
+  # send the request body immediately.
   # CLI flag: -storage.gcs.expect-continue-timeout
   [expect_continue_timeout: <duration> | default = 1s]
 
-  # Maximum number of idle (keep-alive) connections across all hosts. 0 means no
-  # limit.
+  # (advanced) Maximum number of idle (keep-alive) connections across all hosts.
+  # 0 means no limit.
   # CLI flag: -storage.gcs.max-idle-connections
   [max_idle_conns: <int> | default = 0]
 
-  # Maximum number of idle (keep-alive) connections to keep per-host. If 0, a
-  # built-in default value is used.
+  # (advanced) Maximum number of idle (keep-alive) connections to keep per-host.
+  # If 0, a built-in default value is used.
   # CLI flag: -storage.gcs.max-idle-connections-per-host
   [max_idle_conns_per_host: <int> | default = 1000]
 
-  # Maximum number of connections per host. 0 means no limit.
+  # (advanced) Maximum number of connections per host. 0 means no limit.
   # CLI flag: -storage.gcs.max-connections-per-host
   [max_conns_per_host: <int> | default = 0]
 ```
@@ -2698,12 +3520,12 @@ The `azure_storage_backend` block configures the connection to Azure object stor
 # CLI flag: -storage.azure.endpoint-suffix
 [endpoint_suffix: <string> | default = ""]
 
-# Number of retries for recoverable errors
+# (advanced) Number of retries for recoverable errors
 # CLI flag: -storage.azure.max-retries
 [max_retries: <int> | default = 3]
 
-# User assigned managed identity. If empty, then System assigned identity is
-# used.
+# (advanced) User assigned managed identity. If empty, then System assigned
+# identity is used.
 # CLI flag: -storage.azure.user-assigned-id
 [user_assigned_id: <string> | default = ""]
 ```
@@ -2775,17 +3597,17 @@ The `swift_storage_backend` block configures the connection to OpenStack Object 
 # CLI flag: -storage.swift.container-name
 [container_name: <string> | default = ""]
 
-# Max retries on requests error.
+# (advanced) Max retries on requests error.
 # CLI flag: -storage.swift.max-retries
 [max_retries: <int> | default = 3]
 
-# Time after which a connection attempt is aborted.
+# (advanced) Time after which a connection attempt is aborted.
 # CLI flag: -storage.swift.connect-timeout
 [connect_timeout: <duration> | default = 10s]
 
-# Time after which an idle request is aborted. The timeout watchdog is reset
-# each time some data is received, so the timeout triggers after X time no data
-# is received on a request.
+# (advanced) Time after which an idle request is aborted. The timeout watchdog
+# is reset each time some data is received, so the timeout triggers after X time
+# no data is received on a request.
 # CLI flag: -storage.swift.request-timeout
 [request_timeout: <duration> | default = 5s]
 ```

--- a/pkg/pyroscope/pyroscope.go
+++ b/pkg/pyroscope/pyroscope.go
@@ -84,21 +84,21 @@ type Config struct {
 	Target            flagext.StringSliceCSV  `yaml:"target,omitempty"`
 	API               api.Config              `yaml:"api"`
 	Server            server.Config           `yaml:"server,omitempty"`
-	Metastore         metastore.Config        `yaml:"metastore"          doc:"hidden"`
+	Metastore         metastore.Config        `yaml:"metastore"`
 	Distributor       distributor.Config      `yaml:"distributor,omitempty"`
 	Frontend          frontend.Config         `yaml:"frontend,omitempty"`
-	QueryBackend      querybackend.Config     `yaml:"query_backend"      doc:"hidden"`
-	AdaptivePlacement placement.Config        `yaml:"adaptive_placement" doc:"hidden"`
-	Symbolizer        symbolizer.Config       `yaml:"symbolizer"         doc:"hidden"`
+	QueryBackend      querybackend.Config     `yaml:"query_backend"`
+	AdaptivePlacement placement.Config        `yaml:"adaptive_placement"`
+	Symbolizer        symbolizer.Config       `yaml:"symbolizer"`
 	Worker            worker.Config           `yaml:"frontend_worker"`
 	LimitsConfig      validation.Limits       `yaml:"limits"`
-	SegmentWriter     segmentwriter.Config    `yaml:"segment_writer"     doc:"hidden"`
+	SegmentWriter     segmentwriter.Config    `yaml:"segment_writer"`
 	MemberlistKV      memberlist.KVConfig     `yaml:"memberlist"`
 	PhlareDB          phlaredb.Config         `yaml:"pyroscopedb,omitempty"`
 	Tracing           tracing.Config          `yaml:"tracing"`
-	OverridesExporter exporter.Config         `yaml:"overrides_exporter"      doc:"hidden"`
+	OverridesExporter exporter.Config         `yaml:"overrides_exporter"`
 	RuntimeConfig     runtimeconfig.Config    `yaml:"runtime_config"`
-	CompactionWorker  compactionworker.Config `yaml:"compaction_worker"  doc:"hidden"`
+	CompactionWorker  compactionworker.Config `yaml:"compaction_worker"`
 	TenantSettings    settings.Config         `yaml:"tenant_settings"`
 
 	Storage       StorageConfig       `yaml:"storage"`

--- a/tools/doc-generator/main.go
+++ b/tools/doc-generator/main.go
@@ -131,15 +131,14 @@ func generateBlockMarkdown(blocks []*parse.ConfigBlock, blockName, fieldName str
 	return ""
 }
 
+var (
+	outputFormat = flag.String("format", "markdown", "Output format: markdown or yaml-example")
+	skipBlocks   = flag.String("skip-blocks", "", "Comma-separated list of top-level block names to omit from yaml-example output")
+)
+
 func main() {
 	// Parse the generator flags.
 	flag.Parse()
-	if flag.NArg() != 1 {
-		fmt.Fprintf(os.Stderr, "Usage: doc-generator template-file")
-		os.Exit(1)
-	}
-
-	templatePath := flag.Arg(0)
 
 	// In order to match YAML config fields with CLI flags, we map
 	// the memory address of the CLI flag variables and match them with
@@ -157,6 +156,26 @@ func main() {
 	// Annotate the flags prefix for each root block, and remove the
 	// prefix wherever encountered in the config blocks.
 	annotateFlagPrefix(blocks)
+
+	if *outputFormat == "yaml-example" {
+		skip := map[string]bool{}
+		for _, name := range strings.Split(*skipBlocks, ",") {
+			if name = strings.TrimSpace(name); name != "" {
+				skip[name] = true
+			}
+		}
+		w := &yamlExampleWriter{skipBlocks: skip}
+		w.writeConfigYAML(blocks)
+		fmt.Print(w.string())
+		return
+	}
+
+	if flag.NArg() != 1 {
+		fmt.Fprintf(os.Stderr, "Usage: doc-generator [-format yaml-example] template-file\n")
+		os.Exit(1)
+	}
+
+	templatePath := flag.Arg(0)
 
 	// Generate documentation markdown.
 	data := struct {

--- a/tools/doc-generator/parse/parser.go
+++ b/tools/doc-generator/parse/parser.go
@@ -287,27 +287,29 @@ func config(block *ConfigBlock, cfg interface{}, flags map[uintptr]*flag.Flag, r
 		fieldFlag := getFieldFlag(field, fieldValue, flags)
 		if fieldFlag == nil {
 			block.Add(&ConfigEntry{
-				Kind:         kind,
-				Name:         fieldName,
-				Required:     isFieldRequired(field),
-				FieldDesc:    getFieldDescription(cfg, field, ""),
-				FieldType:    fieldType,
-				FieldExample: getFieldExample(fieldName, field.Type),
-				Element:      element,
+				Kind:          kind,
+				Name:          fieldName,
+				Required:      isFieldRequired(field),
+				FieldDesc:     getFieldDescription(cfg, field, ""),
+				FieldType:     fieldType,
+				FieldExample:  getFieldExample(fieldName, field.Type),
+				FieldCategory: getFieldCategory(field),
+				Element:       element,
 			})
 			continue
 		}
 
 		block.Add(&ConfigEntry{
-			Kind:         kind,
-			Name:         fieldName,
-			Required:     isFieldRequired(field),
-			FieldFlag:    fieldFlag.Name,
-			FieldDesc:    getFieldDescription(cfg, field, fieldFlag.Usage),
-			FieldType:    fieldType,
-			FieldDefault: getFieldDefault(field, fieldFlag.DefValue),
-			FieldExample: getFieldExample(fieldName, field.Type),
-			Element:      element,
+			Kind:          kind,
+			Name:          fieldName,
+			Required:      isFieldRequired(field),
+			FieldFlag:     fieldFlag.Name,
+			FieldDesc:     getFieldDescription(cfg, field, fieldFlag.Usage),
+			FieldType:     fieldType,
+			FieldDefault:  getFieldDefault(field, fieldFlag.DefValue),
+			FieldExample:  getFieldExample(fieldName, field.Type),
+			FieldCategory: getFieldCategory(field),
+			Element:       element,
 		})
 	}
 
@@ -498,13 +500,14 @@ func getCustomFieldEntry(cfg interface{}, field reflect.StructField, fieldValue 
 		}
 
 		return &ConfigEntry{
-			Kind:         KindField,
-			Name:         getFieldName(field),
-			Required:     isFieldRequired(field),
-			FieldFlag:    fieldFlag.Name,
-			FieldDesc:    getFieldDescription(cfg, field, fieldFlag.Usage),
-			FieldType:    typeString,
-			FieldDefault: getFieldDefault(field, fieldFlag.DefValue),
+			Kind:          KindField,
+			Name:          getFieldName(field),
+			Required:      isFieldRequired(field),
+			FieldFlag:     fieldFlag.Name,
+			FieldDesc:     getFieldDescription(cfg, field, fieldFlag.Usage),
+			FieldType:     typeString,
+			FieldDefault:  getFieldDefault(field, fieldFlag.DefValue),
+			FieldCategory: getFieldCategory(field),
 		}
 	}
 	if field.Type == reflect.TypeOf(flagext.URLValue{}) {
@@ -514,13 +517,14 @@ func getCustomFieldEntry(cfg interface{}, field reflect.StructField, fieldValue 
 		}
 
 		return &ConfigEntry{
-			Kind:         KindField,
-			Name:         getFieldName(field),
-			Required:     isFieldRequired(field),
-			FieldFlag:    fieldFlag.Name,
-			FieldDesc:    getFieldDescription(cfg, field, fieldFlag.Usage),
-			FieldType:    typeURL,
-			FieldDefault: getFieldDefault(field, fieldFlag.DefValue),
+			Kind:          KindField,
+			Name:          getFieldName(field),
+			Required:      isFieldRequired(field),
+			FieldFlag:     fieldFlag.Name,
+			FieldDesc:     getFieldDescription(cfg, field, fieldFlag.Usage),
+			FieldType:     typeURL,
+			FieldDefault:  getFieldDefault(field, fieldFlag.DefValue),
+			FieldCategory: getFieldCategory(field),
 		}
 	}
 	if field.Type == reflect.TypeOf(flagext.Secret{}) {
@@ -530,13 +534,14 @@ func getCustomFieldEntry(cfg interface{}, field reflect.StructField, fieldValue 
 		}
 
 		return &ConfigEntry{
-			Kind:         KindField,
-			Name:         getFieldName(field),
-			Required:     isFieldRequired(field),
-			FieldFlag:    fieldFlag.Name,
-			FieldDesc:    getFieldDescription(cfg, field, fieldFlag.Usage),
-			FieldType:    "string",
-			FieldDefault: getFieldDefault(field, fieldFlag.DefValue),
+			Kind:          KindField,
+			Name:          getFieldName(field),
+			Required:      isFieldRequired(field),
+			FieldFlag:     fieldFlag.Name,
+			FieldDesc:     getFieldDescription(cfg, field, fieldFlag.Usage),
+			FieldType:     "string",
+			FieldDefault:  getFieldDefault(field, fieldFlag.DefValue),
+			FieldCategory: getFieldCategory(field),
 		}
 	}
 	if field.Type == reflect.TypeOf(model.Duration(0)) {
@@ -546,13 +551,14 @@ func getCustomFieldEntry(cfg interface{}, field reflect.StructField, fieldValue 
 		}
 
 		return &ConfigEntry{
-			Kind:         KindField,
-			Name:         getFieldName(field),
-			Required:     isFieldRequired(field),
-			FieldFlag:    fieldFlag.Name,
-			FieldDesc:    getFieldDescription(cfg, field, fieldFlag.Usage),
-			FieldType:    "duration",
-			FieldDefault: getFieldDefault(field, fieldFlag.DefValue),
+			Kind:          KindField,
+			Name:          getFieldName(field),
+			Required:      isFieldRequired(field),
+			FieldFlag:     fieldFlag.Name,
+			FieldDesc:     getFieldDescription(cfg, field, fieldFlag.Usage),
+			FieldType:     "duration",
+			FieldDefault:  getFieldDefault(field, fieldFlag.DefValue),
+			FieldCategory: getFieldCategory(field),
 		}
 	}
 	if field.Type == reflect.TypeOf(flagext.Time{}) {
@@ -562,13 +568,14 @@ func getCustomFieldEntry(cfg interface{}, field reflect.StructField, fieldValue 
 		}
 
 		return &ConfigEntry{
-			Kind:         KindField,
-			Name:         getFieldName(field),
-			Required:     isFieldRequired(field),
-			FieldFlag:    fieldFlag.Name,
-			FieldDesc:    getFieldDescription(cfg, field, fieldFlag.Usage),
-			FieldType:    "time",
-			FieldDefault: getFieldDefault(field, fieldFlag.DefValue),
+			Kind:          KindField,
+			Name:          getFieldName(field),
+			Required:      isFieldRequired(field),
+			FieldFlag:     fieldFlag.Name,
+			FieldDesc:     getFieldDescription(cfg, field, fieldFlag.Usage),
+			FieldType:     "time",
+			FieldDefault:  getFieldDefault(field, fieldFlag.DefValue),
+			FieldCategory: getFieldCategory(field),
 		}
 	}
 
@@ -636,6 +643,10 @@ func getDocTagFlag(f reflect.StructField, name string) bool {
 func getDocTagValue(f reflect.StructField, name string) string {
 	cfg := parseDocTag(f)
 	return cfg[name]
+}
+
+func getFieldCategory(f reflect.StructField) string {
+	return f.Tag.Get("category")
 }
 
 func parseDocTag(f reflect.StructField) map[string]string {

--- a/tools/doc-generator/parse/root_blocks.go
+++ b/tools/doc-generator/parse/root_blocks.go
@@ -9,10 +9,12 @@ import (
 	"github.com/grafana/dskit/kv/memberlist"
 	"github.com/grafana/dskit/server"
 
+	"github.com/grafana/pyroscope/v2/pkg/compactionworker"
 	"github.com/grafana/pyroscope/v2/pkg/compactor"
 	"github.com/grafana/pyroscope/v2/pkg/distributor"
 	"github.com/grafana/pyroscope/v2/pkg/frontend"
 	"github.com/grafana/pyroscope/v2/pkg/ingester"
+	"github.com/grafana/pyroscope/v2/pkg/metastore"
 	"github.com/grafana/pyroscope/v2/pkg/objstore/providers/azure"
 	"github.com/grafana/pyroscope/v2/pkg/objstore/providers/filesystem"
 	"github.com/grafana/pyroscope/v2/pkg/objstore/providers/gcs"
@@ -20,10 +22,15 @@ import (
 	"github.com/grafana/pyroscope/v2/pkg/objstore/providers/swift"
 	"github.com/grafana/pyroscope/v2/pkg/querier"
 	"github.com/grafana/pyroscope/v2/pkg/querier/worker"
+	"github.com/grafana/pyroscope/v2/pkg/querybackend"
 	"github.com/grafana/pyroscope/v2/pkg/scheduler"
+	"github.com/grafana/pyroscope/v2/pkg/segmentwriter"
+	placement "github.com/grafana/pyroscope/v2/pkg/segmentwriter/client/distributor/placement/adaptiveplacement"
 	"github.com/grafana/pyroscope/v2/pkg/storegateway"
+	"github.com/grafana/pyroscope/v2/pkg/symbolizer"
 	"github.com/grafana/pyroscope/v2/pkg/usagestats"
 	"github.com/grafana/pyroscope/v2/pkg/validation"
+	"github.com/grafana/pyroscope/v2/pkg/validation/exporter"
 )
 
 // RootBlocks is an ordered list of root blocks. The order is the same order that will
@@ -40,6 +47,21 @@ var RootBlocks = []RootBlock{
 		Desc:       "The distributor block configures the distributor.",
 	},
 	{
+		Name:       "segment_writer",
+		StructType: reflect.TypeOf(segmentwriter.Config{}),
+		Desc:       "The segment_writer block configures the segment-writer (V2 write path).",
+	},
+	{
+		Name:       "metastore",
+		StructType: reflect.TypeOf(metastore.Config{}),
+		Desc:       "The metastore block configures the metastore (V2).",
+	},
+	{
+		Name:       "compaction_worker",
+		StructType: reflect.TypeOf(compactionworker.Config{}),
+		Desc:       "The compaction_worker block configures the compaction-worker (V2).",
+	},
+	{
 		Name:       "ingester",
 		StructType: reflect.TypeOf(ingester.Config{}),
 		Desc:       "The ingester block configures the ingester.",
@@ -53,6 +75,11 @@ var RootBlocks = []RootBlock{
 		Name:       "query_frontend",
 		StructType: reflect.TypeOf(frontend.Config{}),
 		Desc:       "The query_frontend block configures the query-frontend.",
+	},
+	{
+		Name:       "query_backend",
+		StructType: reflect.TypeOf(querybackend.Config{}),
+		Desc:       "The query_backend block configures the query-backend (V2 read path).",
 	},
 	{
 		Name:       "frontend_worker",
@@ -73,6 +100,21 @@ var RootBlocks = []RootBlock{
 		Name:       "compactor",
 		StructType: reflect.TypeOf(compactor.Config{}),
 		Desc:       "The compactor block configures the compactor.",
+	},
+	{
+		Name:       "adaptive_placement",
+		StructType: reflect.TypeOf(placement.Config{}),
+		Desc:       "The adaptive_placement block configures adaptive placement for the segment-writer (V2).",
+	},
+	{
+		Name:       "symbolizer",
+		StructType: reflect.TypeOf(symbolizer.Config{}),
+		Desc:       "The symbolizer block configures the symbolizer (V2).",
+	},
+	{
+		Name:       "overrides_exporter",
+		StructType: reflect.TypeOf(exporter.Config{}),
+		Desc:       "The overrides_exporter block configures the overrides exporter.",
 	},
 	{
 		Name:       "grpc_client",

--- a/tools/doc-generator/writer.go
+++ b/tools/doc-generator/writer.go
@@ -225,6 +225,114 @@ func pad(length int) string {
 	return strings.Repeat(" ", length)
 }
 
+type yamlExampleWriter struct {
+	out        strings.Builder
+	skipBlocks map[string]bool
+}
+
+func (w *yamlExampleWriter) writeConfigYAML(blocks []*parse.ConfigBlock) {
+	var topBlock *parse.ConfigBlock
+	for _, b := range blocks {
+		if b.Name == "" {
+			topBlock = b
+			break
+		}
+	}
+	if topBlock == nil {
+		return
+	}
+
+	w.out.WriteString("# Pyroscope example configuration file.\n")
+	w.out.WriteString("#\n")
+	w.out.WriteString("# All fields are shown with their default values, commented out.\n")
+	w.out.WriteString("# Uncomment and modify the ones you want to override.\n")
+	w.out.WriteString("# For the full reference see:\n")
+	w.out.WriteString("#   https://grafana.com/docs/pyroscope/latest/configure-server/reference-configuration-parameters/\n")
+	w.out.WriteString("\n")
+
+	w.writeBlock(topBlock, 0)
+}
+
+func (w *yamlExampleWriter) hasBasicContent(block *parse.ConfigBlock) bool {
+	for _, entry := range block.Entries {
+		switch entry.Kind {
+		case parse.KindBlock:
+			if w.hasBasicContent(entry.Block) {
+				return true
+			}
+		default:
+			if entry.FieldCategory == "" || entry.FieldCategory == "basic" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (w *yamlExampleWriter) writeBlock(block *parse.ConfigBlock, indent int) {
+	first := true
+	for _, entry := range block.Entries {
+		switch entry.Kind {
+		case parse.KindBlock:
+			if w.skipBlocks[entry.Name] {
+				continue
+			}
+			if !w.hasBasicContent(entry.Block) {
+				continue
+			}
+			if !first {
+				w.out.WriteString("\n")
+			}
+			first = false
+			w.out.WriteString(pad(indent) + entry.Name + ":\n")
+			w.writeBlock(entry.Block, indent+tabWidth)
+
+		case parse.KindField, parse.KindSlice, parse.KindMap:
+			if entry.FieldCategory != "" && entry.FieldCategory != "basic" {
+				continue
+			}
+			if !first {
+				w.out.WriteString("\n")
+			}
+			first = false
+			if entry.FieldDesc != "" {
+				w.writeDescComment(entry.FieldDesc, indent)
+			}
+			w.out.WriteString(fmt.Sprintf("%s# %s: %s\n", pad(indent), entry.Name, yamlDefaultValue(entry)))
+		}
+	}
+}
+
+func (w *yamlExampleWriter) writeDescComment(desc string, indent int) {
+	wrapped := wordwrap.WrapString(desc, uint(maxLineWidth-indent-2))
+	for _, line := range strings.Split(strings.TrimSpace(wrapped), "\n") {
+		w.out.WriteString(pad(indent) + "# " + line + "\n")
+	}
+}
+
+func (w *yamlExampleWriter) string() string {
+	return strings.TrimSpace(w.out.String()) + "\n"
+}
+
+func yamlDefaultValue(e *parse.ConfigEntry) string {
+	def := e.FieldDefault
+	switch e.FieldType {
+	case "string", "url":
+		return strconv.Quote(def)
+	case "duration":
+		cleaned := cleanupDuration(def)
+		if cleaned == "" {
+			cleaned = "0s"
+		}
+		return cleaned
+	default:
+		if def == "" {
+			return "0"
+		}
+		return def
+	}
+}
+
 func cleanupDuration(value string) string {
 	// This is the list of suffixes to remove from the duration if they're not
 	// the whole duration value.


### PR DESCRIPTION
## Summary

Picks up the work from @alliasgher in #5106:

- Adds a `-format=yaml-example` mode to the doc-generator and wires it into the Makefile so `cmd/pyroscope/pyroscope.yaml` is regenerated automatically.
- Registers the V2 root blocks (`segment_writer`, `metastore`, `compaction_worker`, `query_backend`, `adaptive_placement`, `symbolizer`, `overrides_exporter`) and removes the `doc:"hidden"` tags hiding them, so they appear in both the generated reference docs and the example config.

Credit: @alliasgher (original PR: #5106).

## Test plan

- [ ] `make generate` produces no diff on a clean tree
- [ ] `cmd/pyroscope/pyroscope.yaml` reflects the V2 blocks
- [ ] `docs/sources/configure-server/reference-configuration-parameters/index.md` renders the new blocks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to documentation generation and example config output, with no impact to runtime behavior besides exposing previously hidden config fields in generated docs.
> 
> **Overview**
> Adds a new `-format yaml-example` mode to `tools/doc-generator` (with `-skip-blocks`) to emit a commented YAML config example using default values and only *basic* fields.
> 
> Wires this into `make generate` to auto-regenerate `cmd/pyroscope/pyroscope.yaml`, and updates the generated reference docs to include previously hidden V2 top-level blocks (`metastore`, `segment_writer`, `compaction_worker`, `query_backend`, `adaptive_placement`, `symbolizer`, `overrides_exporter`) plus category annotations like *(advanced)*/*(experimental)*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a8364167bc5256bb07e276ad519312258ecc32b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->