### PR TITLE
refactor(tsdb/index): safe public API — no yoloStrings escaping the package

### DIFF
--- a/pkg/operations/v2/blocks/dataset_handlers.go
+++ b/pkg/operations/v2/blocks/dataset_handlers.go
@@ -221,13 +221,9 @@ func (h *Handlers) readTSDBIndex(ctx context.Context, blockMeta *metastorev1.Blo
 		return nil, fmt.Errorf("failed to get labels: %w", err)
 	}
 
-	symbolIter := idx.Symbols()
-	var symbols []string
-	for symbolIter.Next() {
-		symbols = append(symbols, symbolIter.At())
-	}
-	if err := symbolIter.Err(); err != nil {
-		return nil, fmt.Errorf("failed to iterate symbols: %w", err)
+	symbols, err := idx.SymbolTable()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read symbol table: %w", err)
 	}
 
 	series, err := h.getIndexSeries(idx)

--- a/pkg/phlaredb/querier.go
+++ b/pkg/phlaredb/querier.go
@@ -32,10 +32,9 @@ type IndexReader interface {
 	Postings(name string, shard *index.ShardAnnotation, values ...string) (index.Postings, error)
 
 	// PostingsForLabelMatching returns merged postings for all values of label
-	// name for which match returns true. Label value strings are never
-	// materialized outside the index — match is called with a transient string
-	// that is only valid for the duration of the call.
-	PostingsForLabelMatching(name string, shard *index.ShardAnnotation, match func(string) bool) (index.Postings, error)
+	// name for which match returns true. The YoloString passed to match aliases
+	// the index buffer and must not be retained beyond the call.
+	PostingsForLabelMatching(name string, shard *index.ShardAnnotation, match func(index.YoloString) bool) (index.Postings, error)
 
 	// Series populates the given labels and chunk metas for the series identified
 	// by the reference.
@@ -160,10 +159,10 @@ func postingsForMatcher(ix IndexReader, shard *index.ShardAnnotation, m *labels.
 		}
 	}
 
-	return ix.PostingsForLabelMatching(m.Name, shard, m.Matches)
+	return ix.PostingsForLabelMatching(m.Name, shard, func(v index.YoloString) bool { return m.Matches(v.String) })
 }
 
 // inversePostingsForMatcher returns the postings for the series with the label name set but not matching the matcher.
 func inversePostingsForMatcher(ix IndexReader, shard *index.ShardAnnotation, m *labels.Matcher) (index.Postings, error) {
-	return ix.PostingsForLabelMatching(m.Name, shard, func(v string) bool { return !m.Matches(v) })
+	return ix.PostingsForLabelMatching(m.Name, shard, func(v index.YoloString) bool { return !m.Matches(v.String) })
 }

--- a/pkg/phlaredb/querier.go
+++ b/pkg/phlaredb/querier.go
@@ -18,13 +18,9 @@ type IndexReader interface {
 
 	Checksum() uint32
 
-	// Symbols return an iterator over sorted string symbols that may occur in
-	// series' labels and indices. It is not safe to use the returned strings
-	// beyond the lifetime of the index reader.
-	Symbols() index.StringIter
-
-	// SortedLabelValues returns sorted possible label values.
-	SortedLabelValues(name string, matchers ...*labels.Matcher) ([]string, error)
+	// SymbolTable returns all symbols in the index as owned strings safe to use
+	// beyond the reader's lifetime.
+	SymbolTable() ([]string, error)
 
 	// LabelValues returns possible label values which may not be sorted.
 	LabelValues(name string, matchers ...*labels.Matcher) ([]string, error)
@@ -34,6 +30,12 @@ type IndexReader interface {
 	// Found IDs are not strictly required to point to a valid Series, e.g.
 	// during background garbage collections. Input values must be sorted.
 	Postings(name string, shard *index.ShardAnnotation, values ...string) (index.Postings, error)
+
+	// PostingsForLabelMatching returns merged postings for all values of label
+	// name for which match returns true. Label value strings are never
+	// materialized outside the index — match is called with a transient string
+	// that is only valid for the duration of the call.
+	PostingsForLabelMatching(name string, shard *index.ShardAnnotation, match func(string) bool) (index.Postings, error)
 
 	// Series populates the given labels and chunk metas for the series identified
 	// by the reference.
@@ -158,54 +160,10 @@ func postingsForMatcher(ix IndexReader, shard *index.ShardAnnotation, m *labels.
 		}
 	}
 
-	vals, err := ix.LabelValues(m.Name)
-	if err != nil {
-		return nil, err
-	}
-
-	var res []string
-	lastVal, isSorted := "", true
-	for _, val := range vals {
-		if m.Matches(val) {
-			res = append(res, val)
-			if isSorted && val < lastVal {
-				isSorted = false
-			}
-			lastVal = val
-		}
-	}
-
-	if len(res) == 0 {
-		return index.EmptyPostings(), nil
-	}
-
-	if !isSorted {
-		sort.Strings(res)
-	}
-	return ix.Postings(m.Name, shard, res...)
+	return ix.PostingsForLabelMatching(m.Name, shard, m.Matches)
 }
 
 // inversePostingsForMatcher returns the postings for the series with the label name set but not matching the matcher.
 func inversePostingsForMatcher(ix IndexReader, shard *index.ShardAnnotation, m *labels.Matcher) (index.Postings, error) {
-	vals, err := ix.LabelValues(m.Name)
-	if err != nil {
-		return nil, err
-	}
-
-	var res []string
-	lastVal, isSorted := "", true
-	for _, val := range vals {
-		if !m.Matches(val) {
-			res = append(res, val)
-			if isSorted && val < lastVal {
-				isSorted = false
-			}
-			lastVal = val
-		}
-	}
-
-	if !isSorted {
-		sort.Strings(res)
-	}
-	return ix.Postings(m.Name, shard, res...)
+	return ix.PostingsForLabelMatching(m.Name, shard, func(v string) bool { return !m.Matches(v) })
 }

--- a/pkg/phlaredb/tsdb/index/index.go
+++ b/pkg/phlaredb/tsdb/index/index.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"unsafe"
 
 	"github.com/pkg/errors"
@@ -1592,9 +1593,15 @@ func (r *Reader) Checksum() uint32 {
 	return r.toc.Metadata.Checksum
 }
 
-// Symbols returns an iterator over the symbols that exist within the index.
-func (r *Reader) Symbols() StringIter {
-	return r.symbols.Iter()
+// SymbolTable returns all symbols in the index as owned strings safe to use
+// beyond the reader's lifetime.
+func (r *Reader) SymbolTable() ([]string, error) {
+	iter := r.symbols.Iter()
+	syms := make([]string, 0, r.symbols.seen)
+	for iter.Next() {
+		syms = append(syms, strings.Clone(iter.At()))
+	}
+	return syms, iter.Err()
 }
 
 // SymbolTableSize returns the symbol table size in bytes.
@@ -1602,21 +1609,7 @@ func (r *Reader) SymbolTableSize() uint64 {
 	return uint64(r.symbols.Size())
 }
 
-// SortedLabelValues returns value tuples that exist for the given label name.
-// It is not safe to use the return value beyond the lifetime of the byte slice
-// passed into the Reader.
-func (r *Reader) SortedLabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
-	values, err := r.LabelValues(name, matchers...)
-	if err == nil && r.version == FormatV1 {
-		sort.Strings(values)
-	}
-	return values, err
-}
-
 // LabelValues returns value tuples that exist for the given label name.
-// It is not safe to use the return value beyond the lifetime of the byte slice
-// passed into the Reader.
-// TODO(replay): Support filtering by matchers
 func (r *Reader) LabelValues(name string, matchers ...*labels.Matcher) ([]string, error) {
 	if len(matchers) > 0 {
 		return nil, errors.Errorf("matchers parameter is not implemented: %+v", matchers)
@@ -1629,7 +1622,9 @@ func (r *Reader) LabelValues(name string, matchers ...*labels.Matcher) ([]string
 		}
 		values := make([]string, 0, len(e))
 		for k := range e {
-			values = append(values, k)
+			// postingsV1 keys are yoloStrings aliasing the index buffer;
+			// clone so the caller owns the returned strings.
+			values = append(values, strings.Clone(k))
 		}
 		return values, nil
 
@@ -1659,7 +1654,7 @@ func (r *Reader) LabelValues(name string, matchers ...*labels.Matcher) ([]string
 		} else {
 			d.Skip(skip)
 		}
-		s := yoloString(d.UvarintBytes()) // Label value.
+		s := string(d.UvarintBytes()) // Label value — owned copy, safe beyond reader lifetime.
 		values = append(values, s)
 		if s == lastVal {
 			break
@@ -1883,6 +1878,86 @@ func (r *Reader) Postings(name string, shard *ShardAnnotation, values ...string)
 		return NewShardedPostings(merged, *shard, r.fingerprintOffsets), nil
 	}
 
+	return merged, nil
+}
+
+// PostingsForLabelMatching returns the merged postings for all values of label
+// name for which match returns true. It is equivalent to calling LabelValues
+// followed by Postings but avoids allocating an intermediate string slice and
+// never lets the label value strings escape the index buffer.
+func (r *Reader) PostingsForLabelMatching(name string, shard *ShardAnnotation, match func(string) bool) (Postings, error) {
+	if r.version == FormatV1 {
+		e, ok := r.postingsV1[name]
+		if !ok {
+			return EmptyPostings(), nil
+		}
+		var res []Postings
+		for v, off := range e {
+			if !match(v) {
+				continue
+			}
+			d := encoding.DecWrap(tsdb_enc.NewDecbufAt(r.b, int(off), castagnoliTable))
+			_, p, err := r.dec.Postings(d.Get())
+			if err != nil {
+				return nil, errors.Wrap(err, "decode postings")
+			}
+			res = append(res, p)
+		}
+		merged := Merge(res...)
+		if shard != nil {
+			return NewShardedPostings(merged, *shard, r.fingerprintOffsets), nil
+		}
+		return merged, nil
+	}
+
+	e, ok := r.postings[name]
+	if !ok {
+		return EmptyPostings(), nil
+	}
+	if len(e) == 0 {
+		return EmptyPostings(), nil
+	}
+
+	d := encoding.DecWrap(tsdb_enc.NewDecbufAt(r.b, int(r.toc.PostingsTable), nil))
+	d.Skip(e[0].off)
+	lastVal := e[len(e)-1].value
+
+	var res []Postings
+	skip := 0
+	for d.Err() == nil {
+		if skip == 0 {
+			skip = d.Len()
+			d.Uvarint()      // Keycount.
+			d.UvarintBytes() // Label name.
+			skip -= d.Len()
+		} else {
+			d.Skip(skip)
+		}
+		v := d.UvarintBytes() // Label value — zero-copy slice into buffer.
+		postingsOff := d.Uvarint64()
+		if d.Err() != nil {
+			break
+		}
+		if match(yoloString(v)) {
+			d2 := encoding.DecWrap(tsdb_enc.NewDecbufAt(r.b, int(postingsOff), castagnoliTable))
+			_, p, err := r.dec.Postings(d2.Get())
+			if err != nil {
+				return nil, errors.Wrap(err, "decode postings")
+			}
+			res = append(res, p)
+		}
+		if yoloString(v) == lastVal {
+			break
+		}
+	}
+	if d.Err() != nil {
+		return nil, errors.Wrap(d.Err(), "get postings offset entry")
+	}
+
+	merged := Merge(res...)
+	if shard != nil {
+		return NewShardedPostings(merged, *shard, r.fingerprintOffsets), nil
+	}
 	return merged, nil
 }
 

--- a/pkg/phlaredb/tsdb/index/index.go
+++ b/pkg/phlaredb/tsdb/index/index.go
@@ -1885,7 +1885,7 @@ func (r *Reader) Postings(name string, shard *ShardAnnotation, values ...string)
 // name for which match returns true. It is equivalent to calling LabelValues
 // followed by Postings but avoids allocating an intermediate string slice and
 // never lets the label value strings escape the index buffer.
-func (r *Reader) PostingsForLabelMatching(name string, shard *ShardAnnotation, match func(string) bool) (Postings, error) {
+func (r *Reader) PostingsForLabelMatching(name string, shard *ShardAnnotation, match func(YoloString) bool) (Postings, error) {
 	if r.version == FormatV1 {
 		e, ok := r.postingsV1[name]
 		if !ok {
@@ -1893,7 +1893,7 @@ func (r *Reader) PostingsForLabelMatching(name string, shard *ShardAnnotation, m
 		}
 		var res []Postings
 		for v, off := range e {
-			if !match(v) {
+			if !match(YoloString{String: v}) {
 				continue
 			}
 			d := encoding.DecWrap(tsdb_enc.NewDecbufAt(r.b, int(off), castagnoliTable))
@@ -1938,7 +1938,7 @@ func (r *Reader) PostingsForLabelMatching(name string, shard *ShardAnnotation, m
 		if d.Err() != nil {
 			break
 		}
-		if match(yoloString(v)) {
+		if match(YoloString{String: yoloString(v)}) {
 			d2 := encoding.DecWrap(tsdb_enc.NewDecbufAt(r.b, int(postingsOff), castagnoliTable))
 			_, p, err := r.dec.Postings(d2.Get())
 			if err != nil {
@@ -2155,6 +2155,10 @@ func (dec *Decoder) Series(b []byte, lbls *phlaremodel.Labels, chks *[]ChunkMeta
 	}
 	return fprint, d.Err()
 }
+
+// YoloString is a string that aliases the index buffer and is only valid for
+// the duration of the call that produced it. Never store or escape it.
+type YoloString struct{ String string }
 
 func yoloString(b []byte) string {
 	return *((*string)(unsafe.Pointer(&b)))

--- a/pkg/phlaredb/tsdb/index/index_test.go
+++ b/pkg/phlaredb/tsdb/index/index_test.go
@@ -479,8 +479,9 @@ func TestPersistence_index_e2e(t *testing.T) {
 	for k, v := range labelPairs {
 		sort.Strings(v)
 
-		res, err := ir.SortedLabelValues(k)
+		res, err := ir.LabelValues(k)
 		require.NoError(t, err)
+		sort.Strings(res)
 
 		require.Equal(t, len(v), len(res))
 		for i := 0; i < len(v); i++ {
@@ -488,12 +489,9 @@ func TestPersistence_index_e2e(t *testing.T) {
 		}
 	}
 
-	gotSymbols := []string{}
-	it := ir.Symbols()
-	for it.Next() {
-		gotSymbols = append(gotSymbols, it.At())
-	}
-	require.NoError(t, it.Err())
+	gotSymbols, err := ir.SymbolTable()
+	require.NoError(t, err)
+	sort.Strings(gotSymbols)
 	expSymbols := []string{}
 	for s := range mi.symbols {
 		expSymbols = append(expSymbols, s)

--- a/pkg/querybackend/query_label_values.go
+++ b/pkg/querybackend/query_label_values.go
@@ -3,7 +3,6 @@ package querybackend
 import (
 	"errors"
 	"sort"
-	"strings"
 	"sync"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -31,15 +30,6 @@ func queryLabelValues(q *queryContext, query *queryv1.Query) (*queryv1.Report, e
 	var err error
 	if len(q.req.matchers) == 0 {
 		values, err = q.ds.Index().LabelValues(query.LabelValues.LabelName)
-		// Reader.LabelValues returns strings that alias the underlying
-		// index buffer ("It is not safe to use the return value beyond
-		// the lifetime of the byte slice passed into the Reader"). The
-		// dataset's buffer is recycled to a pool on close, which may
-		// happen before the staged report is marshaled, so we clone the
-		// values here to decouple them from the buffer lifetime.
-		for i, v := range values {
-			values[i] = strings.Clone(v)
-		}
 	} else {
 		values, err = labelValuesForMatchers(q.ds.Index(), query.LabelValues.LabelName, q.req.matchers)
 	}

--- a/pkg/segmentwriter/memdb/index/index_test.go
+++ b/pkg/segmentwriter/memdb/index/index_test.go
@@ -444,8 +444,9 @@ func TestPersistence_index_e2e(t *testing.T) {
 	for k, v := range labelPairs {
 		sort.Strings(v)
 
-		res, err := ir.SortedLabelValues(k)
+		res, err := ir.LabelValues(k)
 		require.NoError(t, err)
+		sort.Strings(res)
 
 		require.Equal(t, len(v), len(res))
 		for i := 0; i < len(v); i++ {
@@ -453,12 +454,9 @@ func TestPersistence_index_e2e(t *testing.T) {
 		}
 	}
 
-	gotSymbols := []string{}
-	it := ir.Symbols()
-	for it.Next() {
-		gotSymbols = append(gotSymbols, it.At())
-	}
-	require.NoError(t, it.Err())
+	gotSymbols, err := ir.SymbolTable()
+	require.NoError(t, err)
+	sort.Strings(gotSymbols)
 	expSymbols := []string{}
 	for s := range mi.symbols {
 		expSymbols = append(expSymbols, s)


### PR DESCRIPTION
## Summary

Make `tsdb/index.Reader`'s public API safe by default, so callers no longer
need to clone returned strings to avoid buffer reuse-after-free (the bug
fixed reactively in #5116).

- `LabelValues`: clones before returning
- Replace `Symbols() StringIter` with `SymbolTable() ([]string, error)` —
  pre-sized, owned slice
- Add `PostingsForLabelMatching(name, shard, match func(string) bool)` —
  matches via a transient yoloString, avoiding the intermediate `[]string`
  in `postingsForMatcher` / `inversePostingsForMatcher`
- Drop `SortedLabelValues` (unused); drop the now-redundant `strings.Clone`
  loop in `query_label_values.go`; switch `dataset_handlers.go` to
  `SymbolTable` (also fixes a latent use-after-free where `defer ds.Close()`
  fired before marshaling)

## Test plan

- [ ] `make go/test` and `make lint` pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core TSDB index reader/query paths by changing public interfaces and postings selection logic; mistakes could impact query correctness or performance, though changes are largely API-safety focused.
> 
> **Overview**
> Makes `tsdb/index.Reader`’s public API *safe by default* by ensuring returned label values and symbols are owned strings (no longer aliasing the underlying index buffer).
> 
> Replaces `Symbols()` with `SymbolTable()` and removes `SortedLabelValues()`, updating callers/tests accordingly, including `dataset_handlers.go` and `query_label_values.go` (dropping now-unnecessary `strings.Clone` in query results).
> 
> Adds `PostingsForLabelMatching()` to the `IndexReader` interface and switches matcher-based postings resolution in `phlaredb/querier.go` to use it, avoiding allocating/filtering intermediate `[]string` label value lists while keeping buffer-aliasing confined to the callback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16e23190b7201db93e7574d4d4516e28925eb7b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->