### PR TITLE
test(phlaredb): drain bidi streams instead of cancelling mid-flight

### DIFF
--- a/pkg/phlaredb/phlaredb_test.go
+++ b/pkg/phlaredb/phlaredb_test.go
@@ -521,31 +521,47 @@ func Test_QueryNotInitializedHead(t *testing.T) {
 	})
 
 	t.Run("MergeProfilesLabels", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(ctx)
 		bidi := client.MergeProfilesLabels(ctx)
 		require.NoError(t, bidi.Send(&ingestv1.MergeProfilesLabelsRequest{
 			Request: &ingestv1.SelectProfilesRequest{},
 		}))
-		cancel()
+		closeBidi(t, bidi)
 	})
 
 	t.Run("MergeProfilesStacktraces", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(ctx)
 		bidi := client.MergeProfilesStacktraces(ctx)
 		require.NoError(t, bidi.Send(&ingestv1.MergeProfilesStacktracesRequest{
 			Request: &ingestv1.SelectProfilesRequest{},
 		}))
-		cancel()
+		closeBidi(t, bidi)
 	})
 
 	t.Run("MergeProfilesPprof", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(ctx)
 		bidi := client.MergeProfilesPprof(ctx)
 		require.NoError(t, bidi.Send(&ingestv1.MergeProfilesPprofRequest{
 			Request: &ingestv1.SelectProfilesRequest{},
 		}))
-		cancel()
+		closeBidi(t, bidi)
 	})
+}
+
+// closeBidi gracefully shuts down a connect bidi stream by signalling
+// end-of-send and draining the response side until EOF.
+//
+// We can't just cancel the context: under -race on Go 1.25 that triggers
+// a data race inside net/http. The HTTP/2 stream reset spawns a goroutine
+// that calls (*readTrackingBody).Close() while the original roundTrip
+// goroutine is still reading the same struct (transport.go:725 vs :765).
+// Closing the stream on the normal codepath avoids the reset entirely.
+func closeBidi[Req, Res any](t *testing.T, bidi *connect.BidiStreamForClient[Req, Res]) {
+	t.Helper()
+	require.NoError(t, bidi.CloseRequest())
+	for {
+		if _, err := bidi.Receive(); err != nil {
+			break
+		}
+	}
+	require.NoError(t, bidi.CloseResponse())
 }
 
 func Test_FlushNotInitializedHead(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes a race condition in `Test_QueryNotInitializedHead` bidi subtests under `-race` on Go 1.25
- Extracts a `closeBidi` helper that signals end-of-send and drains the response side, avoiding the HTTP/2 reset path that races inside `net/http`
- The test's original intent (queries on an uninitialized head don't panic) is preserved

## Test plan

- [ ] Run `go test -race ./pkg/phlaredb/...` to verify no race detector hits

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that adjust bidi stream shutdown semantics to avoid a Go 1.25 `-race` issue, with no production code paths affected.
> 
> **Overview**
> Updates `Test_QueryNotInitializedHead` bidi subtests to stop cancelling the request context mid-stream and instead **gracefully close** the Connect bidi streams.
> 
> Adds a generic `closeBidi` helper that calls `CloseRequest()`, drains `Receive()` until EOF, then `CloseResponse()`, avoiding the HTTP/2 reset path that was triggering `-race` failures on Go 1.25.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3444c96aa0f91e1ac670372b0eb38642aac71e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->