### PR TITLE
perf(tsdb/index): allocation-free postings offset table scan

### DIFF
--- a/pkg/phlaredb/tsdb/index/index.go
+++ b/pkg/phlaredb/tsdb/index/index.go
@@ -589,7 +589,7 @@ func (w *Writer) finishSymbols() error {
 
 	hashPos := w.f.pos
 	// Leave space for the hash. We can only calculate it
-	// now that the number of symbols is known, so mmap and do it from there.
+	// now that the number of symbols is known, so seek back and write it.
 	if err := w.write([]byte("hash")); err != nil {
 		return err
 	}
@@ -1249,8 +1249,8 @@ func newReader(b ByteSlice, c io.Closer) (*Reader, error) {
 		return nil, errors.Wrap(err, "read symbols")
 	}
 
-	// lastNameB/lastValueB alias the mmap buffer and are only converted to
-	// owned strings if the entry turns out to be the final one for its label.
+	// lastNameB/lastValueB alias the underlying buffer and are only converted
+	// to owned strings if the entry turns out to be the final one for its label.
 	var lastNameB, lastValueB []byte
 	lastOff := 0
 	valueCount := 0

--- a/pkg/phlaredb/tsdb/index/index.go
+++ b/pkg/phlaredb/tsdb/index/index.go
@@ -1249,30 +1249,35 @@ func newReader(b ByteSlice, c io.Closer) (*Reader, error) {
 		return nil, errors.Wrap(err, "read symbols")
 	}
 
-	var lastKey []string
+	// lastNameB/lastValueB alias the mmap buffer and are only converted to
+	// owned strings if the entry turns out to be the final one for its label.
+	var lastNameB, lastValueB []byte
 	lastOff := 0
 	valueCount := 0
 	// For the postings offset table we keep every label name but only every nth
 	// label value (plus the first and last one), to save memory.
-	if err := ReadOffsetTable(r.b, r.toc.PostingsTable, func(key []string, _ uint64, off int) error {
-		if len(key) != 2 {
-			return errors.Errorf("unexpected key length for posting table %d", len(key))
-		}
-		if _, ok := r.postings[key[0]]; !ok {
-			// Next label name.
-			r.postings[key[0]] = []postingOffset{}
-			if lastKey != nil {
-				// Always include last value for each label name.
-				r.postings[lastKey[0]] = append(r.postings[lastKey[0]], postingOffset{value: lastKey[1], off: lastOff})
+	if err := readPostingsOffsetTable(r.b, r.toc.PostingsTable, func(name, value []byte, _ uint64, off int) error {
+		// yoloString aliases the buffer — safe for map lookup (no allocation).
+		if _, ok := r.postings[yoloString(name)]; !ok {
+			// First entry for a new label name: flush the deferred "last" entry
+			// from the previous label, then allocate an owned key string.
+			if lastNameB != nil {
+				ln := string(lastNameB)
+				r.postings[ln] = append(r.postings[ln], postingOffset{value: string(lastValueB), off: lastOff})
 			}
-			lastKey = nil
+			lastNameB = nil
 			valueCount = 0
+			r.postings[string(name)] = []postingOffset{}
 		}
 		if valueCount%symbolFactor == 0 {
-			r.postings[key[0]] = append(r.postings[key[0]], postingOffset{value: key[1], off: off})
-			lastKey = nil
+			// Sampled entry: allocate owned strings only for what we keep.
+			ln := string(name)
+			r.postings[ln] = append(r.postings[ln], postingOffset{value: string(value), off: off})
+			lastNameB = nil
 		} else {
-			lastKey = key
+			// Discard this entry for now; remember it as a candidate "last".
+			lastNameB = name
+			lastValueB = value
 			lastOff = off
 		}
 		valueCount++
@@ -1280,8 +1285,9 @@ func newReader(b ByteSlice, c io.Closer) (*Reader, error) {
 	}); err != nil {
 		return nil, errors.Wrap(err, "read postings table")
 	}
-	if lastKey != nil {
-		r.postings[lastKey[0]] = append(r.postings[lastKey[0]], postingOffset{value: lastKey[1], off: lastOff})
+	if lastNameB != nil {
+		ln := string(lastNameB)
+		r.postings[ln] = append(r.postings[ln], postingOffset{value: string(lastValueB), off: lastOff})
 	}
 	// Trim any extra space in the slices.
 	for k, v := range r.postings {
@@ -1346,15 +1352,12 @@ type Range struct {
 // for all postings lists.
 func (r *Reader) PostingsRanges() (map[labels.Label]Range, error) {
 	m := map[labels.Label]Range{}
-	if err := ReadOffsetTable(r.b, r.toc.PostingsTable, func(key []string, off uint64, _ int) error {
-		if len(key) != 2 {
-			return errors.Errorf("unexpected key length for posting table %d", len(key))
-		}
+	if err := readPostingsOffsetTable(r.b, r.toc.PostingsTable, func(name, value []byte, off uint64, _ int) error {
 		d := encoding.DecWrap(tsdb_enc.NewDecbufAt(r.b, int(off), castagnoliTable))
 		if d.Err() != nil {
 			return d.Err()
 		}
-		m[labels.Label{Name: key[0], Value: key[1]}] = Range{
+		m[labels.Label{Name: string(name), Value: string(value)}] = Range{
 			Start: int64(off) + 4,
 			End:   int64(off) + 4 + int64(d.Len()),
 		}
@@ -1496,29 +1499,27 @@ func (s *symbolsIter) Next() bool {
 func (s symbolsIter) At() string { return s.cur }
 func (s symbolsIter) Err() error { return s.err }
 
-// ReadOffsetTable reads an offset table and at the given position calls f for each
-// found entry. If f returns an error it stops decoding and returns the received error.
-func ReadOffsetTable(bs ByteSlice, off uint64, f func([]string, uint64, int) error) error {
+// readPostingsOffsetTable reads the postings offset table at off and calls f for
+// every entry. The name and value byte slices passed to f alias the underlying
+// buffer (no per-entry allocation); convert with string(...) if you need to
+// retain them. labelOffset is the position of the entry within the table.
+func readPostingsOffsetTable(bs ByteSlice, off uint64, f func(name, value []byte, postingsOffset uint64, labelOffset int) error) error {
 	d := encoding.DecWrap(tsdb_enc.NewDecbufAt(bs, int(off), castagnoliTable))
 	startLen := d.Len()
 	cnt := d.Be32()
 
 	for d.Err() == nil && d.Len() > 0 && cnt > 0 {
 		offsetPos := startLen - d.Len()
-		keyCount := d.Uvarint()
-		// The Postings offset table takes only 2 keys per entry (name and value of label),
-		// and the LabelIndices offset table takes only 1 key per entry (a label name).
-		// Hence setting the size to max of both, i.e. 2.
-		keys := make([]string, 0, 2)
-
-		for i := 0; i < keyCount; i++ {
-			keys = append(keys, d.UvarintStr())
+		if keyCount := d.Uvarint(); keyCount != 2 {
+			return errors.Errorf("unexpected number of keys for postings offset table %d", keyCount)
 		}
+		name := d.UvarintBytes()
+		value := d.UvarintBytes()
 		o := d.Uvarint64()
 		if d.Err() != nil {
 			break
 		}
-		if err := f(keys, o, offsetPos); err != nil {
+		if err := f(name, value, o, offsetPos); err != nil {
 			return err
 		}
 		cnt--

--- a/pkg/phlaredb/tsdb/index/index_test.go
+++ b/pkg/phlaredb/tsdb/index/index_test.go
@@ -227,27 +227,32 @@ func TestIndexRW_Postings(t *testing.T) {
 
 	// The label indices are no longer used, so test them by hand here.
 	labelIndices := map[string][]string{}
-	require.NoError(t, ReadOffsetTable(ir.b, ir.toc.LabelIndicesTable, func(key []string, off uint64, _ int) error {
-		if len(key) != 1 {
-			return errors.Errorf("unexpected key length for label indices table %d", len(key))
-		}
-
-		d := encoding.NewDecbufAt(ir.b, int(off), castagnoliTable)
-		vals := []string{}
-		nc := d.Be32int()
-		if nc != 1 {
-			return errors.Errorf("unexpected number of label indices table names %d", nc)
-		}
-		for i := d.Be32(); i > 0; i-- {
-			v, err := ir.lookupSymbol(d.Be32())
-			if err != nil {
-				return err
+	{
+		d := encoding.NewDecbufAt(ir.b, int(ir.toc.LabelIndicesTable), castagnoliTable)
+		cnt := d.Be32()
+		for d.Err() == nil && d.Len() > 0 && cnt > 0 {
+			if keyCount := d.Uvarint(); keyCount != 1 {
+				require.Failf(t, "label indices table", "unexpected key count %d", keyCount)
 			}
-			vals = append(vals, v)
+			name := string(d.UvarintBytes())
+			off := d.Uvarint64()
+			require.NoError(t, d.Err())
+
+			d2 := encoding.NewDecbufAt(ir.b, int(off), castagnoliTable)
+			vals := []string{}
+			nc := d2.Be32int()
+			require.Equal(t, 1, nc, "unexpected number of label indices table names")
+			for i := d2.Be32(); i > 0; i-- {
+				v, err := ir.lookupSymbol(d2.Be32())
+				require.NoError(t, err)
+				vals = append(vals, v)
+			}
+			require.NoError(t, d2.Err())
+			labelIndices[name] = vals
+			cnt--
 		}
-		labelIndices[key[0]] = vals
-		return d.Err()
-	}))
+		require.NoError(t, d.Err())
+	}
 	require.Equal(t, map[string][]string{
 		"a": {"1"},
 		"b": {"1", "2", "3", "4"},
@@ -581,6 +586,68 @@ func TestSymbols(t *testing.T) {
 func TestDecoder_Postings_WrongInput(t *testing.T) {
 	_, _, err := (&Decoder{}).Postings([]byte("the cake is a lie"))
 	require.Error(t, err)
+}
+
+// BenchmarkNewReader measures the cost of opening an index file, dominated by
+// the postings-offset-table scan in newReader. The fixture uses several label
+// names with > symbolFactor (32) values each so the sampling logic is exercised.
+func BenchmarkNewReader(b *testing.B) {
+	dir := b.TempDir()
+	fn := filepath.Join(dir, IndexFilename)
+
+	iw, err := NewWriter(context.Background(), fn)
+	require.NoError(b, err)
+
+	const (
+		numNames   = 10
+		numValues  = 200
+		numSeries  = numNames * numValues
+		nameFormat = "label_%02d"
+		valFormat  = "value_%04d"
+	)
+
+	symbolSet := map[string]struct{}{}
+	for n := 0; n < numNames; n++ {
+		symbolSet[fmt.Sprintf(nameFormat, n)] = struct{}{}
+	}
+	for v := 0; v < numValues; v++ {
+		symbolSet[fmt.Sprintf(valFormat, v)] = struct{}{}
+	}
+	syms := make([]string, 0, len(symbolSet))
+	for s := range symbolSet {
+		syms = append(syms, s)
+	}
+	sort.Strings(syms)
+	for _, s := range syms {
+		require.NoError(b, iw.AddSymbol(s))
+	}
+
+	series := make([]phlaremodel.Labels, 0, numSeries)
+	for n := 0; n < numNames; n++ {
+		name := fmt.Sprintf(nameFormat, n)
+		for v := 0; v < numValues; v++ {
+			series = append(series, phlaremodel.LabelsFromStrings(name, fmt.Sprintf(valFormat, v)))
+		}
+	}
+	sort.Slice(series, func(i, j int) bool {
+		return series[i].Hash() < series[j].Hash()
+	})
+	for i, s := range series {
+		require.NoError(b, iw.AddSeries(storage.SeriesRef(i), s, model.Fingerprint(s.Hash())))
+	}
+	require.NoError(b, iw.Close())
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		r, err := NewFileReader(fn)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := r.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
 }
 
 func TestWriter_ShouldReturnErrorOnSeriesWithDuplicatedLabelNames(t *testing.T) {


### PR DESCRIPTION
## Summary

`newReader` spent ~96% of its allocations inside `ReadOffsetTable`: every entry materialised a `[]string` plus two string clones for name and value, even for the ~31/32 entries that symbolFactor sampling immediately discards.

This PR introduces `readPostingsOffsetTable`, a sibling of `ReadOffsetTable` that yields `(name, value []byte)` slices aliasing the mmap buffer instead of allocating strings. The `newReader` callback:

- uses `yoloString` for map lookups (zero allocation),
- defers `string(name)` / `string(value)` conversion until an entry is actually retained, and
- tracks the "last value" candidate as raw byte-slice aliases, cloning only at flush time.

## Impact

This path represents 66% of the allocation counts in query-backends (and a very small amount of compaction workers)

<img width="1711" height="384" alt="image" src="https://github.com/user-attachments/assets/fa6fc25e-e0f4-4a3f-bc37-1b852cfd6d97" />




## Benchmark

`BenchmarkNewReader` with 10 label names × 200 values each:

```
             │      sec/op       │      sec/op      vs base  │
NewReader-12      305.1µ ± 1%       124.2µ ± 1%    -59.30%

             │       B/op        │       B/op       vs base  │
NewReader-12      270.7Ki ± 0%      169.8Ki ± 0%   -37.30%

             │     allocs/op     │   allocs/op    vs base    │
NewReader-12       6075.0 ± 0%       244.0 ± 0%   -95.98%
```

Allocation count drops from 6 075 → 244 (−96%), wall time from 305 µs → 124 µs (−59%).

## Notes

- `readPostingsOffsetTable` is unexported and used only by `newReader` and `PostingsRanges`.
- This builds on #5158 (FormatV1 reader support removed), which clears away the V1 branch that previously shared `ReadOffsetTable`.
- Inspired by the newer version of Prometheus code base: https://github.com/prometheus/prometheus/blob/43e5fc6a248c1a73d30dff86428f74d11aedbedc/tsdb/index/index.go#L1297-L1302

## Test plan

- [ ] `go test ./pkg/phlaredb/tsdb/index/... -run . -bench BenchmarkNewReader` passes and shows regression-free numbers
- [ ] Existing index reader tests (`TestNewReader`, table-driven cases) pass unchanged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches TSDB index reading/parsing and introduces more buffer-aliasing (`[]byte`/`yoloString`) to avoid allocations, which could cause subtle lifetime/aliasing bugs if misused despite being localized and covered by tests/bench.
> 
> **Overview**
> Reduces `NewReader` startup allocations/time by replacing the generic `ReadOffsetTable` postings scan with an allocation-free `readPostingsOffsetTable` that returns `(name, value []byte)` slices aliasing the index buffer, and only materializes `string` values for sampled/required entries (including correct handling of the per-label “last value” entry).
> 
> Updates `PostingsRanges` to use the new postings-table iterator, adjusts the label-indices test to decode the table directly, and adds `BenchmarkNewReader` to track open-index performance/regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e07c1e058ce94d818a9a6de5e15a89e4c7f135bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->