### PR TITLE
helm: default to v2 storage architecture, bump chart to 2.0.1

### DIFF
--- a/operations/pyroscope/helm/pyroscope/Chart.yaml
+++ b/operations/pyroscope/helm/pyroscope/Chart.yaml
@@ -3,8 +3,8 @@ name: pyroscope
 description: horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 home: https://grafana.com/oss/pyroscope/
 type: application
-version: 2.0.1
-appVersion: 2.0.1
+version: 2.0.2
+appVersion: 2.0.2
 dependencies:
   - name: grafana-agent
     alias: agent

--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -1,6 +1,6 @@
 # pyroscope
 
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
+![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.2](https://img.shields.io/badge/AppVersion-2.0.2-informational?style=flat-square)
 
 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 
@@ -32,8 +32,8 @@ horizontally-scalable, highly-available, multi-tenant continuous profiling aggre
 | architecture.storage.migration.ingesterWeight | float | `1` | Specifies the fraction [0:1] that should be send to the v1 write path / ingester in combined mode. 0 means no traffics is sent to ingester. 1 means 100% of requests are sent to ingester. |
 | architecture.storage.migration.queryBackendFrom | string | `"auto"` | Specify a time stamp from when the v2 read path should serve traffic. Defaults to "auto" which determines the split point from the metastore. |
 | architecture.storage.migration.segmentWriterWeight | float | `1` | Specifies the fraction [0:1] that should be send to the v2 write path / segment-writer in combined mode. 0 means no traffics is sent to segment-writer. 1 means 100% of requests are sent to segment-writer. |
-| architecture.storage.v1 | bool | `true` | Enable v1 storage layer. |
-| architecture.storage.v2 | bool | `false` | Enable v2 storage layer. |
+| architecture.storage.v1 | bool | `false` | Enable v1 storage layer. |
+| architecture.storage.v2 | bool | `true` | Enable v2 storage layer. |
 | extraObjects | list | `[]` | Array of extra K8s manifests to deploy alongside the chart |
 | global.imageRegistry | string | `nil` | Overrides the Docker registry globally for all images |
 | httpRoute.annotations | object | `{}` | Additional annotations to add to HTTPRoute resource. |

--- a/operations/pyroscope/helm/pyroscope/ci/micro-services-values.yaml
+++ b/operations/pyroscope/helm/pyroscope/ci/micro-services-values.yaml
@@ -2,17 +2,12 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+architecture:
+  microservices:
+    enabled: true
+
 pyroscope:
   components:
-    querier:
-      kind: Deployment
-      replicaCount: 3
-      resources:
-        limits:
-          memory: 1Gi
-        requests:
-          memory: 32Mi
-          cpu: 10m
     query-frontend:
       kind: Deployment
       replicaCount: 2
@@ -22,7 +17,7 @@ pyroscope:
         requests:
           memory: 32Mi
           cpu: 10m
-    query-scheduler:
+    query-backend:
       kind: Deployment
       replicaCount: 2
       resources:
@@ -40,7 +35,7 @@ pyroscope:
         requests:
           memory: 32Mi
           cpu: 50m
-    ingester:
+    segment-writer:
       kind: StatefulSet
       replicaCount: 3
       resources:
@@ -49,19 +44,6 @@ pyroscope:
         requests:
           memory: 256Mi
           cpu: 100m
-    store-gateway:
-      kind: StatefulSet
-      replicaCount: 3
-      persistence:
-      # The store-gateway needs not need persistent storage, but we still run it as a StatefulSet
-      # This is to avoid having blocks of data being
-        enabled: false
-      resources:
-        limits:
-          memory: 4Gi
-        requests:
-          memory: 64Mi
-          cpu: 20m
       initContainers:
         - name: create-bucket
           image: minio/mc:RELEASE.2025-04-08T15-39-49Z
@@ -83,6 +65,24 @@ pyroscope:
                   fieldPath: metadata.namespace
             - name: MINIO_ENDPOINT
               value: $(POD_NAMESPACE)-minio
+    metastore:
+      kind: StatefulSet
+      replicaCount: 3
+      resources:
+        limits:
+          memory: 1Gi
+        requests:
+          memory: 64Mi
+          cpu: 10m
+    compaction-worker:
+      kind: StatefulSet
+      replicaCount: 3
+      resources:
+        limits:
+          memory: 1Gi
+        requests:
+          memory: 64Mi
+          cpu: 10m
 
 minio:
   enabled: true

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -27,10 +27,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -48,10 +48,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -69,10 +69,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -90,10 +90,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -111,10 +111,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -132,10 +132,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -176,10 +176,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -523,10 +523,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1381,10 +1381,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1398,10 +1398,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1550,6 +1550,51 @@ subjects:
     name: pyroscope-dev-alloy
     namespace: default
 ---
+# Source: pyroscope/templates/rbac-discovery.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pyroscope-dev-discovery
+  labels:
+    helm.sh/chart: pyroscope-2.0.2
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  - endpoints
+  - services
+  - pods
+  verbs:
+  - get
+  - watch
+  - list
+---
+# Source: pyroscope/templates/rbac-discovery.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pyroscope-dev-discovery
+  labels:
+    helm.sh/chart: pyroscope-2.0.2
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pyroscope-dev-discovery
+subjects:
+- kind: ServiceAccount
+  name: pyroscope-dev
+  namespace: default
+---
 # Source: pyroscope/charts/alloy/templates/cluster_service.yaml
 apiVersion: v1
 kind: Service
@@ -1683,10 +1728,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1710,10 +1755,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1723,6 +1768,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1735,10 +1784,10 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1749,6 +1798,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1761,10 +1814,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1774,6 +1827,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1786,10 +1843,10 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1800,6 +1857,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1812,10 +1873,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1825,6 +1886,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1837,10 +1902,10 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1851,6 +1916,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1863,10 +1932,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1876,6 +1945,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1888,10 +1961,10 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1902,6 +1975,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1914,10 +1991,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -1927,6 +2004,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1939,10 +2020,10 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -1953,6 +2034,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1965,10 +2050,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -1978,6 +2063,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1990,10 +2079,10 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2004,6 +2093,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2016,10 +2109,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2029,6 +2122,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2041,10 +2138,10 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2055,6 +2152,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2067,10 +2168,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2082,9 +2183,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2107,7 +2208,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2119,8 +2220,9 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2128,12 +2230,17 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -2171,10 +2278,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2186,9 +2293,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2211,7 +2318,7 @@ spec:
         - name: "querier"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -2223,8 +2330,9 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2232,12 +2340,17 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -2275,10 +2388,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2290,9 +2403,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2315,7 +2428,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2327,8 +2440,9 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2336,12 +2450,17 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -2379,10 +2498,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2394,9 +2513,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2419,7 +2538,7 @@ spec:
         - name: "query-scheduler"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-scheduler"
@@ -2431,8 +2550,9 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2440,12 +2560,17 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -2483,10 +2608,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2511,10 +2636,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2542,10 +2667,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2570,10 +2695,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2781,10 +2906,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -2799,9 +2924,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2824,7 +2949,7 @@ spec:
         - name: "compactor"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -2836,8 +2961,9 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2845,12 +2971,17 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -2893,10 +3024,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -2911,9 +3042,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2936,7 +3067,7 @@ spec:
         - name: "ingester"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -2948,8 +3079,9 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2957,12 +3089,17 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -3001,10 +3138,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -3019,9 +3156,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3044,7 +3181,7 @@ spec:
         - name: "store-gateway"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"
@@ -3056,8 +3193,9 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3065,12 +3203,17 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -27,10 +27,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -48,10 +48,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -69,10 +69,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -90,10 +90,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -111,10 +111,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -132,10 +132,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -153,10 +153,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -174,10 +174,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -218,10 +218,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -565,10 +565,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1423,10 +1423,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1440,10 +1440,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1592,6 +1592,51 @@ subjects:
     name: pyroscope-dev-alloy
     namespace: default
 ---
+# Source: pyroscope/templates/rbac-discovery.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pyroscope-dev-discovery
+  labels:
+    helm.sh/chart: pyroscope-2.0.2
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  - endpoints
+  - services
+  - pods
+  verbs:
+  - get
+  - watch
+  - list
+---
+# Source: pyroscope/templates/rbac-discovery.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pyroscope-dev-discovery
+  labels:
+    helm.sh/chart: pyroscope-2.0.2
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pyroscope-dev-discovery
+subjects:
+- kind: ServiceAccount
+  name: pyroscope-dev
+  namespace: default
+---
 # Source: pyroscope/charts/alloy/templates/cluster_service.yaml
 apiVersion: v1
 kind: Service
@@ -1725,10 +1770,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1752,10 +1797,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1765,6 +1810,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1777,10 +1826,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1791,6 +1840,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1803,10 +1856,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1816,6 +1869,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1828,10 +1885,10 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1842,6 +1899,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1854,10 +1915,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1867,6 +1928,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1879,10 +1944,10 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1893,6 +1958,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1905,10 +1974,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1918,6 +1987,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1930,10 +2003,10 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1944,6 +2017,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1956,10 +2033,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1969,6 +2046,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1981,10 +2062,10 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1995,6 +2076,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2007,10 +2092,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2020,6 +2105,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2032,10 +2121,10 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2046,6 +2135,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2058,10 +2151,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2071,6 +2164,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2083,10 +2180,10 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2097,6 +2194,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2109,10 +2210,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2122,6 +2223,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2134,10 +2239,10 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2148,6 +2253,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2160,10 +2269,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2173,6 +2282,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2185,10 +2298,10 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2199,6 +2312,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2211,10 +2328,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -2227,9 +2344,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2252,7 +2369,7 @@ spec:
         - name: "ad-hoc-profiles"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ad-hoc-profiles"
@@ -2264,8 +2381,9 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2273,12 +2391,17 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -2316,10 +2439,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2332,9 +2455,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2357,7 +2480,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2369,8 +2492,9 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2378,12 +2502,17 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -2421,10 +2550,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2437,9 +2566,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2462,7 +2591,7 @@ spec:
         - name: "querier"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -2474,8 +2603,9 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2483,12 +2613,17 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -2526,10 +2661,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2542,9 +2677,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2567,7 +2702,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2579,8 +2714,9 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2588,12 +2724,17 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -2631,10 +2772,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2647,9 +2788,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2672,7 +2813,7 @@ spec:
         - name: "query-scheduler"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-scheduler"
@@ -2684,8 +2825,9 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2693,12 +2835,17 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -2736,10 +2883,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2752,9 +2899,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2777,7 +2924,7 @@ spec:
         - name: "tenant-settings"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tenant-settings"
@@ -2789,8 +2936,9 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2798,12 +2946,17 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -3024,10 +3177,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -3042,9 +3195,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3067,7 +3220,7 @@ spec:
         - name: "compactor"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -3079,8 +3232,9 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3088,12 +3242,17 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -3136,10 +3295,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -3154,9 +3313,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3179,7 +3338,7 @@ spec:
         - name: "ingester"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -3191,8 +3350,9 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3200,12 +3360,17 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -3244,10 +3409,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -3262,9 +3427,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3287,7 +3452,7 @@ spec:
         - name: "store-gateway"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"
@@ -3299,8 +3464,9 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3308,12 +3474,17 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -27,10 +27,10 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -48,10 +48,10 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -69,10 +69,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -90,10 +90,10 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -111,10 +111,10 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -132,10 +132,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -153,10 +153,10 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -174,10 +174,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -218,10 +218,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -565,10 +565,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1423,10 +1423,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1440,10 +1440,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1598,10 +1598,10 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -1623,10 +1623,10 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1770,10 +1770,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1797,10 +1797,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1826,10 +1826,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1856,10 +1856,10 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -1885,10 +1885,10 @@ metadata:
   name: pyroscope-dev-admin-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -1915,10 +1915,10 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -1944,10 +1944,10 @@ metadata:
   name: pyroscope-dev-compaction-worker-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -1974,10 +1974,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2003,10 +2003,10 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2033,10 +2033,10 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -2066,10 +2066,10 @@ metadata:
   name: pyroscope-dev-metastore-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -2101,10 +2101,10 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2130,10 +2130,10 @@ metadata:
   name: pyroscope-dev-query-backend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2160,10 +2160,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2189,10 +2189,10 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2219,10 +2219,10 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -2248,10 +2248,10 @@ metadata:
   name: pyroscope-dev-segment-writer-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -2278,10 +2278,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2307,10 +2307,10 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2337,10 +2337,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -2353,9 +2353,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2378,7 +2378,7 @@ spec:
         - name: "ad-hoc-profiles"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ad-hoc-profiles"
@@ -2447,10 +2447,10 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -2463,9 +2463,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2488,7 +2488,7 @@ spec:
         - name: "admin"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=admin"
@@ -2557,10 +2557,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2573,9 +2573,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2598,7 +2598,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2667,10 +2667,10 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2683,9 +2683,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2708,7 +2708,7 @@ spec:
         - name: "query-backend"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-backend"
@@ -2777,10 +2777,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2793,9 +2793,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2818,7 +2818,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2887,10 +2887,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2903,9 +2903,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2928,7 +2928,7 @@ spec:
         - name: "tenant-settings"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tenant-settings"
@@ -3180,10 +3180,10 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -3198,9 +3198,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3223,7 +3223,7 @@ spec:
         - name: "compaction-worker"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compaction-worker"
@@ -3293,10 +3293,10 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -3311,9 +3311,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3336,7 +3336,7 @@ spec:
         - name: "metastore"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=metastore"
@@ -3422,10 +3422,10 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -3440,9 +3440,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3465,7 +3465,7 @@ spec:
         - name: "segment-writer"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=segment-writer"

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -24,22 +24,43 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: pyroscope-dev-compactor
+  name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "compactor"
+    app.kubernetes.io/component: "admin"
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: pyroscope
       app.kubernetes.io/instance: pyroscope-dev
-      app.kubernetes.io/component: "compactor"
+      app.kubernetes.io/component: "admin"
+---
+# Source: pyroscope/templates/deployments-statefulsets.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: pyroscope-dev-compaction-worker
+  namespace: default
+  labels:
+    helm.sh/chart: pyroscope-2.0.2
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "compaction-worker"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pyroscope
+      app.kubernetes.io/instance: pyroscope-dev
+      app.kubernetes.io/component: "compaction-worker"
 ---
 # Source: pyroscope/templates/deployments-statefulsets.yaml
 apiVersion: policy/v1
@@ -48,10 +69,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -66,43 +87,43 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: pyroscope-dev-ingester
+  name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "ingester"
+    app.kubernetes.io/component: "metastore"
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: pyroscope
       app.kubernetes.io/instance: pyroscope-dev
-      app.kubernetes.io/component: "ingester"
+      app.kubernetes.io/component: "metastore"
 ---
 # Source: pyroscope/templates/deployments-statefulsets.yaml
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: pyroscope-dev-querier
+  name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "querier"
+    app.kubernetes.io/component: "query-backend"
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: pyroscope
       app.kubernetes.io/instance: pyroscope-dev
-      app.kubernetes.io/component: "querier"
+      app.kubernetes.io/component: "query-backend"
 ---
 # Source: pyroscope/templates/deployments-statefulsets.yaml
 apiVersion: policy/v1
@@ -111,10 +132,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -129,43 +150,22 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: pyroscope-dev-query-scheduler
+  name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "query-scheduler"
+    app.kubernetes.io/component: "segment-writer"
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: pyroscope
       app.kubernetes.io/instance: pyroscope-dev
-      app.kubernetes.io/component: "query-scheduler"
----
-# Source: pyroscope/templates/deployments-statefulsets.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: pyroscope-dev-store-gateway
-  namespace: default
-  labels:
-    helm.sh/chart: pyroscope-2.0.1
-    app.kubernetes.io/name: pyroscope
-    app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "store-gateway"
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: pyroscope
-      app.kubernetes.io/instance: pyroscope-dev
-      app.kubernetes.io/component: "store-gateway"
+      app.kubernetes.io/component: "segment-writer"
 ---
 # Source: pyroscope/templates/deployments-statefulsets.yaml
 apiVersion: policy/v1
@@ -174,10 +174,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -218,10 +218,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -565,10 +565,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1423,10 +1423,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1440,10 +1440,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1592,6 +1592,51 @@ subjects:
     name: pyroscope-dev-alloy
     namespace: default
 ---
+# Source: pyroscope/templates/rbac-discovery.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pyroscope-dev-discovery
+  labels:
+    helm.sh/chart: pyroscope-2.0.2
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  - endpoints
+  - services
+  - pods
+  verbs:
+  - get
+  - watch
+  - list
+---
+# Source: pyroscope/templates/rbac-discovery.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pyroscope-dev-discovery
+  labels:
+    helm.sh/chart: pyroscope-2.0.2
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pyroscope-dev-discovery
+subjects:
+- kind: ServiceAccount
+  name: pyroscope-dev
+  namespace: default
+---
 # Source: pyroscope/charts/alloy/templates/cluster_service.yaml
 apiVersion: v1
 kind: Service
@@ -1725,10 +1770,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1752,10 +1797,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1765,6 +1810,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1777,10 +1826,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1791,6 +1840,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1800,15 +1853,15 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: pyroscope-dev-compactor
+  name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "compactor"
+    app.kubernetes.io/component: "admin"
 spec:
   type: ClusterIP
   ports:
@@ -1816,24 +1869,28 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/component: "compactor"
+    app.kubernetes.io/component: "admin"
 ---
 # Source: pyroscope/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: pyroscope-dev-compactor-headless
+  name: pyroscope-dev-admin-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "compactor"
+    app.kubernetes.io/component: "admin"
 spec:
   type: ClusterIP
   clusterIP: None
@@ -1842,10 +1899,73 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/component: "compactor"
+    app.kubernetes.io/component: "admin"
+---
+# Source: pyroscope/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: pyroscope-dev-compaction-worker
+  namespace: default
+  labels:
+    helm.sh/chart: pyroscope-2.0.2
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "compaction-worker"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 4040
+      targetPort: http2
+      protocol: TCP
+      name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector:
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/component: "compaction-worker"
+---
+# Source: pyroscope/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: pyroscope-dev-compaction-worker-headless
+  namespace: default
+  labels:
+    helm.sh/chart: pyroscope-2.0.2
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "compaction-worker"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 4040
+      targetPort: http2
+      protocol: TCP
+      name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector:
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/component: "compaction-worker"
 ---
 # Source: pyroscope/templates/services.yaml
 apiVersion: v1
@@ -1854,10 +1974,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1867,6 +1987,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1879,10 +2003,10 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1893,6 +2017,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1902,15 +2030,15 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: pyroscope-dev-ingester
+  name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "ingester"
+    app.kubernetes.io/component: "metastore"
 spec:
   type: ClusterIP
   ports:
@@ -1918,24 +2046,32 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+    - port: 9099
+      targetPort: raft
+      protocol: TCP
+      name: raft
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/component: "ingester"
+    app.kubernetes.io/component: "metastore"
 ---
 # Source: pyroscope/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: pyroscope-dev-ingester-headless
+  name: pyroscope-dev-metastore-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "ingester"
+    app.kubernetes.io/component: "metastore"
 spec:
   type: ClusterIP
   clusterIP: None
@@ -1944,24 +2080,33 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+    - port: 9099
+      targetPort: raft
+      protocol: TCP
+      name: raft
+  publishNotReadyAddresses: true
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/component: "ingester"
+    app.kubernetes.io/component: "metastore"
 ---
 # Source: pyroscope/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: pyroscope-dev-querier
+  name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "querier"
+    app.kubernetes.io/component: "query-backend"
 spec:
   type: ClusterIP
   ports:
@@ -1969,24 +2114,28 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/component: "querier"
+    app.kubernetes.io/component: "query-backend"
 ---
 # Source: pyroscope/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: pyroscope-dev-querier-headless
+  name: pyroscope-dev-query-backend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "querier"
+    app.kubernetes.io/component: "query-backend"
 spec:
   type: ClusterIP
   clusterIP: None
@@ -1995,10 +2144,14 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/component: "querier"
+    app.kubernetes.io/component: "query-backend"
 ---
 # Source: pyroscope/templates/services.yaml
 apiVersion: v1
@@ -2007,10 +2160,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2020,6 +2173,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2032,10 +2189,10 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2046,6 +2203,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2055,15 +2216,15 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: pyroscope-dev-query-scheduler
+  name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "query-scheduler"
+    app.kubernetes.io/component: "segment-writer"
 spec:
   type: ClusterIP
   ports:
@@ -2071,24 +2232,28 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/component: "query-scheduler"
+    app.kubernetes.io/component: "segment-writer"
 ---
 # Source: pyroscope/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: pyroscope-dev-query-scheduler-headless
+  name: pyroscope-dev-segment-writer-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "query-scheduler"
+    app.kubernetes.io/component: "segment-writer"
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2097,61 +2262,14 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
-  selector:
-    app.kubernetes.io/name: pyroscope
-    app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/component: "query-scheduler"
----
-# Source: pyroscope/templates/services.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: pyroscope-dev-store-gateway
-  namespace: default
-  labels:
-    helm.sh/chart: pyroscope-2.0.1
-    app.kubernetes.io/name: pyroscope
-    app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "store-gateway"
-spec:
-  type: ClusterIP
-  ports:
-    - port: 4040
-      targetPort: http2
+    - port: 9095
+      targetPort: grpc
       protocol: TCP
-      name: http2
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/component: "store-gateway"
----
-# Source: pyroscope/templates/services.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: pyroscope-dev-store-gateway-headless
-  namespace: default
-  labels:
-    helm.sh/chart: pyroscope-2.0.1
-    app.kubernetes.io/name: pyroscope
-    app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "store-gateway"
-spec:
-  type: ClusterIP
-  clusterIP: None
-  ports:
-    - port: 4040
-      targetPort: http2
-      protocol: TCP
-      name: http2
-  selector:
-    app.kubernetes.io/name: pyroscope
-    app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/component: "store-gateway"
+    app.kubernetes.io/component: "segment-writer"
 ---
 # Source: pyroscope/templates/services.yaml
 apiVersion: v1
@@ -2160,10 +2278,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2173,6 +2291,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2185,10 +2307,10 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2199,6 +2321,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2211,10 +2337,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -2227,9 +2353,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2252,7 +2378,7 @@ spec:
         - name: "ad-hoc-profiles"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ad-hoc-profiles"
@@ -2263,8 +2389,9 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2272,12 +2399,17 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -2294,7 +2426,117 @@ spec:
               mountPath: /data
           resources:
             limits:
-              memory: 4Gi
+              memory: 256Mi
+            requests:
+              cpu: 0.1
+              memory: 16Mi
+      volumes:
+        - name: config
+          configMap:
+            name: pyroscope-dev-config
+        - name: overrides-config
+          configMap:
+            name: pyroscope-dev-overrides-config
+        - name: data
+          emptyDir: {}
+---
+# Source: pyroscope/templates/deployments-statefulsets.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pyroscope-dev-admin
+  namespace: default
+  labels:
+    helm.sh/chart: pyroscope-2.0.2
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "admin"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pyroscope
+      app.kubernetes.io/instance: pyroscope-dev
+      app.kubernetes.io/component: "admin"
+  template:
+    metadata:
+      annotations:
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/cpu.port_name: http2
+        profiles.grafana.com/cpu.scrape: "true"
+        profiles.grafana.com/goroutine.port_name: http2
+        profiles.grafana.com/goroutine.scrape: "true"
+        profiles.grafana.com/memory.port_name: http2
+        profiles.grafana.com/memory.scrape: "true"
+      labels:
+        app.kubernetes.io/name: pyroscope
+        app.kubernetes.io/instance: pyroscope-dev
+        app.kubernetes.io/component: "admin"
+        name: "admin"
+    spec:
+      serviceAccountName: pyroscope-dev
+      securityContext:
+        fsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+      dnsPolicy: ClusterFirst
+      containers:
+        - name: "admin"
+          securityContext:
+            {}
+          image: "grafana/pyroscope:2.0.2"
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=admin"
+            - "-self-profiling.disable-push=true"
+            - "-server.http-listen-port=4040"
+            - "-memberlist.cluster-label=default-pyroscope-dev-micro-services"
+            - "-memberlist.join=dns+pyroscope-dev-memberlist.default.svc.cluster.local.:7946"
+            - "-config.file=/etc/pyroscope/config.yaml"
+            - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
+            - "-log.level=debug"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE_FQDN
+              value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
+          ports:
+            - name: http2
+              containerPort: 4040
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http2
+              scheme: HTTP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/pyroscope/config.yaml
+              subPath: config.yaml
+            - name: overrides-config
+              mountPath: /etc/pyroscope/overrides/
+            - name: data
+              mountPath: /data
+          resources:
+            limits:
+              memory: 256Mi
             requests:
               cpu: 0.1
               memory: 16Mi
@@ -2315,10 +2557,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2331,9 +2573,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2356,7 +2598,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2367,8 +2609,9 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2376,12 +2619,17 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -2416,28 +2664,28 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: pyroscope-dev-querier
+  name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "querier"
+    app.kubernetes.io/component: "query-backend"
 spec:
   replicas: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: pyroscope
       app.kubernetes.io/instance: pyroscope-dev
-      app.kubernetes.io/component: "querier"
+      app.kubernetes.io/component: "query-backend"
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2447,8 +2695,8 @@ spec:
       labels:
         app.kubernetes.io/name: pyroscope
         app.kubernetes.io/instance: pyroscope-dev
-        app.kubernetes.io/component: "querier"
-        name: "querier"
+        app.kubernetes.io/component: "query-backend"
+        name: "query-backend"
     spec:
       serviceAccountName: pyroscope-dev
       securityContext:
@@ -2457,13 +2705,13 @@ spec:
         runAsUser: 10001
       dnsPolicy: ClusterFirst
       containers:
-        - name: "querier"
+        - name: "query-backend"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
-            - "-target=querier"
+            - "-target=query-backend"
             - "-self-profiling.disable-push=true"
             - "-server.http-listen-port=4040"
             - "-memberlist.cluster-label=default-pyroscope-dev-micro-services"
@@ -2471,9 +2719,9 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
-            - "-store-gateway.sharding-ring.replication-factor=3"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2481,12 +2729,17 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -2524,10 +2777,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2540,9 +2793,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2565,7 +2818,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2576,8 +2829,9 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2585,6 +2839,8 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
@@ -2592,109 +2848,8 @@ spec:
             - name: memberlist
               containerPort: 7946
               protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: http2
-              scheme: HTTP
-          volumeMounts:
-            - name: config
-              mountPath: /etc/pyroscope/config.yaml
-              subPath: config.yaml
-            - name: overrides-config
-              mountPath: /etc/pyroscope/overrides/
-            - name: data
-              mountPath: /data
-          resources:
-            limits:
-              memory: 1Gi
-            requests:
-              cpu: 100m
-              memory: 256Mi
-      volumes:
-        - name: config
-          configMap:
-            name: pyroscope-dev-config
-        - name: overrides-config
-          configMap:
-            name: pyroscope-dev-overrides-config
-        - name: data
-          emptyDir: {}
----
-# Source: pyroscope/templates/deployments-statefulsets.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: pyroscope-dev-query-scheduler
-  namespace: default
-  labels:
-    helm.sh/chart: pyroscope-2.0.1
-    app.kubernetes.io/name: pyroscope
-    app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "query-scheduler"
-spec:
-  replicas: 2
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: pyroscope
-      app.kubernetes.io/instance: pyroscope-dev
-      app.kubernetes.io/component: "query-scheduler"
-  template:
-    metadata:
-      annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
-        profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
-        profiles.grafana.com/cpu.port_name: http2
-        profiles.grafana.com/cpu.scrape: "true"
-        profiles.grafana.com/goroutine.port_name: http2
-        profiles.grafana.com/goroutine.scrape: "true"
-        profiles.grafana.com/memory.port_name: http2
-        profiles.grafana.com/memory.scrape: "true"
-      labels:
-        app.kubernetes.io/name: pyroscope
-        app.kubernetes.io/instance: pyroscope-dev
-        app.kubernetes.io/component: "query-scheduler"
-        name: "query-scheduler"
-    spec:
-      serviceAccountName: pyroscope-dev
-      securityContext:
-        fsGroup: 10001
-        runAsNonRoot: true
-        runAsUser: 10001
-      dnsPolicy: ClusterFirst
-      containers:
-        - name: "query-scheduler"
-          securityContext:
-            {}
-          image: "grafana/pyroscope:2.0.1"
-          imagePullPolicy: IfNotPresent
-          args:
-            - "-target=query-scheduler"
-            - "-self-profiling.disable-push=true"
-            - "-server.http-listen-port=4040"
-            - "-memberlist.cluster-label=default-pyroscope-dev-micro-services"
-            - "-memberlist.join=dns+pyroscope-dev-memberlist.default.svc.cluster.local.:7946"
-            - "-config.file=/etc/pyroscope/config.yaml"
-            - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
-            - "-log.level=debug"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE_FQDN
-              value: "default.svc.cluster.local."
-          ports:
-            - name: http2
-              containerPort: 4040
-              protocol: TCP
-            - name: memberlist
-              containerPort: 7946
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -2732,10 +2887,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2748,9 +2903,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2773,7 +2928,7 @@ spec:
         - name: "tenant-settings"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tenant-settings"
@@ -2784,8 +2939,9 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2793,12 +2949,17 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -2815,7 +2976,7 @@ spec:
               mountPath: /data
           resources:
             limits:
-              memory: 4Gi
+              memory: 256Mi
             requests:
               cpu: 0.1
               memory: 16Mi
@@ -3016,30 +3177,30 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: pyroscope-dev-compactor
+  name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "compactor"
+    app.kubernetes.io/component: "compaction-worker"
 spec:
-  serviceName: pyroscope-dev-compactor-headless
+  serviceName: pyroscope-dev-compaction-worker-headless
   podManagementPolicy: Parallel
   replicas: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: pyroscope
       app.kubernetes.io/instance: pyroscope-dev
-      app.kubernetes.io/component: "compactor"
+      app.kubernetes.io/component: "compaction-worker"
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3049,8 +3210,8 @@ spec:
       labels:
         app.kubernetes.io/name: pyroscope
         app.kubernetes.io/instance: pyroscope-dev
-        app.kubernetes.io/component: "compactor"
-        name: "compactor"
+        app.kubernetes.io/component: "compaction-worker"
+        name: "compaction-worker"
     spec:
       serviceAccountName: pyroscope-dev
       securityContext:
@@ -3059,13 +3220,13 @@ spec:
         runAsUser: 10001
       dnsPolicy: ClusterFirst
       containers:
-        - name: "compactor"
+        - name: "compaction-worker"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
-            - "-target=compactor"
+            - "-target=compaction-worker"
             - "-self-profiling.disable-push=true"
             - "-server.http-listen-port=4040"
             - "-memberlist.cluster-label=default-pyroscope-dev-micro-services"
@@ -3073,8 +3234,9 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3082,12 +3244,17 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -3102,16 +3269,12 @@ spec:
               mountPath: /etc/pyroscope/overrides/
             - name: data
               mountPath: /data
-              subPath: default
-            - name: data
-              mountPath: /data-compactor
-              subPath: compactor
           resources:
             limits:
-              memory: 16Gi
+              memory: 2Gi
             requests:
               cpu: 1
-              memory: 8Gi
+              memory: 1Gi
       terminationGracePeriodSeconds: 1200
       volumes:
         - name: config
@@ -3127,30 +3290,30 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: pyroscope-dev-ingester
+  name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "ingester"
+    app.kubernetes.io/component: "metastore"
 spec:
-  serviceName: pyroscope-dev-ingester-headless
+  serviceName: pyroscope-dev-metastore-headless
   podManagementPolicy: Parallel
   replicas: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: pyroscope
       app.kubernetes.io/instance: pyroscope-dev
-      app.kubernetes.io/component: "ingester"
+      app.kubernetes.io/component: "metastore"
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3160,8 +3323,8 @@ spec:
       labels:
         app.kubernetes.io/name: pyroscope
         app.kubernetes.io/instance: pyroscope-dev
-        app.kubernetes.io/component: "ingester"
-        name: "ingester"
+        app.kubernetes.io/component: "metastore"
+        name: "metastore"
     spec:
       serviceAccountName: pyroscope-dev
       securityContext:
@@ -3170,13 +3333,13 @@ spec:
         runAsUser: 10001
       dnsPolicy: ClusterFirst
       containers:
-        - name: "ingester"
+        - name: "metastore"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
-            - "-target=ingester"
+            - "-target=metastore"
             - "-self-profiling.disable-push=true"
             - "-server.http-listen-port=4040"
             - "-memberlist.cluster-label=default-pyroscope-dev-micro-services"
@@ -3184,8 +3347,19 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-metastore.index.cleanup-interval=1m"
+            - "-metastore.raft.bootstrap-expect-peers=3"
+            - "-metastore.snapshot-compact-on-restore=true"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.data-dir=./data-metastore/data"
+            - "-metastore.raft.dir=./data-metastore/raft"
+            - "-metastore.raft.snapshots-dir=./data-metastore/raft"
+            - "-metastore.raft.bind-address=:9099"
+            - "-metastore.raft.server-id=$(POD_NAME).$(PYROSCOPE_METASTORE_SERVICE)"
+            - "-metastore.raft.advertise-address=$(POD_NAME).$(PYROSCOPE_METASTORE_SERVICE)"
+            - "-metastore.raft.bootstrap-peers=dnssrvnoa+_raft._tcp.$(PYROSCOPE_METASTORE_SERVICE)"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3193,12 +3367,20 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: raft
+              containerPort: 9099
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -3213,13 +3395,16 @@ spec:
               mountPath: /etc/pyroscope/overrides/
             - name: data
               mountPath: /data
+            - name: data
+              mountPath: /data-metastore
+              subPath: .metastore
           resources:
             limits:
-              memory: 16Gi
+              memory: 2Gi
             requests:
               cpu: 1
-              memory: 8Gi
-      terminationGracePeriodSeconds: 600
+              memory: 1Gi
+      terminationGracePeriodSeconds: 1200
       volumes:
         - name: config
           configMap:
@@ -3234,30 +3419,30 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: pyroscope-dev-store-gateway
+  name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "store-gateway"
+    app.kubernetes.io/component: "segment-writer"
 spec:
-  serviceName: pyroscope-dev-store-gateway-headless
+  serviceName: pyroscope-dev-segment-writer-headless
   podManagementPolicy: Parallel
   replicas: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: pyroscope
       app.kubernetes.io/instance: pyroscope-dev
-      app.kubernetes.io/component: "store-gateway"
+      app.kubernetes.io/component: "segment-writer"
   template:
     metadata:
       annotations:
-        checksum/config: c5f99e75b792a411f69b791544f3283bf17a662201303db642b329e942b52298
+        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3267,8 +3452,8 @@ spec:
       labels:
         app.kubernetes.io/name: pyroscope
         app.kubernetes.io/instance: pyroscope-dev
-        app.kubernetes.io/component: "store-gateway"
-        name: "store-gateway"
+        app.kubernetes.io/component: "segment-writer"
+        name: "segment-writer"
     spec:
       serviceAccountName: pyroscope-dev
       securityContext:
@@ -3277,13 +3462,13 @@ spec:
         runAsUser: 10001
       dnsPolicy: ClusterFirst
       containers:
-        - name: "store-gateway"
+        - name: "segment-writer"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
-            - "-target=store-gateway"
+            - "-target=segment-writer"
             - "-self-profiling.disable-push=true"
             - "-server.http-listen-port=4040"
             - "-memberlist.cluster-label=default-pyroscope-dev-micro-services"
@@ -3291,9 +3476,9 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
-            - "-store-gateway.sharding-ring.replication-factor=3"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3301,6 +3486,8 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
@@ -3308,12 +3495,14 @@ spec:
             - name: memberlist
               containerPort: 7946
               protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
           readinessProbe:
             httpGet:
               path: /ready
               port: http2
               scheme: HTTP
-            initialDelaySeconds: 60
           volumeMounts:
             - name: config
               mountPath: /etc/pyroscope/config.yaml
@@ -3324,10 +3513,11 @@ spec:
               mountPath: /data
           resources:
             limits:
-              memory: 16Gi
+              memory: 4Gi
             requests:
               cpu: 1
-              memory: 8Gi
+              memory: 2Gi
+      terminationGracePeriodSeconds: 600
       volumes:
         - name: config
           configMap:

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -43,10 +43,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/templates/configmap-alloy.yaml
@@ -56,10 +56,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -914,10 +914,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -931,10 +931,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1082,10 +1082,10 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -1107,10 +1107,10 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1186,10 +1186,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1213,10 +1213,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1246,10 +1246,10 @@ metadata:
   name: pyroscope-dev-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1371,10 +1371,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1389,9 +1389,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ac9201897d9e0c615be86351df4d32ec53b636b9683bf9c99e86002ff9d55362
+        checksum/config: 753348e68675509482b48ba79580501d9190bec211b691085df540c1bd087139
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -1414,7 +1414,7 @@ spec:
         - name: "pyroscope"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=all"

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -43,10 +43,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/templates/configmap-alloy.yaml
@@ -56,10 +56,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -914,10 +914,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -931,10 +931,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1076,6 +1076,51 @@ subjects:
     name: pyroscope-dev-alloy
     namespace: default
 ---
+# Source: pyroscope/templates/rbac-discovery.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pyroscope-dev-discovery
+  labels:
+    helm.sh/chart: pyroscope-2.0.2
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  - endpoints
+  - services
+  - pods
+  verbs:
+  - get
+  - watch
+  - list
+---
+# Source: pyroscope/templates/rbac-discovery.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pyroscope-dev-discovery
+  labels:
+    helm.sh/chart: pyroscope-2.0.2
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pyroscope-dev-discovery
+subjects:
+- kind: ServiceAccount
+  name: pyroscope-dev
+  namespace: default
+---
 # Source: pyroscope/charts/alloy/templates/cluster_service.yaml
 apiVersion: v1
 kind: Service
@@ -1141,10 +1186,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1168,10 +1213,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1181,6 +1226,14 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+    - port: 9099
+      targetPort: raft
+      protocol: TCP
+      name: raft
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1193,10 +1246,10 @@ metadata:
   name: pyroscope-dev-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1207,6 +1260,15 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
+    - port: 9095
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+    - port: 9099
+      targetPort: raft
+      protocol: TCP
+      name: raft
+  publishNotReadyAddresses: true
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1309,10 +1371,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.1
+    helm.sh/chart: pyroscope-2.0.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.1"
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1327,9 +1389,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ac9201897d9e0c615be86351df4d32ec53b636b9683bf9c99e86002ff9d55362
+        checksum/config: 753348e68675509482b48ba79580501d9190bec211b691085df540c1bd087139
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.1"
+        profiles.grafana.com/service_git_ref: "v2.0.2"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -1352,7 +1414,7 @@ spec:
         - name: "pyroscope"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.1"
+          image: "grafana/pyroscope:2.0.2"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=all"
@@ -1363,8 +1425,16 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
-            - "-architecture.storage=v1"
-            - "-write-path=ingester"
+            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.address=kubernetes:///pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
+            - "-metastore.data-dir=./data-metastore/data"
+            - "-metastore.raft.dir=./data-metastore/raft"
+            - "-metastore.raft.snapshots-dir=./data-metastore/raft"
+            - "-metastore.raft.bind-address=:9099"
+            - "-metastore.raft.server-id=$(POD_NAME).$(PYROSCOPE_METASTORE_SERVICE)"
+            - "-metastore.raft.advertise-address=$(POD_NAME).$(PYROSCOPE_METASTORE_SERVICE)"
+            - "-metastore.raft.bootstrap-peers=dnssrvnoa+_raft._tcp.$(PYROSCOPE_METASTORE_SERVICE)"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -1372,12 +1442,20 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
+            - name: PYROSCOPE_METASTORE_SERVICE
+              value: "pyroscope-dev-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
+              protocol: TCP
+            - name: grpc
+              containerPort: 9095
+              protocol: TCP
+            - name: raft
+              containerPort: 9099
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -1392,6 +1470,9 @@ spec:
               mountPath: /etc/pyroscope/overrides/
             - name: data
               mountPath: /data
+            - name: data
+              mountPath: /data-metastore
+              subPath: .metastore
           resources:
             {}
       volumes:

--- a/operations/pyroscope/helm/pyroscope/values.yaml
+++ b/operations/pyroscope/helm/pyroscope/values.yaml
@@ -212,9 +212,9 @@ pyroscope:
 architecture:
   storage:
     # -- (bool) Enable v1 storage layer.
-    v1: true
+    v1: false
     # -- (bool) Enable v2 storage layer.
-    v2: false
+    v2: true
 
     migration:
       # -- (float) Specifies the fraction [0:1] that should be send to the v1 write path / ingester in combined mode. 0 means no traffics is sent to ingester. 1 means 100% of requests are sent to ingester.

--- a/operations/pyroscope/jsonnet/values.json
+++ b/operations/pyroscope/jsonnet/values.json
@@ -332,8 +332,8 @@
         "queryBackendFrom": "auto",
         "segmentWriterWeight": 1
       },
-      "v1": true,
-      "v2": false
+      "v1": false,
+      "v2": true
     }
   },
   "extraObjects": [],


### PR DESCRIPTION
## Summary

- Switches the default storage architecture from v1 to v2 (`architecture.storage.v2: true`) so new deployments use the v2 write path (segment-writer, metastore, compaction-worker) and query backend out of the box — the v2.0.0 chart had this inadvertently inverted
- Fixes comment/value ordering in `values.yaml` that was breaking README generation in CI
- Bumps chart version to 2.0.1 / appVersion to 2.0.2

Also includes a previously-merged community contribution (extraObjects) that landed on this branch.

## Test plan

- [ ] Rendered manifests regenerated and included in this PR
- [ ] Verify fresh `helm install` brings up v2 components (segment-writer, query-backend) rather than v1 ingesters
- [ ] Verify existing v1 deployments can opt back in via `architecture.storage.v1: true`