### PR TITLE
fix(querybackend): sum time loses first sample

### DIFF
--- a/pkg/querybackend/query_time_series.go
+++ b/pkg/querybackend/query_time_series.go
@@ -232,7 +232,7 @@ func (a *timeSeriesAggregator) build() *queryv1.Report {
 	sum := typesv1.TimeSeriesAggregationType_TIME_SERIES_AGGREGATION_TYPE_SUM
 	stepMilli := time.Duration(a.query.GetStep() * float64(time.Second)).Milliseconds()
 	seriesIterator := timeseries.NewTimeSeriesMergeIterator(a.series.TimeSeries())
-	series := timeseries.RangeSeries(seriesIterator, a.startTime, a.endTime, stepMilli, &sum)
+	series := timeseries.RangeSeries(seriesIterator, a.startTime+stepMilli, a.endTime, stepMilli, &sum)
 	return &queryv1.Report{
 		TimeSeries: &queryv1.TimeSeriesReport{
 			Query:      a.query,
@@ -269,7 +269,7 @@ func (a *timeSeriesCompactAggregator) aggregate(report *queryv1.Report) error {
 func (a *timeSeriesCompactAggregator) build() *queryv1.Report {
 	stepMilli := time.Duration(a.query.GetStep() * float64(time.Second)).Milliseconds()
 	seriesIterator := a.merger.Iterator()
-	series := timeseriescompact.RangeSeries(seriesIterator, a.startTime, a.endTime, stepMilli)
+	series := timeseriescompact.RangeSeries(seriesIterator, a.startTime+stepMilli, a.endTime, stepMilli)
 	return &queryv1.Report{
 		TimeSeriesCompact: &queryv1.TimeSeriesCompactReport{
 			Query:          a.query,

--- a/pkg/querybackend/query_time_series_test.go
+++ b/pkg/querybackend/query_time_series_test.go
@@ -115,7 +115,7 @@ func resolveRefs(refs []int64, table *queryv1.AttributeTable) []string {
 }
 
 func TestTimeSeriesCompactAggregator(t *testing.T) {
-	agg, query := newTestCompactAggregator(1000, 2000)
+	agg, query := newTestCompactAggregator(0, 2000)
 
 	// Report 1: exemplar with 3 attributes (pod, version, region) at timestamp 1000
 	report1 := makeCompactReport(query, &queryv1.AttributeTable{
@@ -207,7 +207,7 @@ func TestTimeSeriesCompactAggregator(t *testing.T) {
 
 func TestTimeSeriesCompactAnnotations(t *testing.T) {
 	t.Run("same_timestamp_merges_annotations", func(t *testing.T) {
-		agg, query := newTestCompactAggregator(1000, 2000)
+		agg, query := newTestCompactAggregator(0, 2000)
 
 		// Report 1: annotations error=true, host=server-1
 		report1 := makeCompactReport(query, &queryv1.AttributeTable{
@@ -251,7 +251,7 @@ func TestTimeSeriesCompactAnnotations(t *testing.T) {
 
 	t.Run("different_timestamps_no_corruption", func(t *testing.T) {
 		// annotations at different timestamps should not be corrupted by later points.
-		agg, query := newTestCompactAggregator(1000, 3000)
+		agg, query := newTestCompactAggregator(0, 3000)
 
 		report := makeCompactReport(query, &queryv1.AttributeTable{
 			Keys:   []string{"service_name", "error", "host", "region"},
@@ -277,6 +277,82 @@ func TestTimeSeriesCompactAnnotations(t *testing.T) {
 		assert.ElementsMatch(t, []string{"host=server-1"}, resolveRefs(series.Points[1].AnnotationRefs, attrTable))
 		assert.ElementsMatch(t, []string{"region=us-east"}, resolveRefs(series.Points[2].AnnotationRefs, attrTable))
 	})
+}
+
+func TestTimeSeriesCompactAggregator_FirstSampleNotLost(t *testing.T) {
+	agg, query := newTestCompactAggregator(1000, 5000)
+
+	report := makeCompactReport(query, &queryv1.AttributeTable{
+		Keys:   []string{"service_name"},
+		Values: []string{"test-svc"},
+	}, []*queryv1.Series{{
+		AttributeRefs: []int64{0},
+		Points: []*queryv1.Point{
+			{Timestamp: 1000, Value: 100},
+			{Timestamp: 2500, Value: 200},
+			{Timestamp: 3500, Value: 300},
+		},
+	}})
+
+	require.NoError(t, agg.aggregate(report))
+	result := agg.build()
+
+	require.NotNil(t, result.TimeSeriesCompact)
+	require.Len(t, result.TimeSeriesCompact.TimeSeries, 1)
+
+	series := result.TimeSeriesCompact.TimeSeries[0]
+
+	require.Len(t, series.Points, 3, "all three samples should produce visible points; first sample at Ts==startTime must not be lost")
+	assert.Equal(t, int64(2000), series.Points[0].Timestamp)
+	assert.Equal(t, 100.0, series.Points[0].Value)
+	assert.Equal(t, int64(3000), series.Points[1].Timestamp)
+	assert.Equal(t, 200.0, series.Points[1].Value)
+	assert.Equal(t, int64(4000), series.Points[2].Timestamp)
+	assert.Equal(t, 300.0, series.Points[2].Value)
+}
+
+func TestTimeSeriesAggregator_FirstSampleNotLost(t *testing.T) {
+	query := &queryv1.TimeSeriesQuery{
+		GroupBy: []string{"service_name"},
+		Step:    1.0,
+	}
+	req := &queryv1.InvokeRequest{
+		StartTime: 1000,
+		EndTime:   5000,
+		Query: []*queryv1.Query{{
+			TimeSeries: query,
+		}},
+	}
+	agg := newTimeSeriesAggregator(req).(*timeSeriesAggregator)
+
+	report := &queryv1.Report{
+		TimeSeries: &queryv1.TimeSeriesReport{
+			Query: query,
+			TimeSeries: []*typesv1.Series{{
+				Labels: []*typesv1.LabelPair{{Name: "service_name", Value: "test-svc"}},
+				Points: []*typesv1.Point{
+					{Timestamp: 1000, Value: 100},
+					{Timestamp: 2500, Value: 200},
+					{Timestamp: 3500, Value: 300},
+				},
+			}},
+		},
+	}
+
+	require.NoError(t, agg.aggregate(report))
+	result := agg.build()
+
+	require.NotNil(t, result.TimeSeries)
+	require.Len(t, result.TimeSeries.TimeSeries, 1)
+
+	series := result.TimeSeries.TimeSeries[0]
+	require.Len(t, series.Points, 3, "all three samples should produce visible points; first sample at Ts==startTime must not be lost")
+	assert.Equal(t, int64(2000), series.Points[0].Timestamp)
+	assert.Equal(t, 100.0, series.Points[0].Value)
+	assert.Equal(t, int64(3000), series.Points[1].Timestamp)
+	assert.Equal(t, 200.0, series.Points[1].Value)
+	assert.Equal(t, int64(4000), series.Points[2].Timestamp)
+	assert.Equal(t, 300.0, series.Points[2].Value)
 }
 
 type benchmarkFixture struct {


### PR DESCRIPTION
## Summary
- Closes https://github.com/grafana/pyroscope/issues/4937
- Restores original start time for RangeSeries bucketing in the V2 query backend aggregators.
- The query frontend subtracts one step from Start for data fetching, but the aggregator was reusing this adjusted start for bucketing too, creating a phantom first bucket outside the visible range.
## Root Cause
QueryFrontend.SelectSeries sets InvokeRequest.StartTime = Start - step so profiles for the first bucket are fetched. But timeSeriesAggregator.build() and timeSeriesCompactAggregator.build() passed this adjusted start directly to RangeSeries. The first bucket landed at (Start - step) instead of Start, and the UI never displayed it — losing the first sample.
The fix adds stepMilli back to startTime before calling RangeSeries, matching the V1 querier where data fetching and bucketing use different start times.

## Test plan
- [x] TestTimeSeriesAggregator_FirstSampleNotLost
- [x] TestTimeSeriesCompactAggregator_FirstSampleNotLost
- [x] All 61 tests in ./pkg/querybackend/... pass
- [x] All 72 tests in ./pkg/model/timeseries/... and ./pkg/model/timeseriescompact/... pass
- [x] Manual verification with Alloy self-profiling reproducer from #4937

## Manual Test
<img width="1510" height="609" alt="Screenshot 2026-05-17 at 16 08 40" src="https://github.com/user-attachments/assets/e29b7420-00ee-4c8c-b1d4-b7b2822c8b6f" />

### The object summary of profiler
```
{
    "description": "Verification data for issue #4937 fix - first sample time no longer lost",
    "source": "Grafana network inspector response from local Pyroscope instance after fix",
    "time_series": {
        "timestamps_ms": [1779004962044, 1779004992044, 1779005022044, 1779005052044, 1779005082044, 1779005097044, 1779005127044, 1779005157044, 1779005187044, 1779005217044],
        "cpu_cores":     [0.01933333333333333, 0.017333333333333333, 0.02, 0.017333333333333333, 0.02, 0.010666666666666666, 0.015333333333333334, 0.016666666666666666, 0.018666666666666668, 0.015333333333333334],
        "total_points": 10,
        "step_seconds": 30,
        "calculation": {
            "rateCalculated": true,
            "unit": "cores",
            "first_point_value": 0.01933333333333333,
            "first_point_nonzero": true,
            "total_cpu_cores_sum": 0.17466666666666664,
            "avg_cpu_cores": 0.017466666666666664,
            "explanation": "Each value represents CPU usage in cores over a 30s step. Values are rate-calculated: raw nanoseconds / (step * 1e9). For example, first point 0.01933 cores = 580,000,000 ns / (30 * 1e9)."
        }
    },
    "flamegraph": {
        "root_total_ns": 2270000000,
        "root_total_seconds": 2.27,
        "unit": "ns",
        "cross_check": "2,270,000,000 ns = sum of all CPU time across the queried range (all 10 time buckets merged)"
    },
    "fix_confirmation": {
        "first_sample_present": true,
        "all_points_nonzero": true,
        "matches_expected_count": "10 points for ~5 min window at 30s step"
    },
    "full_response_gist": "See linked GitHub Gist for the complete raw API response"
}

```
complete object: https://gist.github.com/salamidrus/e888c7c352c7c566e138b4b05d4cff46