### PR TITLE
fix(compactionworker): correct time_to_compaction_seconds histogram buckets

### DIFF
--- a/pkg/compactionworker/metrics.go
+++ b/pkg/compactionworker/metrics.go
@@ -42,7 +42,7 @@ func newMetrics(r prometheus.Registerer) *workerMetrics {
 			Name: "time_to_compaction_seconds",
 			Help: "The time elapsed since the oldest compacted block was created.",
 
-			Buckets:                         prometheus.ExponentialBuckets(1, 3600, 16),
+			Buckets:                         prometheus.ExponentialBucketsRange(1, 14400, 16),
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  50,
 			NativeHistogramMinResetDuration: time.Hour,


### PR DESCRIPTION
## Summary

- Replace `prometheus.ExponentialBuckets(1, 3600, 16)` with `prometheus.ExponentialBucketsRange(1, 14400, 16)` in `pkg/compactionworker/metrics.go`

The old call produced only two meaningful bucket boundaries below 1 hour (at 1s and 3600s), so `histogram_quantile(0.95, ...)` would linearly interpolate inside the huge 1s–3600s bucket and return a flat ~3420s (~57 min) regardless of the actual distribution.

`ExponentialBucketsRange(1, 14400, 16)` spreads 16 boundaries evenly (on a log scale) between 1s and 14400s (4 h), which covers the default max L2 source-block age of 10800s with a safety margin. Per-level `histogram_quantile` lines will now vary meaningfully over time. Native histogram consumers (`NativeHistogramBucketFactor: 1.1`) were already correct and are unaffected.