### PR TITLE
chore: Disable install scripts in package manager configs

### DIFF
--- a/examples/language-sdk-instrumentation/nodejs/express-pull/.yarnrc
+++ b/examples/language-sdk-instrumentation/nodejs/express-pull/.yarnrc
@@ -1,1 +1,3 @@
 --install.ignore-scripts true
+
+ignore-scripts true

--- a/examples/language-sdk-instrumentation/nodejs/express-ts-inline/.yarnrc
+++ b/examples/language-sdk-instrumentation/nodejs/express-ts-inline/.yarnrc
@@ -1,1 +1,3 @@
 --install.ignore-scripts true
+
+ignore-scripts true

--- a/examples/language-sdk-instrumentation/nodejs/express-ts/.yarnrc
+++ b/examples/language-sdk-instrumentation/nodejs/express-ts/.yarnrc
@@ -1,1 +1,3 @@
 --install.ignore-scripts true
+
+ignore-scripts true

--- a/examples/language-sdk-instrumentation/nodejs/express/.yarnrc
+++ b/examples/language-sdk-instrumentation/nodejs/express/.yarnrc
@@ -1,1 +1,3 @@
 --install.ignore-scripts true
+
+ignore-scripts true

--- a/examples/language-sdk-instrumentation/nodejs/tinyhttp/.yarnrc
+++ b/examples/language-sdk-instrumentation/nodejs/tinyhttp/.yarnrc
@@ -1,1 +1,3 @@
 --install.ignore-scripts true
+
+ignore-scripts true


### PR DESCRIPTION
This change disables lifecycle scripts where package manager config files are present.

- Yarn 2+: `enableScripts: false` in `.yarnrc.yml`
- Yarn classic: `enableScripts false` in `.yarnrc`
- npm: `ignore-scripts=true` in `.npmrc`

See:
- https://yarnpkg.com/configuration/yarnrc#enableScripts
- https://docs.npmjs.com/cli/v10/using-npm/config#ignore-scripts

[_Created by Sourcegraph batch change `Kristian.Bremberg/disable-lifecycle-scripts-auto`._](https://grafana.sourcegraph.com/users/Kristian.Bremberg/batch-changes/disable-lifecycle-scripts-auto)