### PR TITLE
feature(ui): Add autocomplete to v2 embedded UI query bar

### DIFF
--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -93,6 +93,38 @@ Banner comments are not allowed. Do not use decorative section dividers such as:
 // ─── Section name ────────────────────────
 ```
 
+## Documenting non-obvious tradeoffs
+
+The default is no comments — well-named identifiers and obvious code don't need narration. But when a piece of code makes a **specific, non-obvious tradeoff** that a future maintainer might reasonably want to revisit, leave a comment that captures the decision.
+
+A tradeoff comment should answer three questions:
+
+1. **What is this doing that looks unusual?** Name the pattern or shape directly.
+2. **Why this instead of the obvious alternative?** Identify the alternative and the specific reason it was rejected (a lint rule, a performance constraint, a library quirk, a known bug).
+3. **What would have to change for the alternative to win?** Give the maintainer a concrete trigger for reconsidering.
+
+This kind of comment is the opposite of describing *what* the code does — it documents the *decision* behind the code so the decision can be re-litigated later with full context.
+
+**When to write one:**
+
+- A workaround for a lint rule or framework quirk.
+- A pattern that differs from how the same problem is solved elsewhere in this codebase.
+- A choice that trades simplicity for performance, or vice versa.
+- A deviation from React/TypeScript idioms (e.g. unused state setters as re-render triggers, reading mutable module state during render, using refs to bypass exhaustive-deps).
+- Anything where a careful reader would reasonably ask "why isn't this written the obvious way?"
+
+**When NOT to write one:**
+
+- The code is the obvious solution.
+- The "why" is captured by the function name or a nearby type signature.
+- The reason is the current task or PR (that belongs in the commit message).
+
+See `src/hooks/useLabelSuggestions.ts` for an example.
+
+## Dependency workarounds
+
+Several packages are patched via `yarn patch` due to incompatibilities with our stack. Before debugging a dependency issue, read `WORKAROUNDS.md` — it documents each patch, why it exists, and when it can be removed. Patch files live in `.yarn/patches/`.
+
 ## Components
 
 Components should be hand built and purpose driven. It is okay to make them generic and extensible, but only when necessary. For example, if a button is needed, make a "Button" component, but don't add size variants until a size variant is required.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -7,13 +7,18 @@ import { QueryBar } from '@components/QueryBar';
 import { TimeSeries } from '@components/TimeSeries';
 import { Panel } from '@components/Panel';
 import { TenantDialog } from '@components/TenantDialog';
-import { usePyroscopeQuery, type ProfileType } from '@hooks/usePyroscopeQuery';
+import {
+  parseTimeRange,
+  usePyroscopeQuery,
+  type ProfileType,
+} from '@hooks/usePyroscopeQuery';
 import { useTenant } from '@hooks/useTenant';
 import {
   profileTypeLabel,
   profileTypeRateLabel,
   sortProfileTypes,
 } from '@api/client';
+import { buildQuery, parseQuery } from './queryLang';
 
 function useTheme() {
   const [theme, setTheme] = useState<'dark' | 'light'>('dark');
@@ -24,19 +29,6 @@ function useTheme() {
     else document.documentElement.removeAttribute('data-theme');
   };
   return { theme, setTheme: setAndApply };
-}
-
-function buildQuery(service: string, pt: ProfileType): string {
-  return `{service_name="${service}", profile_type="${pt}"}`;
-}
-
-function parseQuery(
-  q: string,
-): { service: string; profileType: string } | null {
-  const service = q.match(/service_name\s*=\s*"([^"]+)"/)?.[1];
-  const profileType = q.match(/profile_type\s*=\s*"([^"]+)"/)?.[1];
-  if (!service || !profileType) return null;
-  return { service, profileType };
 }
 
 export default function App() {
@@ -88,6 +80,8 @@ export default function App() {
     !!service && queryInput !== buildQuery(service, profileType);
   const handleReset = () => setQueryUserInput(null);
 
+  const timeWindow = absoluteRange ?? parseTimeRange(timeRange);
+
   if (tenant.status === 'loading') return null;
 
   if (tenant.status === 'needs_tenant_id') {
@@ -133,6 +127,9 @@ export default function App() {
             query.execute(parsed.service, parsed.profileType, timeRange);
           }
         }}
+        start={timeWindow.start}
+        end={timeWindow.end}
+        tenantID={tenant.tenantID}
       />
 
       {query.error && (

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -32,6 +32,11 @@ export async function checkMultitenancy(): Promise<
   'single_tenant' | 'multi_tenant' | 'error'
 > {
   try {
+    // /LabelNames requires a time range; the backend returns 400 without
+    // one regardless of auth state. We send a short recent window so the
+    // auth-vs-no-auth distinction (401 vs 200) is the only signal we read.
+    const end = Date.now();
+    const start = end - 5 * 60_000;
     const res = await fetch(
       `${getBasePath()}/querier.v1.QuerierService/LabelNames`,
       {
@@ -40,7 +45,7 @@ export async function checkMultitenancy(): Promise<
           'Content-Type': 'application/json',
           'X-Scope-OrgID': '',
         },
-        body: JSON.stringify({ matchers: [] }),
+        body: JSON.stringify({ matchers: [], start, end }),
       },
     );
     if (res.ok) return 'single_tenant';

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -51,7 +51,11 @@ export async function checkMultitenancy(): Promise<
   }
 }
 
-async function post<T>(path: string, body: unknown): Promise<T> {
+async function post<T>(
+  path: string,
+  body: unknown,
+  signal?: AbortSignal,
+): Promise<T> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
   };
@@ -60,9 +64,43 @@ async function post<T>(path: string, body: unknown): Promise<T> {
     method: 'POST',
     headers,
     body: JSON.stringify(body),
+    signal,
   });
   if (!res.ok) throw new Error(`${path} ${res.status} ${res.statusText}`);
   return res.json() as Promise<T>;
+}
+
+interface NamesResponse {
+  names?: string[];
+}
+
+export async function fetchLabelNames(
+  matchers: string[],
+  start: number,
+  end: number,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const data = await post<NamesResponse>(
+    '/querier.v1.QuerierService/LabelNames',
+    { matchers, start, end },
+    signal,
+  );
+  return data.names ?? [];
+}
+
+export async function fetchLabelValues(
+  name: string,
+  matchers: string[],
+  start: number,
+  end: number,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const data = await post<NamesResponse>(
+    '/querier.v1.QuerierService/LabelValues',
+    { name, matchers, start, end },
+    signal,
+  );
+  return data.names ?? [];
 }
 
 interface LabelSet {

--- a/ui/src/components/QueryBar.css
+++ b/ui/src/components/QueryBar.css
@@ -9,8 +9,14 @@
   flex-shrink: 0;
 }
 
-.querybar-input {
+.querybar-input-wrap {
+  position: relative;
   flex: 1;
+  min-width: 0;
+}
+
+.querybar-input {
+  width: 100%;
   height: 28px;
   background: var(--bg-secondary);
   color: var(--text-primary);
@@ -20,7 +26,6 @@
   font-size: var(--text-sm);
   font-family: var(--font-mono);
   outline: none;
-  min-width: 0;
   transition:
     border-color var(--duration-base) var(--ease-out),
     box-shadow var(--duration-base) var(--ease-out);

--- a/ui/src/components/QueryBar.tsx
+++ b/ui/src/components/QueryBar.tsx
@@ -39,13 +39,14 @@ export function QueryBar({
   const [lastRun, setLastRun] = useState<string | null>(null);
   const dirty = lastRun === null || lastRun !== query;
 
-  const { context, suggestions, definitelyEmpty } = useLabelSuggestions({
-    query,
-    cursor,
-    start,
-    end,
-    tenantID,
-  });
+  const { context, suggestions, definitelyEmpty, loading } =
+    useLabelSuggestions({
+      query,
+      cursor,
+      start,
+      end,
+      tenantID,
+    });
 
   // Clamp the highlight against the current suggestions length. This avoids
   // a setState-in-effect reset; if the list shrinks below the previous
@@ -59,7 +60,8 @@ export function QueryBar({
     focused &&
     interacted &&
     !escaped &&
-    (suggestions.length > 0 || definitelyEmpty);
+    context.kind !== 'none' &&
+    (suggestions.length > 0 || definitelyEmpty || loading);
 
   useEffect(() => {
     if (pendingCursorRef.current === null) return;
@@ -139,6 +141,7 @@ export function QueryBar({
         {open && (
           <SuggestionList
             items={suggestions}
+            loading={loading}
             highlightedIndex={safeHighlight}
             onHover={setHighlightedIndex}
             onAccept={accept}

--- a/ui/src/components/QueryBar.tsx
+++ b/ui/src/components/QueryBar.tsx
@@ -25,6 +25,11 @@ export function QueryBar({
   const [focused, setFocused] = useState(false);
   const [escaped, setEscaped] = useState(false);
   const [highlightedIndex, setHighlightedIndex] = useState(0);
+  // Gates the dropdown on the user having actually typed or accepted a
+  // suggestion since the input was last focused. Without this, clicking
+  // into the input would pop the dropdown solely from the cursor position,
+  // which is noisy when the user just wants to read or move the caret.
+  const [interacted, setInteracted] = useState(false);
 
   // Carries the caret position that should be applied to the input after the
   // next commit. We use a ref instead of state so the post-commit effect can
@@ -34,7 +39,7 @@ export function QueryBar({
   const [lastRun, setLastRun] = useState<string | null>(null);
   const dirty = lastRun === null || lastRun !== query;
 
-  const { context, suggestions } = useLabelSuggestions({
+  const { context, suggestions, definitelyEmpty } = useLabelSuggestions({
     query,
     cursor,
     start,
@@ -50,7 +55,11 @@ export function QueryBar({
       ? 0
       : Math.min(highlightedIndex, suggestions.length - 1);
 
-  const open = focused && !escaped && suggestions.length > 0;
+  const open =
+    focused &&
+    interacted &&
+    !escaped &&
+    (suggestions.length > 0 || definitelyEmpty);
 
   useEffect(() => {
     if (pendingCursorRef.current === null) return;
@@ -73,6 +82,7 @@ export function QueryBar({
     setCursor(newCursor);
     setHighlightedIndex(0);
     setEscaped(false);
+    setInteracted(true);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -107,6 +117,7 @@ export function QueryBar({
           value={query}
           onChange={(e) => {
             setEscaped(false);
+            setInteracted(true);
             setHighlightedIndex(0);
             onQueryChange(e.target.value);
             setCursor(e.target.selectionStart ?? e.target.value.length);
@@ -119,7 +130,10 @@ export function QueryBar({
             setFocused(true);
             setCursor(e.currentTarget.selectionStart ?? 0);
           }}
-          onBlur={() => setFocused(false)}
+          onBlur={() => {
+            setFocused(false);
+            setInteracted(false);
+          }}
           onKeyDown={handleKeyDown}
         />
         {open && (

--- a/ui/src/components/QueryBar.tsx
+++ b/ui/src/components/QueryBar.tsx
@@ -1,32 +1,136 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Icon } from '@components/core/Icon';
+import { SuggestionList } from '@components/SuggestionList';
+import { useLabelSuggestions } from '@hooks/useLabelSuggestions';
+import { applySuggestion } from '../queryLang';
 import './QueryBar.css';
 
 export function QueryBar({
   query,
   onQueryChange,
   onRun,
+  start,
+  end,
+  tenantID,
 }: {
   query: string;
   onQueryChange: (q: string) => void;
   onRun: (query: string) => void;
+  start: number;
+  end: number;
+  tenantID?: string;
 }) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [cursor, setCursor] = useState(0);
+  const [focused, setFocused] = useState(false);
+  const [escaped, setEscaped] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+
+  // Carries the caret position that should be applied to the input after the
+  // next commit. We use a ref instead of state so the post-commit effect can
+  // clear it without a cascading setState.
+  const pendingCursorRef = useRef<number | null>(null);
+
   const [lastRun, setLastRun] = useState<string | null>(null);
   const dirty = lastRun === null || lastRun !== query;
+
+  const { context, suggestions } = useLabelSuggestions({
+    query,
+    cursor,
+    start,
+    end,
+    tenantID,
+  });
+
+  // Clamp the highlight against the current suggestions length. This avoids
+  // a setState-in-effect reset; if the list shrinks below the previous
+  // index we just fall back to the end of the list.
+  const safeHighlight =
+    suggestions.length === 0
+      ? 0
+      : Math.min(highlightedIndex, suggestions.length - 1);
+
+  const open = focused && !escaped && suggestions.length > 0;
+
+  useEffect(() => {
+    if (pendingCursorRef.current === null) return;
+    const el = inputRef.current;
+    if (!el) return;
+    const pos = pendingCursorRef.current;
+    el.setSelectionRange(pos, pos);
+    pendingCursorRef.current = null;
+  }, [query]);
 
   const handleRun = () => {
     setLastRun(query);
     onRun(query);
   };
 
+  const accept = (item: string) => {
+    const { next, cursor: newCursor } = applySuggestion(query, context, item);
+    pendingCursorRef.current = newCursor;
+    onQueryChange(next);
+    setCursor(newCursor);
+    setHighlightedIndex(0);
+    setEscaped(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (open && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
+      e.preventDefault();
+      const dir = e.key === 'ArrowDown' ? 1 : -1;
+      const n = suggestions.length;
+      setHighlightedIndex((safeHighlight + dir + n) % n);
+      return;
+    }
+    if (e.key === 'Enter') {
+      if (open && suggestions[safeHighlight]) {
+        e.preventDefault();
+        accept(suggestions[safeHighlight]);
+        return;
+      }
+      handleRun();
+      return;
+    }
+    if (e.key === 'Escape' && open) {
+      e.preventDefault();
+      setEscaped(true);
+    }
+  };
+
   return (
     <div className="querybar">
-      <input
-        className="querybar-input"
-        value={query}
-        onChange={(e) => onQueryChange(e.target.value)}
-        onKeyDown={(e) => e.key === 'Enter' && handleRun()}
-      />
+      <div className="querybar-input-wrap">
+        <input
+          ref={inputRef}
+          className="querybar-input"
+          value={query}
+          onChange={(e) => {
+            setEscaped(false);
+            setHighlightedIndex(0);
+            onQueryChange(e.target.value);
+            setCursor(e.target.selectionStart ?? e.target.value.length);
+          }}
+          onSelect={(e) => {
+            setHighlightedIndex(0);
+            setCursor(e.currentTarget.selectionStart ?? cursor);
+          }}
+          onFocus={(e) => {
+            setFocused(true);
+            setCursor(e.currentTarget.selectionStart ?? 0);
+          }}
+          onBlur={() => setFocused(false)}
+          onKeyDown={handleKeyDown}
+        />
+        {open && (
+          <SuggestionList
+            items={suggestions}
+            highlightedIndex={safeHighlight}
+            onHover={setHighlightedIndex}
+            onAccept={accept}
+          />
+        )}
+      </div>
 
       <button className="querybar-run" onClick={handleRun}>
         <Icon name={dirty ? 'play' : 'refresh'} size={10} />

--- a/ui/src/components/QueryBar.tsx
+++ b/ui/src/components/QueryBar.tsx
@@ -90,8 +90,12 @@ export function QueryBar({
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (open && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
       e.preventDefault();
-      const dir = e.key === 'ArrowDown' ? 1 : -1;
       const n = suggestions.length;
+      // Dropdown can be open with an empty list while loading or when
+      // definitelyEmpty. Skip navigation rather than dividing by zero,
+      // which would set highlightedIndex to NaN.
+      if (n === 0) return;
+      const dir = e.key === 'ArrowDown' ? 1 : -1;
       setHighlightedIndex((safeHighlight + dir + n) % n);
       return;
     }

--- a/ui/src/components/SuggestionList.css
+++ b/ui/src/components/SuggestionList.css
@@ -1,0 +1,20 @@
+.suggestion-list {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  max-height: 280px;
+  overflow-y: auto;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  padding: var(--space-1) 0;
+}
+
+.suggestion-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/ui/src/components/SuggestionList.css
+++ b/ui/src/components/SuggestionList.css
@@ -18,3 +18,10 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.suggestion-empty {
+  padding: var(--space-1-5) var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  font-style: italic;
+}

--- a/ui/src/components/SuggestionList.tsx
+++ b/ui/src/components/SuggestionList.tsx
@@ -12,6 +12,13 @@ export function SuggestionList({
   onHover: (i: number) => void;
   onAccept: (item: string) => void;
 }) {
+  if (items.length === 0) {
+    return (
+      <div className="suggestion-list" role="listbox">
+        <div className="suggestion-empty">No matches</div>
+      </div>
+    );
+  }
   return (
     <div className="suggestion-list" role="listbox">
       {items.map((item, i) => (

--- a/ui/src/components/SuggestionList.tsx
+++ b/ui/src/components/SuggestionList.tsx
@@ -3,11 +3,13 @@ import './SuggestionList.css';
 
 export function SuggestionList({
   items,
+  loading,
   highlightedIndex,
   onHover,
   onAccept,
 }: {
   items: string[];
+  loading: boolean;
   highlightedIndex: number;
   onHover: (i: number) => void;
   onAccept: (item: string) => void;
@@ -15,7 +17,9 @@ export function SuggestionList({
   if (items.length === 0) {
     return (
       <div className="suggestion-list" role="listbox">
-        <div className="suggestion-empty">No matches</div>
+        <div className="suggestion-empty">
+          {loading ? 'Loading…' : 'No matches'}
+        </div>
       </div>
     );
   }

--- a/ui/src/components/SuggestionList.tsx
+++ b/ui/src/components/SuggestionList.tsx
@@ -1,0 +1,36 @@
+import { DropdownItem } from '@components/core/Dropdown';
+import './SuggestionList.css';
+
+export function SuggestionList({
+  items,
+  highlightedIndex,
+  onHover,
+  onAccept,
+}: {
+  items: string[];
+  highlightedIndex: number;
+  onHover: (i: number) => void;
+  onAccept: (item: string) => void;
+}) {
+  return (
+    <div className="suggestion-list" role="listbox">
+      {items.map((item, i) => (
+        <div
+          key={item}
+          // Prevent the click from blurring the input — onMouseDown fires
+          // before the input loses focus, so preventDefault here keeps the
+          // caret in place and lets onAccept update both value and selection.
+          onMouseDown={(e) => {
+            e.preventDefault();
+            onAccept(item);
+          }}
+          onMouseEnter={() => onHover(i)}
+        >
+          <DropdownItem selected={i === highlightedIndex} mono>
+            <span className="suggestion-text">{item}</span>
+          </DropdownItem>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/ui/src/hooks/useDebouncedValue.ts
+++ b/ui/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,10 @@
+import { useEffect, useState } from 'react';
+
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(id);
+  }, [value, delayMs]);
+  return debounced;
+}

--- a/ui/src/hooks/useLabelSuggestions.ts
+++ b/ui/src/hooks/useLabelSuggestions.ts
@@ -1,0 +1,125 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { fetchLabelNames, fetchLabelValues } from '@api/client';
+import { getCursorContext, type CursorContext } from '../queryLang';
+import { useDebouncedValue } from './useDebouncedValue';
+
+const cache = new Map<string, string[]>();
+const BUCKET_MS = 10_000;
+const MAX_SUGGESTIONS = 200;
+const DEBOUNCE_NAMES_MS = 150;
+const DEBOUNCE_VALUES_MS = 250;
+
+export interface LabelSuggestionsArgs {
+  query: string;
+  cursor: number;
+  start: number;
+  end: number;
+  tenantID?: string;
+}
+
+export interface LabelSuggestionsResult {
+  context: CursorContext;
+  suggestions: string[];
+  loading: boolean;
+}
+
+export function useLabelSuggestions({
+  query,
+  cursor,
+  start,
+  end,
+  tenantID,
+}: LabelSuggestionsArgs): LabelSuggestionsResult {
+  const context = useMemo(
+    () => getCursorContext(query, cursor),
+    [query, cursor],
+  );
+
+  // Bucket the time range so that relative ranges (`now-1h`) — which mutate
+  // start/end every render — don't churn the request key.
+  const startBucket = Math.floor(start / BUCKET_MS) * BUCKET_MS;
+  const endBucket = Math.floor(end / BUCKET_MS) * BUCKET_MS;
+
+  const requestKey = useMemo(() => {
+    if (context.kind === 'none') return '';
+    if (context.kind === 'name') {
+      return JSON.stringify([
+        'n',
+        context.otherMatchers,
+        startBucket,
+        endBucket,
+        tenantID ?? '',
+      ]);
+    }
+    return JSON.stringify([
+      'v',
+      context.labelName,
+      context.otherMatchers,
+      startBucket,
+      endBucket,
+      tenantID ?? '',
+    ]);
+  }, [context, startBucket, endBucket, tenantID]);
+
+  const debounceMs =
+    context.kind === 'value' ? DEBOUNCE_VALUES_MS : DEBOUNCE_NAMES_MS;
+  const debouncedKey = useDebouncedValue(requestKey, debounceMs);
+
+  // The fetch effect reads the most recent context/buckets via a ref so it
+  // can depend solely on debouncedKey (avoiding a re-run on every render
+  // driven by start/end churn). The sync effect below runs in declaration
+  // order, ahead of the fetch effect, so the ref is current when the fetch
+  // effect reads it.
+  const paramsRef = useRef({ context, startBucket, endBucket });
+  useEffect(() => {
+    paramsRef.current = { context, startBucket, endBucket };
+  });
+
+  const [, setFetchTick] = useState(0);
+
+  useEffect(() => {
+    if (!debouncedKey || cache.has(debouncedKey)) return;
+
+    const controller = new AbortController();
+    const { context: ctx, startBucket: s, endBucket: e } = paramsRef.current;
+    const promise =
+      ctx.kind === 'name'
+        ? fetchLabelNames(ctx.otherMatchers, s, e, controller.signal)
+        : ctx.kind === 'value'
+          ? fetchLabelValues(
+              ctx.labelName,
+              ctx.otherMatchers,
+              s,
+              e,
+              controller.signal,
+            )
+          : Promise.resolve<string[]>([]);
+
+    promise
+      .then((names) => {
+        cache.set(debouncedKey, names);
+        setFetchTick((v) => v + 1);
+      })
+      .catch((err: unknown) => {
+        if ((err as { name?: string }).name === 'AbortError') return;
+        cache.set(debouncedKey, []);
+        setFetchTick((v) => v + 1);
+      });
+
+    return () => controller.abort();
+  }, [debouncedKey]);
+
+  const suggestions = useMemo(() => {
+    if (context.kind === 'none') return [];
+    const results = cache.get(debouncedKey) ?? [];
+    const prefix = context.prefix.toLowerCase();
+    const filtered = prefix
+      ? results.filter((n) => n.toLowerCase().includes(prefix))
+      : results.slice();
+    return filtered.slice(0, MAX_SUGGESTIONS);
+  }, [debouncedKey, context]);
+
+  const loading = !!debouncedKey && !cache.has(debouncedKey);
+
+  return { context, suggestions, loading };
+}

--- a/ui/src/hooks/useLabelSuggestions.ts
+++ b/ui/src/hooks/useLabelSuggestions.ts
@@ -75,6 +75,20 @@ export function useLabelSuggestions({
     paramsRef.current = { context, startBucket, endBucket };
   });
 
+  // Force a re-render after the cache is populated by an async fetch.
+  //
+  // The cache is module-scope mutable state that React doesn't observe.
+  // After `cache.set(...)` we need *something* to trigger a re-render so the
+  // `suggestions` memo recomputes and reads the new entry. An unused state
+  // setter does that minimally.
+  //
+  // The more idiomatic alternative is to put results in `useState` and let
+  // the cache be an optimization, but that requires a synchronous setState
+  // inside the fetch effect on cache hits — which trips
+  // react-hooks/set-state-in-effect. A future maintainer can swap in the
+  // useState shape (and rely on the "async initialization from external
+  // data" lint exception documented in CLAUDE.md) if the indirection here
+  // ever becomes a debugging hazard.
   const [, setFetchTick] = useState(0);
 
   useEffect(() => {

--- a/ui/src/hooks/useLabelSuggestions.ts
+++ b/ui/src/hooks/useLabelSuggestions.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { fetchLabelNames, fetchLabelValues } from '@api/client';
 import {
   getCursorContext,
+  isInternalLabel,
   toDisplayLabel,
   toInternalLabel,
   type CursorContext,
@@ -108,10 +109,17 @@ export function useLabelSuggestions({
     const promise =
       ctx.kind === 'name'
         ? fetchLabelNames(ctx.otherMatchers, s, e, controller.signal).then(
-            // Translate internal label names back to their display form
-            // (e.g. __profile_type__ → profile_type) and dedupe in case the
-            // backend ever returns both spellings.
-            (names) => Array.from(new Set(names.map(toDisplayLabel))),
+            // Translate to display form first (so __profile_type__ becomes
+            // profile_type) and then drop anything still wrapped in double
+            // underscores — those are reserved internal labels. Dedupe in
+            // case the backend ever returns both an internal name and its
+            // alias.
+            (names) =>
+              Array.from(
+                new Set(
+                  names.map(toDisplayLabel).filter((n) => !isInternalLabel(n)),
+                ),
+              ),
           )
         : ctx.kind === 'value'
           ? fetchLabelValues(

--- a/ui/src/hooks/useLabelSuggestions.ts
+++ b/ui/src/hooks/useLabelSuggestions.ts
@@ -130,6 +130,10 @@ export function useLabelSuggestions({
       })
       .catch((err: unknown) => {
         if ((err as { name?: string }).name === 'AbortError') return;
+        // Negative-cache errors so `loading` can resolve to false; without
+        // this the dropdown would be stuck on "Loading…" forever after a
+        // failed fetch. The empty-prefix branch in `definitelyEmpty` keeps
+        // this from masquerading as a "No matches" result.
         cache.set(debouncedKey, []);
         setFetchTick((v) => v + 1);
       });
@@ -137,24 +141,37 @@ export function useLabelSuggestions({
     return () => controller.abort();
   }, [debouncedKey]);
 
-  const suggestions = useMemo(() => {
-    if (context.kind === 'none') return [];
+  // Computed inline rather than via useMemo. The body reads cache.get(),
+  // which is mutable module-scope state that React's dependency tracking
+  // can't observe — memoization would return a stale empty array after the
+  // fetch resolved and called setFetchTick. Filtering up to 200 strings on
+  // every render is cheap enough that the memo wasn't earning its keep.
+  let suggestions: string[] = [];
+  if (context.kind !== 'none') {
     const results = cache.get(debouncedKey) ?? [];
-    const prefix = context.prefix.toLowerCase();
-    const filtered = prefix
-      ? results.filter((n) => n.toLowerCase().includes(prefix))
+    const prefixLower = context.prefix.toLowerCase();
+    const filtered = prefixLower
+      ? results.filter((n) => n.toLowerCase().includes(prefixLower))
       : results.slice();
-    return filtered.slice(0, MAX_SUGGESTIONS);
-  }, [debouncedKey, context]);
+    suggestions = filtered.slice(0, MAX_SUGGESTIONS);
+  }
 
-  const loading = !!debouncedKey && !cache.has(debouncedKey);
+  // Loading covers the entire window from "user typed something" through
+  // "fetch settled" — including the debounce window — so the dropdown can
+  // surface a "Loading…" affordance immediately on a keystroke instead of
+  // staying blank for 150ms.
+  const loading =
+    context.kind !== 'none' &&
+    !(requestKey === debouncedKey && cache.has(debouncedKey));
 
-  // We have a "definite" answer only when the user has stopped typing long
-  // enough for the debounce to settle (requestKey === debouncedKey) and the
-  // cache has been populated for that key. Without this, "No matches"
-  // would flash during every keystroke.
+  // "No matches" should only appear when the user is actively filtering
+  // (non-empty prefix) and the backend has confirmed there's nothing. With
+  // an empty prefix the user just opened a slot — there's nothing to
+  // "match against" yet, and showing "No matches" reads as a bug.
+  const prefix = context.kind === 'none' ? '' : context.prefix;
   const definitelyEmpty =
     context.kind !== 'none' &&
+    prefix !== '' &&
     requestKey === debouncedKey &&
     cache.has(debouncedKey) &&
     suggestions.length === 0;

--- a/ui/src/hooks/useLabelSuggestions.ts
+++ b/ui/src/hooks/useLabelSuggestions.ts
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { fetchLabelNames, fetchLabelValues } from '@api/client';
-import { getCursorContext, type CursorContext } from '../queryLang';
+import {
+  getCursorContext,
+  toDisplayLabel,
+  toInternalLabel,
+  type CursorContext,
+} from '../queryLang';
 import { useDebouncedValue } from './useDebouncedValue';
 
 const cache = new Map<string, string[]>();
@@ -102,10 +107,15 @@ export function useLabelSuggestions({
     const { context: ctx, startBucket: s, endBucket: e } = paramsRef.current;
     const promise =
       ctx.kind === 'name'
-        ? fetchLabelNames(ctx.otherMatchers, s, e, controller.signal)
+        ? fetchLabelNames(ctx.otherMatchers, s, e, controller.signal).then(
+            // Translate internal label names back to their display form
+            // (e.g. __profile_type__ → profile_type) and dedupe in case the
+            // backend ever returns both spellings.
+            (names) => Array.from(new Set(names.map(toDisplayLabel))),
+          )
         : ctx.kind === 'value'
           ? fetchLabelValues(
-              ctx.labelName,
+              toInternalLabel(ctx.labelName),
               ctx.otherMatchers,
               s,
               e,

--- a/ui/src/hooks/useLabelSuggestions.ts
+++ b/ui/src/hooks/useLabelSuggestions.ts
@@ -21,6 +21,10 @@ export interface LabelSuggestionsResult {
   context: CursorContext;
   suggestions: string[];
   loading: boolean;
+  // True when the most recently committed request has resolved to an empty
+  // result. Distinct from `suggestions.length === 0`, which is also true
+  // during the debounce window before any fetch has been attempted.
+  definitelyEmpty: boolean;
 }
 
 export function useLabelSuggestions({
@@ -135,5 +139,15 @@ export function useLabelSuggestions({
 
   const loading = !!debouncedKey && !cache.has(debouncedKey);
 
-  return { context, suggestions, loading };
+  // We have a "definite" answer only when the user has stopped typing long
+  // enough for the debounce to settle (requestKey === debouncedKey) and the
+  // cache has been populated for that key. Without this, "No matches"
+  // would flash during every keystroke.
+  const definitelyEmpty =
+    context.kind !== 'none' &&
+    requestKey === debouncedKey &&
+    cache.has(debouncedKey) &&
+    suggestions.length === 0;
+
+  return { context, suggestions, loading, definitelyEmpty };
 }

--- a/ui/src/hooks/useLabelSuggestions.ts
+++ b/ui/src/hooks/useLabelSuggestions.ts
@@ -154,8 +154,14 @@ export function useLabelSuggestions({
   // can't observe — memoization would return a stale empty array after the
   // fetch resolved and called setFetchTick. Filtering up to 200 strings on
   // every render is cheap enough that the memo wasn't earning its keep.
+  //
+  // Gate on `requestKey === debouncedKey` so we never surface results from
+  // the previous slot during the debounce window. Without this, moving from
+  // a name slot to a value slot (or changing matchers) would show the old
+  // slot's names until the debounce settled, and Enter would insert them
+  // into the new slot via the current `context`.
   let suggestions: string[] = [];
-  if (context.kind !== 'none') {
+  if (context.kind !== 'none' && requestKey === debouncedKey) {
     const results = cache.get(debouncedKey) ?? [];
     const prefixLower = context.prefix.toLowerCase();
     const filtered = prefixLower

--- a/ui/src/hooks/usePyroscopeQuery.ts
+++ b/ui/src/hooks/usePyroscopeQuery.ts
@@ -30,7 +30,7 @@ export interface QueryResult {
   execute: (service: string, profileType: string, timeRange: string) => void;
 }
 
-function parseTimeRange(range: string): { start: number; end: number } {
+export function parseTimeRange(range: string): { start: number; end: number } {
   const now = Date.now();
   const m = range.match(/^now-(\d+)([mhd])$/);
   if (!m) return { start: now - 3_600_000, end: now };

--- a/ui/src/queryLang.test.ts
+++ b/ui/src/queryLang.test.ts
@@ -5,6 +5,8 @@ import {
   applySuggestion,
   buildQuery,
   parseQuery,
+  toDisplayLabel,
+  toInternalLabel,
 } from './queryLang';
 
 describe('tokenize', () => {
@@ -251,6 +253,27 @@ describe('applySuggestion', () => {
     const ctx = getCursorContext(q, 4);
     const { next } = applySuggestion(q, ctx, 'api');
     expect(next).toBe('{a="api"}');
+  });
+});
+
+describe('label name translation', () => {
+  it('maps display names to their internal form', () => {
+    expect(toInternalLabel('profile_type')).toBe('__profile_type__');
+    expect(toInternalLabel('service_name')).toBe('service_name');
+  });
+
+  it('maps internal names to their display form', () => {
+    expect(toDisplayLabel('__profile_type__')).toBe('profile_type');
+    expect(toDisplayLabel('service_name')).toBe('service_name');
+  });
+
+  it('serializes profile_type matchers using the internal label name', () => {
+    const q = '{profile_type="cpu", service_name="ap"}';
+    const cursor = q.indexOf('"ap"') + 2;
+    const ctx = getCursorContext(q, cursor);
+    expect(ctx.kind).toBe('value');
+    if (ctx.kind !== 'value') return;
+    expect(ctx.otherMatchers).toEqual(['{__profile_type__="cpu"}']);
   });
 });
 

--- a/ui/src/queryLang.test.ts
+++ b/ui/src/queryLang.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect } from 'vitest';
+import {
+  tokenize,
+  getCursorContext,
+  applySuggestion,
+  buildQuery,
+  parseQuery,
+} from './queryLang';
+
+describe('tokenize', () => {
+  it('reports -1 for missing braces', () => {
+    const t = tokenize('foo');
+    expect(t.braceOpen).toBe(-1);
+    expect(t.braceClose).toBe(-1);
+    expect(t.matchers).toEqual([]);
+  });
+
+  it('parses a single complete matcher', () => {
+    const t = tokenize('{service_name="api"}');
+    expect(t.braceOpen).toBe(0);
+    expect(t.braceClose).toBe(19);
+    expect(t.matchers).toHaveLength(1);
+    const [m] = t.matchers;
+    expect(m.name).toBe('service_name');
+    expect(m.op).toBe('=');
+    expect(m.value).toBe('api');
+    expect(m.complete).toBe(true);
+    expect(m.valueClosed).toBe(true);
+  });
+
+  it('parses multiple matchers separated by commas', () => {
+    const t = tokenize('{a="b",c="d"}');
+    expect(t.matchers).toHaveLength(2);
+    expect(t.matchers.map((m) => m.name)).toEqual(['a', 'c']);
+    expect(t.matchers.every((m) => m.complete)).toBe(true);
+  });
+
+  it('does not split on commas inside a quoted value', () => {
+    const t = tokenize('{labels="foo,bar"}');
+    expect(t.matchers).toHaveLength(1);
+    expect(t.matchers[0].value).toBe('foo,bar');
+    expect(t.matchers[0].complete).toBe(true);
+  });
+
+  it('handles escaped quotes inside values', () => {
+    const t = tokenize('{a="foo\\"bar"}');
+    expect(t.matchers).toHaveLength(1);
+    expect(t.matchers[0].valueClosed).toBe(true);
+    expect(t.matchers[0].complete).toBe(true);
+  });
+
+  it('handles an unterminated quoted value', () => {
+    const t = tokenize('{a="api');
+    expect(t.matchers).toHaveLength(1);
+    expect(t.matchers[0].valueClosed).toBe(false);
+    expect(t.matchers[0].complete).toBe(false);
+    expect(t.matchers[0].value).toBe('api');
+  });
+
+  it('handles empty braces with a single empty slot', () => {
+    const t = tokenize('{}');
+    expect(t.matchers).toHaveLength(1);
+    expect(t.matchers[0].name).toBe('');
+    expect(t.matchers[0].complete).toBe(false);
+  });
+
+  it('handles a partial name with no operator', () => {
+    const t = tokenize('{serv');
+    expect(t.matchers).toHaveLength(1);
+    expect(t.matchers[0].name).toBe('serv');
+    expect(t.matchers[0].op).toBe('');
+    expect(t.matchers[0].complete).toBe(false);
+  });
+
+  it('recognizes the four operators', () => {
+    expect(tokenize('{a="b"}').matchers[0].op).toBe('=');
+    expect(tokenize('{a!="b"}').matchers[0].op).toBe('!=');
+    expect(tokenize('{a=~"b"}').matchers[0].op).toBe('=~');
+    expect(tokenize('{a!~"b"}').matchers[0].op).toBe('!~');
+  });
+
+  it('preserves a trailing empty slot after a comma', () => {
+    const t = tokenize('{a="b", }');
+    expect(t.matchers).toHaveLength(2);
+    expect(t.matchers[0].name).toBe('a');
+    expect(t.matchers[1].name).toBe('');
+  });
+});
+
+describe('getCursorContext', () => {
+  it('returns none before the opening brace', () => {
+    expect(getCursorContext('{a="b"}', 0).kind).toBe('none');
+    expect(getCursorContext('foo{a="b"}', 2).kind).toBe('none');
+  });
+
+  it('returns none after the closing brace', () => {
+    const q = '{a="b"}';
+    // braceClose is at index 6
+    expect(getCursorContext(q, 7).kind).toBe('none');
+  });
+
+  it('suggests names right after the opening brace', () => {
+    const ctx = getCursorContext('{}', 1);
+    expect(ctx.kind).toBe('name');
+    if (ctx.kind !== 'name') return;
+    expect(ctx.prefix).toBe('');
+    expect(ctx.replaceRange).toEqual([1, 1]);
+    expect(ctx.otherMatchers).toEqual([]);
+  });
+
+  it('suggests names with a partial prefix', () => {
+    const ctx = getCursorContext('{serv', 5);
+    expect(ctx.kind).toBe('name');
+    if (ctx.kind !== 'name') return;
+    expect(ctx.prefix).toBe('serv');
+    expect(ctx.replaceRange).toEqual([1, 5]);
+  });
+
+  it('suggests names with cursor inside a partial name', () => {
+    // {ser|vice}
+    const q = '{service}';
+    const ctx = getCursorContext(q, 4);
+    expect(ctx.kind).toBe('name');
+    if (ctx.kind !== 'name') return;
+    expect(ctx.prefix).toBe('ser');
+  });
+
+  it('suggests values with cursor inside a quoted value', () => {
+    // {a="ap|i"}
+    const q = '{a="api"}';
+    const ctx = getCursorContext(q, 6);
+    expect(ctx.kind).toBe('value');
+    if (ctx.kind !== 'value') return;
+    expect(ctx.labelName).toBe('a');
+    expect(ctx.prefix).toBe('ap');
+    expect(ctx.replaceRange).toEqual([4, 7]);
+  });
+
+  it('suggests values with an empty value', () => {
+    // {a="|"}
+    const q = '{a=""}';
+    const ctx = getCursorContext(q, 4);
+    expect(ctx.kind).toBe('value');
+    if (ctx.kind !== 'value') return;
+    expect(ctx.prefix).toBe('');
+    expect(ctx.replaceRange).toEqual([4, 4]);
+  });
+
+  it('suggests values for an unclosed quoted value', () => {
+    // {a="ap|
+    const q = '{a="ap';
+    const ctx = getCursorContext(q, 6);
+    expect(ctx.kind).toBe('value');
+    if (ctx.kind !== 'value') return;
+    expect(ctx.prefix).toBe('ap');
+    expect(ctx.replaceRange).toEqual([4, 6]);
+  });
+
+  it('returns none with cursor between operator and opening quote', () => {
+    // {a=|"b"}
+    const q = '{a="b"}';
+    const ctx = getCursorContext(q, 3);
+    expect(ctx.kind).toBe('none');
+  });
+
+  it('returns none with cursor past the closing quote', () => {
+    // {a="b"|}
+    const q = '{a="b"}';
+    const ctx = getCursorContext(q, 6);
+    expect(ctx.kind).toBe('none');
+  });
+
+  it('includes other complete matchers in otherMatchers', () => {
+    // {region="us-east", service_name="ap|"}
+    const q = '{region="us-east", service_name="api"}';
+    // Find cursor inside "api"
+    const cursor = q.indexOf('api') + 2; // after 'ap'
+    const ctx = getCursorContext(q, cursor);
+    expect(ctx.kind).toBe('value');
+    if (ctx.kind !== 'value') return;
+    expect(ctx.otherMatchers).toEqual(['{region="us-east"}']);
+  });
+
+  it('excludes the matcher under the cursor from otherMatchers', () => {
+    const q = '{a="x", b="y"}';
+    // Cursor inside "y"
+    const ctx = getCursorContext(q, q.indexOf('"y"') + 2);
+    expect(ctx.kind).toBe('value');
+    if (ctx.kind !== 'value') return;
+    expect(ctx.otherMatchers).toEqual(['{a="x"}']);
+  });
+
+  it('suggests names in a new slot after a comma', () => {
+    const q = '{a="b", }';
+    // Cursor right before the closing brace
+    const ctx = getCursorContext(q, 8);
+    expect(ctx.kind).toBe('name');
+    if (ctx.kind !== 'name') return;
+    expect(ctx.prefix).toBe('');
+    expect(ctx.otherMatchers).toEqual(['{a="b"}']);
+  });
+});
+
+describe('applySuggestion', () => {
+  it('appends ="| when accepting a name with no following operator', () => {
+    const q = '{}';
+    const ctx = getCursorContext(q, 1);
+    const { next, cursor } = applySuggestion(q, ctx, 'service_name');
+    expect(next).toBe('{service_name="}');
+    // cursor between the quotes
+    expect(cursor).toBe(next.indexOf('"') + 1);
+  });
+
+  it('replaces a partial name and adds ="', () => {
+    const q = '{serv}';
+    const ctx = getCursorContext(q, 5);
+    const { next, cursor } = applySuggestion(q, ctx, 'service_name');
+    expect(next).toBe('{service_name="}');
+    expect(cursor).toBe(next.indexOf('"') + 1);
+  });
+
+  it('replaces a name without inserting an operator when one already follows', () => {
+    const q = '{a="b"}';
+    // Cursor right after 'a'
+    const ctx = getCursorContext(q, 2);
+    const { next, cursor } = applySuggestion(q, ctx, 'region');
+    expect(next).toBe('{region="b"}');
+    // cursor lands right after 'region', before '='
+    expect(cursor).toBe('{region'.length);
+  });
+
+  it('replaces a partial value and leaves the closing quote intact', () => {
+    const q = '{a="ap"}';
+    const ctx = getCursorContext(q, q.indexOf('ap') + 2);
+    const { next, cursor } = applySuggestion(q, ctx, 'api');
+    expect(next).toBe('{a="api"}');
+    // cursor lands right after the closing quote
+    expect(cursor).toBe(next.indexOf('"', 4) + 1);
+  });
+
+  it('appends a closing quote when the value is unclosed', () => {
+    const q = '{a="ap';
+    const ctx = getCursorContext(q, q.length);
+    const { next, cursor } = applySuggestion(q, ctx, 'api');
+    expect(next).toBe('{a="api"');
+    expect(cursor).toBe(next.length);
+  });
+
+  it('handles accepting a value for an empty quoted string', () => {
+    const q = '{a=""}';
+    const ctx = getCursorContext(q, 4);
+    const { next } = applySuggestion(q, ctx, 'api');
+    expect(next).toBe('{a="api"}');
+  });
+});
+
+describe('parseQuery / buildQuery', () => {
+  it('round-trips a built query', () => {
+    const q = buildQuery('my-service', 'process_cpu:cpu:nanoseconds:cpu:nanoseconds');
+    const parsed = parseQuery(q);
+    expect(parsed).toEqual({
+      service: 'my-service',
+      profileType: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds',
+    });
+  });
+
+  it('returns null when required labels are absent', () => {
+    expect(parseQuery('{foo="bar"}')).toBeNull();
+  });
+
+  it('tolerates extra whitespace around the operator', () => {
+    const parsed = parseQuery('{service_name = "api", profile_type = "cpu"}');
+    expect(parsed).toEqual({ service: 'api', profileType: 'cpu' });
+  });
+});

--- a/ui/src/queryLang.test.ts
+++ b/ui/src/queryLang.test.ts
@@ -290,7 +290,10 @@ describe('label name translation', () => {
 
 describe('parseQuery / buildQuery', () => {
   it('round-trips a built query', () => {
-    const q = buildQuery('my-service', 'process_cpu:cpu:nanoseconds:cpu:nanoseconds');
+    const q = buildQuery(
+      'my-service',
+      'process_cpu:cpu:nanoseconds:cpu:nanoseconds',
+    );
     const parsed = parseQuery(q);
     expect(parsed).toEqual({
       service: 'my-service',

--- a/ui/src/queryLang.test.ts
+++ b/ui/src/queryLang.test.ts
@@ -7,6 +7,7 @@ import {
   parseQuery,
   toDisplayLabel,
   toInternalLabel,
+  isInternalLabel,
 } from './queryLang';
 
 describe('tokenize', () => {
@@ -265,6 +266,16 @@ describe('label name translation', () => {
   it('maps internal names to their display form', () => {
     expect(toDisplayLabel('__profile_type__')).toBe('profile_type');
     expect(toDisplayLabel('service_name')).toBe('service_name');
+  });
+
+  it('detects internal __xxx__ labels', () => {
+    expect(isInternalLabel('__delta__')).toBe(true);
+    expect(isInternalLabel('__session_id__')).toBe(true);
+    expect(isInternalLabel('__profile_type__')).toBe(true);
+    expect(isInternalLabel('service_name')).toBe(false);
+    expect(isInternalLabel('profile_type')).toBe(false);
+    expect(isInternalLabel('__partial')).toBe(false);
+    expect(isInternalLabel('partial__')).toBe(false);
   });
 
   it('serializes profile_type matchers using the internal label name', () => {

--- a/ui/src/queryLang.test.ts
+++ b/ui/src/queryLang.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
 import {
   tokenize,
   getCursorContext,
@@ -8,199 +10,194 @@ import {
   toDisplayLabel,
   toInternalLabel,
   isInternalLabel,
-} from './queryLang';
+} from './queryLang.ts';
 
 describe('tokenize', () => {
   it('reports -1 for missing braces', () => {
     const t = tokenize('foo');
-    expect(t.braceOpen).toBe(-1);
-    expect(t.braceClose).toBe(-1);
-    expect(t.matchers).toEqual([]);
+    assert.equal(t.braceOpen, -1);
+    assert.equal(t.braceClose, -1);
+    assert.deepEqual(t.matchers, []);
   });
 
   it('parses a single complete matcher', () => {
     const t = tokenize('{service_name="api"}');
-    expect(t.braceOpen).toBe(0);
-    expect(t.braceClose).toBe(19);
-    expect(t.matchers).toHaveLength(1);
+    assert.equal(t.braceOpen, 0);
+    assert.equal(t.braceClose, 19);
+    assert.equal(t.matchers.length, 1);
     const [m] = t.matchers;
-    expect(m.name).toBe('service_name');
-    expect(m.op).toBe('=');
-    expect(m.value).toBe('api');
-    expect(m.complete).toBe(true);
-    expect(m.valueClosed).toBe(true);
+    assert.equal(m.name, 'service_name');
+    assert.equal(m.op, '=');
+    assert.equal(m.value, 'api');
+    assert.equal(m.complete, true);
+    assert.equal(m.valueClosed, true);
   });
 
   it('parses multiple matchers separated by commas', () => {
     const t = tokenize('{a="b",c="d"}');
-    expect(t.matchers).toHaveLength(2);
-    expect(t.matchers.map((m) => m.name)).toEqual(['a', 'c']);
-    expect(t.matchers.every((m) => m.complete)).toBe(true);
+    assert.equal(t.matchers.length, 2);
+    assert.deepEqual(
+      t.matchers.map((m) => m.name),
+      ['a', 'c'],
+    );
+    assert.equal(
+      t.matchers.every((m) => m.complete),
+      true,
+    );
   });
 
   it('does not split on commas inside a quoted value', () => {
     const t = tokenize('{labels="foo,bar"}');
-    expect(t.matchers).toHaveLength(1);
-    expect(t.matchers[0].value).toBe('foo,bar');
-    expect(t.matchers[0].complete).toBe(true);
+    assert.equal(t.matchers.length, 1);
+    assert.equal(t.matchers[0].value, 'foo,bar');
+    assert.equal(t.matchers[0].complete, true);
   });
 
   it('handles escaped quotes inside values', () => {
     const t = tokenize('{a="foo\\"bar"}');
-    expect(t.matchers).toHaveLength(1);
-    expect(t.matchers[0].valueClosed).toBe(true);
-    expect(t.matchers[0].complete).toBe(true);
+    assert.equal(t.matchers.length, 1);
+    assert.equal(t.matchers[0].valueClosed, true);
+    assert.equal(t.matchers[0].complete, true);
   });
 
   it('handles an unterminated quoted value', () => {
     const t = tokenize('{a="api');
-    expect(t.matchers).toHaveLength(1);
-    expect(t.matchers[0].valueClosed).toBe(false);
-    expect(t.matchers[0].complete).toBe(false);
-    expect(t.matchers[0].value).toBe('api');
+    assert.equal(t.matchers.length, 1);
+    assert.equal(t.matchers[0].valueClosed, false);
+    assert.equal(t.matchers[0].complete, false);
+    assert.equal(t.matchers[0].value, 'api');
   });
 
   it('handles empty braces with a single empty slot', () => {
     const t = tokenize('{}');
-    expect(t.matchers).toHaveLength(1);
-    expect(t.matchers[0].name).toBe('');
-    expect(t.matchers[0].complete).toBe(false);
+    assert.equal(t.matchers.length, 1);
+    assert.equal(t.matchers[0].name, '');
+    assert.equal(t.matchers[0].complete, false);
   });
 
   it('handles a partial name with no operator', () => {
     const t = tokenize('{serv');
-    expect(t.matchers).toHaveLength(1);
-    expect(t.matchers[0].name).toBe('serv');
-    expect(t.matchers[0].op).toBe('');
-    expect(t.matchers[0].complete).toBe(false);
+    assert.equal(t.matchers.length, 1);
+    assert.equal(t.matchers[0].name, 'serv');
+    assert.equal(t.matchers[0].op, '');
+    assert.equal(t.matchers[0].complete, false);
   });
 
   it('recognizes the four operators', () => {
-    expect(tokenize('{a="b"}').matchers[0].op).toBe('=');
-    expect(tokenize('{a!="b"}').matchers[0].op).toBe('!=');
-    expect(tokenize('{a=~"b"}').matchers[0].op).toBe('=~');
-    expect(tokenize('{a!~"b"}').matchers[0].op).toBe('!~');
+    assert.equal(tokenize('{a="b"}').matchers[0].op, '=');
+    assert.equal(tokenize('{a!="b"}').matchers[0].op, '!=');
+    assert.equal(tokenize('{a=~"b"}').matchers[0].op, '=~');
+    assert.equal(tokenize('{a!~"b"}').matchers[0].op, '!~');
   });
 
   it('preserves a trailing empty slot after a comma', () => {
     const t = tokenize('{a="b", }');
-    expect(t.matchers).toHaveLength(2);
-    expect(t.matchers[0].name).toBe('a');
-    expect(t.matchers[1].name).toBe('');
+    assert.equal(t.matchers.length, 2);
+    assert.equal(t.matchers[0].name, 'a');
+    assert.equal(t.matchers[1].name, '');
   });
 });
 
 describe('getCursorContext', () => {
   it('returns none before the opening brace', () => {
-    expect(getCursorContext('{a="b"}', 0).kind).toBe('none');
-    expect(getCursorContext('foo{a="b"}', 2).kind).toBe('none');
+    assert.equal(getCursorContext('{a="b"}', 0).kind, 'none');
+    assert.equal(getCursorContext('foo{a="b"}', 2).kind, 'none');
   });
 
   it('returns none after the closing brace', () => {
     const q = '{a="b"}';
-    // braceClose is at index 6
-    expect(getCursorContext(q, 7).kind).toBe('none');
+    assert.equal(getCursorContext(q, 7).kind, 'none');
   });
 
   it('suggests names right after the opening brace', () => {
     const ctx = getCursorContext('{}', 1);
-    expect(ctx.kind).toBe('name');
+    assert.equal(ctx.kind, 'name');
     if (ctx.kind !== 'name') return;
-    expect(ctx.prefix).toBe('');
-    expect(ctx.replaceRange).toEqual([1, 1]);
-    expect(ctx.otherMatchers).toEqual([]);
+    assert.equal(ctx.prefix, '');
+    assert.deepEqual(ctx.replaceRange, [1, 1]);
+    assert.deepEqual(ctx.otherMatchers, []);
   });
 
   it('suggests names with a partial prefix', () => {
     const ctx = getCursorContext('{serv', 5);
-    expect(ctx.kind).toBe('name');
+    assert.equal(ctx.kind, 'name');
     if (ctx.kind !== 'name') return;
-    expect(ctx.prefix).toBe('serv');
-    expect(ctx.replaceRange).toEqual([1, 5]);
+    assert.equal(ctx.prefix, 'serv');
+    assert.deepEqual(ctx.replaceRange, [1, 5]);
   });
 
   it('suggests names with cursor inside a partial name', () => {
-    // {ser|vice}
     const q = '{service}';
     const ctx = getCursorContext(q, 4);
-    expect(ctx.kind).toBe('name');
+    assert.equal(ctx.kind, 'name');
     if (ctx.kind !== 'name') return;
-    expect(ctx.prefix).toBe('ser');
+    assert.equal(ctx.prefix, 'ser');
   });
 
   it('suggests values with cursor inside a quoted value', () => {
-    // {a="ap|i"}
     const q = '{a="api"}';
     const ctx = getCursorContext(q, 6);
-    expect(ctx.kind).toBe('value');
+    assert.equal(ctx.kind, 'value');
     if (ctx.kind !== 'value') return;
-    expect(ctx.labelName).toBe('a');
-    expect(ctx.prefix).toBe('ap');
-    expect(ctx.replaceRange).toEqual([4, 7]);
+    assert.equal(ctx.labelName, 'a');
+    assert.equal(ctx.prefix, 'ap');
+    assert.deepEqual(ctx.replaceRange, [4, 7]);
   });
 
   it('suggests values with an empty value', () => {
-    // {a="|"}
     const q = '{a=""}';
     const ctx = getCursorContext(q, 4);
-    expect(ctx.kind).toBe('value');
+    assert.equal(ctx.kind, 'value');
     if (ctx.kind !== 'value') return;
-    expect(ctx.prefix).toBe('');
-    expect(ctx.replaceRange).toEqual([4, 4]);
+    assert.equal(ctx.prefix, '');
+    assert.deepEqual(ctx.replaceRange, [4, 4]);
   });
 
   it('suggests values for an unclosed quoted value', () => {
-    // {a="ap|
     const q = '{a="ap';
     const ctx = getCursorContext(q, 6);
-    expect(ctx.kind).toBe('value');
+    assert.equal(ctx.kind, 'value');
     if (ctx.kind !== 'value') return;
-    expect(ctx.prefix).toBe('ap');
-    expect(ctx.replaceRange).toEqual([4, 6]);
+    assert.equal(ctx.prefix, 'ap');
+    assert.deepEqual(ctx.replaceRange, [4, 6]);
   });
 
   it('returns none with cursor between operator and opening quote', () => {
-    // {a=|"b"}
     const q = '{a="b"}';
     const ctx = getCursorContext(q, 3);
-    expect(ctx.kind).toBe('none');
+    assert.equal(ctx.kind, 'none');
   });
 
   it('returns none with cursor past the closing quote', () => {
-    // {a="b"|}
     const q = '{a="b"}';
     const ctx = getCursorContext(q, 6);
-    expect(ctx.kind).toBe('none');
+    assert.equal(ctx.kind, 'none');
   });
 
   it('includes other complete matchers in otherMatchers', () => {
-    // {region="us-east", service_name="ap|"}
     const q = '{region="us-east", service_name="api"}';
-    // Find cursor inside "api"
-    const cursor = q.indexOf('api') + 2; // after 'ap'
+    const cursor = q.indexOf('api') + 2;
     const ctx = getCursorContext(q, cursor);
-    expect(ctx.kind).toBe('value');
+    assert.equal(ctx.kind, 'value');
     if (ctx.kind !== 'value') return;
-    expect(ctx.otherMatchers).toEqual(['{region="us-east"}']);
+    assert.deepEqual(ctx.otherMatchers, ['{region="us-east"}']);
   });
 
   it('excludes the matcher under the cursor from otherMatchers', () => {
     const q = '{a="x", b="y"}';
-    // Cursor inside "y"
     const ctx = getCursorContext(q, q.indexOf('"y"') + 2);
-    expect(ctx.kind).toBe('value');
+    assert.equal(ctx.kind, 'value');
     if (ctx.kind !== 'value') return;
-    expect(ctx.otherMatchers).toEqual(['{a="x"}']);
+    assert.deepEqual(ctx.otherMatchers, ['{a="x"}']);
   });
 
   it('suggests names in a new slot after a comma', () => {
     const q = '{a="b", }';
-    // Cursor right before the closing brace
     const ctx = getCursorContext(q, 8);
-    expect(ctx.kind).toBe('name');
+    assert.equal(ctx.kind, 'name');
     if (ctx.kind !== 'name') return;
-    expect(ctx.prefix).toBe('');
-    expect(ctx.otherMatchers).toEqual(['{a="b"}']);
+    assert.equal(ctx.prefix, '');
+    assert.deepEqual(ctx.otherMatchers, ['{a="b"}']);
   });
 });
 
@@ -209,82 +206,78 @@ describe('applySuggestion', () => {
     const q = '{}';
     const ctx = getCursorContext(q, 1);
     const { next, cursor } = applySuggestion(q, ctx, 'service_name');
-    expect(next).toBe('{service_name="}');
-    // cursor between the quotes
-    expect(cursor).toBe(next.indexOf('"') + 1);
+    assert.equal(next, '{service_name="}');
+    assert.equal(cursor, next.indexOf('"') + 1);
   });
 
   it('replaces a partial name and adds ="', () => {
     const q = '{serv}';
     const ctx = getCursorContext(q, 5);
     const { next, cursor } = applySuggestion(q, ctx, 'service_name');
-    expect(next).toBe('{service_name="}');
-    expect(cursor).toBe(next.indexOf('"') + 1);
+    assert.equal(next, '{service_name="}');
+    assert.equal(cursor, next.indexOf('"') + 1);
   });
 
   it('replaces a name without inserting an operator when one already follows', () => {
     const q = '{a="b"}';
-    // Cursor right after 'a'
     const ctx = getCursorContext(q, 2);
     const { next, cursor } = applySuggestion(q, ctx, 'region');
-    expect(next).toBe('{region="b"}');
-    // cursor lands right after 'region', before '='
-    expect(cursor).toBe('{region'.length);
+    assert.equal(next, '{region="b"}');
+    assert.equal(cursor, '{region'.length);
   });
 
   it('replaces a partial value and leaves the closing quote intact', () => {
     const q = '{a="ap"}';
     const ctx = getCursorContext(q, q.indexOf('ap') + 2);
     const { next, cursor } = applySuggestion(q, ctx, 'api');
-    expect(next).toBe('{a="api"}');
-    // cursor lands right after the closing quote
-    expect(cursor).toBe(next.indexOf('"', 4) + 1);
+    assert.equal(next, '{a="api"}');
+    assert.equal(cursor, next.indexOf('"', 4) + 1);
   });
 
   it('appends a closing quote when the value is unclosed', () => {
     const q = '{a="ap';
     const ctx = getCursorContext(q, q.length);
     const { next, cursor } = applySuggestion(q, ctx, 'api');
-    expect(next).toBe('{a="api"');
-    expect(cursor).toBe(next.length);
+    assert.equal(next, '{a="api"');
+    assert.equal(cursor, next.length);
   });
 
   it('handles accepting a value for an empty quoted string', () => {
     const q = '{a=""}';
     const ctx = getCursorContext(q, 4);
     const { next } = applySuggestion(q, ctx, 'api');
-    expect(next).toBe('{a="api"}');
+    assert.equal(next, '{a="api"}');
   });
 });
 
 describe('label name translation', () => {
   it('maps display names to their internal form', () => {
-    expect(toInternalLabel('profile_type')).toBe('__profile_type__');
-    expect(toInternalLabel('service_name')).toBe('service_name');
+    assert.equal(toInternalLabel('profile_type'), '__profile_type__');
+    assert.equal(toInternalLabel('service_name'), 'service_name');
   });
 
   it('maps internal names to their display form', () => {
-    expect(toDisplayLabel('__profile_type__')).toBe('profile_type');
-    expect(toDisplayLabel('service_name')).toBe('service_name');
+    assert.equal(toDisplayLabel('__profile_type__'), 'profile_type');
+    assert.equal(toDisplayLabel('service_name'), 'service_name');
   });
 
   it('detects internal __xxx__ labels', () => {
-    expect(isInternalLabel('__delta__')).toBe(true);
-    expect(isInternalLabel('__session_id__')).toBe(true);
-    expect(isInternalLabel('__profile_type__')).toBe(true);
-    expect(isInternalLabel('service_name')).toBe(false);
-    expect(isInternalLabel('profile_type')).toBe(false);
-    expect(isInternalLabel('__partial')).toBe(false);
-    expect(isInternalLabel('partial__')).toBe(false);
+    assert.equal(isInternalLabel('__delta__'), true);
+    assert.equal(isInternalLabel('__session_id__'), true);
+    assert.equal(isInternalLabel('__profile_type__'), true);
+    assert.equal(isInternalLabel('service_name'), false);
+    assert.equal(isInternalLabel('profile_type'), false);
+    assert.equal(isInternalLabel('__partial'), false);
+    assert.equal(isInternalLabel('partial__'), false);
   });
 
   it('serializes profile_type matchers using the internal label name', () => {
     const q = '{profile_type="cpu", service_name="ap"}';
     const cursor = q.indexOf('"ap"') + 2;
     const ctx = getCursorContext(q, cursor);
-    expect(ctx.kind).toBe('value');
+    assert.equal(ctx.kind, 'value');
     if (ctx.kind !== 'value') return;
-    expect(ctx.otherMatchers).toEqual(['{__profile_type__="cpu"}']);
+    assert.deepEqual(ctx.otherMatchers, ['{__profile_type__="cpu"}']);
   });
 });
 
@@ -295,18 +288,18 @@ describe('parseQuery / buildQuery', () => {
       'process_cpu:cpu:nanoseconds:cpu:nanoseconds',
     );
     const parsed = parseQuery(q);
-    expect(parsed).toEqual({
+    assert.deepEqual(parsed, {
       service: 'my-service',
       profileType: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds',
     });
   });
 
   it('returns null when required labels are absent', () => {
-    expect(parseQuery('{foo="bar"}')).toBeNull();
+    assert.equal(parseQuery('{foo="bar"}'), null);
   });
 
   it('tolerates extra whitespace around the operator', () => {
     const parsed = parseQuery('{service_name = "api", profile_type = "cpu"}');
-    expect(parsed).toEqual({ service: 'api', profileType: 'cpu' });
+    assert.deepEqual(parsed, { service: 'api', profileType: 'cpu' });
   });
 });

--- a/ui/src/queryLang.ts
+++ b/ui/src/queryLang.ts
@@ -1,0 +1,284 @@
+export type Operator = '=' | '!=' | '=~' | '!~';
+
+export interface Matcher {
+  name: string;
+  op: Operator | '';
+  value: string;
+  start: number;
+  end: number;
+  nameStart: number;
+  nameEnd: number;
+  opStart: number;
+  opEnd: number;
+  valueStart: number;
+  valueEnd: number;
+  valueClosed: boolean;
+  complete: boolean;
+}
+
+export interface Tokens {
+  matchers: Matcher[];
+  braceOpen: number;
+  braceClose: number;
+}
+
+export type CursorContext =
+  | {
+      kind: 'name';
+      prefix: string;
+      replaceRange: [number, number];
+      otherMatchers: string[];
+    }
+  | {
+      kind: 'value';
+      labelName: string;
+      prefix: string;
+      replaceRange: [number, number];
+      otherMatchers: string[];
+    }
+  | { kind: 'none' };
+
+const IDENT = /[A-Za-z0-9_]/;
+const WS = /\s/;
+
+export function tokenize(q: string): Tokens {
+  const braceOpen = q.indexOf('{');
+  if (braceOpen === -1) {
+    return { matchers: [], braceOpen: -1, braceClose: -1 };
+  }
+
+  let braceClose = -1;
+  let inQuote = false;
+  let escaped = false;
+  for (let i = braceOpen + 1; i < q.length; i++) {
+    const ch = q[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (inQuote) {
+      if (ch === '\\') escaped = true;
+      else if (ch === '"') inQuote = false;
+      continue;
+    }
+    if (ch === '"') inQuote = true;
+    else if (ch === '}') {
+      braceClose = i;
+      break;
+    }
+  }
+
+  const contentEnd = braceClose === -1 ? q.length : braceClose;
+  const slots: Array<[number, number]> = [];
+  let slotStart = braceOpen + 1;
+  inQuote = false;
+  escaped = false;
+  for (let i = braceOpen + 1; i < contentEnd; i++) {
+    const ch = q[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (inQuote) {
+      if (ch === '\\') escaped = true;
+      else if (ch === '"') inQuote = false;
+      continue;
+    }
+    if (ch === '"') inQuote = true;
+    else if (ch === ',') {
+      slots.push([slotStart, i]);
+      slotStart = i + 1;
+    }
+  }
+  slots.push([slotStart, contentEnd]);
+
+  const matchers = slots.map(([s, e]) => parseSlot(q, s, e));
+  return { matchers, braceOpen, braceClose };
+}
+
+function parseSlot(q: string, slotStart: number, slotEnd: number): Matcher {
+  let i = slotStart;
+  while (i < slotEnd && WS.test(q[i])) i++;
+  const nameStart = i;
+  while (i < slotEnd && IDENT.test(q[i])) i++;
+  const nameEnd = i;
+  const name = q.slice(nameStart, nameEnd);
+
+  while (i < slotEnd && WS.test(q[i])) i++;
+  const opStart = i;
+  let op: Operator | '' = '';
+  const c0 = q[i];
+  const c1 = q[i + 1];
+  if (c0 === '!' && c1 === '=') {
+    op = '!=';
+    i += 2;
+  } else if (c0 === '!' && c1 === '~') {
+    op = '!~';
+    i += 2;
+  } else if (c0 === '=' && c1 === '~') {
+    op = '=~';
+    i += 2;
+  } else if (c0 === '=') {
+    op = '=';
+    i += 1;
+  }
+  const opEnd = i;
+
+  while (i < slotEnd && WS.test(q[i])) i++;
+
+  let valueStart = -1;
+  let valueEnd = -1;
+  let value = '';
+  let valueClosed = false;
+  if (q[i] === '"') {
+    valueStart = i;
+    i++;
+    const textStart = i;
+    let esc = false;
+    while (i < slotEnd) {
+      if (esc) {
+        esc = false;
+        i++;
+        continue;
+      }
+      if (q[i] === '\\') {
+        esc = true;
+        i++;
+        continue;
+      }
+      if (q[i] === '"') {
+        valueEnd = i;
+        valueClosed = true;
+        i++;
+        break;
+      }
+      i++;
+    }
+    if (!valueClosed) valueEnd = i;
+    value = q.slice(textStart, valueEnd);
+  }
+
+  const complete = name.length > 0 && op !== '' && valueClosed;
+
+  return {
+    name,
+    op,
+    value,
+    start: slotStart,
+    end: slotEnd,
+    nameStart,
+    nameEnd,
+    opStart,
+    opEnd,
+    valueStart,
+    valueEnd,
+    valueClosed,
+    complete,
+  };
+}
+
+function serializeMatcher(m: Matcher): string {
+  return `{${m.name}${m.op}"${m.value}"}`;
+}
+
+export function getCursorContext(
+  query: string,
+  cursor: number,
+): CursorContext {
+  const { matchers, braceOpen, braceClose } = tokenize(query);
+  if (braceOpen === -1) return { kind: 'none' };
+  if (cursor <= braceOpen) return { kind: 'none' };
+  if (braceClose !== -1 && cursor > braceClose) return { kind: 'none' };
+
+  const slot = matchers.find((m) => cursor >= m.start && cursor <= m.end);
+  if (!slot) return { kind: 'none' };
+
+  const otherMatchers = matchers
+    .filter((m) => m !== slot && m.complete)
+    .map(serializeMatcher);
+
+  // Cursor inside a quoted value (between the quotes).
+  if (slot.valueStart !== -1 && cursor > slot.valueStart) {
+    const closingPos = slot.valueClosed ? slot.valueEnd : -1;
+    const inValue =
+      closingPos === -1 ? cursor <= slot.end : cursor <= closingPos;
+    if (inValue) {
+      const prefix = query.slice(slot.valueStart + 1, cursor);
+      const replaceEnd = closingPos === -1 ? cursor : closingPos;
+      return {
+        kind: 'value',
+        labelName: slot.name,
+        prefix,
+        replaceRange: [slot.valueStart + 1, replaceEnd],
+        otherMatchers,
+      };
+    }
+  }
+
+  // Cursor in or right after the label-name token (no op typed yet, or op being typed).
+  // We treat positions from slot start up to (and including) nameEnd as "name" position,
+  // as long as no operator has been parsed.
+  if (slot.op === '' && cursor <= slot.nameEnd + 0) {
+    const prefix = query.slice(slot.nameStart, cursor);
+    return {
+      kind: 'name',
+      prefix,
+      replaceRange: [slot.nameStart, Math.max(slot.nameEnd, cursor)],
+      otherMatchers,
+    };
+  }
+
+  // Cursor strictly inside the name (when op is also typed) — still complete the name.
+  if (cursor >= slot.nameStart && cursor <= slot.nameEnd) {
+    const prefix = query.slice(slot.nameStart, cursor);
+    return {
+      kind: 'name',
+      prefix,
+      replaceRange: [slot.nameStart, slot.nameEnd],
+      otherMatchers,
+    };
+  }
+
+  return { kind: 'none' };
+}
+
+export function applySuggestion(
+  query: string,
+  context: CursorContext,
+  suggestion: string,
+): { next: string; cursor: number } {
+  if (context.kind === 'none') return { next: query, cursor: query.length };
+
+  if (context.kind === 'name') {
+    const [s, e] = context.replaceRange;
+    const after = query[e] ?? '';
+    const needsOp = after !== '=' && after !== '!';
+    const insertion = needsOp ? `${suggestion}="` : suggestion;
+    const next = query.slice(0, s) + insertion + query.slice(e);
+    const cursor = s + insertion.length;
+    return { next, cursor };
+  }
+
+  // value
+  const [s, e] = context.replaceRange;
+  const after = query[e] ?? '';
+  const needsCloseQuote = after !== '"';
+  const insertion = needsCloseQuote ? `${suggestion}"` : suggestion;
+  const next = query.slice(0, s) + insertion + query.slice(e);
+  // Cursor lands after the closing quote.
+  const cursor = needsCloseQuote ? s + insertion.length : s + suggestion.length + 1;
+  return { next, cursor };
+}
+
+export function buildQuery(service: string, profileType: string): string {
+  return `{service_name="${service}", profile_type="${profileType}"}`;
+}
+
+export function parseQuery(
+  q: string,
+): { service: string; profileType: string } | null {
+  const service = q.match(/service_name\s*=\s*"([^"]+)"/)?.[1];
+  const profileType = q.match(/profile_type\s*=\s*"([^"]+)"/)?.[1];
+  if (!service || !profileType) return null;
+  return { service, profileType };
+}

--- a/ui/src/queryLang.ts
+++ b/ui/src/queryLang.ts
@@ -59,6 +59,14 @@ export function toDisplayLabel(name: string): string {
   return INTERNAL_TO_DISPLAY[name] ?? name;
 }
 
+// Labels wrapped in double underscores (e.g. __delta__, __session_id__) are
+// reserved internals and should not surface in autocomplete. Aliased labels
+// like __profile_type__ are first translated via `toDisplayLabel`, so this
+// check sees the display form (`profile_type`) and lets them through.
+export function isInternalLabel(name: string): boolean {
+  return name.startsWith('__') && name.endsWith('__');
+}
+
 export function tokenize(q: string): Tokens {
   const braceOpen = q.indexOf('{');
   if (braceOpen === -1) {

--- a/ui/src/queryLang.ts
+++ b/ui/src/queryLang.ts
@@ -207,10 +207,7 @@ function serializeMatcher(m: Matcher): string {
   return `{${toInternalLabel(m.name)}${m.op}"${m.value}"}`;
 }
 
-export function getCursorContext(
-  query: string,
-  cursor: number,
-): CursorContext {
+export function getCursorContext(query: string, cursor: number): CursorContext {
   const { matchers, braceOpen, braceClose } = tokenize(query);
   if (braceOpen === -1) return { kind: 'none' };
   if (cursor <= braceOpen) return { kind: 'none' };
@@ -292,7 +289,9 @@ export function applySuggestion(
   const insertion = needsCloseQuote ? `${suggestion}"` : suggestion;
   const next = query.slice(0, s) + insertion + query.slice(e);
   // Cursor lands after the closing quote.
-  const cursor = needsCloseQuote ? s + insertion.length : s + suggestion.length + 1;
+  const cursor = needsCloseQuote
+    ? s + insertion.length
+    : s + suggestion.length + 1;
   return { next, cursor };
 }
 

--- a/ui/src/queryLang.ts
+++ b/ui/src/queryLang.ts
@@ -41,6 +41,24 @@ export type CursorContext =
 const IDENT = /[A-Za-z0-9_]/;
 const WS = /\s/;
 
+// Label names that are presented to the user in a friendlier form than the
+// backend uses. The query bar accepts and renders the display name; we
+// translate to/from the internal name whenever a matcher crosses the API.
+const DISPLAY_TO_INTERNAL: Record<string, string> = {
+  profile_type: '__profile_type__',
+};
+const INTERNAL_TO_DISPLAY: Record<string, string> = Object.fromEntries(
+  Object.entries(DISPLAY_TO_INTERNAL).map(([d, i]) => [i, d]),
+);
+
+export function toInternalLabel(name: string): string {
+  return DISPLAY_TO_INTERNAL[name] ?? name;
+}
+
+export function toDisplayLabel(name: string): string {
+  return INTERNAL_TO_DISPLAY[name] ?? name;
+}
+
 export function tokenize(q: string): Tokens {
   const braceOpen = q.indexOf('{');
   if (braceOpen === -1) {
@@ -178,7 +196,7 @@ function parseSlot(q: string, slotStart: number, slotEnd: number): Matcher {
 }
 
 function serializeMatcher(m: Matcher): string {
-  return `{${m.name}${m.op}"${m.value}"}`;
+  return `{${toInternalLabel(m.name)}${m.op}"${m.value}"}`;
 }
 
 export function getCursorContext(


### PR DESCRIPTION
This adds autocomplete support to the v2 embedded UI. Now label names and values will be suggested based on the query contents.

The query language parsing doesn't use a 3rd party library and does not have full parity with the PromQL language selector syntax (for example, this implementation only supports `=` operator). However, I think it's enough of an improvement to ship as-is to make it easier to discover the label names/values that can be added to a query.


https://github.com/user-attachments/assets/0341c3cb-1f9c-42f3-86c9-5d103a04489d

