### PR TITLE
fix: allow storage prefixes to start with digits

### DIFF
--- a/pkg/objstore/client/config.go
+++ b/pkg/objstore/client/config.go
@@ -147,8 +147,8 @@ func validStoragePrefixPart(part string) bool {
 	if part == "." || part == ".." {
 		return false
 	}
-	for i, b := range part {
-		if (b < 'a' || b > 'z') && (b < 'A' || b > 'Z') && b != '_' && b != '-' && b != '.' && (b < '0' || b > '9' || i == 0) {
+	for _, b := range part {
+		if (b < 'a' || b > 'z') && (b < 'A' || b > 'Z') && b != '_' && b != '-' && b != '.' && (b < '0' || b > '9') {
 			return false
 		}
 	}

--- a/pkg/objstore/client/factory_test.go
+++ b/pkg/objstore/client/factory_test.go
@@ -114,8 +114,16 @@ func TestClient_ConfigValidation(t *testing.T) {
 			cfg:  Config{StorageBackendConfig: StorageBackendConfig{Backend: Filesystem}, Prefix: "helloWORLD123"},
 		},
 		{
+			name: "prefix/valid-starts-with-digit",
+			cfg:  Config{StorageBackendConfig: StorageBackendConfig{Backend: Filesystem}, Prefix: "2026"},
+		},
+		{
 			name: "prefix/valid-subdir",
 			cfg:  Config{StorageBackendConfig: StorageBackendConfig{Backend: Filesystem}, Prefix: "hello/world/env"},
+		},
+		{
+			name: "prefix/valid-subdir-starts-with-digit",
+			cfg:  Config{StorageBackendConfig: StorageBackendConfig{Backend: Filesystem}, Prefix: "hello/2026/env"},
 		},
 		{
 			name: "prefix/valid-subdir-trailing-slash",


### PR DESCRIPTION
Small follow-up to #4044. `storage.prefix` docs say digits are allowed, but config validation still rejects a segment if it starts with one. So `2026` or `hello/2026/env` is valid-looking config and then boom, nope.

This is triggerable in real object stores, not just a test thing: S3/GCS/Azure object names/prefixes allow digit-leading path parts within their normal object-name limits.

Repro on main:
```sh
go test ./pkg/objstore/client -run 'TestClient_ConfigValidation/prefix/valid.*digit'
```

Before: fails with `ErrStoragePrefixInvalidCharacters`.
After: passes.

Checked:
```sh
go test ./pkg/objstore/...
git diff --check
```