### PR TITLE
docs: remove public preview note from pyroscope.receive_http

### DIFF
--- a/docs/sources/configure-client/grafana-alloy/receive_profiles.md
+++ b/docs/sources/configure-client/grafana-alloy/receive_profiles.md
@@ -14,10 +14,6 @@ The `pyroscope.receive_http` component in Alloy receives profiles from applicati
 
 For more information about this component, refer to the [pyroscope.receive_http component](https://grafana.com/docs/alloy/<ALLOY_VERSION>/reference/components/pyroscope/pyroscope.receive_http/) documentation.
 
-{{< admonition type="note" >}}
-The `pyroscope.receive_http` component is currently in public preview. To use this component, set the `--stability.level` flag to `public-preview`. For more information about Alloy's run usage, refer to the [run command documentation](https://grafana.com/docs/grafana-cloud/send-data/alloy/reference/cli/run/#the-run-command) documentation.
-{{< /admonition >}}
-
 To set up profile receiving, you need to:
 1. Configure Alloy components
 2. Configure your application's SDK


### PR DESCRIPTION
## Summary
- The `pyroscope.receive_http` Alloy component is no longer in public preview, so the admonition pointing users at `--stability.level=public-preview` is outdated and misleading. Remove the note from the receive-profiles guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)