### PR TITLE
chore(examples): bump rideshare_rails pyroscope-otel to ~> 0.2.0

### DIFF
--- a/examples/language-sdk-instrumentation/ruby/rideshare_rails/Gemfile
+++ b/examples/language-sdk-instrumentation/ruby/rideshare_rails/Gemfile
@@ -22,7 +22,7 @@ gem "puma", "~> 6.0"
 
 gem 'pyroscope', '= 0.6.7'
 
-gem "pyroscope-otel", "~> 0.1.1"
+gem "pyroscope-otel", "~> 0.2.0"
 gem 'opentelemetry-sdk', "~> 1.2.0"
 gem 'opentelemetry-exporter-jaeger', '~> 0.22.0'
 gem 'opentelemetry-instrumentation-rails' # it's top span is "http get" which is not super usefull for demo


### PR DESCRIPTION
## Summary
- The `pyroscope` gem 1.0 introduced breaking API changes (`Pyroscope.thread_id` removed, `_add_tags` / `_remove_tags` switched from 2-arg to 1-arg signature). `pyroscope-otel` 0.2.0 ([release](https://rubygems.org/gems/pyroscope-otel/versions/0.2.0), [PR](https://github.com/grafana/otel-profiling-ruby/pull/25)) adopts that new API and pins `pyroscope >= 1.0, < 2.0`.
- The previous `~> 0.1.1` constraint in `examples/language-sdk-instrumentation/ruby/rideshare_rails/Gemfile` caps below `0.2` and blocks resolution against `pyroscope` 1.x.
- Bumps the constraint to `~> 0.2.0` so the rideshare_rails example can resolve.

The other two Ruby examples (`rideshare/Gemfile` has `gem 'pyroscope-otel'` with no version pin, `simple/Gemfile` doesn't use pyroscope-otel) don't need changes — they'll resolve transitively when \`make tools/update_examples\` next bumps \`pyroscope\` to 1.x.

## Test plan
- [ ] CI green
- [ ] After this lands, the next \`make tools/update_examples\` Ruby step (\`bundle update pyroscope\` in rideshare_rails) resolves cleanly instead of hitting the previous \`pyroscope-otel >= 0.1.4 depends on pyroscope < 1.0\` conflict.