### PR TITLE
fix(ci): update helm-charts action version

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   call-update-helm-repo-pyroscope:
-    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@9ddb81243bfc8aea3bf3d0a9954451d407cee1c6
+    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@77e5ea2de369fa1ff3441b08765c164be209eaa2
     permissions:
       contents: "write"
       id-token: "write"
@@ -19,7 +19,7 @@ jobs:
       ct_configfile: operations/pyroscope/helm/ct.yaml
       github_app: grafana-pyroscope-releases
   call-update-helm-repo-pyroscope-monitoring:
-    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@9ddb81243bfc8aea3bf3d0a9954451d407cee1c6
+    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@77e5ea2de369fa1ff3441b08765c164be209eaa2
     permissions:
       contents: "write"
       id-token: "write"


### PR DESCRIPTION
I missed to update the pinned version commit in the `helm-release.yml` workflow in #5171  which made the run [fail](https://github.com/grafana/pyroscope/actions/runs/26288284384/workflow).

Using the last commit in the helm-charts repo with the last improvements and fixes included.