### PR TITLE
fix(tools): drop obsolete pyroscope_pprofrs cargo adds from updateRust

### DIFF
--- a/tools/update_examples.go
+++ b/tools/update_examples.go
@@ -108,13 +108,8 @@ func updateRust() {
 	libTags := getTagsV("grafana/pyroscope-rs", extractRSVersion("lib"))
 	lastLibTag := libTags[len(libTags)-1]
 	fmt.Println(lastLibTag)
-	pprofRsTags := getTagsV("grafana/pyroscope-rs", extractRSVersion("pprofrs"))
-	lastPprofRsTag := pprofRsTags[len(pprofRsTags)-1]
-	fmt.Println(lastPprofRsTag)
 	s.sh(fmt.Sprintf("cd examples/language-sdk-instrumentation/rust/rideshare/server && cargo add pyroscope@^%s", lastLibTag.version()))
-	s.sh(fmt.Sprintf("cd examples/language-sdk-instrumentation/rust/rideshare/server && cargo add pyroscope_pprofrs@^%s", lastPprofRsTag.version()))
 	s.sh(fmt.Sprintf("cd examples/language-sdk-instrumentation/rust/basic && cargo add pyroscope@^%s", lastLibTag.version()))
-	s.sh(fmt.Sprintf("cd examples/language-sdk-instrumentation/rust/basic && cargo add pyroscope_pprofrs@^%s", lastPprofRsTag.version()))
 }
 
 func updateDotnet() {


### PR DESCRIPTION
## Summary
- The `pprof-rs` backend was integrated into the main `pyroscope` crate as the optional feature `backend-pprof-rs` in [pyroscope-rs#317](https://github.com/grafana/pyroscope-rs/pull/317) (commit `dd1867c`, Feb 2026).
- The Rust example Cargo.toml files were already migrated to depend on `pyroscope = { version = "2.0.0", features = ["backend-pprof-rs"] }` and no longer reference the separate `pyroscope_pprofrs` crate.
- `pyroscope_pprofrs` is now frozen on crates.io at `0.2.10`. The `pprofrs-*` git tags on `grafana/pyroscope-rs` continued past that (`0.2.11`, `0.2.12`) but no longer correspond to publishable packages, so `cargo add pyroscope_pprofrs@^0.2.12` fails with `could not be found in registry index`.
- Drop the `pprofrs` tag lookup and the two now-obsolete `cargo add pyroscope_pprofrs@…` calls from `updateRust`. `cargo add pyroscope@^X` preserves the existing `features = ["backend-pprof-rs"]` in the Cargo.toml.

## Test plan
- [ ] CI green
- [ ] After this lands, the Rust step of `make tools/update_examples` runs without the previous `could not be found in registry index` error.