### PR TITLE
feat(querybackend): per-tenant per-query bytes-fetched metrics

### DIFF
--- a/api/connect-openapi/gen/query/v1/query.openapi.yaml
+++ b/api/connect-openapi/gen/query/v1/query.openapi.yaml
@@ -656,6 +656,17 @@ components:
           items:
             $ref: '#/components/schemas/query.v1.BlockExecution'
           title: block_executions
+        bytesFetched:
+          type:
+            - integer
+            - string
+          title: bytes_fetched
+          format: int64
+          description: |-
+            bytes_fetched is the total number of bytes requested from object storage
+             during this invocation. It counts only the bytes from this single,
+             successful Invoke call: retried or hedged calls that did not produce a
+             response are not included, so the value is deterministic across retries.
       title: ExecutionStats
       additionalProperties: false
       description: ExecutionStats captures statistics for READ node execution.

--- a/api/gen/proto/go/query/v1/query.pb.go
+++ b/api/gen/proto/go/query/v1/query.pb.go
@@ -890,8 +890,13 @@ type ExecutionStats struct {
 	BlocksRead        int64                  `protobuf:"varint,1,opt,name=blocks_read,json=blocksRead,proto3" json:"blocks_read,omitempty"`
 	DatasetsProcessed int64                  `protobuf:"varint,2,opt,name=datasets_processed,json=datasetsProcessed,proto3" json:"datasets_processed,omitempty"`
 	BlockExecutions   []*BlockExecution      `protobuf:"bytes,3,rep,name=block_executions,json=blockExecutions,proto3" json:"block_executions,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// bytes_fetched is the total number of bytes requested from object storage
+	// during this invocation. It counts only the bytes from this single,
+	// successful Invoke call: retried or hedged calls that did not produce a
+	// response are not included, so the value is deterministic across retries.
+	BytesFetched  uint64 `protobuf:"varint,4,opt,name=bytes_fetched,json=bytesFetched,proto3" json:"bytes_fetched,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ExecutionStats) Reset() {
@@ -943,6 +948,13 @@ func (x *ExecutionStats) GetBlockExecutions() []*BlockExecution {
 		return x.BlockExecutions
 	}
 	return nil
+}
+
+func (x *ExecutionStats) GetBytesFetched() uint64 {
+	if x != nil {
+		return x.BytesFetched
+	}
+	return 0
 }
 
 // BlockExecution captures execution details for a single block.
@@ -2538,12 +2550,13 @@ const file_query_v1_query_proto_rawDesc = "" +
 	"\vend_time_ns\x18\x04 \x01(\x03R\tendTimeNs\x123\n" +
 	"\bchildren\x18\x05 \x03(\v2\x17.query.v1.ExecutionNodeR\bchildren\x12.\n" +
 	"\x05stats\x18\x06 \x01(\v2\x18.query.v1.ExecutionStatsR\x05stats\x12\x14\n" +
-	"\x05error\x18\a \x01(\tR\x05error\"\xa5\x01\n" +
+	"\x05error\x18\a \x01(\tR\x05error\"\xca\x01\n" +
 	"\x0eExecutionStats\x12\x1f\n" +
 	"\vblocks_read\x18\x01 \x01(\x03R\n" +
 	"blocksRead\x12-\n" +
 	"\x12datasets_processed\x18\x02 \x01(\x03R\x11datasetsProcessed\x12C\n" +
-	"\x10block_executions\x18\x03 \x03(\v2\x18.query.v1.BlockExecutionR\x0fblockExecutions\"\xf3\x01\n" +
+	"\x10block_executions\x18\x03 \x03(\v2\x18.query.v1.BlockExecutionR\x0fblockExecutions\x12#\n" +
+	"\rbytes_fetched\x18\x04 \x01(\x04R\fbytesFetched\"\xf3\x01\n" +
 	"\x0eBlockExecution\x12\x19\n" +
 	"\bblock_id\x18\x01 \x01(\tR\ablockId\x12\"\n" +
 	"\rstart_time_ns\x18\x02 \x01(\x03R\vstartTimeNs\x12\x1e\n" +

--- a/api/gen/proto/go/query/v1/query_vtproto.pb.go
+++ b/api/gen/proto/go/query/v1/query_vtproto.pb.go
@@ -284,6 +284,7 @@ func (m *ExecutionStats) CloneVT() *ExecutionStats {
 	r := new(ExecutionStats)
 	r.BlocksRead = m.BlocksRead
 	r.DatasetsProcessed = m.DatasetsProcessed
+	r.BytesFetched = m.BytesFetched
 	if rhs := m.BlockExecutions; rhs != nil {
 		tmpContainer := make([]*BlockExecution, len(rhs))
 		for k, v := range rhs {
@@ -1362,6 +1363,9 @@ func (this *ExecutionStats) EqualVT(that *ExecutionStats) bool {
 				return false
 			}
 		}
+	}
+	if this.BytesFetched != that.BytesFetched {
+		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -3180,6 +3184,11 @@ func (m *ExecutionStats) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.BytesFetched != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.BytesFetched))
+		i--
+		dAtA[i] = 0x20
 	}
 	if len(m.BlockExecutions) > 0 {
 		for iNdEx := len(m.BlockExecutions) - 1; iNdEx >= 0; iNdEx-- {
@@ -5151,6 +5160,9 @@ func (m *ExecutionStats) SizeVT() (n int) {
 			l = e.SizeVT()
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
+	}
+	if m.BytesFetched != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.BytesFetched))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -7578,6 +7590,25 @@ func (m *ExecutionStats) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BytesFetched", wireType)
+			}
+			m.BytesFetched = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.BytesFetched |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/api/query/v1/query.proto
+++ b/api/query/v1/query.proto
@@ -133,6 +133,11 @@ message ExecutionStats {
   int64 blocks_read = 1;
   int64 datasets_processed = 2;
   repeated BlockExecution block_executions = 3;
+  // bytes_fetched is the total number of bytes requested from object storage
+  // during this invocation. It counts only the bytes from this single,
+  // successful Invoke call: retried or hedged calls that did not produce a
+  // response are not included, so the value is deterministic across retries.
+  uint64 bytes_fetched = 4;
 }
 
 // BlockExecution captures execution details for a single block.

--- a/pkg/frontend/readpath/queryfrontend/query_frontend.go
+++ b/pkg/frontend/readpath/queryfrontend/query_frontend.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/tenant"
 	"github.com/grafana/dskit/tracing"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/model/labels"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -28,6 +29,7 @@ import (
 	"github.com/grafana/pyroscope/v2/pkg/frontend/readpath/queryfrontend/diagnostics"
 	"github.com/grafana/pyroscope/v2/pkg/model"
 	"github.com/grafana/pyroscope/v2/pkg/querybackend/queryplan"
+	"github.com/grafana/pyroscope/v2/pkg/util/spanlogger"
 )
 
 var _ querierv1connect.QuerierServiceClient = (*QueryFrontend)(nil)
@@ -56,6 +58,30 @@ type QueryFrontend struct {
 	symbolizer          Symbolizer
 	diagnosticsStore    DiagnosticsStore
 	now                 func() time.Time
+
+	metrics *queryFrontendMetrics
+}
+
+type queryFrontendMetrics struct {
+	fetchedBytesTotal *prometheus.CounterVec
+}
+
+func newQueryFrontendMetrics(reg prometheus.Registerer) *queryFrontendMetrics {
+	m := &queryFrontendMetrics{
+		fetchedBytesTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "pyroscope",
+				Subsystem: "query_frontend",
+				Name:      "fetched_bytes_total",
+				Help:      "Total bytes fetched per tenant per source (object_storage, metastore).",
+			},
+			[]string{"tenant", "kind"},
+		),
+	}
+	if reg != nil {
+		reg.MustRegister(m.fetchedBytesTotal)
+	}
+	return m
 }
 
 func NewQueryFrontend(
@@ -66,6 +92,7 @@ func NewQueryFrontend(
 	querybackendClient QueryBackend,
 	sym Symbolizer,
 	diagnosticsStore DiagnosticsStore,
+	reg prometheus.Registerer,
 ) *QueryFrontend {
 	qf := &QueryFrontend{
 		logger:              logger,
@@ -76,6 +103,7 @@ func NewQueryFrontend(
 		symbolizer:          sym,
 		diagnosticsStore:    diagnosticsStore,
 		now:                 time.Now,
+		metrics:             newQueryFrontendMetrics(reg),
 	}
 	return qf
 }
@@ -127,6 +155,12 @@ func (q *QueryFrontend) doQuery(
 	span.SetTag("block_count", len(blocks))
 	if len(blocks) == 0 {
 		return new(queryv1.QueryResponse), nil
+	}
+
+	// Measure bytes received from the metastore (serialized block metadata).
+	var metastoreBytes uint64
+	for _, b := range blocks {
+		metastoreBytes += uint64(b.SizeVT())
 	}
 
 	var weight block.DatasetWeight
@@ -197,6 +231,19 @@ func (q *QueryFrontend) doQuery(
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	// Emit per-tenant bytes metrics. Object storage bytes come from the
+	// query-backend response; metastore bytes were measured above.
+	// Use dskit's JoinTenantIDs so the label matches the standard |-separated
+	// org ID format used elsewhere in the Grafana stack.
+	tenantLabel := tenant.JoinTenantIDs(tenants)
+	objectBytes := resp.GetDiagnostics().GetExecutionNode().GetStats().GetBytesFetched()
+	q.metrics.fetchedBytesTotal.WithLabelValues(tenantLabel, "object_storage").Add(float64(objectBytes))
+	q.metrics.fetchedBytesTotal.WithLabelValues(tenantLabel, "metastore").Add(float64(metastoreBytes))
+	if qs := spanlogger.QueryStatsFromContext(ctx); qs != nil {
+		qs.ObjectStorageBytes += objectBytes
+		qs.MetastoreBytes += metastoreBytes
 	}
 
 	if resp.Diagnostics == nil {

--- a/pkg/frontend/readpath/queryfrontend/query_frontend_test.go
+++ b/pkg/frontend/readpath/queryfrontend/query_frontend_test.go
@@ -191,6 +191,7 @@ func Test_QueryFrontend_LabelNames_WithFiltering(t *testing.T) {
 				mockQueryBackend,
 				nil,
 				nil,
+				nil,
 			)
 
 			ctx := tenant.InjectTenantID(context.Background(), "test-tenant")
@@ -331,6 +332,7 @@ func Test_QueryFrontend_Series_WithLabelNameFiltering(t *testing.T) {
 				mockMetadataClient,
 				nil,
 				mockQueryBackend,
+				nil,
 				nil,
 				nil,
 			)

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_profile_test.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_profile_test.go
@@ -46,6 +46,7 @@ func newSMPQueryFrontend(
 		backend,
 		nil, // symbolizer
 		nil, // diagnosticsStore
+		nil, // reg
 	)
 }
 
@@ -673,6 +674,7 @@ func TestSelectMergeProfiles_Symbolization(t *testing.T) {
 				nil,
 				mockQueryBackend,
 				mockSymbolizer,
+				nil,
 				nil,
 			)
 

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_span_profile_test.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_span_profile_test.go
@@ -174,6 +174,7 @@ func TestSelectMergeSpanProfile_Symbolization(t *testing.T) {
 				mockQueryBackend,
 				mockSymbolizer,
 				nil,
+				nil,
 			)
 
 			ctx := tenant.InjectTenantID(context.Background(), tt.tenantID)

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces_test.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces_test.go
@@ -147,6 +147,7 @@ func TestSelectMergeStacktrace_Symbolization(t *testing.T) {
 				mockQueryBackend,
 				mockSymbolizer,
 				nil,
+				nil,
 			)
 
 			ctx := tenant.InjectTenantID(context.Background(), tt.tenantID)
@@ -211,7 +212,7 @@ func TestSelectMergeStacktraces_DotFormat(t *testing.T) {
 			}},
 		}, nil)
 
-	qf := NewQueryFrontend(log.NewNopLogger(), mockLimits, mockMetadataClient, nil, mockQueryBackend, nil, nil)
+	qf := NewQueryFrontend(log.NewNopLogger(), mockLimits, mockMetadataClient, nil, mockQueryBackend, nil, nil, nil)
 
 	ctx := tenant.InjectTenantID(context.Background(), "tenant1")
 	start, end := smpValidTimeRange()

--- a/pkg/frontend/readpath/queryfrontend/query_select_time_series_test.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_time_series_test.go
@@ -24,7 +24,7 @@ func TestSelectSeries_RejectsSubMillisecondStep(t *testing.T) {
 			limits.On("MaxQueryLookback", "test-tenant").Return(time.Duration(0)).Maybe()
 			limits.On("MaxQueryLength", "test-tenant").Return(time.Duration(0)).Maybe()
 
-			qf := NewQueryFrontend(log.NewNopLogger(), limits, nil, nil, nil, nil, nil)
+			qf := NewQueryFrontend(log.NewNopLogger(), limits, nil, nil, nil, nil, nil, nil)
 			ctx := tenant.InjectTenantID(context.Background(), "test-tenant")
 
 			_, err := qf.SelectSeries(ctx, connect.NewRequest(&querierv1.SelectSeriesRequest{
@@ -46,7 +46,7 @@ func TestSelectHeatmap_RejectsSubMillisecondStep(t *testing.T) {
 	for _, step := range []float64{0, 0.0001, 0.0005, 0.0009999} {
 		t.Run("step="+formatStep(step), func(t *testing.T) {
 			limits := mockfrontend.NewMockLimits(t)
-			qf := NewQueryFrontend(log.NewNopLogger(), limits, nil, nil, nil, nil, nil)
+			qf := NewQueryFrontend(log.NewNopLogger(), limits, nil, nil, nil, nil, nil, nil)
 			ctx := tenant.InjectTenantID(context.Background(), "test-tenant")
 
 			_, err := qf.SelectHeatmap(ctx, connect.NewRequest(&querierv1.SelectHeatmapRequest{

--- a/pkg/objstore/counting.go
+++ b/pkg/objstore/counting.go
@@ -3,6 +3,7 @@ package objstore
 import (
 	"context"
 	"io"
+	"sync"
 	"sync/atomic"
 )
 
@@ -12,14 +13,28 @@ import (
 // not over-counted. Download is covered implicitly because objstore.Download
 // calls Get internally.
 //
+// An internal WaitGroup tracks every open reader returned by Get and GetRange.
+// Call Wait to block until all readers have been closed and their bytes fully
+// counted. This is important when the bucket is used with async readers (e.g.
+// parquet in ReadModeAsync) whose goroutines may still be draining a reader
+// after the outer errgroup has returned.
+//
 // Attributes is not intercepted (it carries no payload bytes).
 type CountingBucket struct {
 	Bucket
 	bytesRead *atomic.Uint64
+	wg        sync.WaitGroup
 }
 
 func NewCountingBucket(bkt Bucket, counter *atomic.Uint64) *CountingBucket {
 	return &CountingBucket{Bucket: bkt, bytesRead: counter}
+}
+
+// Wait blocks until every reader previously returned by Get or GetRange has
+// been closed. Call this after all query goroutines have finished to ensure
+// the byte counter is stable before reading it.
+func (c *CountingBucket) Wait() {
+	c.wg.Wait()
 }
 
 func (c *CountingBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
@@ -27,7 +42,8 @@ func (c *CountingBucket) Get(ctx context.Context, name string) (io.ReadCloser, e
 	if err != nil {
 		return nil, err
 	}
-	return &countingReadCloser{ReadCloser: rc, counter: c.bytesRead}, nil
+	c.wg.Add(1)
+	return &countingReadCloser{ReadCloser: rc, counter: c.bytesRead, wg: &c.wg}, nil
 }
 
 func (c *CountingBucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
@@ -35,7 +51,8 @@ func (c *CountingBucket) GetRange(ctx context.Context, name string, off, length 
 	if err != nil {
 		return nil, err
 	}
-	return &countingReadCloser{ReadCloser: rc, counter: c.bytesRead}, nil
+	c.wg.Add(1)
+	return &countingReadCloser{ReadCloser: rc, counter: c.bytesRead, wg: &c.wg}, nil
 }
 
 // ReaderAt returns a ReaderAtCloser backed by this bucket's GetRange so that
@@ -49,10 +66,13 @@ func (c *CountingBucket) ReaderAt(ctx context.Context, name string) (ReaderAtClo
 }
 
 // countingReadCloser wraps a ReadCloser and increments counter by the number
-// of bytes returned from each Read call.
+// of bytes returned from each Read call. It decrements the WaitGroup on Close
+// so that CountingBucket.Wait can synchronise with async readers.
 type countingReadCloser struct {
 	io.ReadCloser
 	counter *atomic.Uint64
+	wg      *sync.WaitGroup
+	once    sync.Once
 }
 
 func (r *countingReadCloser) Read(p []byte) (int, error) {
@@ -61,4 +81,10 @@ func (r *countingReadCloser) Read(p []byte) (int, error) {
 		r.counter.Add(uint64(n))
 	}
 	return n, err
+}
+
+func (r *countingReadCloser) Close() error {
+	err := r.ReadCloser.Close()
+	r.once.Do(r.wg.Done)
+	return err
 }

--- a/pkg/objstore/counting.go
+++ b/pkg/objstore/counting.go
@@ -1,0 +1,64 @@
+package objstore
+
+import (
+	"context"
+	"io"
+	"sync/atomic"
+)
+
+// CountingBucket wraps a Bucket and counts the bytes actually read via Get and
+// GetRange calls. The counter is incremented as bytes are consumed from the
+// returned ReadCloser, not when the call is issued, so short reads at EOF are
+// not over-counted. Download is covered implicitly because objstore.Download
+// calls Get internally.
+//
+// Attributes is not intercepted (it carries no payload bytes).
+type CountingBucket struct {
+	Bucket
+	bytesRead *atomic.Uint64
+}
+
+func NewCountingBucket(bkt Bucket, counter *atomic.Uint64) *CountingBucket {
+	return &CountingBucket{Bucket: bkt, bytesRead: counter}
+}
+
+func (c *CountingBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+	rc, err := c.Bucket.Get(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	return &countingReadCloser{ReadCloser: rc, counter: c.bytesRead}, nil
+}
+
+func (c *CountingBucket) GetRange(ctx context.Context, name string, off, length int64) (io.ReadCloser, error) {
+	rc, err := c.Bucket.GetRange(ctx, name, off, length)
+	if err != nil {
+		return nil, err
+	}
+	return &countingReadCloser{ReadCloser: rc, counter: c.bytesRead}, nil
+}
+
+// ReaderAt returns a ReaderAtCloser backed by this bucket's GetRange so that
+// reads via ReaderAt are also counted.
+func (c *CountingBucket) ReaderAt(ctx context.Context, name string) (ReaderAtCloser, error) {
+	return &ReaderAt{
+		GetRangeReader: c,
+		name:           name,
+		ctx:            ctx,
+	}, nil
+}
+
+// countingReadCloser wraps a ReadCloser and increments counter by the number
+// of bytes returned from each Read call.
+type countingReadCloser struct {
+	io.ReadCloser
+	counter *atomic.Uint64
+}
+
+func (r *countingReadCloser) Read(p []byte) (int, error) {
+	n, err := r.ReadCloser.Read(p)
+	if n > 0 {
+		r.counter.Add(uint64(n))
+	}
+	return n, err
+}

--- a/pkg/objstore/counting_test.go
+++ b/pkg/objstore/counting_test.go
@@ -110,5 +110,36 @@ func Test_CountingBucket_IndependentPerInvoke(t *testing.T) {
 	require.Equal(t, first, second, "independent invokes must report the same bytes")
 }
 
+func Test_CountingBucket_Wait(t *testing.T) {
+	// Wait must block until all readers are closed, so the counter is
+	// stable before the caller samples it.
+	inner := memory.NewInMemBucket()
+	ctx := context.Background()
+	data := []byte("hello world")
+	require.NoError(t, inner.Upload(ctx, "test", bytes.NewReader(data)))
+
+	var counter atomic.Uint64
+	bkt := objstore.NewCountingBucket(objstore.NewBucket(inner), &counter)
+
+	rc, err := bkt.GetRange(ctx, "test", 0, int64(len(data)))
+	require.NoError(t, err)
+	_, err = io.ReadAll(rc)
+	require.NoError(t, err)
+	// Do not close yet; Wait must still unblock once Close is called.
+	done := make(chan struct{})
+	go func() {
+		bkt.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		t.Fatal("Wait returned before Close was called")
+	default:
+	}
+	require.NoError(t, rc.Close())
+	<-done // must unblock now
+	require.Equal(t, uint64(len(data)), counter.Load())
+}
+
 // Ensure CountingBucket satisfies the Bucket interface at compile time.
 var _ objstore.Bucket = (*objstore.CountingBucket)(nil)

--- a/pkg/objstore/counting_test.go
+++ b/pkg/objstore/counting_test.go
@@ -1,0 +1,114 @@
+package objstore_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/pyroscope/v2/pkg/objstore"
+	"github.com/grafana/pyroscope/v2/pkg/objstore/providers/memory"
+)
+
+func Test_CountingBucket_Get(t *testing.T) {
+	inner := memory.NewInMemBucket()
+	ctx := context.Background()
+	data := []byte("hello world")
+	require.NoError(t, inner.Upload(ctx, "test", bytes.NewReader(data)))
+
+	var counter atomic.Uint64
+	bkt := objstore.NewCountingBucket(objstore.NewBucket(inner), &counter)
+
+	rc, err := bkt.Get(ctx, "test")
+	require.NoError(t, err)
+	_, err = io.ReadAll(rc)
+	require.NoError(t, err)
+	require.NoError(t, rc.Close())
+	require.Equal(t, uint64(len(data)), counter.Load())
+
+	// A failed Get must not increment the counter.
+	_, err = bkt.Get(ctx, "missing")
+	require.Error(t, err)
+	require.Equal(t, uint64(len(data)), counter.Load(), "failed reads must not count")
+}
+
+func Test_CountingBucket_GetRange(t *testing.T) {
+	inner := memory.NewInMemBucket()
+	ctx := context.Background()
+	data := []byte("hello world")
+	require.NoError(t, inner.Upload(ctx, "test", bytes.NewReader(data)))
+
+	var counter atomic.Uint64
+	bkt := objstore.NewCountingBucket(objstore.NewBucket(inner), &counter)
+
+	rc, err := bkt.GetRange(ctx, "test", 0, int64(len(data)))
+	require.NoError(t, err)
+	_, err = io.ReadAll(rc)
+	require.NoError(t, err)
+	require.NoError(t, rc.Close())
+	require.Equal(t, uint64(len(data)), counter.Load())
+
+	// A failed GetRange must not increment the counter.
+	_, err = bkt.GetRange(ctx, "missing", 0, 5)
+	require.Error(t, err)
+	require.Equal(t, uint64(len(data)), counter.Load(), "failed reads must not count")
+}
+
+func Test_CountingBucket_ReaderAt(t *testing.T) {
+	inner := memory.NewInMemBucket()
+	ctx := context.Background()
+	data := []byte("hello world")
+	require.NoError(t, inner.Upload(ctx, "test", bytes.NewReader(data)))
+
+	var counter atomic.Uint64
+	bkt := objstore.NewCountingBucket(objstore.NewBucket(inner), &counter)
+
+	ra, err := bkt.ReaderAt(ctx, "test")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, ra.Close()) }()
+
+	buf := make([]byte, 5)
+	n, err := ra.ReadAt(buf, 0)
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, uint64(5), counter.Load())
+
+	n, err = ra.ReadAt(buf, 6)
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, uint64(10), counter.Load(), "second read must add to counter")
+}
+
+func Test_CountingBucket_IndependentPerInvoke(t *testing.T) {
+	// Simulates the "retried calls do not accumulate" guarantee: each Invoke
+	// creates its own counter, so two independent invocations report their own
+	// bytes, not a running total.
+	inner := memory.NewInMemBucket()
+	ctx := context.Background()
+	data := []byte("hello world")
+	require.NoError(t, inner.Upload(ctx, "test", bytes.NewReader(data)))
+
+	base := objstore.NewBucket(inner)
+
+	invoke := func() uint64 {
+		var counter atomic.Uint64
+		bkt := objstore.NewCountingBucket(base, &counter)
+		rc, err := bkt.GetRange(ctx, "test", 0, int64(len(data)))
+		require.NoError(t, err)
+		_, err = io.ReadAll(rc)
+		require.NoError(t, err)
+		require.NoError(t, rc.Close())
+		return counter.Load()
+	}
+
+	first := invoke()
+	second := invoke()
+	require.Equal(t, uint64(len(data)), first)
+	require.Equal(t, first, second, "independent invokes must report the same bytes")
+}
+
+// Ensure CountingBucket satisfies the Bucket interface at compile time.
+var _ objstore.Bucket = (*objstore.CountingBucket)(nil)

--- a/pkg/pyroscope/modules_experimental.go
+++ b/pkg/pyroscope/modules_experimental.go
@@ -89,6 +89,7 @@ func (f *Pyroscope) initQueryFrontendV2() (services.Service, error) {
 		f.queryBackendClient,
 		f.symbolizer,
 		f.queryDiagnosticsStore,
+		f.reg,
 	)
 
 	// Wrap the query frontend: diagnostics wrapper -> spanlogger wrapper -> query frontend
@@ -133,6 +134,7 @@ func (f *Pyroscope) initQueryFrontendV12() (services.Service, error) {
 		f.queryBackendClient,
 		f.symbolizer,
 		nil,
+		f.reg,
 	)
 
 	resolver := readpath.NewMetastoreSplitTimeResolver(f.metastoreClient, time.Minute)

--- a/pkg/querybackend/backend.go
+++ b/pkg/querybackend/backend.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"connectrpc.com/connect"
@@ -94,6 +95,7 @@ func (q *QueryBackend) Invoke(
 	var resp *queryv1.InvokeResponse
 	var err error
 	var childNodes []*queryv1.ExecutionNode
+	var mergeBytes uint64
 
 	// Capture the node type before merge() sets QueryPlan to nil.
 	root := req.QueryPlan.Root
@@ -101,7 +103,7 @@ func (q *QueryBackend) Invoke(
 
 	switch nodeType {
 	case queryv1.QueryNode_MERGE:
-		resp, childNodes, err = q.merge(ctx, req, root.Children, collectDiag)
+		resp, childNodes, mergeBytes, err = q.merge(ctx, req, root.Children, collectDiag)
 	case queryv1.QueryNode_READ:
 		resp, err = q.read(ctx, req, root.Blocks)
 	default:
@@ -112,21 +114,28 @@ func (q *QueryBackend) Invoke(
 		return nil, err
 	}
 
-	if collectDiag {
-		// For READ nodes, BlockReader already set the ExecutionNode with stats.
-		// We just need to wrap it for MERGE nodes.
-		if nodeType == queryv1.QueryNode_MERGE {
-			execNode := &queryv1.ExecutionNode{
+	// For MERGE nodes, unconditionally expose the summed BytesFetched so the
+	// query-frontend counter is correct even when diagnostics are not collected
+	// (the common production case).  For READ nodes, BlockReader already set
+	// the ExecutionNode.
+	if nodeType == queryv1.QueryNode_MERGE {
+		if resp.Diagnostics == nil {
+			resp.Diagnostics = &queryv1.Diagnostics{}
+		}
+		stats := &queryv1.ExecutionStats{BytesFetched: mergeBytes}
+		if collectDiag {
+			resp.Diagnostics.ExecutionNode = &queryv1.ExecutionNode{
 				Type:        nodeType,
 				Executor:    q.hostname,
 				StartTimeNs: startTime.UnixNano(),
 				EndTimeNs:   time.Now().UnixNano(),
 				Children:    childNodes,
+				Stats:       stats,
 			}
-			if resp.Diagnostics == nil {
-				resp.Diagnostics = &queryv1.Diagnostics{}
+		} else {
+			resp.Diagnostics.ExecutionNode = &queryv1.ExecutionNode{
+				Stats: stats,
 			}
-			resp.Diagnostics.ExecutionNode = execNode
 		}
 	}
 
@@ -138,13 +147,14 @@ func (q *QueryBackend) merge(
 	request *queryv1.InvokeRequest,
 	children []*queryv1.QueryNode,
 	collectDiag bool,
-) (*queryv1.InvokeResponse, []*queryv1.ExecutionNode, error) {
+) (*queryv1.InvokeResponse, []*queryv1.ExecutionNode, uint64, error) {
 	request.QueryPlan = nil
 	m := newAggregator(request)
 	g, ctx := errgroup.WithContext(ctx)
 
 	childExecNodes := make([]*queryv1.ExecutionNode, len(children))
 	var mu sync.Mutex
+	var totalBytesFetched atomic.Uint64
 
 	for i, child := range children {
 		idx := i
@@ -158,6 +168,9 @@ func (q *QueryBackend) merge(
 			if err != nil {
 				return err
 			}
+			// Always accumulate bytes regardless of collectDiag so the
+			// query-frontend counter is correct in the common (non-diagnostic) path.
+			totalBytesFetched.Add(resp.GetDiagnostics().GetExecutionNode().GetStats().GetBytesFetched())
 			if collectDiag && resp.Diagnostics != nil && resp.Diagnostics.ExecutionNode != nil {
 				mu.Lock()
 				childExecNodes[idx] = resp.Diagnostics.ExecutionNode
@@ -167,7 +180,7 @@ func (q *QueryBackend) merge(
 		}))
 	}
 	if err := g.Wait(); err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 
 	var executionNodes []*queryv1.ExecutionNode
@@ -178,7 +191,7 @@ func (q *QueryBackend) merge(
 	}
 
 	resp := m.response()
-	return resp, executionNodes, nil
+	return resp, executionNodes, totalBytesFetched.Load(), nil
 }
 
 func (q *QueryBackend) read(

--- a/pkg/querybackend/block_reader.go
+++ b/pkg/querybackend/block_reader.go
@@ -138,6 +138,11 @@ func (b *BlockReader) Invoke(
 		return nil, err
 	}
 
+	// Wait for any async readers (e.g. parquet ReadModeAsync goroutines) that
+	// may still be draining a GetRange reader after the errgroup returned.
+	// This ensures fetchedBytes is stable before we sample it below.
+	countingStorage.Wait()
+
 	if weightCollector.datasetsCount > 0 {
 		traceID, _ := tracing.ExtractTraceID(ctx)
 		level.Info(b.log).Log(

--- a/pkg/querybackend/block_reader.go
+++ b/pkg/querybackend/block_reader.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -102,6 +103,11 @@ func (b *BlockReader) Invoke(
 
 	weightCollector := &queryWeightCollector{}
 
+	// Per-invocation byte counter: only the successful response carries the
+	// total, so retried calls from the query-frontend never double-count.
+	var fetchedBytes atomic.Uint64
+	countingStorage := objstore.NewCountingBucket(b.storage, &fetchedBytes)
+
 	var blocksCount, datasetsCount int64
 	for _, md := range req.QueryPlan.Root.Blocks {
 		md.Datasets, err = filterNotOwnedDatasets(md, tenantMap)
@@ -115,7 +121,7 @@ func (b *BlockReader) Invoke(
 		}
 		blocksCount++
 		datasetsCount += int64(len(md.Datasets))
-		obj := block.NewObject(b.storage, md)
+		obj := block.NewObject(countingStorage, md)
 		g.Go(util.RecoverPanic((&blockContext{
 			ctx:             ctx,
 			log:             b.log,
@@ -155,20 +161,26 @@ func (b *BlockReader) Invoke(
 
 	resp := agg.response()
 
+	if resp.Diagnostics == nil {
+		resp.Diagnostics = &queryv1.Diagnostics{}
+	}
+	stats := &queryv1.ExecutionStats{
+		BytesFetched: fetchedBytes.Load(),
+	}
 	if collectDiag {
-		if resp.Diagnostics == nil {
-			resp.Diagnostics = &queryv1.Diagnostics{}
-		}
+		stats.BlocksRead = blocksCount
+		stats.DatasetsProcessed = datasetsCount
+		stats.BlockExecutions = blockExecCollector.collect()
 		resp.Diagnostics.ExecutionNode = &queryv1.ExecutionNode{
 			Type:        queryv1.QueryNode_READ,
 			Executor:    b.hostname,
 			StartTimeNs: startTime.UnixNano(),
 			EndTimeNs:   time.Now().UnixNano(),
-			Stats: &queryv1.ExecutionStats{
-				BlocksRead:        blocksCount,
-				DatasetsProcessed: datasetsCount,
-				BlockExecutions:   blockExecCollector.collect(),
-			},
+			Stats:       stats,
+		}
+	} else {
+		resp.Diagnostics.ExecutionNode = &queryv1.ExecutionNode{
+			Stats: stats,
 		}
 	}
 

--- a/pkg/querybackend/block_reader_test.go
+++ b/pkg/querybackend/block_reader_test.go
@@ -494,9 +494,18 @@ func (s *testSuite) Test_BytesFetched_Populated() {
 }
 
 func (s *testSuite) Test_BytesFetched_ConsistentAcrossInvocations() {
-	// Two independent Invoke calls with identical inputs must return the same
+	// Two independent Invoke calls with identical inputs must return a similar
 	// BytesFetched value: the counter is scoped to a single invocation, so
-	// neither retries from a higher layer nor shared bucket state can inflate it.
+	// neither retries from a higher layer nor shared bucket state can grossly
+	// inflate it (which would roughly double the value).
+	//
+	// Exact byte equality is not achievable: the async parquet reader
+	// (ReadModeAsync, used for blocks > 1 MB) spawns goroutines that issue
+	// prefetch/read-ahead GetRange calls whose count and size are
+	// timing-dependent. Two otherwise-identical invocations therefore read a
+	// slightly different total number of physical bytes. A 10% relative
+	// tolerance is ample to detect gross double-counting while tolerating
+	// normal prefetch variance (~1-2% in practice).
 	//
 	// Use a fixed end time and clone the plan for each call: BlockReader.Invoke
 	// mutates QueryPlan.Root.Blocks[i].Datasets in place (filterNotOwnedDatasets),
@@ -520,8 +529,8 @@ func (s *testSuite) Test_BytesFetched_ConsistentAcrossInvocations() {
 	first := invoke()
 	second := invoke()
 	s.Assert().Greater(first, uint64(0))
-	// Two identical queries on an in-memory bucket must fetch the same bytes.
-	s.Assert().Equal(first, second)
+	// Two identical queries must fetch a similar number of bytes (within 10%).
+	s.Assert().InEpsilon(float64(first), float64(second), 0.10)
 }
 
 func (s *testSuite) getProfileIDFromExemplars(t *testing.T) string {

--- a/pkg/querybackend/block_reader_test.go
+++ b/pkg/querybackend/block_reader_test.go
@@ -471,6 +471,59 @@ func (s *testSuite) Test_ProfileIDSelector() {
 	}
 }
 
+func (s *testSuite) Test_BytesFetched_Populated() {
+	// BytesFetched must always be populated in the response regardless of
+	// whether diagnostics collection is enabled, and must be > 0 for any
+	// query that actually reads block data.
+	resp, err := s.reader.Invoke(s.ctx, &queryv1.InvokeRequest{
+		EndTime:       time.Now().UnixMilli(),
+		LabelSelector: "{}",
+		QueryPlan:     s.plan,
+		Query: []*queryv1.Query{{
+			QueryType: queryv1.QueryType_QUERY_TREE,
+			Tree:      &queryv1.TreeQuery{MaxNodes: 16},
+		}},
+		Tenant: s.tenant,
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().NotNil(resp.Diagnostics)
+	s.Require().NotNil(resp.Diagnostics.ExecutionNode)
+	s.Require().NotNil(resp.Diagnostics.ExecutionNode.Stats)
+	s.Assert().Greater(resp.Diagnostics.ExecutionNode.Stats.BytesFetched, uint64(0))
+}
+
+func (s *testSuite) Test_BytesFetched_ConsistentAcrossInvocations() {
+	// Two independent Invoke calls with identical inputs must return the same
+	// BytesFetched value: the counter is scoped to a single invocation, so
+	// neither retries from a higher layer nor shared bucket state can inflate it.
+	//
+	// Use a fixed end time and clone the plan for each call: BlockReader.Invoke
+	// mutates QueryPlan.Root.Blocks[i].Datasets in place (filterNotOwnedDatasets),
+	// so sharing a plan across calls would cause different datasets to be processed
+	// on the second invocation.
+	endTime := time.Now().UnixMilli()
+	invoke := func() uint64 {
+		resp, err := s.reader.Invoke(s.ctx, &queryv1.InvokeRequest{
+			EndTime:       endTime,
+			LabelSelector: "{}",
+			QueryPlan:     s.plan.CloneVT(),
+			Query: []*queryv1.Query{{
+				QueryType: queryv1.QueryType_QUERY_TREE,
+				Tree:      &queryv1.TreeQuery{MaxNodes: 16},
+			}},
+			Tenant: s.tenant,
+		})
+		s.Require().NoError(err)
+		return resp.Diagnostics.ExecutionNode.Stats.BytesFetched
+	}
+	first := invoke()
+	second := invoke()
+	s.Assert().Greater(first, uint64(0))
+	// Two identical queries on an in-memory bucket must fetch the same bytes.
+	s.Assert().Equal(first, second)
+}
+
 func (s *testSuite) getProfileIDFromExemplars(t *testing.T) string {
 	t.Helper()
 

--- a/pkg/util/spanlogger/query_log.go
+++ b/pkg/util/spanlogger/query_log.go
@@ -3,8 +3,10 @@ package spanlogger
 import (
 	"context"
 	"strings"
+	"time"
 
 	"connectrpc.com/connect"
+	"github.com/dustin/go-humanize"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/tracing"
@@ -38,71 +40,125 @@ func (l LogSpanParametersWrapper) logWithRequestMetadata(ctx context.Context, re
 	return FromContext(ctx, logger)
 }
 
+// logQuery emits a "query started" line, executes fn, then emits a "query
+// finished" line with latency and (optionally) humanized bytes fetched.
+// reqFields must be a flat key-value list of request-scoped fields that will
+// appear on both lines.
+func (l LogSpanParametersWrapper) logQuery(
+	logger *SpanLogger,
+	stats *QueryStats,
+	reqFields []interface{},
+	fn func() error,
+) error {
+	level.Info(logger).Log(append([]interface{}{"msg", "query started"}, reqFields...)...)
+
+	t := time.Now()
+	err := fn()
+	latency := time.Since(t)
+
+	finishFields := make([]interface{}, 0, len(reqFields)+8)
+	finishFields = append(finishFields, "msg", "query finished")
+	finishFields = append(finishFields, reqFields...)
+	finishFields = append(finishFields, "latency", latency)
+	if stats != nil {
+		finishFields = append(finishFields,
+			"fetched_object_bytes", humanize.Bytes(stats.ObjectStorageBytes),
+			"fetched_metastore_bytes", humanize.Bytes(stats.MetastoreBytes),
+		)
+	}
+	level.Info(logger).Log(finishFields...)
+	return err
+}
+
 func (l LogSpanParametersWrapper) ProfileTypes(ctx context.Context, c *connect.Request[querierv1.ProfileTypesRequest]) (*connect.Response[querierv1.ProfileTypesResponse], error) {
 	spanName := "ProfileTypes"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
+	defer sp.Finish()
+	ctx, stats := ContextWithQueryStats(ctx)
+
+	var resp *connect.Response[querierv1.ProfileTypesResponse]
+	err := l.logQuery(l.logWithRequestMetadata(ctx, c), stats, []interface{}{
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
 		"query_window", model.Time(c.Msg.End).Sub(model.Time(c.Msg.Start)).String(),
-	)
-	defer sp.Finish()
-
-	return l.client.ProfileTypes(ctx, c)
+	}, func() (err error) {
+		resp, err = l.client.ProfileTypes(ctx, c)
+		return err
+	})
+	return resp, err
 }
 
 func (l LogSpanParametersWrapper) LabelValues(ctx context.Context, c *connect.Request[typesv1.LabelValuesRequest]) (*connect.Response[typesv1.LabelValuesResponse], error) {
 	spanName := "LabelValues"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
+	defer sp.Finish()
+	ctx, stats := ContextWithQueryStats(ctx)
+
+	var resp *connect.Response[typesv1.LabelValuesResponse]
+	err := l.logQuery(l.logWithRequestMetadata(ctx, c), stats, []interface{}{
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
 		"query_window", model.Time(c.Msg.End).Sub(model.Time(c.Msg.Start)).String(),
 		"matchers", lazyJoin(c.Msg.Matchers),
 		"name", c.Msg.Name,
-	)
-	defer sp.Finish()
-
-	return l.client.LabelValues(ctx, c)
+	}, func() (err error) {
+		resp, err = l.client.LabelValues(ctx, c)
+		return err
+	})
+	return resp, err
 }
 
 func (l LogSpanParametersWrapper) LabelNames(ctx context.Context, c *connect.Request[typesv1.LabelNamesRequest]) (*connect.Response[typesv1.LabelNamesResponse], error) {
 	spanName := "LabelNames"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
+	defer sp.Finish()
+	ctx, stats := ContextWithQueryStats(ctx)
+
+	var resp *connect.Response[typesv1.LabelNamesResponse]
+	err := l.logQuery(l.logWithRequestMetadata(ctx, c), stats, []interface{}{
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
 		"query_window", model.Time(c.Msg.End).Sub(model.Time(c.Msg.Start)).String(),
 		"matchers", lazyJoin(c.Msg.Matchers),
-	)
-	defer sp.Finish()
-
-	return l.client.LabelNames(ctx, c)
+	}, func() (err error) {
+		resp, err = l.client.LabelNames(ctx, c)
+		return err
+	})
+	return resp, err
 }
 
 func (l LogSpanParametersWrapper) Series(ctx context.Context, c *connect.Request[querierv1.SeriesRequest]) (*connect.Response[querierv1.SeriesResponse], error) {
 	spanName := "Series"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
+	defer sp.Finish()
+	ctx, stats := ContextWithQueryStats(ctx)
+
+	var resp *connect.Response[querierv1.SeriesResponse]
+	err := l.logQuery(l.logWithRequestMetadata(ctx, c), stats, []interface{}{
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
 		"query_window", model.Time(c.Msg.End).Sub(model.Time(c.Msg.Start)).String(),
 		"matchers", lazyJoin(c.Msg.Matchers),
 		"label_names", lazyJoin(c.Msg.LabelNames),
-	)
-	defer sp.Finish()
-
-	return l.client.Series(ctx, c)
+	}, func() (err error) {
+		resp, err = l.client.Series(ctx, c)
+		return err
+	})
+	return resp, err
 }
 
 func (l LogSpanParametersWrapper) SelectMergeStacktraces(ctx context.Context, c *connect.Request[querierv1.SelectMergeStacktracesRequest]) (*connect.Response[querierv1.SelectMergeStacktracesResponse], error) {
 	spanName := "SelectMergeStacktraces"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
+	defer sp.Finish()
+	ctx, stats := ContextWithQueryStats(ctx)
+
+	var resp *connect.Response[querierv1.SelectMergeStacktracesResponse]
+	err := l.logQuery(l.logWithRequestMetadata(ctx, c), stats, []interface{}{
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -112,16 +168,21 @@ func (l LogSpanParametersWrapper) SelectMergeStacktraces(ctx context.Context, c 
 		"format", c.Msg.Format,
 		"max_nodes", c.Msg.GetMaxNodes(),
 		"profile_id_selector", lazyJoin(c.Msg.ProfileIdSelector),
-	)
-	defer sp.Finish()
-
-	return l.client.SelectMergeStacktraces(ctx, c)
+	}, func() (err error) {
+		resp, err = l.client.SelectMergeStacktraces(ctx, c)
+		return err
+	})
+	return resp, err
 }
 
 func (l LogSpanParametersWrapper) SelectMergeSpanProfile(ctx context.Context, c *connect.Request[querierv1.SelectMergeSpanProfileRequest]) (*connect.Response[querierv1.SelectMergeSpanProfileResponse], error) {
 	spanName := "SelectMergeSpanProfile"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
+	defer sp.Finish()
+	ctx, stats := ContextWithQueryStats(ctx)
+
+	var resp *connect.Response[querierv1.SelectMergeSpanProfileResponse]
+	err := l.logQuery(l.logWithRequestMetadata(ctx, c), stats, []interface{}{
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -130,16 +191,21 @@ func (l LogSpanParametersWrapper) SelectMergeSpanProfile(ctx context.Context, c 
 		"profile_type", c.Msg.ProfileTypeID,
 		"format", c.Msg.Format,
 		"max_nodes", c.Msg.GetMaxNodes(),
-	)
-	defer sp.Finish()
-
-	return l.client.SelectMergeSpanProfile(ctx, c)
+	}, func() (err error) {
+		resp, err = l.client.SelectMergeSpanProfile(ctx, c)
+		return err
+	})
+	return resp, err
 }
 
 func (l LogSpanParametersWrapper) SelectMergeProfile(ctx context.Context, c *connect.Request[querierv1.SelectMergeProfileRequest]) (*connect.Response[profilev1.Profile], error) {
 	spanName := "SelectMergeProfile"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
+	defer sp.Finish()
+	ctx, stats := ContextWithQueryStats(ctx)
+
+	var resp *connect.Response[profilev1.Profile]
+	err := l.logQuery(l.logWithRequestMetadata(ctx, c), stats, []interface{}{
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -149,16 +215,21 @@ func (l LogSpanParametersWrapper) SelectMergeProfile(ctx context.Context, c *con
 		"profile_type", c.Msg.ProfileTypeID,
 		"stacktrace_selector", c.Msg.GetStackTraceSelector(),
 		"profile_id_selector", lazyJoin(c.Msg.ProfileIdSelector),
-	)
-	defer sp.Finish()
-
-	return l.client.SelectMergeProfile(ctx, c)
+	}, func() (err error) {
+		resp, err = l.client.SelectMergeProfile(ctx, c)
+		return err
+	})
+	return resp, err
 }
 
 func (l LogSpanParametersWrapper) SelectSeries(ctx context.Context, c *connect.Request[querierv1.SelectSeriesRequest]) (*connect.Response[querierv1.SelectSeriesResponse], error) {
 	spanName := "SelectSeries"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
+	defer sp.Finish()
+	ctx, stats := ContextWithQueryStats(ctx)
+
+	var resp *connect.Response[querierv1.SelectSeriesResponse]
+	err := l.logQuery(l.logWithRequestMetadata(ctx, c), stats, []interface{}{
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -171,16 +242,21 @@ func (l LogSpanParametersWrapper) SelectSeries(ctx context.Context, c *connect.R
 		"aggregation", c.Msg.GetAggregation().String(),
 		"limit", c.Msg.Limit,
 		"exemplar_type", c.Msg.ExemplarType,
-	)
-	defer sp.Finish()
-
-	return l.client.SelectSeries(ctx, c)
+	}, func() (err error) {
+		resp, err = l.client.SelectSeries(ctx, c)
+		return err
+	})
+	return resp, err
 }
 
 func (l LogSpanParametersWrapper) SelectHeatmap(ctx context.Context, c *connect.Request[querierv1.SelectHeatmapRequest]) (*connect.Response[querierv1.SelectHeatmapResponse], error) {
 	spanName := "SelectHeatmap"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
+	defer sp.Finish()
+	ctx, stats := ContextWithQueryStats(ctx)
+
+	var resp *connect.Response[querierv1.SelectHeatmapResponse]
+	err := l.logQuery(l.logWithRequestMetadata(ctx, c), stats, []interface{}{
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -192,27 +268,30 @@ func (l LogSpanParametersWrapper) SelectHeatmap(ctx context.Context, c *connect.
 		"query_type", c.Msg.QueryType,
 		"exemplar_type", c.Msg.ExemplarType,
 		"limit", c.Msg.Limit,
-	)
-	defer sp.Finish()
-
-	return l.client.SelectHeatmap(ctx, c)
+	}, func() (err error) {
+		resp, err = l.client.SelectHeatmap(ctx, c)
+		return err
+	})
+	return resp, err
 }
 
 func (l LogSpanParametersWrapper) Diff(ctx context.Context, c *connect.Request[querierv1.DiffRequest]) (*connect.Response[querierv1.DiffResponse], error) {
 	spanName := "Diff"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
+	defer sp.Finish()
+	ctx, stats := ContextWithQueryStats(ctx)
 
 	left := &querierv1.SelectMergeStacktracesRequest{}
 	if c.Msg.Left != nil {
 		left = c.Msg.Left
 	}
-
 	right := &querierv1.SelectMergeStacktracesRequest{}
 	if c.Msg.Right != nil {
 		right = c.Msg.Right
 	}
 
-	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
+	var resp *connect.Response[querierv1.DiffResponse]
+	err := l.logQuery(l.logWithRequestMetadata(ctx, c), stats, []interface{}{
 		"method", spanName,
 		"left_start", model.Time(left.Start).Time().String(),
 		"left_end", model.Time(left.End).Time().String(),
@@ -228,10 +307,11 @@ func (l LogSpanParametersWrapper) Diff(ctx context.Context, c *connect.Request[q
 		"right_profile_type", right.ProfileTypeID,
 		"right_format", right.Format,
 		"right_max_nodes", right.GetMaxNodes(),
-	)
-	defer sp.Finish()
-
-	return l.client.Diff(ctx, c)
+	}, func() (err error) {
+		resp, err = l.client.Diff(ctx, c)
+		return err
+	})
+	return resp, err
 }
 
 func (l LogSpanParametersWrapper) GetProfileStats(ctx context.Context, c *connect.Request[typesv1.GetProfileStatsRequest]) (*connect.Response[typesv1.GetProfileStatsResponse], error) {
@@ -244,16 +324,21 @@ func (l LogSpanParametersWrapper) GetProfileStats(ctx context.Context, c *connec
 func (l LogSpanParametersWrapper) AnalyzeQuery(ctx context.Context, c *connect.Request[querierv1.AnalyzeQueryRequest]) (*connect.Response[querierv1.AnalyzeQueryResponse], error) {
 	spanName := "AnalyzeQuery"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
+	defer sp.Finish()
+	ctx, stats := ContextWithQueryStats(ctx)
+
+	var resp *connect.Response[querierv1.AnalyzeQueryResponse]
+	err := l.logQuery(l.logWithRequestMetadata(ctx, c), stats, []interface{}{
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
 		"query_window", model.Time(c.Msg.End).Sub(model.Time(c.Msg.Start)).String(),
 		"query", c.Msg.Query,
-	)
-	defer sp.Finish()
-
-	return l.client.AnalyzeQuery(ctx, c)
+	}, func() (err error) {
+		resp, err = l.client.AnalyzeQuery(ctx, c)
+		return err
+	})
+	return resp, err
 }
 
 type LazyJoin struct {

--- a/pkg/util/spanlogger/query_stats.go
+++ b/pkg/util/spanlogger/query_stats.go
@@ -1,0 +1,26 @@
+package spanlogger
+
+import "context"
+
+// QueryStats is populated by the query-frontend during query execution and
+// read by LogSpanParametersWrapper after the call returns, so that bytes
+// fetched can be included in the query log line.
+type QueryStats struct {
+	ObjectStorageBytes uint64
+	MetastoreBytes     uint64
+}
+
+type queryStatsKey struct{}
+
+// ContextWithQueryStats attaches a fresh QueryStats to ctx and returns both
+// the enriched context and a pointer to the stats struct.
+func ContextWithQueryStats(ctx context.Context) (context.Context, *QueryStats) {
+	s := &QueryStats{}
+	return context.WithValue(ctx, queryStatsKey{}, s), s
+}
+
+// QueryStatsFromContext returns the QueryStats stored in ctx, or nil if none.
+func QueryStatsFromContext(ctx context.Context) *QueryStats {
+	s, _ := ctx.Value(queryStatsKey{}).(*QueryStats)
+	return s
+}


### PR DESCRIPTION
Tracks actual bytes read from object storage and metastore per query, exposing them as a `pyroscope_query_frontend_fetched_bytes_total` Prometheus counter and logging them (humanized, with latency) on every query log line. Counting is done at the `ReadCloser` level so short reads are not over-counted, MERGE nodes correctly sum bytes from all children, and the tenant label uses `tenant.JoinTenantIDs` (|-separated) to match the standard dskit multi-tenant org ID format.