### PR TITLE
fix(ui): patch CVE-2026-45149 and CVE-2026-46625 in yarn dependencies

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -41,8 +41,10 @@
   "resolutions": {
     "react-custom-scrollbars-2@npm:4.5.0": "patch:react-custom-scrollbars-2@npm%3A4.5.0#~/.yarn/patches/react-custom-scrollbars-2-npm-4.5.0-420f40d266.patch",
     "brace-expansion@npm:^1.1.7": "npm:1.1.13",
+    "brace-expansion@npm:^5.0.2": "npm:5.0.6",
     "dompurify": "npm:^3.4.0",
     "immutable": "npm:5.1.5",
+    "js-cookie": "npm:3.0.7",
     "uuid": "npm:^11.1.1"
   }
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2624,12 +2624,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.2":
-  version: 5.0.5
-  resolution: "brace-expansion@npm:5.0.5"
+"brace-expansion@npm:5.0.6":
+  version: 5.0.6
+  resolution: "brace-expansion@npm:5.0.6"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/4d238e14ed4f5cc9c07285550a41cef23121ca08ba99fa9eb5b55b580dcb6bf868b8210aa10526bdc9f8dc97f33ca2a7259039c4cc131a93042beddb424c48e3
+  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
   languageName: node
   linkType: hard
 
@@ -4158,10 +4158,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-cookie@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "js-cookie@npm:2.2.1"
-  checksum: 10c0/ee67fc0f8495d0800b851910b5eb5bf49d3033adff6493d55b5c097ca6da46f7fe666b10e2ecb13cfcaf5b88d71c205ce00a7e646de791689bfd053bbb36a376
+"js-cookie@npm:3.0.7":
+  version: 3.0.7
+  resolution: "js-cookie@npm:3.0.7"
+  checksum: 10c0/c921c43014e98bb94a1765663a1a10d693048d61444e374c1ecf459eba92320381f9c406e724df9aa44e819c4b606e6a7240f2abe2d5c54ad1e73a3002b191c2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Pins `brace-expansion` to `5.0.6` via yarn resolution — fixes [CVE-2026-45149](https://avd.aquasec.com/nvd/cve-2026-45149) (MEDIUM: large numeric range bypasses DoS protection)
- Pins `js-cookie` to `3.0.7` via yarn resolution — fixes [CVE-2026-46625](https://avd.aquasec.com/nvd/cve-2026-46625) (HIGH: prototype hijack in `assign()` enables cookie-attribute injection)

Both packages were transitive dependencies (`minimatch` → `brace-expansion`; `react-use` → `js-cookie`). The fixes are applied via the `resolutions` field in `ui/package.json` to override the installed versions without changing direct dependency declarations.

`js-cookie` 3.x is a major version bump but its core `get`/`set`/`remove` API used by `react-use` is unchanged.

## Test plan

- [x] `trivy fs ui/yarn.lock` reports 0 vulnerabilities after the change
- [ ] UI builds without errors (`yarn build`)