### PR TITLE
docs: refresh stale agent guides (ui v2 layout, Go version, tracing)

### DIFF
--- a/.cursor/rules/development-workflow.mdc
+++ b/.cursor/rules/development-workflow.mdc
@@ -8,10 +8,9 @@ alwaysApply: false
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25 (see `go.mod`)
 - Docker
-- Node v18
-- Yarn v1.22
+- Node.js (recent LTS) + Yarn 4 (Berry) — only needed for frontend work in `ui/`
 - All other tools auto-download to `.tmp/bin/`
 
 ## Build Commands
@@ -23,12 +22,10 @@ make go/bin
 # Run Go tests
 make go/test
 
-# Build frontend
-yarn install
-yarn dev          # Dev server on :4041
-
-# Run backend for frontend development
-yarn backend:dev  # Runs Pyroscope server
+# Frontend dev (run from ui/): Vite dev server on :5173, proxies API to :4040
+cd ui && yarn install && yarn dev
+# Production frontend build (Docker -> ui/dist; required before `make build`)
+make frontend/build
 
 # Docker image
 make GOOS=linux GOARCH=amd64 docker-image/pyroscope/build

--- a/.cursor/rules/pyroscope-general.mdc
+++ b/.cursor/rules/pyroscope-general.mdc
@@ -100,4 +100,4 @@ Pyroscope uses a **microservices architecture** where a single binary can run di
 3. **Don't** create unbounded goroutines - use worker pools or semaphores
 4. **Don't** log PII or sensitive data
 5. **Don't** commit changes to `node_modules/` or generated code without source changes
-6. **Don't** edit the frontend without reading `ui/CLAUDE.md` first - the UI now lives in `ui/` (a dependency-minimal React+Vite rewrite), not `public/app/`
+6. **Don't** modify frontend code (`ui/`) - the frontend is not actively developed and changes are discouraged; if you do need to change it, read `ui/CLAUDE.md` first

--- a/.cursor/rules/pyroscope-general.mdc
+++ b/.cursor/rules/pyroscope-general.mdc
@@ -68,7 +68,7 @@ Pyroscope uses a **microservices architecture** where a single binary can run di
 │   ├── objstore/            # Object storage abstraction
 │   ├── api/                 # API definitions and handlers
 │   └── og/                  # Legacy code (original Pyroscope) - DO NOT USE
-├── public/app/              # React/TypeScript frontend
+├── ui/                      # React/TypeScript frontend (Vite) - has its own ui/CLAUDE.md
 ├── api/                     # API definitions (protobuf, OpenAPI)
 ├── docs/                    # Documentation
 ├── operations/              # Deployment configs (jsonnet, helm)
@@ -83,7 +83,7 @@ Pyroscope uses a **microservices architecture** where a single binary can run di
 - **parquet-go**: Parquet file format implementation
 - **go-kit/log**: Structured logging
 - **prometheus/client_golang**: Metrics instrumentation
-- **opentracing-go**: Distributed tracing
+- **opentelemetry**: Distributed tracing
 
 ## Critical Rules
 
@@ -100,4 +100,4 @@ Pyroscope uses a **microservices architecture** where a single binary can run di
 3. **Don't** create unbounded goroutines - use worker pools or semaphores
 4. **Don't** log PII or sensitive data
 5. **Don't** commit changes to `node_modules/` or generated code without source changes
-6. **Don't** modify frontend code (`public/app/`) - the frontend is not actively developed and changes are discouraged
+6. **Don't** edit the frontend without reading `ui/CLAUDE.md` first - the UI now lives in `ui/` (a dependency-minimal React+Vite rewrite), not `public/app/`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ Pyroscope uses a **microservices architecture** where a single binary can run di
 │   ├── objstore/            # Object storage abstraction
 │   ├── api/                 # API definitions and handlers
 │   └── og/                  # Legacy code (original Pyroscope)
-├── public/app/              # React/TypeScript frontend
+├── ui/                      # React/TypeScript frontend (Vite) - has its own ui/CLAUDE.md
 ├── api/                     # API definitions (protobuf, OpenAPI)
 ├── docs/                    # Documentation
 ├── operations/              # Deployment configs (jsonnet, helm)
@@ -78,31 +78,30 @@ Pyroscope uses a **microservices architecture** where a single binary can run di
 ## Tech Stack
 
 ### Backend
-- **Language**: Go 1.24+
+- **Language**: Go 1.25 (see `go.mod`)
 - **RPC**: gRPC with Connect protocol
 - **Storage**: Parquet, TSDB
 - **Hash Ring**: Consistent hashing with memberlist (gossip protocol)
 - **Observability**: Prometheus metrics, Structured logs, Distributed traces, pprof profiles
 
 ### Frontend
-- **Language**: TypeScript
-- **Framework**: React
-- **Build**: Webpack
-- **Styling**: Emotion (CSS-in-JS)
-- **State**: React hooks, Context API
-- **UI Library**: Grafana UI components
+The frontend lives in `ui/` and is a dependency-minimal rewrite of the old `public/app` UI.
+**`ui/CLAUDE.md` and `ui/DESIGN.md` are the authoritative guides — read them before touching the UI.** Summary:
+- **Stack**: React 19 + Vite 8 + TypeScript 5.9, package-managed with **Yarn 4 (Berry)** — use `yarn`, not `npm`
+- **No UI library**: styling via CSS custom properties / semantic tokens in `src/theme.css` (no Emotion, no Grafana UI)
+- **Resist new dependencies** — prefer a small local implementation; minimizing the dependency surface is the whole point of the rewrite
 
 ### Testing
 - **Go**: Standard `testing` package, testify for assertions
-- **Frontend**: Jest, React Testing Library, Cypress (e2e)
+- **Frontend**: Vitest (`yarn test` from `ui/`)
 
 ## Development Workflow
 
 ### Setup & Build
 
 ```bash
-# Install dependencies (Go 1.24+, Docker, Node v18, Yarn v1.22)
-# All other tools auto-download to .tmp/bin/
+# Prerequisites: Go 1.25, Docker, Node, Yarn 4 (Berry).
+# All other build tools auto-download to .tmp/bin/
 
 # Build backend
 make go/bin
@@ -110,12 +109,10 @@ make go/bin
 # Run tests
 make go/test
 
-# Build frontend
-yarn install
-yarn dev          # Dev server on :4041
-
-# Run backend for frontend development
-yarn backend:dev  # Runs Pyroscope server
+# Frontend dev (run from ui/): Vite dev server on :5173, proxies API to :4040
+cd ui && yarn install && yarn dev
+# Production frontend build (Docker -> ui/dist; required before `make build`):
+make frontend/build
 
 # Docker image
 make GOOS=linux GOARCH=amd64 docker-image/pyroscope/build
@@ -189,11 +186,13 @@ go run ./cmd/pyroscope -symbolizer.enabled=true
 
 ### TypeScript/React Code
 
+The `ui/` frontend has its own authoritative guides — **follow `ui/CLAUDE.md` and `ui/DESIGN.md`**. In brief:
+
 1. **File Extensions**: `.tsx` for components, `.ts` for utilities
-2. **Components**: Use functional components with hooks
-3. **Styling**: Use Emotion CSS-in-JS with Grafana UI theme
+2. **Components**: Functional components with hooks; keep state management simple (the rewrite deliberately dropped Redux)
+3. **Styling**: Use semantic CSS custom properties from `src/theme.css`; never reference primitive tokens directly, and don't add Emotion or Grafana UI
 4. **Props**: Define explicit TypeScript interfaces for all component props
-5. **Formatting**: Use Prettier (run via `yarn lint`)
+5. **Formatting**: Prettier + ESLint — `yarn format` / `yarn lint` from `ui/`
 
 ## Common Patterns
 

--- a/docs/internal/contributing/README.md
+++ b/docs/internal/contributing/README.md
@@ -19,7 +19,7 @@ a piece of work is finished it should:
 
 To be able to run make targets you'll need to install:
 
-- [Go](https://go.dev/doc/install) (>= 1.24)
+- [Go](https://go.dev/doc/install) (>= 1.25, see `go.mod`)
 - [Docker](https://docs.docker.com/engine/install/)
 
 All other required tools will be automatically downloaded `$(pwd)/.tmp/bin`.
@@ -88,46 +88,28 @@ This will Pyroscope on `:4040` and the embedded Grafana on port `:4041`.
 
 #### Frontend development
 
-The frontend application is not in active development. While the UI it provides is usable and stable,
-the recommended way to view and analyze profiling data is to use the 
+The web UI lives in the `ui/` directory and is a dependency-minimal rewrite (React + Vite + TypeScript)
+of the older `public/app` UI. See [`ui/CLAUDE.md`](../../../ui/CLAUDE.md) and
+[`ui/DESIGN.md`](../../../ui/DESIGN.md) for the authoritative frontend guide.
+
+For end users, the recommended way to view and analyze profiling data is the
 [Profiles Drilldown](https://grafana.com/docs/grafana/latest/visualizations/simplified-exploration/profiles/) Grafana app (pre-installed in recent Grafana versions).
 
-If you do need to make changes to the frontend code, the following instructions should get you started.
-
-**Versions for development tools**:
-- Node v18
-- Yarn v1.22
-
-The frontend code is located in the `public/app` directory, although its `package.json` file is at the repository root.
-
-To run the local frontend application in development mode:
+The frontend uses **Yarn 4 (Berry)** and its `package.json` lives in `ui/` (not at the repository root).
+To run it in development mode:
 
 ```sh
+cd ui
 yarn install
 yarn dev
 ```
 
-This will:
-- install and update frontend dependencies
-- launch a process that will build the frontend code
-- serve the built app at `http://localhost:4041`
-- keep the web app updated any time you update the frontend source code
+This serves the app at `http://localhost:5173` and proxies API requests to a Pyroscope server at
+`http://localhost:4040`. In a separate terminal, start a server for it to talk to, for example:
 
-The web app will not initially be connected to a Pyroscope server, so all attempts to fetch data will fail.
-
-To launch a pyroscope server for development purposes:
 ```sh
-yarn backend:dev
+go run ./cmd/pyroscope
 ```
-
-This yarn script actually runs the following:
-```sh
-make build run 'PARAMS=--config.file ./cmd/pyroscope/pyroscope.yaml'
-```
-
-It can take a while for this process to build and start serving pyroscope data, but
-once it is fully active, the pyroscope web app service at `http://localhost:4041`
-will be able to interact with it.
 
 ### Dependency management
 

--- a/docs/internal/contributing/README.md
+++ b/docs/internal/contributing/README.md
@@ -88,12 +88,15 @@ This will Pyroscope on `:4040` and the embedded Grafana on port `:4041`.
 
 #### Frontend development
 
+The frontend application is not in active development. While the UI it provides is usable and stable,
+the recommended way to view and analyze profiling data is to use the
+[Profiles Drilldown](https://grafana.com/docs/grafana/latest/visualizations/simplified-exploration/profiles/) Grafana app (pre-installed in recent Grafana versions).
+
+If you do need to make changes to the frontend code, the following instructions should get you started.
+
 The web UI lives in the `ui/` directory and is a dependency-minimal rewrite (React + Vite + TypeScript)
 of the older `public/app` UI. See [`ui/CLAUDE.md`](../../../ui/CLAUDE.md) and
 [`ui/DESIGN.md`](../../../ui/DESIGN.md) for the authoritative frontend guide.
-
-For end users, the recommended way to view and analyze profiling data is the
-[Profiles Drilldown](https://grafana.com/docs/grafana/latest/visualizations/simplified-exploration/profiles/) Grafana app (pre-installed in recent Grafana versions).
 
 The frontend uses **Yarn 4 (Berry)** and its `package.json` lives in `ui/` (not at the repository root).
 To run it in development mode:

--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -1,6 +1,6 @@
 # Pyroscope UI
 
-React + Vite + TypeScript frontend for Pyroscope. This frontend is a rewrite of the old UI (found in ../public/app). The objective of the app is to provide a single page query UI to query Pyroscope profiling data. The canonical implementation can be found in the old UI. When in doubt, try model behaviors found there.
+React + Vite + TypeScript frontend for Pyroscope. This frontend is a rewrite of the old UI that lived in `public/app` (removed in the ui v2 migration; still available in git history). The objective of the app is to provide a single page query UI to query Pyroscope profiling data. The old UI remains the canonical reference for behavior — when in doubt, check it out from git history and mirror what it did.
 
 ## Philosophy and ethos
 


### PR DESCRIPTION
## What this PR does

The agent- and contributor-facing guides have drifted out of date. This PR refreshes them to match the current repo. **Docs only — no code changes.**

Most of the staleness comes from the embedded ui v2 migration (#4948), which replaced the old `public/app` frontend with a dependency-minimal React + Vite app in `ui/` (which has its own `ui/CLAUDE.md`) but left the guides describing the removed stack. Two unrelated facts were also wrong (Go version, tracing library).

### Stale → corrected

| Topic | Was | Now |
|---|---|---|
| Frontend location | `public/app/` + root `package.json` | `ui/` (`package.json` in `ui/`) |
| Frontend stack | Webpack / Emotion / Jest / Cypress / Grafana UI | React + Vite + TypeScript, Vitest, Yarn 4 (Berry), no UI library |
| Dev server | `yarn dev` on `:4041`, `yarn backend:dev` | `cd ui && yarn dev` on `:5173`, proxies API to `:4040` |
| Go version | 1.24 | 1.25 (`go.mod` requires it) |
| Tracing dep (Cursor rule) | opentracing-go | OpenTelemetry |

### Files

- `AGENTS.md` (the `CLAUDE.md` symlink target) — frontend section now points to `ui/CLAUDE.md` / `ui/DESIGN.md`; corrected stack, dev/build commands, repo tree.
- `.cursor/rules/development-workflow.mdc`, `.cursor/rules/pyroscope-general.mdc` — same corrections (prerequisites, dev commands, repo tree, tracing dep, "don't edit the frontend" rule).
- `docs/internal/contributing/README.md` — rewrote the "Frontend development" section; the documented root `yarn install && yarn dev` no longer worked at all (there is no root `package.json`).
- `ui/CLAUDE.md` — it pointed readers at `../public/app` as the canonical reference, but that directory was removed in the same migration; clarified it now lives only in git history.

The remaining `:4041` and `public/app` mentions are intentional: the embedded Grafana genuinely runs on `:4041`, and `public/app` is referenced only as the predecessor of the rewrite.