### PR TITLE
fix(compactor): use realistic compaction size buckets

### DIFF
--- a/pkg/compactor/bucket_compactor.go
+++ b/pkg/compactor/bucket_compactor.go
@@ -297,7 +297,7 @@ func newCompactorMetrics(r prometheus.Registerer) *CompactorMetrics {
 	m.Size = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:                            "pyroscope_compaction_size_bytes",
 		Help:                            "Final block size after compaction by level",
-		Buckets:                         prometheus.ExponentialBuckets(32, 1.5, 12),
+		Buckets:                         prometheus.ExponentialBuckets(1<<20, 2, 15),
 		NativeHistogramBucketFactor:     1.1,
 		NativeHistogramMaxBucketNumber:  50,
 		NativeHistogramMinResetDuration: time.Hour,

--- a/pkg/compactor/bucket_compactor_test.go
+++ b/pkg/compactor/bucket_compactor_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,6 +29,40 @@ import (
 	"github.com/grafana/pyroscope/v2/pkg/phlaredb/block"
 	"github.com/grafana/pyroscope/v2/pkg/util/extprom"
 )
+
+func TestCompactorMetrics_SizeBuckets(t *testing.T) {
+	metrics := newCompactorMetrics(nil)
+	observer, err := metrics.Size.GetMetricWithLabelValues("1")
+	require.NoError(t, err)
+	metricObserver, ok := observer.(prometheus.Metric)
+	require.True(t, ok)
+
+	var metric dto.Metric
+	require.NoError(t, metricObserver.Write(&metric))
+
+	var got []float64
+	for _, bucket := range metric.GetHistogram().GetBucket() {
+		got = append(got, bucket.GetUpperBound())
+	}
+
+	assert.Equal(t, []float64{
+		1 << 20,
+		1 << 21,
+		1 << 22,
+		1 << 23,
+		1 << 24,
+		1 << 25,
+		1 << 26,
+		1 << 27,
+		1 << 28,
+		1 << 29,
+		1 << 30,
+		1 << 31,
+		1 << 32,
+		1 << 33,
+		1 << 34,
+	}, got)
+}
 
 func TestGroupKey(t *testing.T) {
 	for _, tcase := range []struct {


### PR DESCRIPTION
## Summary

Closes #4910

The `pyroscope_compaction_size_bytes` histogram previously used finite buckets from 32 bytes to roughly 2.7 KiB. Real compacted blocks are commonly in the MB-to-GB range, so observations landed in `+Inf` and classic histogram quantiles were not useful.

This updates the finite bucket range to 1 MiB through 16 GiB and adds a unit test that verifies the registered bucket boundaries.

## Test plan

- [x] `go test ./pkg/compactor -run TestCompactorMetrics_SizeBuckets`