### PR TITLE
fix(vcs): resolve Kotlin files from Java mappings

### DIFF
--- a/docs/sources/view-and-analyze-profile-data/line-by-line.md
+++ b/docs/sources/view-and-analyze-profile-data/line-by-line.md
@@ -416,7 +416,7 @@ The system extracts Go version information from paths like `/usr/local/go/go1.24
 
 Java applications **require** explicit mappings in `.pyroscope.yaml`:
 
-- **Function name conversion**: Java function names like `org/example/App$Inner.method` are automatically converted to `org/example/App.java`
+- **Function name conversion**: Java function names like `org/example/App$Inner.method` are automatically converted to `org/example/App.java`. If the Java source file is not found, Pyroscope also tries the Kotlin `.kt` extension for JVM applications written in Kotlin.
 - **No fallback**: Unlike Go and Python, Java files cannot be resolved without configuration
 - **Inner classes**: Automatically handled (inner class markers are stripped)
 

--- a/pkg/frontend/vcs/source/find_java.go
+++ b/pkg/frontend/vcs/source/find_java.go
@@ -15,10 +15,17 @@ import (
 )
 
 const (
-	ExtJava = ".java"
+	ExtJava   = ".java"
+	ExtKotlin = ".kt"
 )
 
+var javaSourceFileExtensions = []string{ExtJava, ExtKotlin}
+
 func convertJavaFunctionNameToPath(functionName string) string {
+	return convertJavaFunctionNameToPathWithExt(functionName, ExtJava)
+}
+
+func convertJavaFunctionNameToPathWithExt(functionName, ext string) string {
 	pathSegments := strings.Split(functionName, "/")
 	last := len(pathSegments) - 1
 
@@ -43,7 +50,7 @@ func convertJavaFunctionNameToPath(functionName string) string {
 		pathSegments[last] = pathSegments[last][:pos]
 	}
 
-	pathSegments[last] = pathSegments[last] + ExtJava
+	pathSegments[last] = pathSegments[last] + ext
 	return strings.Join(pathSegments, "/")
 }
 
@@ -54,17 +61,19 @@ func (ff FileFinder) findJavaFile(ctx context.Context, mappings ...*config.Mappi
 	sp.SetTag("file.function_name", ff.file.FunctionName)
 	sp.SetTag("file.path", ff.file.Path)
 
-	javaPath := convertJavaFunctionNameToPath(ff.file.FunctionName)
-	for _, m := range mappings {
-		resp, err := ff.fetchMappingFile(ctx, m, javaPath)
-		if err != nil {
-			if errors.Is(err, client.ErrNotFound) {
+	for _, ext := range javaSourceFileExtensions {
+		javaPath := convertJavaFunctionNameToPathWithExt(ff.file.FunctionName, ext)
+		for _, m := range mappings {
+			resp, err := ff.fetchMappingFile(ctx, m, javaPath)
+			if err != nil {
+				if errors.Is(err, client.ErrNotFound) {
+					continue
+				}
+				level.Warn(ff.logger).Log("msg", "failed to fetch mapping file", "err", err)
 				continue
 			}
-			level.Warn(ff.logger).Log("msg", "failed to fetch mapping file", "err", err)
-			continue
+			return resp, nil
 		}
-		return resp, nil
 	}
 
 	return nil, connect.NewError(connect.CodeNotFound, errors.New("no mappings provided, file not resolvable"))

--- a/pkg/frontend/vcs/source/find_test.go
+++ b/pkg/frontend/vcs/source/find_test.go
@@ -141,6 +141,17 @@ source_code:
           path: spring-webmvc/src/main/java
 `
 
+const kotlinPyroscopeYAML = `---
+source_code:
+  mappings:
+    - function_name:
+        - prefix: org/example/rideshare
+      language: java
+      source:
+        local:
+          path: src/main/kotlin
+`
+
 const goPyroscopeYAML = `---
 source_code:
   mappings:
@@ -249,6 +260,28 @@ func TestFileFinder_Find(t *testing.T) {
 			},
 			expectedContent: "# CONTENT Math.java",
 			expectedURL:     "https://github.com/openjdk/jdk/blob/jdk-17+0/src/java.base/share/classes/java/lang/Math.java",
+			expectedError:   false,
+		},
+		{
+			name: "java/mapped-local-kotlin-fallback",
+			fileSpec: config.FileSpec{
+				FunctionName: "org/example/rideshare/RideShareController.orderCar",
+			},
+			rootPath:      "examples/language-sdk-instrumentation/java/rideshare",
+			ref:           "main",
+			pyroscopeYAML: kotlinPyroscopeYAML,
+			mockFiles: []mockFileResponse{
+				{
+					request: client.FileRequest{
+						Repo: "pyroscope",
+						Path: "examples/language-sdk-instrumentation/java/rideshare/src/main/kotlin/org/example/rideshare/RideShareController.kt",
+						Ref:  "main",
+					},
+					content: "# CONTENT RideShareController.kt",
+				},
+			},
+			expectedContent: "# CONTENT RideShareController.kt",
+			expectedURL:     "https://github.com/grafana/pyroscope/blob/main/examples/language-sdk-instrumentation/java/rideshare/src/main/kotlin/org/example/rideshare/RideShareController.kt",
 			expectedError:   false,
 		},
 		// Go tests


### PR DESCRIPTION
## Summary

Closes #4878

Java source mappings now keep the existing `.java` lookup first and then fall back to `.kt` when the Java source file is not found. This lets JVM applications written in Kotlin use the existing `language: java` mapping flow without changing the config schema.

The PR also adds an integration-style `FileFinder` test for a Kotlin local mapping and documents the fallback behavior in the source code integration guide.

## Test plan

- [x] `go test ./pkg/frontend/vcs/source`