### PR TITLE
fix(pyroscope): make self-profiling push URL configurable

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -1219,6 +1219,8 @@ Usage of ./pyroscope:
     	When running in single binary (--target=all) Pyroscope will push (Go SDK) profiles to itself. Set to true to disable self-profiling.
   -self-profiling.mutex-profile-fraction int
     	 (default 5)
+  -self-profiling.push-url string
+    	URL where single-binary self-profiling profiles are pushed. If empty, Pyroscope pushes to itself using the HTTP listen port and the scheme implied by server HTTP TLS.
   -self-profiling.tenant-id string
     	Tenant ID for self-profiling data. If empty, no tenant header is sent (anonymous).
   -self-profiling.use-k6-middleware

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -211,6 +211,8 @@ Usage of ./pyroscope:
     	When running in single binary (--target=all) Pyroscope will push (Go SDK) profiles to itself. Set to true to disable self-profiling.
   -self-profiling.mutex-profile-fraction int
     	 (default 5)
+  -self-profiling.push-url string
+    	URL where single-binary self-profiling profiles are pushed. If empty, Pyroscope pushes to itself using the HTTP listen port and the scheme implied by server HTTP TLS.
   -self-profiling.tenant-id string
     	Tenant ID for self-profiling data. If empty, no tenant header is sent (anonymous).
   -self-profiling.use-k6-middleware

--- a/cmd/pyroscope/pyroscope.yaml
+++ b/cmd/pyroscope/pyroscope.yaml
@@ -760,6 +760,11 @@ self_profiling:
   # profiles to itself. Set to true to disable self-profiling.
   # disable_push: false
 
+  # URL where single-binary self-profiling profiles are pushed. If empty,
+  # Pyroscope pushes to itself using the HTTP listen port and the scheme implied
+  # by server HTTP TLS.
+  # push_url: ""
+
   # mutex_profile_fraction: 5
 
   # block_profile_rate: 5

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -286,6 +286,12 @@ self_profiling:
   # CLI flag: -self-profiling.disable-push
   [disable_push: <boolean> | default = false]
 
+  # URL where single-binary self-profiling profiles are pushed. If empty,
+  # Pyroscope pushes to itself using the HTTP listen port and the scheme implied
+  # by server HTTP TLS.
+  # CLI flag: -self-profiling.push-url
+  [push_url: <string> | default = ""]
+
   # CLI flag: -self-profiling.mutex-profile-fraction
   [mutex_profile_fraction: <int> | default = 5]
 

--- a/pkg/pyroscope/pyroscope.go
+++ b/pkg/pyroscope/pyroscope.go
@@ -142,6 +142,7 @@ func (c *StorageConfig) RegisterFlags(f *flag.FlagSet) {
 
 type SelfProfilingConfig struct {
 	DisablePush          bool   `yaml:"disable_push,omitempty"`
+	PushURL              string `yaml:"push_url,omitempty"`
 	MutexProfileFraction int    `yaml:"mutex_profile_fraction,omitempty"`
 	BlockProfileRate     int    `yaml:"block_profile_rate,omitempty"`
 	UseK6Middleware      bool   `yaml:"use_k6_middleware,omitempty"`
@@ -158,6 +159,12 @@ func (c *SelfProfilingConfig) RegisterFlags(f *flag.FlagSet) {
 		false,
 		"When running in single binary (--target=all) Pyroscope will push (Go SDK) profiles to itself. Set to true to disable self-profiling.",
 	)
+	f.StringVar(
+		&c.PushURL,
+		"self-profiling.push-url",
+		"",
+		"URL where single-binary self-profiling profiles are pushed. If empty, Pyroscope pushes to itself using the HTTP listen port and the scheme implied by server HTTP TLS.",
+	)
 	f.BoolVar(
 		&c.UseK6Middleware,
 		"self-profiling.use-k6-middleware",
@@ -170,6 +177,23 @@ func (c *SelfProfilingConfig) RegisterFlags(f *flag.FlagSet) {
 		"",
 		"Tenant ID for self-profiling data. If empty, no tenant header is sent (anonymous).",
 	)
+}
+
+func (c SelfProfilingConfig) serverAddress(serverCfg server.Config) string {
+	if c.PushURL != "" {
+		return c.PushURL
+	}
+	scheme := "http"
+	if httpTLSEnabled(serverCfg.HTTPTLSConfig) {
+		scheme = "https"
+	}
+	return fmt.Sprintf("%s://localhost:%d", scheme, serverCfg.HTTPListenPort)
+}
+
+func httpTLSEnabled(cfg server.TLSConfig) bool {
+	hasCert := cfg.TLSCertPath != "" || cfg.TLSCert != ""
+	hasKey := cfg.TLSKeyPath != "" || string(cfg.TLSKey) != ""
+	return hasCert && hasKey
 }
 
 func (c *Config) RegisterFlags(f *flag.FlagSet) {
@@ -635,7 +659,7 @@ func (f *Pyroscope) Run() error {
 		if !f.Cfg.SelfProfiling.DisablePush && slices.Contains(f.Cfg.Target, All) {
 			_, err := pyroscope.Start(pyroscope.Config{
 				ApplicationName: "pyroscope",
-				ServerAddress:   fmt.Sprintf("http://%s:%d", "localhost", f.Cfg.Server.HTTPListenPort),
+				ServerAddress:   f.Cfg.SelfProfiling.serverAddress(f.Cfg.Server),
 				TenantID:        f.Cfg.SelfProfiling.TenantID,
 				Tags: map[string]string{
 					"hostname":           os.Getenv("HOSTNAME"),

--- a/pkg/pyroscope/pyroscope_test.go
+++ b/pkg/pyroscope/pyroscope_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/grafana/dskit/server"
+	"github.com/prometheus/common/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -134,6 +136,74 @@ func TestRegisterServerFlagsWithChangedDefaultValues_V2(t *testing.T) {
 		require.NotNil(t, grpcRecv)
 		assert.Equal(t, "104857600", grpcRecv.DefValue)
 	})
+}
+
+func TestSelfProfilingConfig_ServerAddress(t *testing.T) {
+	tests := []struct {
+		name               string
+		selfProfiling      SelfProfilingConfig
+		server             server.Config
+		expectedAddress    string
+		expectedTLSEnabled bool
+	}{
+		{
+			name:            "defaults to local HTTP listener",
+			server:          server.Config{HTTPListenPort: 4040},
+			expectedAddress: "http://localhost:4040",
+		},
+		{
+			name:            "custom push URL overrides local listener",
+			selfProfiling:   SelfProfilingConfig{PushURL: "https://profiles.example.test"},
+			server:          server.Config{HTTPListenPort: 4040},
+			expectedAddress: "https://profiles.example.test",
+		},
+		{
+			name: "uses HTTPS when HTTP TLS files are configured",
+			server: server.Config{
+				HTTPListenPort: 4040,
+				HTTPTLSConfig: server.TLSConfig{
+					TLSCertPath: "server.crt",
+					TLSKeyPath:  "server.key",
+				},
+			},
+			expectedAddress:    "https://localhost:4040",
+			expectedTLSEnabled: true,
+		},
+		{
+			name: "uses HTTPS when inline HTTP TLS config is configured",
+			server: server.Config{
+				HTTPListenPort: 4040,
+				HTTPTLSConfig: server.TLSConfig{
+					TLSCert: "cert",
+					TLSKey:  config.Secret("key"),
+				},
+			},
+			expectedAddress:    "https://localhost:4040",
+			expectedTLSEnabled: true,
+		},
+		{
+			name: "keeps HTTP when TLS config is incomplete",
+			server: server.Config{
+				HTTPListenPort: 4040,
+				HTTPTLSConfig: server.TLSConfig{
+					TLSCertPath: "server.crt",
+				},
+			},
+			expectedAddress: "http://localhost:4040",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedAddress, tt.selfProfiling.serverAddress(tt.server))
+			assert.Equal(t, tt.expectedTLSEnabled, httpTLSEnabled(tt.server.HTTPTLSConfig))
+		})
+	}
+}
+
+func TestSelfProfilingConfig_PushURLFlag(t *testing.T) {
+	cfg := newTestConfig(t, []string{"-self-profiling.push-url=https://profiles.example.test"})
+	require.Equal(t, "https://profiles.example.test", cfg.SelfProfiling.PushURL)
 }
 
 func TestConfigDiff(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #5173

The built-in self-profiling client used a hardcoded `http://localhost:<port>` push target. With HTTP TLS enabled this sends plain HTTP to a TLS listener. This PR adds `self_profiling.push_url` / `--self-profiling.push-url` so operators can set the push destination explicitly, and defaults the generated local address to `https://localhost:<port>` when HTTP TLS is configured.

Generated config reference, sample YAML, and help snapshots are updated for the new flag.

## Test plan

- [x] `go test ./pkg/pyroscope -run 'TestSelfProfilingConfig|TestFlagDefaults'`
- [x] `go test ./cmd/pyroscope -run TestHelp`