### PR TITLE
fix(metastore/index): avoid stale shard cache reads in GetBlocks and QueryMetadata

### DIFF
--- a/pkg/metastore/index/index.go
+++ b/pkg/metastore/index/index.go
@@ -74,6 +74,7 @@ type Store interface {
 	CreateBuckets(*bbolt.Tx) error
 	Partitions(tx *bbolt.Tx) iter.Seq[indexstore.Partition]
 	LoadShard(tx *bbolt.Tx, p indexstore.Partition, tenant string, shard uint32) (*indexstore.Shard, error)
+	LoadShardVersion(tx *bbolt.Tx, p indexstore.Partition, tenant string, shard uint32) (uint64, error)
 	DeleteShard(tx *bbolt.Tx, p indexstore.Partition, tenant string, shard uint32) error
 }
 
@@ -169,7 +170,11 @@ func (i *Index) ReplaceBlocks(tx *bbolt.Tx, compacted *metastorev1.CompactedBloc
 func (i *Index) GetBlocks(tx *bbolt.Tx, list *metastorev1.BlockList) ([]*metastorev1.BlockMeta, error) {
 	metas := make([]*metastorev1.BlockMeta, 0, len(list.Blocks))
 	for k, partitioned := range i.partitionedList(list) {
-		s, err := i.shards.getForRead(tx, k, partitioned.Tenant, partitioned.Shard)
+		version, err := i.store.LoadShardVersion(tx, k, partitioned.Tenant, partitioned.Shard)
+		if err != nil {
+			return nil, err
+		}
+		s, err := i.shards.getForReadAtVersion(tx, k, partitioned.Tenant, partitioned.Shard, version)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/metastore/index/index_cache.go
+++ b/pkg/metastore/index/index_cache.go
@@ -106,7 +106,7 @@ func (c *shardCache) getForWriteUnsafe(tx *bbolt.Tx, p indexstore.Partition, ten
 	return s, nil
 }
 
-func (c *shardCache) getForRead(tx *bbolt.Tx, p indexstore.Partition, tenant string, shard uint32) (*indexstore.Shard, error) {
+func (c *shardCache) getForReadAtVersion(tx *bbolt.Tx, p indexstore.Partition, tenant string, shard uint32, version uint64) (*indexstore.Shard, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	k := shardCacheKey{
@@ -116,8 +116,17 @@ func (c *shardCache) getForRead(tx *bbolt.Tx, p indexstore.Partition, tenant str
 	}
 	x, found := c.cache.Get(k)
 	if found && x != nil {
-		c.metrics.recordShardReadHit()
-		return x.ShallowCopy(), nil
+		// Write-cached shards are always safe to reuse because writes are
+		// serialized and observe the latest shard state. Read-cached shards are
+		// only safe when the caller has no version information (`version == 0`,
+		// for old on-disk shard indexes) or when the cached version is at least
+		// as new as the caller's transaction snapshot. Otherwise, reload from the
+		// current transaction to avoid mixing new block metadata with a stale
+		// string table loaded by an older read transaction.
+		if !x.readOnly || version == 0 || x.ShardIndex.Version >= version {
+			c.metrics.recordShardReadHit()
+			return x.ShallowCopy(), nil
+		}
 	}
 	c.metrics.recordShardReadMiss()
 	s, err := c.store.LoadShard(tx, p, tenant, shard)

--- a/pkg/metastore/index/index_test.go
+++ b/pkg/metastore/index/index_test.go
@@ -94,7 +94,7 @@ func TestIndex_PartitionList(t *testing.T) {
 		assert.Equal(t, newBlockMeta.MaxTime, updated.ShardIndex.MaxTime)
 
 		require.NoError(t, db.View(func(tx *bbolt.Tx) error {
-			s, err := idx.shards.getForRead(tx, p, tenant, shardID)
+			s, err := idx.shards.getForReadAtVersion(tx, p, tenant, shardID, updated.ShardIndex.Version)
 			if err != nil {
 				return err
 			}

--- a/pkg/metastore/index/metrics_test.go
+++ b/pkg/metastore/index/metrics_test.go
@@ -56,14 +56,14 @@ func TestCacheMetrics(t *testing.T) {
 
 	// Read lookup on the same key: writable entry counts as a read hit too.
 	require.NoError(t, db.View(func(tx *bbolt.Tx) error {
-		_, err := sc.getForRead(tx, p, tenant, shardID)
+		_, err := sc.getForReadAtVersion(tx, p, tenant, shardID, 0)
 		return err
 	}))
 	require.Equal(t, float64(1), testutil.ToFloat64(m.cacheRequests.WithLabelValues("shard_read", "hit")))
 
 	// Read lookup on a new key: miss + entry inserted as read-only.
 	require.NoError(t, db.View(func(tx *bbolt.Tx) error {
-		_, err := sc.getForRead(tx, p, tenant, shardID+1)
+		_, err := sc.getForReadAtVersion(tx, p, tenant, shardID+1, 0)
 		return err
 	}))
 	require.Equal(t, float64(1), testutil.ToFloat64(m.cacheRequests.WithLabelValues("shard_read", "miss")))

--- a/pkg/metastore/index/query.go
+++ b/pkg/metastore/index/query.go
@@ -325,7 +325,7 @@ func (si *shardIterator) Next() bool {
 	}
 	c := si.shards[0]
 	si.shards = si.shards[1:]
-	si.cur, si.err = si.index.shards.getForRead(si.tx, c.Partition, c.Tenant, c.Shard)
+	si.cur, si.err = si.index.shards.getForReadAtVersion(si.tx, c.Partition, c.Tenant, c.Shard, c.ShardIndex.Version)
 	return si.err == nil
 }
 

--- a/pkg/metastore/index/query_test.go
+++ b/pkg/metastore/index/query_test.go
@@ -325,6 +325,84 @@ func TestIndex_Query(t *testing.T) {
 	})
 }
 
+func TestIndex_QueryMetadata_StaleReadCacheReloadsShard(t *testing.T) {
+	db := test.BoltDB(t)
+	idxWriter := NewIndex(util.Logger, NewStore(), DefaultConfig, nil)
+	require.NoError(t, db.Update(idxWriter.Init))
+
+	const tenant = "tenant-a"
+	const shard = uint32(1)
+	minT := test.UnixMilli("2024-09-23T08:00:00.000Z")
+	maxT := test.UnixMilli("2024-09-23T09:00:00.000Z")
+
+	base := &metastorev1.BlockMeta{
+		Id:      test.ULID("2024-09-23T08:00:00.001Z"),
+		Tenant:  1,
+		Shard:   shard,
+		MinTime: minT,
+		MaxTime: maxT,
+		Datasets: []*metastorev1.Dataset{{
+			Tenant:  1,
+			MinTime: minT,
+			MaxTime: maxT,
+			Labels:  []int32{1, 2, 3},
+		}},
+		StringTable: []string{"", tenant, "service_name", "old"},
+	}
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		return idxWriter.InsertBlock(tx, base.CloneVT())
+	}))
+
+	staleTx, err := db.Begin(false)
+	require.NoError(t, err)
+	defer func() { _ = staleTx.Rollback() }()
+
+	newer := &metastorev1.BlockMeta{
+		Id:      test.ULID("2024-09-23T08:30:00.002Z"),
+		Tenant:  1,
+		Shard:   shard,
+		MinTime: minT,
+		MaxTime: maxT,
+		Datasets: []*metastorev1.Dataset{{
+			Tenant:  1,
+			MinTime: minT,
+			MaxTime: maxT,
+			Labels:  []int32{1, 2, 4},
+		}},
+		StringTable: []string{"", tenant, "service_name", "old", "new"},
+	}
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		return idxWriter.InsertBlock(tx, newer.CloneVT())
+	}))
+
+	idxReader := NewIndex(util.Logger, NewStore(), DefaultConfig, nil)
+	_, err = idxReader.GetBlocks(staleTx, &metastorev1.BlockList{
+		Tenant: tenant,
+		Shard:  shard,
+		Blocks: []string{base.Id},
+	})
+	require.NoError(t, err)
+
+	var found []*metastorev1.BlockMeta
+	require.NoError(t, db.View(func(tx *bbolt.Tx) error {
+		found, err = idxReader.QueryMetadata(tx, context.Background(), MetadataQuery{
+			Expr:      `{service_name=~".+"}`,
+			StartTime: time.UnixMilli(minT),
+			EndTime:   time.UnixMilli(maxT),
+			Tenant:    []string{tenant},
+			Labels:    []string{"service_name"},
+		})
+		return err
+	}))
+	require.NoError(t, err)
+	require.Len(t, found, 2)
+	assert.Equal(t, []string{base.Id, newer.Id}, []string{found[0].Id, found[1].Id})
+	assert.Equal(t, []string{"old", "new"}, []string{
+		found[0].StringTable[found[0].Datasets[0].Labels[2]],
+		found[1].StringTable[found[1].Datasets[0].Labels[2]],
+	})
+}
+
 func TestIndex_QueryConcurrency(t *testing.T) {
 	const N = 10
 	for i := 0; i < N && !t.Failed(); i++ {

--- a/pkg/metastore/index/store/index_store.go
+++ b/pkg/metastore/index/store/index_store.go
@@ -77,6 +77,21 @@ func (m *IndexStore) LoadShard(tx *bbolt.Tx, p Partition, tenant string, shard u
 	return s, nil
 }
 
+func (m *IndexStore) LoadShardVersion(tx *bbolt.Tx, p Partition, tenant string, shard uint32) (uint64, error) {
+	shardBucket := getTenantShardBucket(tx, p, tenant, shard)
+	if shardBucket == nil {
+		return 0, nil
+	}
+	var idx ShardIndex
+	if b := shardBucket.Get(tenantShardIndexKeyNameBytes); len(b) > 0 {
+		if err := idx.UnmarshalBinary(b); err != nil {
+			return 0, fmt.Errorf("error loading tenant shard version %s/%d partition %q: %w", tenant, shard, p, err)
+		}
+		return idx.Version, nil
+	}
+	return 0, nil
+}
+
 func (m *IndexStore) DeleteShard(tx *bbolt.Tx, p Partition, tenant string, shard uint32) error {
 	partitions := getPartitionsBucket(tx)
 	partitionKey := p.Bytes()

--- a/pkg/metastore/index/store/shard.go
+++ b/pkg/metastore/index/store/shard.go
@@ -78,19 +78,15 @@ func (s *Shard) Store(tx *bbolt.Tx, md *metastorev1.BlockMeta) error {
 		return err
 	}
 
-	var updateIndex bool
+	s.ShardIndex.Version++
 	if s.ShardIndex.MinTime == 0 || s.ShardIndex.MinTime > md.MinTime {
 		s.ShardIndex.MinTime = md.MinTime
-		updateIndex = true
 	}
 	if s.ShardIndex.MaxTime < md.MaxTime {
 		s.ShardIndex.MaxTime = md.MaxTime
-		updateIndex = true
 	}
-	if updateIndex {
-		if err = shardBucket.Put(tenantShardIndexKeyNameBytes, s.ShardIndex.MarshalBinary()); err != nil {
-			return err
-		}
+	if err = shardBucket.Put(tenantShardIndexKeyNameBytes, s.ShardIndex.MarshalBinary()); err != nil {
+		return err
 	}
 
 	return shardBucket.Put([]byte(md.Id), value)

--- a/pkg/metastore/index/store/shard_index.go
+++ b/pkg/metastore/index/store/shard_index.go
@@ -8,6 +8,7 @@ import (
 type ShardIndex struct {
 	MinTime int64
 	MaxTime int64
+	Version uint64
 }
 
 func (i *ShardIndex) UnmarshalBinary(data []byte) error {
@@ -16,13 +17,17 @@ func (i *ShardIndex) UnmarshalBinary(data []byte) error {
 	}
 	i.MinTime = int64(binary.BigEndian.Uint64(data[0:8]))
 	i.MaxTime = int64(binary.BigEndian.Uint64(data[8:16]))
+	if len(data) >= 24 {
+		i.Version = binary.BigEndian.Uint64(data[16:24])
+	}
 	return nil
 }
 
 func (i *ShardIndex) MarshalBinary() []byte {
-	b := make([]byte, 16)
+	b := make([]byte, 24)
 	binary.BigEndian.PutUint64(b[0:8], uint64(i.MinTime))
 	binary.BigEndian.PutUint64(b[8:16], uint64(i.MaxTime))
+	binary.BigEndian.PutUint64(b[16:24], i.Version)
 	return b
 }
 


### PR DESCRIPTION
## Summary

This fixes a metastore shard cache bug where a shard loaded from an older read transaction could remain in the shared cache and later be reused with newer block metadata from a different transaction snapshot.

That mismatch could cause:
- `QueryMetadata` to panic with `index out of range`
- `GetBlocks` to export metadata using a stale string table

## What changed

- add a persisted per-shard `Version` to `ShardIndex`
- bump and store the shard version on every shard write
- make shard cache reads version-aware
- reload cached read-only shards when the caller's transaction snapshot sees a newer shard version
- use the version-aware read path in both `QueryMetadata` and `GetBlocks`
- make direct shard version lookup return an error on malformed shard index data
- add a regression test covering the stale-read cache poisoning sequence

## Why

A stale read transaction could populate the shared shard cache with an older string table. Later, a fresh transaction could read newer block bytes for the same shard while reusing that cached shard snapshot. The version check prevents mixing block metadata from one snapshot with a string table from another.

## Testing

- `go test ./pkg/metastore/index/... -count=1`

## Notes

- The shard index format remains backward compatible:
  - new code can read old shard indexes without a version
  - old code ignores the trailing version bytes in the new format
- shards still on the old format report version `0` until rewritten by the new code
