### PR TITLE
feat: add optional admin HTTP server on separate port

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -32,7 +32,7 @@ Usage of ./pyroscope:
   -adaptive-placement.unit-size-bytes uint
     	Shards are allocated based on the utilisation of units per second. The option specifies the unit size in bytes. (default 131072)
   -admin-server.http-listen-address string
-    	Address for the admin HTTP server. Defaults to localhost so the port is not exposed externally. (default "localhost")
+    	Address for the admin HTTP server. Defaults to localhost so the port is not exposed externally. Use :: or 0.0.0.0 to listen on all interfaces. (default "localhost")
   -admin-server.http-listen-port int
     	Port for the admin HTTP server (metrics, pprof, admin). (default 4042)
   -admin-server.mode value

--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -31,6 +31,12 @@ Usage of ./pyroscope:
     	Number of shards per tenant. If 0, the limit is not applied.
   -adaptive-placement.unit-size-bytes uint
     	Shards are allocated based on the utilisation of units per second. The option specifies the unit size in bytes. (default 131072)
+  -admin-server.http-listen-address string
+    	Address for the admin HTTP server. Defaults to localhost so the port is not exposed externally. (default "localhost")
+  -admin-server.http-listen-port int
+    	Port for the admin HTTP server (metrics, pprof, admin). (default 4042)
+  -admin-server.mode value
+    	Controls the admin server for metrics, pprof and admin endpoints. 'disabled': all routes on the main port (default). 'additional': admin server started, operational routes served on both ports. 'exclusive': admin server started, operational routes removed from main port. (default "disabled")
   -api.base-url string
     	base URL for when the server is behind a reverse proxy with a different path
   -architecture.storage value

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -1,4 +1,10 @@
 Usage of ./pyroscope:
+  -admin-server.http-listen-address string
+    	Address for the admin HTTP server. Defaults to localhost so the port is not exposed externally. (default "localhost")
+  -admin-server.http-listen-port int
+    	Port for the admin HTTP server (metrics, pprof, admin). (default 4042)
+  -admin-server.mode value
+    	Controls the admin server for metrics, pprof and admin endpoints. 'disabled': all routes on the main port (default). 'additional': admin server started, operational routes served on both ports. 'exclusive': admin server started, operational routes removed from main port. (default "disabled")
   -api.base-url string
     	base URL for when the server is behind a reverse proxy with a different path
   -architecture.storage value

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -1,6 +1,6 @@
 Usage of ./pyroscope:
   -admin-server.http-listen-address string
-    	Address for the admin HTTP server. Defaults to localhost so the port is not exposed externally. (default "localhost")
+    	Address for the admin HTTP server. Defaults to localhost so the port is not exposed externally. Use :: or 0.0.0.0 to listen on all interfaces. (default "localhost")
   -admin-server.http-listen-port int
     	Port for the admin HTTP server (metrics, pprof, admin). (default 4042)
   -admin-server.mode value

--- a/cmd/pyroscope/pyroscope.yaml
+++ b/cmd/pyroscope/pyroscope.yaml
@@ -792,6 +792,20 @@ analytics:
 # query old data.
 # architecture_storage: "v1-v2-dual"
 
+admin_server:
+  # Controls the admin server for metrics, pprof and admin endpoints.
+  # 'disabled': all routes on the main port (default). 'additional': admin
+  # server started, operational routes served on both ports. 'exclusive': admin
+  # server started, operational routes removed from main port.
+  # mode: "disabled"
+
+  # Address for the admin HTTP server. Defaults to localhost so the port is not
+  # exposed externally. Use :: or 0.0.0.0 to listen on all interfaces.
+  # http_listen_address: "localhost"
+
+  # Port for the admin HTTP server (metrics, pprof, admin).
+  # http_listen_port: 4042
+
 embedded_grafana:
   # The directory where the Grafana data will be stored.
   # data_path: "./data/__embedded_grafana/"

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -325,6 +325,23 @@ self_profiling:
 # CLI flag: -architecture.storage
 [architecture_storage: <string> | default = "v1-v2-dual"]
 
+admin_server:
+  # Controls the admin server for metrics, pprof and admin endpoints.
+  # 'disabled': all routes on the main port (default). 'additional': admin
+  # server started, operational routes served on both ports. 'exclusive': admin
+  # server started, operational routes removed from main port.
+  # CLI flag: -admin-server.mode
+  [mode: <string> | default = "disabled"]
+
+  # Address for the admin HTTP server. Defaults to localhost so the port is not
+  # exposed externally. Use :: or 0.0.0.0 to listen on all interfaces.
+  # CLI flag: -admin-server.http-listen-address
+  [http_listen_address: <string> | default = "localhost"]
+
+  # Port for the admin HTTP server (metrics, pprof, admin).
+  # CLI flag: -admin-server.http-listen-port
+  [http_listen_port: <int> | default = 4042]
+
 embedded_grafana:
   # The directory where the Grafana data will be stored.
   # CLI flag: -embedded-grafana.data-path

--- a/pkg/api/admin_server_test.go
+++ b/pkg/api/admin_server_test.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/gorilla/mux"
+	"github.com/grafana/dskit/server"
+	grpcgw "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestAPI builds a minimal API wired to a gorilla mux, mirroring the pattern
+// used in distributor_api_test.go.
+func newTestAPIWithMode(t *testing.T, mode AdminServerMode) (*API, *mux.Router, *mux.Router) {
+	t.Helper()
+
+	mainMux := mux.NewRouter()
+	serv := &server.Server{HTTP: mainMux}
+
+	a, err := New(Config{}, serv, grpcgw.NewServeMux(), log.NewNopLogger())
+	require.NoError(t, err)
+
+	adminRouter := mux.NewRouter()
+	a.SetAdminRouter(adminRouter, mode)
+
+	return a, mainMux, adminRouter
+}
+
+// probe sends a GET to the given router and returns the status code.
+func probe(t *testing.T, router http.Handler, path string) int {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec.Code
+}
+
+func TestRegisterInternalRoute_Disabled(t *testing.T) {
+	a, mainMux, adminRouter := newTestAPIWithMode(t, AdminServerDisabled)
+
+	sentinel := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	})
+	a.registerAdminRoute("/test-route", sentinel, WithMethod("GET"))
+
+	// Route must be reachable on the main mux.
+	assert.Equal(t, http.StatusTeapot, probe(t, mainMux, "/test-route"))
+	// Route must NOT be reachable on the internal router.
+	assert.Equal(t, http.StatusNotFound, probe(t, adminRouter, "/test-route"))
+}
+
+func TestRegisterInternalRoute_Exclusive(t *testing.T) {
+	a, mainMux, adminRouter := newTestAPIWithMode(t, AdminServerExclusive)
+
+	sentinel := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	})
+	a.registerAdminRoute("/test-route", sentinel, WithMethod("GET"))
+
+	// Route must NOT be on the main mux.
+	assert.Equal(t, http.StatusNotFound, probe(t, mainMux, "/test-route"))
+	// Route must be reachable on the internal router.
+	assert.Equal(t, http.StatusTeapot, probe(t, adminRouter, "/test-route"))
+}
+
+func TestRegisterInternalRoute_Additional(t *testing.T) {
+	a, mainMux, adminRouter := newTestAPIWithMode(t, AdminServerAdditional)
+
+	sentinel := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	})
+	a.registerAdminRoute("/test-route", sentinel, WithMethod("GET"))
+
+	// Route must be reachable on both muxes.
+	assert.Equal(t, http.StatusTeapot, probe(t, mainMux, "/test-route"))
+	assert.Equal(t, http.StatusTeapot, probe(t, adminRouter, "/test-route"))
+}
+
+func TestRegisterInternalRoute_PathParameters(t *testing.T) {
+	// Verify that gorilla mux path parameters work correctly on the internal router
+	// (they would silently break with http.ServeMux).
+	a, _, adminRouter := newTestAPIWithMode(t, AdminServerExclusive)
+
+	var capturedTenant string
+	a.registerAdminRoute("/ops/tenants/{tenant}/blocks", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedTenant = mux.Vars(r)["tenant"]
+		w.WriteHeader(http.StatusOK)
+	}), WithMethod("GET"))
+
+	req := httptest.NewRequest(http.MethodGet, "/ops/tenants/acme/blocks", nil)
+	rec := httptest.NewRecorder()
+	adminRouter.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "acme", capturedTenant)
+}
+
+func TestSetAdminRouter_NilSafe(t *testing.T) {
+	// When no internal router is set, registerAdminRoute should fall back to
+	// the main mux without panicking.
+	mainMux := mux.NewRouter()
+	serv := &server.Server{HTTP: mainMux}
+	a, err := New(Config{}, serv, grpcgw.NewServeMux(), log.NewNopLogger())
+	require.NoError(t, err)
+	// adminRouter is nil, mode is "" (zero value = disabled path)
+
+	sentinel := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	})
+	require.NotPanics(t, func() {
+		a.registerAdminRoute("/nil-safe-route", sentinel, WithMethod("GET"))
+	})
+	assert.Equal(t, http.StatusTeapot, probe(t, mainMux, "/nil-safe-route"))
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -14,6 +14,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/felixge/fgprof"
 	"github.com/go-kit/log"
+	"github.com/gorilla/mux"
 	"github.com/grafana/dskit/kv/memberlist"
 	"github.com/grafana/dskit/middleware"
 	"github.com/grafana/dskit/server"
@@ -63,10 +64,30 @@ type API struct {
 	httpAuthMiddleware middleware.Interface
 	grpcGatewayMux     *grpcgw.ServeMux
 
-	cfg       Config
-	logger    log.Logger
+	// adminRouter and adminMode together control where operational routes
+	// (metrics, debug, admin, rings, config) are registered.
+	adminRouter *mux.Router
+	adminMode   AdminServerMode
+
+	cfg    Config
+	logger log.Logger
+
+	// indexPage is the main server's /admin index (UI, swagger, build info).
 	indexPage *IndexPageContent
+	// adminIndexPage is the admin server's /admin index (rings, metrics, ops, config).
+	// When the admin server is disabled, operational links fall back to indexPage.
+	adminIndexPage *IndexPageContent
 }
+
+// AdminServerMode mirrors the type defined in the pyroscope package; redeclared
+// here so the api package has no import cycle back to the parent package.
+type AdminServerMode = string
+
+const (
+	AdminServerDisabled   AdminServerMode = "disabled"
+	AdminServerAdditional AdminServerMode = "additional"
+	AdminServerExclusive  AdminServerMode = "exclusive"
+)
 
 func New(cfg Config, s *server.Server, grpcGatewayMux *grpcgw.ServeMux, logger log.Logger) (*API, error) {
 	api := &API{
@@ -75,6 +96,7 @@ func New(cfg Config, s *server.Server, grpcGatewayMux *grpcgw.ServeMux, logger l
 		server:             s,
 		logger:             logger,
 		indexPage:          NewIndexPageContent(),
+		adminIndexPage:     NewIndexPageContent(),
 		grpcGatewayMux:     grpcGatewayMux,
 	}
 
@@ -86,6 +108,46 @@ func New(cfg Config, s *server.Server, grpcGatewayMux *grpcgw.ServeMux, logger l
 	return api, nil
 }
 
+// SetAdminRouter configures the admin router and mode for operational
+// (metrics, debug, admin, ring, config) routes.
+func (a *API) SetAdminRouter(r *mux.Router, mode AdminServerMode) {
+	a.adminRouter = r
+	a.adminMode = mode
+}
+
+// addOperationalLinks adds index-page links to the correct page(s) based on mode:
+//   - disabled:   main server indexPage only.
+//   - additional: both indexPage and adminIndexPage (links visible on both ports).
+//   - exclusive:  adminIndexPage only (links removed from main port).
+func (a *API) addOperationalLinks(weight int, groupDesc string, links []IndexPageLink) {
+	switch a.adminMode {
+	case AdminServerExclusive:
+		a.adminIndexPage.AddLinks(weight, groupDesc, links)
+	case AdminServerAdditional:
+		a.indexPage.AddLinks(weight, groupDesc, links)
+		a.adminIndexPage.AddLinks(weight, groupDesc, links)
+	default:
+		a.indexPage.AddLinks(weight, groupDesc, links)
+	}
+}
+
+// registerAdminRoute registers a handler according to the current admin
+// server mode:
+//   - disabled:   register only on the main server (default behaviour).
+//   - additional: register on both the admin router and the main server.
+//   - exclusive:  register only on the admin router.
+func (a *API) registerAdminRoute(path string, handler http.Handler, registerOpts ...RegisterOption) {
+	switch a.adminMode {
+	case AdminServerExclusive:
+		registerRoute(a.logger, a.adminRouter, path, handler, registerOpts...)
+	case AdminServerAdditional:
+		registerRoute(a.logger, a.adminRouter, path, handler, registerOpts...)
+		registerRoute(a.logger, a.server.HTTP, path, handler, registerOpts...)
+	default:
+		registerRoute(a.logger, a.server.HTTP, path, handler, registerOpts...)
+	}
+}
+
 // registerRoute registers an HTTP handler with the main HTTP server.
 //
 // Register Options allow to filter the HTTP methods and apply middlewares.
@@ -95,9 +157,13 @@ func (a *API) RegisterRoute(path string, handler http.Handler, registerOpts ...R
 
 // RegisterAPI registers the standard endpoints associated with a running Pyroscope.
 func (a *API) RegisterAPI(statusService statusv1.StatusServiceServer) error {
-	// register admin page
-	a.RegisterRoute("/admin", indexHandler("", a.indexPage), a.registerOptionsPublicAccess()...)
-	// expose openapiv2 definition
+	// /admin on the main server always shows the main index (UI, swagger, build info).
+	registerRoute(a.logger, a.server.HTTP, "/admin", indexHandler("", a.indexPage), a.registerOptionsPublicAccess()...)
+	// /admin on the admin server (when enabled) shows the operational index.
+	if a.adminRouter != nil && a.adminMode != AdminServerDisabled {
+		registerRoute(a.logger, a.adminRouter, "/admin", indexHandler("", a.adminIndexPage), a.registerOptionsPublicAccess()...)
+	}
+	// expose openapiv2 definition — main server only (linked from the main /admin page)
 	openapiv2Handler, err := openapiv2.Handler()
 	if err != nil {
 		return fmt.Errorf("unable to initialize openapiv2 handler: %w", err)
@@ -106,24 +172,30 @@ func (a *API) RegisterAPI(statusService statusv1.StatusServiceServer) error {
 	a.indexPage.AddLinks(openAPIDefinitionWeight, "OpenAPI definition", []IndexPageLink{
 		{Desc: "Swagger JSON", Path: "/api/swagger.json"},
 	})
-	// register grpc-gateway api
+	// grpc-gateway (status/config) — on admin server when available
 	publicAccessPrefixAllMethods := []RegisterOption{WithGzipMiddleware(), WithPrefix()}
-	a.RegisterRoute("/api", a.grpcGatewayMux, publicAccessPrefixAllMethods...)
-	// register fgprof
-	a.RegisterRoute("/debug/fgprof", fgprof.Handler(), a.registerOptionsPublicAccess()...)
-	// register static assets
-	a.RegisterRoute("/static/", http.FileServer(http.FS(staticFiles)), a.registerOptionsPrefixPublicAccess()...)
-	// register ui
+	a.registerAdminRoute("/api", a.grpcGatewayMux, publicAccessPrefixAllMethods...)
+	// register fgprof — on internal server when available
+	a.registerAdminRoute("/debug/fgprof", fgprof.Handler(), a.registerOptionsPublicAccess()...)
+	// register ui assets
 	uiAssets, err := ui.Assets()
 	if err != nil {
 		return fmt.Errorf("unable to initialize the ui: %w", err)
 	}
+	uiFileServer := http.FileServer(uiAssets)
+
+	// Static assets and /assets are needed on the admin server too —
+	// query-diagnostics pages reference /static/ CSS and /assets/admin.{css,js}.
+	a.RegisterRoute("/static/", http.FileServer(http.FS(staticFiles)), a.registerOptionsPrefixPublicAccess()...)
+	a.RegisterRoute("/assets/", uiFileServer, a.registerOptionsPrefixPublicAccess()...)
+	if a.adminRouter != nil && a.adminMode != AdminServerDisabled {
+		registerRoute(a.logger, a.adminRouter, "/static/", http.FileServer(http.FS(staticFiles)), a.registerOptionsPrefixPublicAccess()...)
+		registerRoute(a.logger, a.adminRouter, "/assets/", uiFileServer, a.registerOptionsPrefixPublicAccess()...)
+	}
 
 	// The UI used to be at /ui, but now it's at /.
 	a.RegisterRoute("/ui", http.RedirectHandler("/", http.StatusFound), a.registerOptionsPrefixPublicAccess()...)
-	// All assets are served as static files
-	uiFileServer := http.FileServer(uiAssets)
-	a.RegisterRoute("/assets/", uiFileServer, a.registerOptionsPrefixPublicAccess()...)
+	// Remaining UI asset prefixes — main server only
 	a.RegisterRoute("/icons/", uiFileServer, a.registerOptionsPrefixPublicAccess()...)
 	// @grafana/flamegraph hardcodes /public/ prefix; strip it to resolve to build/
 	a.RegisterRoute("/public/", http.StripPrefix("/public", uiFileServer), a.registerOptionsPrefixPublicAccess()...)
@@ -132,10 +204,10 @@ func (a *API) RegisterAPI(statusService statusv1.StatusServiceServer) error {
 	if err := statusv1.RegisterStatusServiceHandlerServer(context.Background(), a.grpcGatewayMux, statusService); err != nil {
 		return err
 	}
-	a.indexPage.AddLinks(buildInfoWeight, "Build information", []IndexPageLink{
+	a.addOperationalLinks(buildInfoWeight, "Build information", []IndexPageLink{
 		{Desc: "Build information", Path: "/api/v1/status/buildinfo"},
 	})
-	a.indexPage.AddLinks(configWeight, "Current config", []IndexPageLink{
+	a.addOperationalLinks(configWeight, "Current config", []IndexPageLink{
 		{Desc: "Including the default values", Path: "/api/v1/status/config"},
 		{Desc: "Only values that differ from the defaults", Path: "/api/v1/status/config/diff"},
 		{Desc: "Default values", Path: "/api/v1/status/config/default"},
@@ -144,7 +216,7 @@ func (a *API) RegisterAPI(statusService statusv1.StatusServiceServer) error {
 }
 
 func (a *API) RegisterRedirectToAdmin() {
-	a.RegisterRoute("/", http.RedirectHandler("/admin", http.StatusFound), a.registerOptionsPublicAccess()...)
+	a.registerAdminRoute("/", http.RedirectHandler("/admin", http.StatusFound), a.registerOptionsPublicAccess()...)
 }
 
 func (a *API) RegisterCatchAll() error {
@@ -168,9 +240,9 @@ func (a *API) RegisterCatchAll() error {
 
 // RegisterRuntimeConfig registers the endpoints associates with the runtime configuration
 func (a *API) RegisterRuntimeConfig(runtimeConfigHandler http.HandlerFunc, userLimitsHandler http.HandlerFunc) {
-	a.RegisterRoute("/runtime_config", runtimeConfigHandler, a.registerOptionsPublicAccess()...)
-	a.RegisterRoute("/api/v1/tenant_limits", userLimitsHandler, a.registerOptionsTenantPath()...)
-	a.indexPage.AddLinks(runtimeConfigWeight, "Current runtime config", []IndexPageLink{
+	a.registerAdminRoute("/runtime_config", runtimeConfigHandler, a.registerOptionsPublicAccess()...)
+	a.registerAdminRoute("/api/v1/tenant_limits", userLimitsHandler, a.registerOptionsTenantPath()...)
+	a.addOperationalLinks(runtimeConfigWeight, "Current runtime config", []IndexPageLink{
 		{Desc: "Entire runtime config (including overrides)", Path: "/runtime_config"},
 		{Desc: "Only values that differ from the defaults", Path: "/runtime_config?mode=diff"},
 	})
@@ -188,8 +260,8 @@ func (a *API) RegisterTenantSettings(ts *settings.TenantSettings) {
 
 // RegisterOverridesExporter registers the endpoints associated with the overrides exporter.
 func (a *API) RegisterOverridesExporter(oe *exporter.OverridesExporter) {
-	a.RegisterRoute("/overrides-exporter/ring", http.HandlerFunc(oe.RingHandler), a.registerOptionsRingPage()...)
-	a.indexPage.AddLinks(defaultWeight, "Overrides-exporter", []IndexPageLink{
+	a.registerAdminRoute("/overrides-exporter/ring", http.HandlerFunc(oe.RingHandler), a.registerOptionsRingPage()...)
+	a.addOperationalLinks(defaultWeight, "Overrides-exporter", []IndexPageLink{
 		{Desc: "Ring status", Path: "/overrides-exporter/ring"},
 	})
 }
@@ -209,8 +281,8 @@ func (a *API) RegisterDistributor(d *distributor.Distributor, limits *validation
 	a.RegisterRoute("/ingest", pyroscopeHandler, writePathOpts...)
 	a.RegisterRoute("/pyroscope/ingest", pyroscopeHandler, writePathOpts...)
 	pushv1connect.RegisterPusherServiceHandler(a.server.HTTP, d, a.connectOptionsAuthDelayRecovery(limits)...)
-	a.RegisterRoute("/distributor/ring", d, a.registerOptionsRingPage()...)
-	a.indexPage.AddLinks(defaultWeight, "Distributor", []IndexPageLink{
+	a.registerAdminRoute("/distributor/ring", d, a.registerOptionsRingPage()...)
+	a.addOperationalLinks(defaultWeight, "Distributor", []IndexPageLink{
 		{Desc: "Ring status", Path: "/distributor/ring"},
 	})
 
@@ -221,16 +293,16 @@ func (a *API) RegisterDistributor(d *distributor.Distributor, limits *validation
 
 // RegisterMemberlistKV registers the endpoints associated with the memberlist KV store.
 func (a *API) RegisterMemberlistKV(pathPrefix string, kvs *memberlist.KVInitService) {
-	a.RegisterRoute("/memberlist", MemberlistStatusHandler(pathPrefix, kvs), a.registerOptionsPublicAccess()...)
-	a.indexPage.AddLinks(memberlistWeight, "Memberlist", []IndexPageLink{
+	a.registerAdminRoute("/memberlist", MemberlistStatusHandler(pathPrefix, kvs), a.registerOptionsPublicAccess()...)
+	a.addOperationalLinks(memberlistWeight, "Memberlist", []IndexPageLink{
 		{Desc: "Status", Path: "/memberlist"},
 	})
 }
 
 // RegisterIngesterRing registers the ring UI page associated with the distributor for writes.
 func (a *API) RegisterIngesterRing(r http.Handler) {
-	a.RegisterRoute("/ring", r, a.registerOptionsRingPage()...)
-	a.indexPage.AddLinks(defaultWeight, "Ingester", []IndexPageLink{
+	a.registerAdminRoute("/ring", r, a.registerOptionsRingPage()...)
+	a.addOperationalLinks(defaultWeight, "Ingester", []IndexPageLink{
 		{Desc: "Ring status", Path: "/ring"},
 	})
 }
@@ -260,27 +332,27 @@ func (a *API) RegisterIngester(svc *ingester.Ingester) {
 }
 
 func (a *API) RegisterReadyHandler(handler http.Handler) {
-	a.RegisterRoute("/ready", handler, WithMethod("GET"))
+	a.registerAdminRoute("/ready", handler, WithMethod("GET"))
 }
 
 func (a *API) RegisterStoreGateway(svc *storegateway.StoreGateway) {
 	storegatewayv1connect.RegisterStoreGatewayServiceHandler(a.server.HTTP, svc, a.connectOptionsAuthRecovery()...)
 
-	a.indexPage.AddLinks(defaultWeight, "Store-gateway", []IndexPageLink{
+	a.addOperationalLinks(defaultWeight, "Store-gateway", []IndexPageLink{
 		{Desc: "Ring status", Path: "/store-gateway/ring"},
 		{Desc: "Tenants & Blocks", Path: "/store-gateway/tenants"},
 	})
-	a.RegisterRoute("/store-gateway/ring", http.HandlerFunc(svc.RingHandler), a.registerOptionsRingPage()...)
-	a.RegisterRoute("/store-gateway/tenants", http.HandlerFunc(svc.TenantsHandler), a.registerOptionsPublicAccess()...)
-	a.RegisterRoute("/store-gateway/tenant/{tenant}/blocks", http.HandlerFunc(svc.BlocksHandler), a.registerOptionsPublicAccess()...)
+	a.registerAdminRoute("/store-gateway/ring", http.HandlerFunc(svc.RingHandler), a.registerOptionsRingPage()...)
+	a.registerAdminRoute("/store-gateway/tenants", http.HandlerFunc(svc.TenantsHandler), a.registerOptionsPublicAccess()...)
+	a.registerAdminRoute("/store-gateway/tenant/{tenant}/blocks", http.HandlerFunc(svc.BlocksHandler), a.registerOptionsPublicAccess()...)
 }
 
 // RegisterCompactor registers routes associated with the compactor.
 func (a *API) RegisterCompactor(c *compactor.MultitenantCompactor) {
-	a.indexPage.AddLinks(defaultWeight, "Compactor", []IndexPageLink{
+	a.addOperationalLinks(defaultWeight, "Compactor", []IndexPageLink{
 		{Desc: "Ring status", Path: "/compactor/ring"},
 	})
-	a.RegisterRoute("/compactor/ring", http.HandlerFunc(c.RingHandler), a.registerOptionsRingPage()...)
+	a.registerAdminRoute("/compactor/ring", http.HandlerFunc(c.RingHandler), a.registerOptionsRingPage()...)
 }
 
 // RegisterFrontendForQuerierHandler registers the endpoints associated with the query frontend.
@@ -323,17 +395,18 @@ type AdminService interface {
 }
 
 func (a *API) RegisterAdmin(ad AdminService) {
-	a.RegisterRoute("/ops/object-store/tenants", http.HandlerFunc(ad.TenantsHandler), a.registerOptionsPublicAccess()...)
-	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks", http.HandlerFunc(ad.BlocksHandler), a.registerOptionsPublicAccess()...)
-	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks/{block}", http.HandlerFunc(ad.BlockHandler), a.registerOptionsPublicAccess()...)
-	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets", http.HandlerFunc(ad.DatasetHandler), a.registerOptionsPublicAccess()...)
-	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets/profiles", http.HandlerFunc(ad.DatasetProfilesHandler), a.registerOptionsPublicAccess()...)
-	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets/profiles/download", http.HandlerFunc(ad.ProfileDownloadHandler), a.registerOptionsPublicAccess()...)
-	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets/profiles/call-tree", http.HandlerFunc(ad.ProfileCallTreeHandler), a.registerOptionsPublicAccess()...)
-	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets/index", http.HandlerFunc(ad.DatasetTSDBIndexHandler), a.registerOptionsPublicAccess()...)
-	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets/symbols", http.HandlerFunc(ad.DatasetSymbolsHandler), a.registerOptionsPublicAccess()...)
+	// Admin/ops routes are served on the internal server when available.
+	a.registerAdminRoute("/ops/object-store/tenants", http.HandlerFunc(ad.TenantsHandler), a.registerOptionsPublicAccess()...)
+	a.registerAdminRoute("/ops/object-store/tenants/{tenant}/blocks", http.HandlerFunc(ad.BlocksHandler), a.registerOptionsPublicAccess()...)
+	a.registerAdminRoute("/ops/object-store/tenants/{tenant}/blocks/{block}", http.HandlerFunc(ad.BlockHandler), a.registerOptionsPublicAccess()...)
+	a.registerAdminRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets", http.HandlerFunc(ad.DatasetHandler), a.registerOptionsPublicAccess()...)
+	a.registerAdminRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets/profiles", http.HandlerFunc(ad.DatasetProfilesHandler), a.registerOptionsPublicAccess()...)
+	a.registerAdminRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets/profiles/download", http.HandlerFunc(ad.ProfileDownloadHandler), a.registerOptionsPublicAccess()...)
+	a.registerAdminRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets/profiles/call-tree", http.HandlerFunc(ad.ProfileCallTreeHandler), a.registerOptionsPublicAccess()...)
+	a.registerAdminRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets/index", http.HandlerFunc(ad.DatasetTSDBIndexHandler), a.registerOptionsPublicAccess()...)
+	a.registerAdminRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets/symbols", http.HandlerFunc(ad.DatasetSymbolsHandler), a.registerOptionsPublicAccess()...)
 
-	a.indexPage.AddLinks(defaultWeight, "Admin", []IndexPageLink{
+	a.addOperationalLinks(defaultWeight, "Admin", []IndexPageLink{
 		{Desc: "Object Storage Tenants & Blocks", Path: "/ops/object-store/tenants"},
 	})
 }

--- a/pkg/api/api_experimental.go
+++ b/pkg/api/api_experimental.go
@@ -19,8 +19,8 @@ func (a *API) RegisterSegmentWriter(svc *segmentwriter.SegmentWriterService) {
 
 // RegisterSegmentWriterRing registers the ring UI page associated with the distributor for writes.
 func (a *API) RegisterSegmentWriterRing(r http.Handler) {
-	a.RegisterRoute("/ring-segment-writer", r, a.registerOptionsRingPage()...)
-	a.indexPage.AddLinks(defaultWeight, "Segment Writer", []IndexPageLink{
+	a.registerAdminRoute("/ring-segment-writer", r, a.registerOptionsRingPage()...)
+	a.addOperationalLinks(defaultWeight, "Segment Writer", []IndexPageLink{
 		{Desc: "Ring status", Path: "/ring-segment-writer"},
 	})
 }
@@ -30,26 +30,26 @@ func (a *API) RegisterQueryBackend(svc *querybackend.QueryBackend) {
 }
 
 func (a *API) RegisterMetastoreAdmin(adm *metastoreadmin.Admin) {
-	a.RegisterRoute("/metastore-nodes", adm.NodeListHandler(), a.registerOptionsRingPage()...)
-	a.RegisterRoute("/metastore-client-test", adm.ClientTestHandler(), a.registerOptionsRingPage()...)
-	a.indexPage.AddLinks(defaultWeight, "Metastore", []IndexPageLink{
+	a.registerAdminRoute("/metastore-nodes", adm.NodeListHandler(), a.registerOptionsRingPage()...)
+	a.registerAdminRoute("/metastore-client-test", adm.ClientTestHandler(), a.registerOptionsRingPage()...)
+	a.addOperationalLinks(defaultWeight, "Metastore", []IndexPageLink{
 		{Desc: "Nodes", Path: "/metastore-nodes"},
 		{Desc: "Client Test", Path: "/metastore-client-test"},
 	})
 }
 
 func (a *API) RegisterQueryDiagnosticsAdmin(adm *querydiagnostics.Admin) {
-	a.RegisterRoute("/query-diagnostics", adm.DiagnosticsHandler(), a.registerOptionsRingPage()...)
-	a.RegisterRoute("/query-diagnostics/list", adm.DiagnosticsListHandler(), a.registerOptionsRingPage()...)
+	a.registerAdminRoute("/query-diagnostics", adm.DiagnosticsHandler(), a.registerOptionsRingPage()...)
+	a.registerAdminRoute("/query-diagnostics/list", adm.DiagnosticsListHandler(), a.registerOptionsRingPage()...)
 
 	// JSON API endpoints for React frontend
-	a.RegisterRoute("/query-diagnostics/api/tenants", adm.TenantsAPIHandler(), a.registerOptionsRingPage()...)
-	a.RegisterRoute("/query-diagnostics/api/diagnostics", adm.DiagnosticsListAPIHandler(), a.registerOptionsRingPage()...)
-	a.RegisterRoute("/query-diagnostics/api/diagnostics/", adm.DiagnosticsGetAPIHandler(), WithGzipMiddleware(), WithMethod("GET"), WithPrefix())
-	a.RegisterRoute("/query-diagnostics/api/export/", adm.DiagnosticsExportAPIHandler(), WithMethod("GET"), WithPrefix())
-	a.RegisterRoute("/query-diagnostics/api/import", adm.DiagnosticsImportAPIHandler(), WithMethod("POST"))
+	a.registerAdminRoute("/query-diagnostics/api/tenants", adm.TenantsAPIHandler(), a.registerOptionsRingPage()...)
+	a.registerAdminRoute("/query-diagnostics/api/diagnostics", adm.DiagnosticsListAPIHandler(), a.registerOptionsRingPage()...)
+	a.registerAdminRoute("/query-diagnostics/api/diagnostics/", adm.DiagnosticsGetAPIHandler(), WithGzipMiddleware(), WithMethod("GET"), WithPrefix())
+	a.registerAdminRoute("/query-diagnostics/api/export/", adm.DiagnosticsExportAPIHandler(), WithMethod("GET"), WithPrefix())
+	a.registerAdminRoute("/query-diagnostics/api/import", adm.DiagnosticsImportAPIHandler(), WithMethod("POST"))
 
-	a.indexPage.AddLinks(defaultWeight, "Query Diagnostics", []IndexPageLink{
+	a.addOperationalLinks(defaultWeight, "Query Diagnostics", []IndexPageLink{
 		{Desc: "Collect Diagnostics", Path: "/query-diagnostics"},
 		{Desc: "View Stored Diagnostics", Path: "/query-diagnostics/list"},
 	})

--- a/pkg/pyroscope/admin_server_test.go
+++ b/pkg/pyroscope/admin_server_test.go
@@ -1,0 +1,124 @@
+package pyroscope
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdminServerMode_FlagDefault(t *testing.T) {
+	cfg := Config{}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg.RegisterFlags(fs)
+
+	assert.Equal(t, AdminServerDisabled, cfg.AdminServer.Mode)
+	assert.Equal(t, "localhost", cfg.AdminServer.HTTPAddress)
+	assert.Equal(t, 4042, cfg.AdminServer.HTTPPort)
+}
+
+func TestAdminServerMode_Set(t *testing.T) {
+	tests := []struct {
+		value   string
+		want    AdminServerMode
+		wantErr bool
+	}{
+		{"disabled", AdminServerDisabled, false},
+		{"additional", AdminServerAdditional, false},
+		{"exclusive", AdminServerExclusive, false},
+		{"bogus", "", true},
+		{"", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			var m AdminServerMode
+			err := m.Set(tt.value)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, m)
+			}
+		})
+	}
+}
+
+func TestAdminServerMode_IsEnabled(t *testing.T) {
+	assert.False(t, AdminServerDisabled.IsEnabled())
+	assert.True(t, AdminServerAdditional.IsEnabled())
+	assert.True(t, AdminServerExclusive.IsEnabled())
+}
+
+func TestAdminServerMode_FlagParsing(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		want    AdminServerMode
+		wantErr bool
+	}{
+		{"default", nil, AdminServerDisabled, false},
+		{"disabled", []string{"-admin-server.mode=disabled"}, AdminServerDisabled, false},
+		{"additional", []string{"-admin-server.mode=additional"}, AdminServerAdditional, false},
+		{"exclusive", []string{"-admin-server.mode=exclusive"}, AdminServerExclusive, false},
+		{"invalid", []string{"-admin-server.mode=bad"}, "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := Config{}
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			c.RegisterFlags(fs)
+			err := fs.Parse(tt.args)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, c.AdminServer.Mode)
+		})
+	}
+}
+
+func TestAdminServerMode_RegisterInstrumentation(t *testing.T) {
+	// In exclusive mode the primary dskit server should have RegisterInstrumentation
+	// disabled so /metrics and /debug/pprof are not served on the main port.
+	// In other modes the primary server keeps them.
+	tests := []struct {
+		mode                        AdminServerMode
+		wantRegisterInstrumentation bool
+	}{
+		{AdminServerDisabled, true},
+		{AdminServerAdditional, true},
+		{AdminServerExclusive, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.mode), func(t *testing.T) {
+			cfg := newTestConfig(t, nil)
+			cfg.AdminServer.Mode = tt.mode
+			// Use port 0 so the OS picks a free port; avoids conflicts across subtests.
+			cfg.AdminServer.HTTPPort = 0
+
+			f := &Pyroscope{Cfg: cfg}
+			require.NoError(t, f.setupModuleManager())
+
+			// Simulate what initServer does: initialise the admin router first
+			// (sets f.adminRouter), then check RegisterInstrumentation.
+			svc, err := f.initAdminServer()
+			require.NoError(t, err)
+			if svc != nil {
+				t.Cleanup(func() { svc.StopAsync() })
+			}
+
+			// Replicate the guard from initServer.
+			f.Cfg.Server.RegisterInstrumentation = true // dskit default
+			if f.Cfg.AdminServer.Mode == AdminServerExclusive {
+				f.Cfg.Server.RegisterInstrumentation = false
+			}
+
+			assert.Equal(t, tt.wantRegisterInstrumentation, f.Cfg.Server.RegisterInstrumentation)
+		})
+	}
+}

--- a/pkg/pyroscope/modules.go
+++ b/pkg/pyroscope/modules.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
 	"os"
 	"slices"
 	"strings"
@@ -13,6 +15,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	gorillaMux "github.com/gorilla/mux"
 	"github.com/grafana/dskit/dns"
 	"github.com/grafana/dskit/kv/codec"
 	"github.com/grafana/dskit/kv/memberlist"
@@ -25,6 +28,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/collectors/version"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.yaml.in/yaml/v3"
 	"google.golang.org/genproto/googleapis/api/httpbody"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -100,6 +104,7 @@ const (
 	PlacementAgent        string = "placement-agent"
 	PlacementManager      string = "placement-manager"
 	HealthServer          string = "health-server"
+	AdminServer           string = "admin-server"
 	RecordingRulesClient  string = "recording-rules-client"
 	Symbolizer            string = "symbolizer"
 	QueryDiagnosticsStore string = "query-diagnostics-store"
@@ -482,6 +487,12 @@ func (f *Pyroscope) initServer() (services.Service, error) {
 		}
 	}
 
+	// In exclusive mode, operational endpoints (/metrics, /debug/pprof) move to the
+	// admin server only; remove them from the main port.
+	if f.Cfg.AdminServer.Mode == AdminServerExclusive {
+		f.Cfg.Server.RegisterInstrumentation = false
+	}
+
 	f.setupWorkerTimeout()
 	if f.isModuleActive(QueryScheduler) || f.isModuleActive(QueryFrontend) {
 		// to ensure that the query scheduler is always able to handle the request, we need to double the timeout
@@ -539,6 +550,52 @@ func (f *Pyroscope) initServer() (services.Service, error) {
 	f.Server.HTTPServer.Handler = util.RecoveryHTTPMiddleware.Wrap(f.Server.HTTPServer.Handler)
 
 	return s, nil
+}
+
+func (f *Pyroscope) initAdminServer() (services.Service, error) {
+	// Always create the router so route-registration calls in API are safe to call
+	// regardless of mode; they just won't be reachable if no listener is started.
+	router := gorillaMux.NewRouter()
+	f.adminRouter = router
+
+	if !f.Cfg.AdminServer.Mode.IsEnabled() {
+		return nil, nil
+	}
+
+	// /metrics
+	router.Handle("/metrics", promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{
+		EnableOpenMetrics: true,
+	})).Methods("GET")
+	// /debug/pprof — net/http/pprof registers its handlers on http.DefaultServeMux,
+	// so we just forward the whole prefix there.
+	router.PathPrefix("/debug/pprof/").Handler(http.DefaultServeMux)
+	router.Handle("/debug/pprof", http.DefaultServeMux)
+
+	addr := net.JoinHostPort(f.Cfg.AdminServer.HTTPAddress, fmt.Sprintf("%d", f.Cfg.AdminServer.HTTPPort))
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("admin server: listen %s: %w", addr, err)
+	}
+
+	srv := &http.Server{
+		Handler: router,
+	}
+
+	return services.NewIdleService(
+		func(_ context.Context) error {
+			level.Info(f.logger).Log("msg", "admin server listening on addresses", "http", addr)
+			go func() {
+				if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+					level.Error(f.logger).Log("msg", "admin server error", "err", err)
+				}
+			}()
+			return nil
+		},
+		func(_ error) error {
+			return srv.Shutdown(context.Background())
+		},
+	), nil
 }
 
 func (f *Pyroscope) initUsageReport() (services.Service, error) {

--- a/pkg/pyroscope/pyroscope.go
+++ b/pkg/pyroscope/pyroscope.go
@@ -111,7 +111,8 @@ type Config struct {
 	ShutdownDelay       time.Duration     `yaml:"shutdown_delay,omitempty"`
 	ArchitectureStorage StorageLayer      `yaml:"architecture_storage,omitempty"`
 
-	EmbeddedGrafana grafana.Config `yaml:"embedded_grafana,omitempty"`
+	AdminServer     AdminServerConfig `yaml:"admin_server,omitempty"`
+	EmbeddedGrafana grafana.Config    `yaml:"embedded_grafana,omitempty"`
 
 	ConfigFile      string `yaml:"-"`
 	ConfigExpandEnv bool   `yaml:"-"`
@@ -139,6 +140,57 @@ type StorageConfig struct {
 
 func (c *StorageConfig) RegisterFlags(f *flag.FlagSet) {
 	c.Bucket.RegisterFlagsWithPrefix("storage.", f)
+}
+
+// AdminServerMode controls how the optional admin HTTP server behaves.
+type AdminServerMode string
+
+const (
+	// AdminServerDisabled is the default: no secondary server, all routes on the main port.
+	AdminServerDisabled AdminServerMode = "disabled"
+	// AdminServerAdditional starts the admin server and registers operational
+	// routes on both ports (main port keeps them too).
+	AdminServerAdditional AdminServerMode = "additional"
+	// AdminServerExclusive starts the admin server and moves operational routes
+	// exclusively to it, removing them from the main port.
+	AdminServerExclusive AdminServerMode = "exclusive"
+)
+
+func (m AdminServerMode) IsEnabled() bool {
+	return m == AdminServerAdditional || m == AdminServerExclusive
+}
+
+func (m *AdminServerMode) String() string { return string(*m) }
+func (m *AdminServerMode) Set(v string) error {
+	switch AdminServerMode(v) {
+	case AdminServerDisabled, AdminServerAdditional, AdminServerExclusive:
+		*m = AdminServerMode(v)
+		return nil
+	default:
+		return fmt.Errorf("invalid admin-server mode %q: must be disabled, additional, or exclusive", v)
+	}
+}
+
+// AdminServerConfig configures an optional secondary HTTP server that exposes
+// metrics, pprof/debug and admin/ops endpoints on a separate port so they can be
+// firewalled independently from the public-facing API port.
+type AdminServerConfig struct {
+	Mode        AdminServerMode `yaml:"mode"`
+	HTTPAddress string          `yaml:"http_listen_address"`
+	HTTPPort    int             `yaml:"http_listen_port"`
+}
+
+func (c *AdminServerConfig) RegisterFlags(f *flag.FlagSet) {
+	c.Mode = AdminServerDisabled
+	f.Var(&c.Mode, "admin-server.mode",
+		"Controls the admin server for metrics, pprof and admin endpoints. "+
+			"'disabled': all routes on the main port (default). "+
+			"'additional': admin server started, operational routes served on both ports. "+
+			"'exclusive': admin server started, operational routes removed from main port.")
+	f.StringVar(&c.HTTPAddress, "admin-server.http-listen-address", "localhost",
+		"Address for the admin HTTP server. Defaults to localhost so the port is not exposed externally. Use :: or 0.0.0.0 to listen on all interfaces.")
+	f.IntVar(&c.HTTPPort, "admin-server.http-listen-port", 4042,
+		"Port for the admin HTTP server (metrics, pprof, admin).")
 }
 
 type SelfProfilingConfig struct {
@@ -210,6 +262,7 @@ func (c *Config) RegisterFlagsWithContext(f *flag.FlagSet) {
 	c.Analytics.RegisterFlags(f)
 	c.LimitsConfig.RegisterFlags(f)
 	c.API.RegisterFlags(f)
+	c.AdminServer.RegisterFlags(f)
 	c.EmbeddedGrafana.RegisterFlags(f)
 	c.TenantSettings.RegisterFlags(f)
 
@@ -376,6 +429,7 @@ type Pyroscope struct {
 
 	API            *api.API
 	Server         *server.Server
+	adminRouter    *mux.Router
 	SignalHandler  *signals.Handler
 	MemberlistKV   *memberlist.KVInitService
 	ingesterRing   *ring.Ring
@@ -471,6 +525,7 @@ func (f *Pyroscope) setupModuleManager() error {
 	mm.RegisterModule(Overrides, f.initOverrides, modules.UserInvisibleModule)
 	mm.RegisterModule(OverridesExporter, f.initOverridesExporter)
 	mm.RegisterModule(Server, f.initServer, modules.UserInvisibleModule)
+	mm.RegisterModule(AdminServer, f.initAdminServer, modules.UserInvisibleModule)
 	mm.RegisterModule(API, f.initAPI, modules.UserInvisibleModule)
 	mm.RegisterModule(Version, f.initVersion, modules.UserInvisibleModule)
 	mm.RegisterModule(Metastore, f.initMetastore)
@@ -514,7 +569,8 @@ func (f *Pyroscope) setupModuleManager() error {
 		},
 
 		Server:                {GRPCGateway, HealthServer},
-		API:                   {Server},
+		AdminServer:           {},
+		API:                   {Server, AdminServer},
 		Metastore:             {Overrides, API, MetastoreClient, Storage, PlacementManager},
 		MetastoreAdmin:        {API, MetastoreClient},
 		Distributor:           {Overrides, SegmentWriterClient, API, UsageReport, Storage, IngesterRing},
@@ -848,6 +904,9 @@ func (f *Pyroscope) initAPI() (services.Service, error) {
 	a, err := api.New(f.Cfg.API, f.Server, f.grpcGatewayMux, f.Server.Log)
 	if err != nil {
 		return nil, err
+	}
+	if f.adminRouter != nil {
+		a.SetAdminRouter(f.adminRouter, string(f.Cfg.AdminServer.Mode))
 	}
 	f.API = a
 


### PR DESCRIPTION
Adds an optional secondary HTTP server (-admin-server.mode=disabled|additional|exclusive) that exposes operational endpoints (metrics, pprof, rings, config, admin/ops) on a dedicated port (default localhost:4042), so they can be firewalled independently from the public API port.

This is step one and a couple of extra things needs adressing:

- Include this in the helm chart so we can roll this out
- Decide how to handle query diagnostics, they currently sit weirdly in between admin and normal query API