### PR TITLE
fix: Validate tenantID in store-gateway

### DIFF
--- a/pkg/storegateway/bucket_stores.go
+++ b/pkg/storegateway/bucket_stores.go
@@ -3,6 +3,7 @@ package storegateway
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -12,6 +13,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/multierror"
+	"github.com/grafana/dskit/tenant"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -339,11 +341,15 @@ func (bs *BucketStores) getOrCreateStore(userID string) (*BucketStore, error) {
 		filters,
 	)
 
-	s, err := NewBucketStore(
+	userSyncDir, err := bs.syncDirForUser(userID)
+	if err != nil {
+		return nil, err
+	}
+	s, err = NewBucketStore(
 		bs.storageBucket,
 		fetcher,
 		userID,
-		bs.syncDirForUser(userID),
+		userSyncDir,
 		userLogger,
 		bs.reg,
 	)
@@ -385,7 +391,11 @@ func (bs *BucketStores) closeBucketStoreAndDeleteLocalFilesForExcludedTenants(in
 			level.Warn(bs.logger).Log("msg", "failed to close bucket store for user", "tenant", userID, "err", err)
 		}
 
-		userSyncDir := bs.syncDirForUser(userID)
+		userSyncDir, err := bs.syncDirForUser(userID)
+		if err != nil {
+			level.Warn(bs.logger).Log("msg", "skipping delete of user sync directory", "tenant", userID, "err", err)
+			continue
+		}
 		err = os.RemoveAll(userSyncDir)
 		if err == nil {
 			level.Info(bs.logger).Log("msg", "deleted user sync directory", "dir", userSyncDir)
@@ -395,8 +405,11 @@ func (bs *BucketStores) closeBucketStoreAndDeleteLocalFilesForExcludedTenants(in
 	}
 }
 
-func (u *BucketStores) syncDirForUser(userID string) string {
-	return filepath.Join(u.cfg.SyncDir, userID)
+func (u *BucketStores) syncDirForUser(userID string) (string, error) {
+	if err := tenant.ValidTenantID(userID); err != nil {
+		return "", fmt.Errorf("syncDirForUser: invalid userID: %w", err)
+	}
+	return filepath.Join(u.cfg.SyncDir, userID), nil
 }
 
 // closeBucketStore closes bucket store for given user

--- a/pkg/storegateway/gateway_blocks_http.go
+++ b/pkg/storegateway/gateway_blocks_http.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/gorilla/mux"
+	"github.com/grafana/dskit/tenant"
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/pyroscope/v2/pkg/phlaredb/block"
@@ -61,6 +62,10 @@ func (s *StoreGateway) BlocksHandler(w http.ResponseWriter, req *http.Request) {
 	tenantID := vars["tenant"]
 	if tenantID == "" {
 		util.WriteTextResponse(w, "Tenant ID can't be empty")
+		return
+	}
+	if err := tenant.ValidTenantID(tenantID); err != nil {
+		http.Error(w, "Invalid tenant ID", http.StatusBadRequest)
 		return
 	}
 


### PR DESCRIPTION
## Summary

Adds tenant ID validation in the store-gateway to prevent path traversal attacks.

### Changes

- **BlocksHandler**: Rejects tenant IDs containing path separators or traversal components (e.g. `../`) before using the value to build a filesystem path.
- **syncDirForUser**: Adds a secondary validation of the tenant ID to prevent accidental path traversal when constructing sync directory paths.

### Security Impact

BlocksHandler is vunerable to this, while the other paths should be safe because of previous validation of tenant IDs.