### PR TITLE
fix: don't panic on unknown QueryNode type

### DIFF
--- a/pkg/querybackend/backend.go
+++ b/pkg/querybackend/backend.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/services"
@@ -104,7 +105,7 @@ func (q *QueryBackend) Invoke(
 	case queryv1.QueryNode_READ:
 		resp, err = q.read(ctx, req, root.Blocks)
 	default:
-		panic("query plan: unknown node type")
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("query plan: unknown node type %v", nodeType))
 	}
 
 	if err != nil {


### PR DESCRIPTION
Replace unconditional panic in QueryBackend.Invoke for unknown
node types with a proper connect.CodeInvalidArgument error, preventing
crash via a crafted query plan.
