### PR TITLE
chore(examples): fix Test Examples CI failures

### DIFF
--- a/examples/language-sdk-instrumentation/dotnet/fast-slow/Dockerfile
+++ b/examples/language-sdk-instrumentation/dotnet/fast-slow/Dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 WORKDIR /dotnet
 
-COPY --from=pyroscope/pyroscope-dotnet:0.15.0-glibc /Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
-COPY --from=pyroscope/pyroscope-dotnet:0.15.0-glibc /Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
+COPY --from=grafana/pyroscope-dotnet:0.15.0-glibc /Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
+COPY --from=grafana/pyroscope-dotnet:0.15.0-glibc /Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
 
 ADD example .
 

--- a/examples/language-sdk-instrumentation/dotnet/fast-slow/musl.Dockerfile
+++ b/examples/language-sdk-instrumentation/dotnet/fast-slow/musl.Dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine
 
 WORKDIR /dotnet
 
-COPY --from=pyroscope/pyroscope-dotnet:0.15.0-musl /Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
-COPY --from=pyroscope/pyroscope-dotnet:0.15.0-musl /Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
+COPY --from=grafana/pyroscope-dotnet:0.15.0-musl /Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
+COPY --from=grafana/pyroscope-dotnet:0.15.0-musl /Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
 
 ADD example .
 

--- a/examples/language-sdk-instrumentation/dotnet/rideshare/Dockerfile
+++ b/examples/language-sdk-instrumentation/dotnet/rideshare/Dockerfile
@@ -22,7 +22,7 @@ RUN sed -i -E 's|<TargetFramework>.*</TargetFramework>|<TargetFramework>net'$SDK
 RUN dotnet publish -o . --framework net$SDK_VERSION --runtime linux-x64 --no-self-contained
 
 # This fetches the SDK
-FROM --platform=linux/amd64 pyroscope/pyroscope-dotnet:0.15.0-glibc AS sdk
+FROM --platform=linux/amd64 grafana/pyroscope-dotnet:0.15.0-glibc AS sdk
 
 # Runtime only image of the targetplatfrom, so the platform the image will be running on.
 FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:$SDK_VERSION-noble-chiseled-extra

--- a/examples/language-sdk-instrumentation/dotnet/rideshare/musl.Dockerfile
+++ b/examples/language-sdk-instrumentation/dotnet/rideshare/musl.Dockerfile
@@ -22,7 +22,7 @@ RUN sed -i -E 's|<TargetFramework>.*</TargetFramework>|<TargetFramework>net'$SDK
 RUN dotnet publish -o . --framework net$SDK_VERSION --runtime linux-musl-x64 --no-self-contained
 
 # This fetches the SDK
-FROM --platform=linux/amd64 pyroscope/pyroscope-dotnet:0.15.0-musl AS sdk
+FROM --platform=linux/amd64 grafana/pyroscope-dotnet:0.15.0-musl AS sdk
 
 # Runtime only image of the targetplatfrom, so the platform the image will be running on.
 FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:$SDK_VERSION-alpine

--- a/examples/language-sdk-instrumentation/dotnet/web-new/Dockerfile
+++ b/examples/language-sdk-instrumentation/dotnet/web-new/Dockerfile
@@ -3,8 +3,8 @@ FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/sdk:6.0
 
 WORKDIR /dotnet
 
-COPY --from=pyroscope/pyroscope-dotnet:0.15.0-glibc /Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
-COPY --from=pyroscope/pyroscope-dotnet:0.15.0-glibc /Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
+COPY --from=grafana/pyroscope-dotnet:0.15.0-glibc /Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
+COPY --from=grafana/pyroscope-dotnet:0.15.0-glibc /Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
 
 ADD example .
 

--- a/examples/language-sdk-instrumentation/python/rideshare/fastapi/Dockerfile
+++ b/examples/language-sdk-instrumentation/python/rideshare/fastapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.11
 
 RUN pip3 install fastapi pyroscope-io==1.0.4 uvicorn[standard]
 

--- a/examples/tracing/dotnet/Dockerfile
+++ b/examples/tracing/dotnet/Dockerfile
@@ -17,7 +17,7 @@ RUN sed -i -E 's|<TargetFramework>.*</TargetFramework>|<TargetFramework>net'$SDK
 RUN dotnet publish -o . --framework net$SDK_VERSION --runtime linux-x64 --no-self-contained
 
 # This fetches the SDK
-FROM --platform=linux/amd64 pyroscope/pyroscope-dotnet:0.13.0-glibc AS sdk
+FROM --platform=linux/amd64 grafana/pyroscope-dotnet:0.15.0-glibc AS sdk
 
 # Runtime only image of the targetplatfrom, so the platform the image will be running on.
 FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:$SDK_VERSION

--- a/examples/tracing/dotnet/docker-compose.yml
+++ b/examples/tracing/dotnet/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       - "3000:3000"
 
   tempo:
-    image: grafana/tempo:latest
+    image: grafana/tempo:2.10.5
     command: [ "-config.file=/etc/tempo.yml" ]
     volumes:
       - ./tempo/tempo.yml:/etc/tempo.yml

--- a/examples/tracing/dotnet/example/Example.csproj
+++ b/examples/tracing/dotnet/example/Example.csproj
@@ -7,10 +7,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageReference Include="Pyroscope.OpenTelemetry" Version="0.2.0" />
   </ItemGroup>
 </Project>

--- a/examples/tracing/dotnet/example/Example.csproj
+++ b/examples/tracing/dotnet/example/Example.csproj
@@ -7,11 +7,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.8.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.3" />
     <PackageReference Include="Pyroscope.OpenTelemetry" Version="0.2.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
   </ItemGroup>
 </Project>

--- a/examples/tracing/golang-push/docker-compose.yml
+++ b/examples/tracing/golang-push/docker-compose.yml
@@ -65,7 +65,7 @@ services:
     - "3000:3000"
 
   tempo:
-    image: grafana/tempo:latest
+    image: grafana/tempo:2.10.5
     command: [ "-config.file=/etc/tempo.yml" ]
     volumes:
       - ./tempo/tempo.yml:/etc/tempo.yml

--- a/examples/tracing/java-wall/docker-compose.yml
+++ b/examples/tracing/java-wall/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     - "3000:3000"
 
   tempo:
-    image: grafana/tempo:2.6.0
+    image: grafana/tempo:2.10.5
     command: [ "-config.file=/etc/tempo.yml" ]
     volumes:
       - ./tempo/tempo.yml:/etc/tempo.yml

--- a/examples/tracing/java/docker-compose.yml
+++ b/examples/tracing/java/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     - "3000:3000"
 
   tempo:
-    image: grafana/tempo:latest
+    image: grafana/tempo:2.10.5
     command: [ "-config.file=/etc/tempo.yml" ]
     volumes:
       - ./tempo/tempo.yml:/etc/tempo.yml

--- a/examples/tracing/python/docker-compose.yaml
+++ b/examples/tracing/python/docker-compose.yaml
@@ -72,7 +72,7 @@ services:
       - "3000:3000"
 
   tempo:
-    image: grafana/tempo:latest
+    image: grafana/tempo:2.10.5
     command: [ "-config.file=/etc/tempo.yml" ]
     volumes:
       - ./tempo/tempo.yml:/etc/tempo.yml

--- a/examples/tracing/ruby/docker-compose.yml
+++ b/examples/tracing/ruby/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       - "3000:3000"
 
   tempo:
-    image: grafana/tempo:latest
+    image: grafana/tempo:2.10.5
     command: [ "-config.file=/etc/tempo.yml" ]
     volumes:
       - ./tempo/tempo.yml:/etc/tempo.yml

--- a/examples/tracing/tempo/docker-compose.yml
+++ b/examples/tracing/tempo/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       - '3000:3000'
 
   tempo:
-    image: grafana/tempo:latest
+    image: grafana/tempo:2.10.5
     command: [ "-config.file=/etc/tempo.yml" ]
     volumes:
       - ./tempo/tempo.yml:/etc/tempo.yml

--- a/tools/tracing/docker-compose.yml
+++ b/tools/tracing/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   tempo:
-    image: grafana/tempo:2.6.1
+    image: grafana/tempo:2.10.5
     volumes:
       - ./tempo.yml:/etc/tempo/config.yml
     command:

--- a/tools/update_examples.go
+++ b/tools/update_examples.go
@@ -25,6 +25,7 @@ var python = flag.Bool("python", false, "")
 var dotnet = flag.Bool("dotnet", false, "")
 var node = flag.Bool("node", false, "")
 var rust = flag.Bool("rust", false, "")
+var tempo = flag.Bool("tempo", false, "")
 
 // this program requires ruby, bundle, yarn, go to be installed
 func main() {
@@ -39,6 +40,7 @@ func main() {
 		*dotnet = true
 		*node = true
 		*rust = true
+		*tempo = true
 	}
 
 	if *golang {
@@ -66,6 +68,9 @@ func main() {
 	}
 	if *rust {
 		updateRust()
+	}
+	if *tempo {
+		updateTempo()
 	}
 }
 
@@ -117,21 +122,64 @@ func updateDotnet() {
 	last := tags[len(tags)-1]
 	fmt.Println(last)
 
-	reDockerGlibc := regexp.MustCompile(`pyroscope/pyroscope-dotnet:\d+\.\d+\.\d+-glibc`)
-	replDockerGlibc := fmt.Sprintf("pyroscope/pyroscope-dotnet:%s-glibc", last.version())
+	reDockerGlibc := regexp.MustCompile(`grafana/pyroscope-dotnet:\d+\.\d+\.\d+-glibc`)
+	replDockerGlibc := fmt.Sprintf("grafana/pyroscope-dotnet:%s-glibc", last.version())
 	replaceInplace(reDockerGlibc, "examples/language-sdk-instrumentation/dotnet/fast-slow/Dockerfile", replDockerGlibc)
 	replaceInplace(reDockerGlibc, "examples/language-sdk-instrumentation/dotnet/rideshare/Dockerfile", replDockerGlibc)
 	replaceInplace(reDockerGlibc, "examples/language-sdk-instrumentation/dotnet/web-new/Dockerfile", replDockerGlibc)
 	replaceInplace(reDockerGlibc, "docs/sources/configure-client/language-sdks/dotnet.md", replDockerGlibc)
 
-	reDockerMusl := regexp.MustCompile(`pyroscope/pyroscope-dotnet:\d+\.\d+\.\d+-musl`)
-	replDockerMusl := fmt.Sprintf("pyroscope/pyroscope-dotnet:%s-musl", last.version())
+	reDockerMusl := regexp.MustCompile(`grafana/pyroscope-dotnet:\d+\.\d+\.\d+-musl`)
+	replDockerMusl := fmt.Sprintf("grafana/pyroscope-dotnet:%s-musl", last.version())
 	replaceInplace(reDockerMusl, "examples/language-sdk-instrumentation/dotnet/fast-slow/musl.Dockerfile", replDockerMusl)
 	replaceInplace(reDockerMusl, "examples/language-sdk-instrumentation/dotnet/rideshare/musl.Dockerfile", replDockerMusl)
 
 	reUrl := regexp.MustCompile(`https://github\.com/grafana/pyroscope-dotnet/releases/download/v\d+\.\d+\.\d+-pyroscope/pyroscope.\d+\.\d+\.\d+-glibc-x86_64.tar.gz`)
 	replUrl := fmt.Sprintf("https://github.com/grafana/pyroscope-dotnet/releases/download/v%s-pyroscope/pyroscope.%s-glibc-x86_64.tar.gz", last.version(), last.version())
 	replaceInplace(reUrl, "docs/sources/configure-client/language-sdks/dotnet.md", replUrl)
+}
+
+func updateTempo() {
+	tags := getTagsV("grafana/tempo", extractTempoVersion(2))
+	last := tags[len(tags)-1]
+	fmt.Println("tempo", last)
+
+	reDockerTempo := regexp.MustCompile(`grafana/tempo:\d+\.\d+\.\d+`)
+	replDockerTempo := fmt.Sprintf("grafana/tempo:%s", last.version())
+	for _, f := range []string{
+		"examples/tracing/dotnet/docker-compose.yml",
+		"examples/tracing/golang-push/docker-compose.yml",
+		"examples/tracing/java/docker-compose.yml",
+		"examples/tracing/java-wall/docker-compose.yml",
+		"examples/tracing/python/docker-compose.yaml",
+		"examples/tracing/ruby/docker-compose.yml",
+		"examples/tracing/tempo/docker-compose.yml",
+		"tools/tracing/docker-compose.yml",
+	} {
+		replaceInplace(reDockerTempo, f, replDockerTempo)
+	}
+}
+
+// extractTempoVersion returns a version extractor that only matches tags for the
+// given major version (e.g. 2 for "2.x.y").
+func extractTempoVersion(major int) func(tag Tag) *version {
+	return func(tag Tag) *version {
+		re := regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)$`)
+		match := re.FindStringSubmatch(tag.Name)
+		if match == nil {
+			return nil
+		}
+		maj, err := strconv.Atoi(match[1])
+		requireNoError(err, "strconv")
+		if maj != major {
+			return nil
+		}
+		minor, err := strconv.Atoi(match[2])
+		requireNoError(err, "strconv")
+		patch, err := strconv.Atoi(match[3])
+		requireNoError(err, "strconv")
+		return &version{major: maj, minor: minor, patch: patch, tag: tag}
+	}
 }
 
 func updatePython() {


### PR DESCRIPTION
Fixes failures reported in https://github.com/grafana/pyroscope/actions/runs/26549809272.

## Changes

### 1. Migrate dotnet SDK image to `grafana/` org
`pyroscope/pyroscope-dotnet:0.15.0-glibc` does not exist — the image was moved to the `grafana/` org. All Dockerfiles updated to use `grafana/pyroscope-dotnet:0.15.0-glibc`.

### 2. Pin Tempo to 2.10.5
`grafana/tempo:latest` is now Tempo 3.x which removed the top-level `ingester` and `compactor` config fields used in our `tempo.yml` files, causing container startup failures in the `tracing/ruby`, `tracing/golang-push`, and other examples. Pinned to `2.10.5` (latest 2.x).

### 3. Fix `tools/update_examples.go`
- Fix `updateDotnet()` regex/replacement to use `grafana/pyroscope-dotnet` instead of `pyroscope/pyroscope-dotnet`
- Add `--tempo` flag and `updateTempo()" that keeps all tracing docker-compose files on the latest Tempo 2.x release automatically
- Add missing `java-wall` and `tools/tracing` to the tempo file list

### 4. Bump Go SDK dependencies
Update `pyroscope-go`, `godeltaprof`, and `jfr-parser` to latest versions.