### PR TITLE
feat: add mapping names to Flamegraph

### DIFF
--- a/api/connect-openapi/gen/querier/v1/querier.openapi.yaml
+++ b/api/connect-openapi/gen/querier/v1/querier.openapi.yaml
@@ -1022,6 +1022,11 @@ components:
             - string
           title: max_self
           format: int64
+        mappingNames:
+          type: array
+          items:
+            type: string
+          title: mapping_names
       title: FlameGraph
       additionalProperties: false
     querier.v1.FlameGraphDiff:
@@ -1426,7 +1431,24 @@ components:
           title: tree
           format: byte
           description: Pyroscope tree bytes.
+        mapping:
+          type: object
+          title: mapping
+          additionalProperties:
+            type: string
+            title: value
       title: SelectMergeSpanProfileResponse
+      additionalProperties: false
+    querier.v1.SelectMergeSpanProfileResponse.MappingEntry:
+      type: object
+      properties:
+        key:
+          type: string
+          title: key
+        value:
+          type: string
+          title: value
+      title: MappingEntry
       additionalProperties: false
     querier.v1.SelectMergeStacktracesRequest:
       type: object
@@ -1507,11 +1529,28 @@ components:
           title: tree
           format: byte
           description: Pyroscope tree bytes.
+        mapping:
+          type: object
+          title: mapping
+          additionalProperties:
+            type: string
+            title: value
         dot:
           type: string
           title: dot
           description: DOT graph representation.
       title: SelectMergeStacktracesResponse
+      additionalProperties: false
+    querier.v1.SelectMergeStacktracesResponse.MappingEntry:
+      type: object
+      properties:
+        key:
+          type: string
+          title: key
+        value:
+          type: string
+          title: value
+      title: MappingEntry
       additionalProperties: false
     querier.v1.SelectSeriesRequest:
       type: object

--- a/api/connect-openapi/gen/query/v1/query.openapi.yaml
+++ b/api/connect-openapi/gen/query/v1/query.openapi.yaml
@@ -1273,7 +1273,24 @@ components:
           title: symbols
           nullable: true
           $ref: '#/components/schemas/query.v1.TreeSymbols'
+        mappingNames:
+          type: object
+          title: mapping_names
+          additionalProperties:
+            type: string
+            title: value
       title: TreeReport
+      additionalProperties: false
+    query.v1.TreeReport.MappingNamesEntry:
+      type: object
+      properties:
+        key:
+          type: string
+          title: key
+        value:
+          type: string
+          title: value
+      title: MappingNamesEntry
       additionalProperties: false
     query.v1.TreeSymbols:
       type: object

--- a/api/gen/proto/go/querier/v1/querier.pb.go
+++ b/api/gen/proto/go/querier/v1/querier.pb.go
@@ -461,9 +461,10 @@ type SelectMergeStacktracesResponse struct {
 	state      protoimpl.MessageState `protogen:"open.v1"`
 	Flamegraph *FlameGraph            `protobuf:"bytes,1,opt,name=flamegraph,proto3" json:"flamegraph,omitempty"`
 	// Pyroscope tree bytes.
-	Tree []byte `protobuf:"bytes,2,opt,name=tree,proto3" json:"tree,omitempty"`
+	Tree    []byte            `protobuf:"bytes,2,opt,name=tree,proto3" json:"tree,omitempty"`
+	Mapping map[string]string `protobuf:"bytes,3,rep,name=mapping,proto3" json:"mapping,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// DOT graph representation.
-	Dot           string `protobuf:"bytes,3,opt,name=dot,proto3" json:"dot,omitempty"`
+	Dot           string `protobuf:"bytes,4,opt,name=dot,proto3" json:"dot,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -508,6 +509,13 @@ func (x *SelectMergeStacktracesResponse) GetFlamegraph() *FlameGraph {
 func (x *SelectMergeStacktracesResponse) GetTree() []byte {
 	if x != nil {
 		return x.Tree
+	}
+	return nil
+}
+
+func (x *SelectMergeStacktracesResponse) GetMapping() map[string]string {
+	if x != nil {
+		return x.Mapping
 	}
 	return nil
 }
@@ -625,7 +633,8 @@ type SelectMergeSpanProfileResponse struct {
 	state      protoimpl.MessageState `protogen:"open.v1"`
 	Flamegraph *FlameGraph            `protobuf:"bytes,1,opt,name=flamegraph,proto3" json:"flamegraph,omitempty"`
 	// Pyroscope tree bytes.
-	Tree          []byte `protobuf:"bytes,2,opt,name=tree,proto3" json:"tree,omitempty"`
+	Tree          []byte            `protobuf:"bytes,2,opt,name=tree,proto3" json:"tree,omitempty"`
+	Mapping       map[string]string `protobuf:"bytes,3,rep,name=mapping,proto3" json:"mapping,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -670,6 +679,13 @@ func (x *SelectMergeSpanProfileResponse) GetFlamegraph() *FlameGraph {
 func (x *SelectMergeSpanProfileResponse) GetTree() []byte {
 	if x != nil {
 		return x.Tree
+	}
+	return nil
+}
+
+func (x *SelectMergeSpanProfileResponse) GetMapping() map[string]string {
+	if x != nil {
+		return x.Mapping
 	}
 	return nil
 }
@@ -776,6 +792,7 @@ type FlameGraph struct {
 	Levels        []*Level               `protobuf:"bytes,2,rep,name=levels,proto3" json:"levels,omitempty"`
 	Total         int64                  `protobuf:"varint,3,opt,name=total,proto3" json:"total,omitempty"`
 	MaxSelf       int64                  `protobuf:"varint,4,opt,name=max_self,json=maxSelf,proto3" json:"max_self,omitempty"`
+	MappingNames  []string               `protobuf:"bytes,5,rep,name=mapping_names,json=mappingNames,proto3" json:"mapping_names,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -836,6 +853,13 @@ func (x *FlameGraph) GetMaxSelf() int64 {
 		return x.MaxSelf
 	}
 	return 0
+}
+
+func (x *FlameGraph) GetMappingNames() []string {
+	if x != nil {
+		return x.MappingNames
+	}
+	return nil
 }
 
 type FlameGraphDiff struct {
@@ -1710,13 +1734,17 @@ const file_querier_v1_querier_proto_rawDesc = "" +
 	"\x13profile_id_selector\x18\b \x03(\tB/\xbaG,:*\x12(['7c9e6679-7425-40de-944b-e07fc1f90ae7']R\x11profileIdSelectorB\f\n" +
 	"\n" +
 	"_max_nodesB\x17\n" +
-	"\x15_stack_trace_selector\"~\n" +
+	"\x15_stack_trace_selector\"\x8d\x02\n" +
 	"\x1eSelectMergeStacktracesResponse\x126\n" +
 	"\n" +
 	"flamegraph\x18\x01 \x01(\v2\x16.querier.v1.FlameGraphR\n" +
 	"flamegraph\x12\x12\n" +
-	"\x04tree\x18\x02 \x01(\fR\x04tree\x12\x10\n" +
-	"\x03dot\x18\x03 \x01(\tR\x03dot\"\xd2\x03\n" +
+	"\x04tree\x18\x02 \x01(\fR\x04tree\x12Q\n" +
+	"\amapping\x18\x03 \x03(\v27.querier.v1.SelectMergeStacktracesResponse.MappingEntryR\amapping\x12\x10\n" +
+	"\x03dot\x18\x04 \x01(\tR\x03dot\x1a:\n" +
+	"\fMappingEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xd2\x03\n" +
 	"\x1dSelectMergeSpanProfileRequest\x12Y\n" +
 	"\x0eprofile_typeID\x18\x01 \x01(\tB2\xbaG/:-\x12+process_cpu:cpu:nanoseconds:cpu:nanosecondsR\rprofileTypeID\x12J\n" +
 	"\x0elabel_selector\x18\x02 \x01(\tB#\xbaG :\x1e\x12\x1c'{namespace=\"my-namespace\"}'R\rlabelSelector\x12S\n" +
@@ -1726,25 +1754,30 @@ const file_querier_v1_querier_proto_rawDesc = "" +
 	"\tmax_nodes\x18\x06 \x01(\x03H\x00R\bmaxNodes\x88\x01\x01\x121\n" +
 	"\x06format\x18\a \x01(\x0e2\x19.querier.v1.ProfileFormatR\x06formatB\f\n" +
 	"\n" +
-	"_max_nodes\"l\n" +
+	"_max_nodes\"\xfb\x01\n" +
 	"\x1eSelectMergeSpanProfileResponse\x126\n" +
 	"\n" +
 	"flamegraph\x18\x01 \x01(\v2\x16.querier.v1.FlameGraphR\n" +
 	"flamegraph\x12\x12\n" +
-	"\x04tree\x18\x02 \x01(\fR\x04tree\"\x8d\x01\n" +
+	"\x04tree\x18\x02 \x01(\fR\x04tree\x12Q\n" +
+	"\amapping\x18\x03 \x03(\v27.querier.v1.SelectMergeSpanProfileResponse.MappingEntryR\amapping\x1a:\n" +
+	"\fMappingEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8d\x01\n" +
 	"\vDiffRequest\x12=\n" +
 	"\x04left\x18\x01 \x01(\v2).querier.v1.SelectMergeStacktracesRequestR\x04left\x12?\n" +
 	"\x05right\x18\x02 \x01(\v2).querier.v1.SelectMergeStacktracesRequestR\x05right\"J\n" +
 	"\fDiffResponse\x12:\n" +
 	"\n" +
 	"flamegraph\x18\x01 \x01(\v2\x1a.querier.v1.FlameGraphDiffR\n" +
-	"flamegraph\"~\n" +
+	"flamegraph\"\xa3\x01\n" +
 	"\n" +
 	"FlameGraph\x12\x14\n" +
 	"\x05names\x18\x01 \x03(\tR\x05names\x12)\n" +
 	"\x06levels\x18\x02 \x03(\v2\x11.querier.v1.LevelR\x06levels\x12\x14\n" +
 	"\x05total\x18\x03 \x01(\x03R\x05total\x12\x19\n" +
-	"\bmax_self\x18\x04 \x01(\x03R\amaxSelf\"\xc0\x01\n" +
+	"\bmax_self\x18\x04 \x01(\x03R\amaxSelf\x12#\n" +
+	"\rmapping_names\x18\x05 \x03(\tR\fmappingNames\"\xc0\x01\n" +
 	"\x0eFlameGraphDiff\x12\x14\n" +
 	"\x05names\x18\x01 \x03(\tR\x05names\x12)\n" +
 	"\x06levels\x18\x02 \x03(\v2\x11.querier.v1.LevelR\x06levels\x12\x14\n" +
@@ -1874,7 +1907,7 @@ func file_querier_v1_querier_proto_rawDescGZIP() []byte {
 }
 
 var file_querier_v1_querier_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_querier_v1_querier_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
+var file_querier_v1_querier_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
 var file_querier_v1_querier_proto_goTypes = []any{
 	(ProfileFormat)(0),                     // 0: querier.v1.ProfileFormat
 	(HeatmapQueryType)(0),                  // 1: querier.v1.HeatmapQueryType
@@ -1900,73 +1933,77 @@ var file_querier_v1_querier_proto_goTypes = []any{
 	(*AnalyzeQueryResponse)(nil),           // 21: querier.v1.AnalyzeQueryResponse
 	(*QueryScope)(nil),                     // 22: querier.v1.QueryScope
 	(*QueryImpact)(nil),                    // 23: querier.v1.QueryImpact
-	(*v1.ProfileType)(nil),                 // 24: types.v1.ProfileType
-	(*v1.Labels)(nil),                      // 25: types.v1.Labels
-	(*v1.StackTraceSelector)(nil),          // 26: types.v1.StackTraceSelector
-	(v1.TimeSeriesAggregationType)(0),      // 27: types.v1.TimeSeriesAggregationType
-	(v1.ExemplarType)(0),                   // 28: types.v1.ExemplarType
-	(*v1.Series)(nil),                      // 29: types.v1.Series
-	(*v1.HeatmapSeries)(nil),               // 30: types.v1.HeatmapSeries
-	(*v1.LabelValuesRequest)(nil),          // 31: types.v1.LabelValuesRequest
-	(*v1.LabelNamesRequest)(nil),           // 32: types.v1.LabelNamesRequest
-	(*v1.GetProfileStatsRequest)(nil),      // 33: types.v1.GetProfileStatsRequest
-	(*v1.LabelValuesResponse)(nil),         // 34: types.v1.LabelValuesResponse
-	(*v1.LabelNamesResponse)(nil),          // 35: types.v1.LabelNamesResponse
-	(*v11.Profile)(nil),                    // 36: google.v1.Profile
-	(*v1.GetProfileStatsResponse)(nil),     // 37: types.v1.GetProfileStatsResponse
+	nil,                                    // 24: querier.v1.SelectMergeStacktracesResponse.MappingEntry
+	nil,                                    // 25: querier.v1.SelectMergeSpanProfileResponse.MappingEntry
+	(*v1.ProfileType)(nil),                 // 26: types.v1.ProfileType
+	(*v1.Labels)(nil),                      // 27: types.v1.Labels
+	(*v1.StackTraceSelector)(nil),          // 28: types.v1.StackTraceSelector
+	(v1.TimeSeriesAggregationType)(0),      // 29: types.v1.TimeSeriesAggregationType
+	(v1.ExemplarType)(0),                   // 30: types.v1.ExemplarType
+	(*v1.Series)(nil),                      // 31: types.v1.Series
+	(*v1.HeatmapSeries)(nil),               // 32: types.v1.HeatmapSeries
+	(*v1.LabelValuesRequest)(nil),          // 33: types.v1.LabelValuesRequest
+	(*v1.LabelNamesRequest)(nil),           // 34: types.v1.LabelNamesRequest
+	(*v1.GetProfileStatsRequest)(nil),      // 35: types.v1.GetProfileStatsRequest
+	(*v1.LabelValuesResponse)(nil),         // 36: types.v1.LabelValuesResponse
+	(*v1.LabelNamesResponse)(nil),          // 37: types.v1.LabelNamesResponse
+	(*v11.Profile)(nil),                    // 38: google.v1.Profile
+	(*v1.GetProfileStatsResponse)(nil),     // 39: types.v1.GetProfileStatsResponse
 }
 var file_querier_v1_querier_proto_depIdxs = []int32{
-	24, // 0: querier.v1.ProfileTypesResponse.profile_types:type_name -> types.v1.ProfileType
-	25, // 1: querier.v1.SeriesResponse.labels_set:type_name -> types.v1.Labels
+	26, // 0: querier.v1.ProfileTypesResponse.profile_types:type_name -> types.v1.ProfileType
+	27, // 1: querier.v1.SeriesResponse.labels_set:type_name -> types.v1.Labels
 	0,  // 2: querier.v1.SelectMergeStacktracesRequest.format:type_name -> querier.v1.ProfileFormat
-	26, // 3: querier.v1.SelectMergeStacktracesRequest.stack_trace_selector:type_name -> types.v1.StackTraceSelector
+	28, // 3: querier.v1.SelectMergeStacktracesRequest.stack_trace_selector:type_name -> types.v1.StackTraceSelector
 	12, // 4: querier.v1.SelectMergeStacktracesResponse.flamegraph:type_name -> querier.v1.FlameGraph
-	0,  // 5: querier.v1.SelectMergeSpanProfileRequest.format:type_name -> querier.v1.ProfileFormat
-	12, // 6: querier.v1.SelectMergeSpanProfileResponse.flamegraph:type_name -> querier.v1.FlameGraph
-	6,  // 7: querier.v1.DiffRequest.left:type_name -> querier.v1.SelectMergeStacktracesRequest
-	6,  // 8: querier.v1.DiffRequest.right:type_name -> querier.v1.SelectMergeStacktracesRequest
-	13, // 9: querier.v1.DiffResponse.flamegraph:type_name -> querier.v1.FlameGraphDiff
-	14, // 10: querier.v1.FlameGraph.levels:type_name -> querier.v1.Level
-	14, // 11: querier.v1.FlameGraphDiff.levels:type_name -> querier.v1.Level
-	26, // 12: querier.v1.SelectMergeProfileRequest.stack_trace_selector:type_name -> types.v1.StackTraceSelector
-	27, // 13: querier.v1.SelectSeriesRequest.aggregation:type_name -> types.v1.TimeSeriesAggregationType
-	26, // 14: querier.v1.SelectSeriesRequest.stack_trace_selector:type_name -> types.v1.StackTraceSelector
-	28, // 15: querier.v1.SelectSeriesRequest.exemplar_type:type_name -> types.v1.ExemplarType
-	29, // 16: querier.v1.SelectSeriesResponse.series:type_name -> types.v1.Series
-	1,  // 17: querier.v1.SelectHeatmapRequest.query_type:type_name -> querier.v1.HeatmapQueryType
-	28, // 18: querier.v1.SelectHeatmapRequest.exemplar_type:type_name -> types.v1.ExemplarType
-	30, // 19: querier.v1.SelectHeatmapResponse.series:type_name -> types.v1.HeatmapSeries
-	22, // 20: querier.v1.AnalyzeQueryResponse.query_scopes:type_name -> querier.v1.QueryScope
-	23, // 21: querier.v1.AnalyzeQueryResponse.query_impact:type_name -> querier.v1.QueryImpact
-	2,  // 22: querier.v1.QuerierService.ProfileTypes:input_type -> querier.v1.ProfileTypesRequest
-	31, // 23: querier.v1.QuerierService.LabelValues:input_type -> types.v1.LabelValuesRequest
-	32, // 24: querier.v1.QuerierService.LabelNames:input_type -> types.v1.LabelNamesRequest
-	4,  // 25: querier.v1.QuerierService.Series:input_type -> querier.v1.SeriesRequest
-	6,  // 26: querier.v1.QuerierService.SelectMergeStacktraces:input_type -> querier.v1.SelectMergeStacktracesRequest
-	8,  // 27: querier.v1.QuerierService.SelectMergeSpanProfile:input_type -> querier.v1.SelectMergeSpanProfileRequest
-	15, // 28: querier.v1.QuerierService.SelectMergeProfile:input_type -> querier.v1.SelectMergeProfileRequest
-	16, // 29: querier.v1.QuerierService.SelectSeries:input_type -> querier.v1.SelectSeriesRequest
-	18, // 30: querier.v1.QuerierService.SelectHeatmap:input_type -> querier.v1.SelectHeatmapRequest
-	10, // 31: querier.v1.QuerierService.Diff:input_type -> querier.v1.DiffRequest
-	33, // 32: querier.v1.QuerierService.GetProfileStats:input_type -> types.v1.GetProfileStatsRequest
-	20, // 33: querier.v1.QuerierService.AnalyzeQuery:input_type -> querier.v1.AnalyzeQueryRequest
-	3,  // 34: querier.v1.QuerierService.ProfileTypes:output_type -> querier.v1.ProfileTypesResponse
-	34, // 35: querier.v1.QuerierService.LabelValues:output_type -> types.v1.LabelValuesResponse
-	35, // 36: querier.v1.QuerierService.LabelNames:output_type -> types.v1.LabelNamesResponse
-	5,  // 37: querier.v1.QuerierService.Series:output_type -> querier.v1.SeriesResponse
-	7,  // 38: querier.v1.QuerierService.SelectMergeStacktraces:output_type -> querier.v1.SelectMergeStacktracesResponse
-	9,  // 39: querier.v1.QuerierService.SelectMergeSpanProfile:output_type -> querier.v1.SelectMergeSpanProfileResponse
-	36, // 40: querier.v1.QuerierService.SelectMergeProfile:output_type -> google.v1.Profile
-	17, // 41: querier.v1.QuerierService.SelectSeries:output_type -> querier.v1.SelectSeriesResponse
-	19, // 42: querier.v1.QuerierService.SelectHeatmap:output_type -> querier.v1.SelectHeatmapResponse
-	11, // 43: querier.v1.QuerierService.Diff:output_type -> querier.v1.DiffResponse
-	37, // 44: querier.v1.QuerierService.GetProfileStats:output_type -> types.v1.GetProfileStatsResponse
-	21, // 45: querier.v1.QuerierService.AnalyzeQuery:output_type -> querier.v1.AnalyzeQueryResponse
-	34, // [34:46] is the sub-list for method output_type
-	22, // [22:34] is the sub-list for method input_type
-	22, // [22:22] is the sub-list for extension type_name
-	22, // [22:22] is the sub-list for extension extendee
-	0,  // [0:22] is the sub-list for field type_name
+	24, // 5: querier.v1.SelectMergeStacktracesResponse.mapping:type_name -> querier.v1.SelectMergeStacktracesResponse.MappingEntry
+	0,  // 6: querier.v1.SelectMergeSpanProfileRequest.format:type_name -> querier.v1.ProfileFormat
+	12, // 7: querier.v1.SelectMergeSpanProfileResponse.flamegraph:type_name -> querier.v1.FlameGraph
+	25, // 8: querier.v1.SelectMergeSpanProfileResponse.mapping:type_name -> querier.v1.SelectMergeSpanProfileResponse.MappingEntry
+	6,  // 9: querier.v1.DiffRequest.left:type_name -> querier.v1.SelectMergeStacktracesRequest
+	6,  // 10: querier.v1.DiffRequest.right:type_name -> querier.v1.SelectMergeStacktracesRequest
+	13, // 11: querier.v1.DiffResponse.flamegraph:type_name -> querier.v1.FlameGraphDiff
+	14, // 12: querier.v1.FlameGraph.levels:type_name -> querier.v1.Level
+	14, // 13: querier.v1.FlameGraphDiff.levels:type_name -> querier.v1.Level
+	28, // 14: querier.v1.SelectMergeProfileRequest.stack_trace_selector:type_name -> types.v1.StackTraceSelector
+	29, // 15: querier.v1.SelectSeriesRequest.aggregation:type_name -> types.v1.TimeSeriesAggregationType
+	28, // 16: querier.v1.SelectSeriesRequest.stack_trace_selector:type_name -> types.v1.StackTraceSelector
+	30, // 17: querier.v1.SelectSeriesRequest.exemplar_type:type_name -> types.v1.ExemplarType
+	31, // 18: querier.v1.SelectSeriesResponse.series:type_name -> types.v1.Series
+	1,  // 19: querier.v1.SelectHeatmapRequest.query_type:type_name -> querier.v1.HeatmapQueryType
+	30, // 20: querier.v1.SelectHeatmapRequest.exemplar_type:type_name -> types.v1.ExemplarType
+	32, // 21: querier.v1.SelectHeatmapResponse.series:type_name -> types.v1.HeatmapSeries
+	22, // 22: querier.v1.AnalyzeQueryResponse.query_scopes:type_name -> querier.v1.QueryScope
+	23, // 23: querier.v1.AnalyzeQueryResponse.query_impact:type_name -> querier.v1.QueryImpact
+	2,  // 24: querier.v1.QuerierService.ProfileTypes:input_type -> querier.v1.ProfileTypesRequest
+	33, // 25: querier.v1.QuerierService.LabelValues:input_type -> types.v1.LabelValuesRequest
+	34, // 26: querier.v1.QuerierService.LabelNames:input_type -> types.v1.LabelNamesRequest
+	4,  // 27: querier.v1.QuerierService.Series:input_type -> querier.v1.SeriesRequest
+	6,  // 28: querier.v1.QuerierService.SelectMergeStacktraces:input_type -> querier.v1.SelectMergeStacktracesRequest
+	8,  // 29: querier.v1.QuerierService.SelectMergeSpanProfile:input_type -> querier.v1.SelectMergeSpanProfileRequest
+	15, // 30: querier.v1.QuerierService.SelectMergeProfile:input_type -> querier.v1.SelectMergeProfileRequest
+	16, // 31: querier.v1.QuerierService.SelectSeries:input_type -> querier.v1.SelectSeriesRequest
+	18, // 32: querier.v1.QuerierService.SelectHeatmap:input_type -> querier.v1.SelectHeatmapRequest
+	10, // 33: querier.v1.QuerierService.Diff:input_type -> querier.v1.DiffRequest
+	35, // 34: querier.v1.QuerierService.GetProfileStats:input_type -> types.v1.GetProfileStatsRequest
+	20, // 35: querier.v1.QuerierService.AnalyzeQuery:input_type -> querier.v1.AnalyzeQueryRequest
+	3,  // 36: querier.v1.QuerierService.ProfileTypes:output_type -> querier.v1.ProfileTypesResponse
+	36, // 37: querier.v1.QuerierService.LabelValues:output_type -> types.v1.LabelValuesResponse
+	37, // 38: querier.v1.QuerierService.LabelNames:output_type -> types.v1.LabelNamesResponse
+	5,  // 39: querier.v1.QuerierService.Series:output_type -> querier.v1.SeriesResponse
+	7,  // 40: querier.v1.QuerierService.SelectMergeStacktraces:output_type -> querier.v1.SelectMergeStacktracesResponse
+	9,  // 41: querier.v1.QuerierService.SelectMergeSpanProfile:output_type -> querier.v1.SelectMergeSpanProfileResponse
+	38, // 42: querier.v1.QuerierService.SelectMergeProfile:output_type -> google.v1.Profile
+	17, // 43: querier.v1.QuerierService.SelectSeries:output_type -> querier.v1.SelectSeriesResponse
+	19, // 44: querier.v1.QuerierService.SelectHeatmap:output_type -> querier.v1.SelectHeatmapResponse
+	11, // 45: querier.v1.QuerierService.Diff:output_type -> querier.v1.DiffResponse
+	39, // 46: querier.v1.QuerierService.GetProfileStats:output_type -> types.v1.GetProfileStatsResponse
+	21, // 47: querier.v1.QuerierService.AnalyzeQuery:output_type -> querier.v1.AnalyzeQueryResponse
+	36, // [36:48] is the sub-list for method output_type
+	24, // [24:36] is the sub-list for method input_type
+	24, // [24:24] is the sub-list for extension type_name
+	24, // [24:24] is the sub-list for extension extendee
+	0,  // [0:24] is the sub-list for field type_name
 }
 
 func init() { file_querier_v1_querier_proto_init() }
@@ -1985,7 +2022,7 @@ func file_querier_v1_querier_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_querier_v1_querier_proto_rawDesc), len(file_querier_v1_querier_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   22,
+			NumMessages:   24,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/querier/v1/querier_vtproto.pb.go
+++ b/api/gen/proto/go/querier/v1/querier_vtproto.pb.go
@@ -176,6 +176,13 @@ func (m *SelectMergeStacktracesResponse) CloneVT() *SelectMergeStacktracesRespon
 		copy(tmpBytes, rhs)
 		r.Tree = tmpBytes
 	}
+	if rhs := m.Mapping; rhs != nil {
+		tmpContainer := make(map[string]string, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.Mapping = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -227,6 +234,13 @@ func (m *SelectMergeSpanProfileResponse) CloneVT() *SelectMergeSpanProfileRespon
 		tmpBytes := make([]byte, len(rhs))
 		copy(tmpBytes, rhs)
 		r.Tree = tmpBytes
+	}
+	if rhs := m.Mapping; rhs != nil {
+		tmpContainer := make(map[string]string, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.Mapping = tmpContainer
 	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -292,6 +306,11 @@ func (m *FlameGraph) CloneVT() *FlameGraph {
 			tmpContainer[k] = v.CloneVT()
 		}
 		r.Levels = tmpContainer
+	}
+	if rhs := m.MappingNames; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.MappingNames = tmpContainer
 	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -808,6 +827,18 @@ func (this *SelectMergeStacktracesResponse) EqualVT(that *SelectMergeStacktraces
 	if string(this.Tree) != string(that.Tree) {
 		return false
 	}
+	if len(this.Mapping) != len(that.Mapping) {
+		return false
+	}
+	for i, vx := range this.Mapping {
+		vy, ok := that.Mapping[i]
+		if !ok {
+			return false
+		}
+		if vx != vy {
+			return false
+		}
+	}
 	if this.Dot != that.Dot {
 		return false
 	}
@@ -875,6 +906,18 @@ func (this *SelectMergeSpanProfileResponse) EqualVT(that *SelectMergeSpanProfile
 	}
 	if string(this.Tree) != string(that.Tree) {
 		return false
+	}
+	if len(this.Mapping) != len(that.Mapping) {
+		return false
+	}
+	for i, vx := range this.Mapping {
+		vy, ok := that.Mapping[i]
+		if !ok {
+			return false
+		}
+		if vx != vy {
+			return false
+		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -964,6 +1007,15 @@ func (this *FlameGraph) EqualVT(that *FlameGraph) bool {
 	}
 	if this.MaxSelf != that.MaxSelf {
 		return false
+	}
+	if len(this.MappingNames) != len(that.MappingNames) {
+		return false
+	}
+	for i, vx := range this.MappingNames {
+		vy := that.MappingNames[i]
+		if vx != vy {
+			return false
+		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -2292,7 +2344,26 @@ func (m *SelectMergeStacktracesResponse) MarshalToSizedBufferVT(dAtA []byte) (in
 		copy(dAtA[i:], m.Dot)
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Dot)))
 		i--
-		dAtA[i] = 0x1a
+		dAtA[i] = 0x22
+	}
+	if len(m.Mapping) > 0 {
+		for k := range m.Mapping {
+			v := m.Mapping[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x1a
+		}
 	}
 	if len(m.Tree) > 0 {
 		i -= len(m.Tree)
@@ -2419,6 +2490,25 @@ func (m *SelectMergeSpanProfileResponse) MarshalToSizedBufferVT(dAtA []byte) (in
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Mapping) > 0 {
+		for k := range m.Mapping {
+			v := m.Mapping[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x1a
+		}
 	}
 	if len(m.Tree) > 0 {
 		i -= len(m.Tree)
@@ -2565,6 +2655,15 @@ func (m *FlameGraph) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.MappingNames) > 0 {
+		for iNdEx := len(m.MappingNames) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.MappingNames[iNdEx])
+			copy(dAtA[i:], m.MappingNames[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.MappingNames[iNdEx])))
+			i--
+			dAtA[i] = 0x2a
+		}
 	}
 	if m.MaxSelf != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.MaxSelf))
@@ -3517,6 +3616,14 @@ func (m *SelectMergeStacktracesResponse) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	if len(m.Mapping) > 0 {
+		for k, v := range m.Mapping {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
+			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
 	l = len(m.Dot)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
@@ -3574,6 +3681,14 @@ func (m *SelectMergeSpanProfileResponse) SizeVT() (n int) {
 	l = len(m.Tree)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.Mapping) > 0 {
+		for k, v := range m.Mapping {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
+			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
 	}
 	n += len(m.unknownFields)
 	return n
@@ -3634,6 +3749,12 @@ func (m *FlameGraph) SizeVT() (n int) {
 	}
 	if m.MaxSelf != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.MaxSelf))
+	}
+	if len(m.MappingNames) > 0 {
+		for _, s := range m.MappingNames {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
 	}
 	n += len(m.unknownFields)
 	return n
@@ -4765,6 +4886,133 @@ func (m *SelectMergeStacktracesResponse) UnmarshalVT(dAtA []byte) error {
 			iNdEx = postIndex
 		case 3:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Mapping", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Mapping == nil {
+				m.Mapping = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Mapping[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Dot", wireType)
 			}
 			var stringLen uint64
@@ -5140,6 +5388,133 @@ func (m *SelectMergeSpanProfileResponse) UnmarshalVT(dAtA []byte) error {
 				m.Tree = []byte{}
 			}
 			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Mapping", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Mapping == nil {
+				m.Mapping = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Mapping[mapkey] = mapvalue
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -5505,6 +5880,38 @@ func (m *FlameGraph) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MappingNames", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.MappingNames = append(m.MappingNames, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/api/gen/proto/go/query/v1/query.pb.go
+++ b/api/gen/proto/go/query/v1/query.pb.go
@@ -1729,6 +1729,7 @@ type TreeReport struct {
 	Query         *TreeQuery             `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty"`
 	Tree          []byte                 `protobuf:"bytes,2,opt,name=tree,proto3" json:"tree,omitempty"`
 	Symbols       *TreeSymbols           `protobuf:"bytes,3,opt,name=symbols,proto3,oneof" json:"symbols,omitempty"`
+	MappingNames  map[string]string      `protobuf:"bytes,4,rep,name=mapping_names,json=mappingNames,proto3" json:"mapping_names,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1780,6 +1781,13 @@ func (x *TreeReport) GetTree() []byte {
 func (x *TreeReport) GetSymbols() *TreeSymbols {
 	if x != nil {
 		return x.Symbols
+	}
+	return nil
+}
+
+func (x *TreeReport) GetMappingNames() map[string]string {
+	if x != nil {
+		return x.MappingNames
 	}
 	return nil
 }
@@ -2606,12 +2614,16 @@ const file_query_v1_query_proto_rawDesc = "" +
 	"\x0emapping_hashes\x18\x05 \x03(\x04R\rmappingHashes\x12'\n" +
 	"\x0flocation_hashes\x18\x06 \x03(\x04R\x0elocationHashes\x12'\n" +
 	"\x0ffunction_hashes\x18\a \x03(\x04R\x0efunctionHashes\x12#\n" +
-	"\rstring_hashes\x18\b \x03(\x04R\fstringHashes\"\x8d\x01\n" +
+	"\rstring_hashes\x18\b \x03(\x04R\fstringHashes\"\x9b\x02\n" +
 	"\n" +
 	"TreeReport\x12)\n" +
 	"\x05query\x18\x01 \x01(\v2\x13.query.v1.TreeQueryR\x05query\x12\x12\n" +
 	"\x04tree\x18\x02 \x01(\fR\x04tree\x124\n" +
-	"\asymbols\x18\x03 \x01(\v2\x15.query.v1.TreeSymbolsH\x00R\asymbols\x88\x01\x01B\n" +
+	"\asymbols\x18\x03 \x01(\v2\x15.query.v1.TreeSymbolsH\x00R\asymbols\x88\x01\x01\x12K\n" +
+	"\rmapping_names\x18\x04 \x03(\v2&.query.v1.TreeReport.MappingNamesEntryR\fmappingNames\x1a?\n" +
+	"\x11MappingNamesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\n" +
 	"\n" +
 	"\b_symbols\"\xc7\x01\n" +
 	"\n" +
@@ -2709,7 +2721,7 @@ func file_query_v1_query_proto_rawDescGZIP() []byte {
 }
 
 var file_query_v1_query_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_query_v1_query_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
+var file_query_v1_query_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
 var file_query_v1_query_proto_goTypes = []any{
 	(QueryType)(0),                  // 0: query.v1.QueryType
 	(ReportType)(0),                 // 1: query.v1.ReportType
@@ -2749,15 +2761,16 @@ var file_query_v1_query_proto_goTypes = []any{
 	(*Point)(nil),                   // 35: query.v1.Point
 	(*Series)(nil),                  // 36: query.v1.Series
 	(*TimeSeriesCompactReport)(nil), // 37: query.v1.TimeSeriesCompactReport
-	(*v1.BlockMeta)(nil),            // 38: metastore.v1.BlockMeta
-	(*v11.Labels)(nil),              // 39: types.v1.Labels
-	(v11.ExemplarType)(0),           // 40: types.v1.ExemplarType
-	(*v11.Series)(nil),              // 41: types.v1.Series
-	(*v11.StackTraceSelector)(nil),  // 42: types.v1.StackTraceSelector
-	(*v12.Mapping)(nil),             // 43: google.v1.Mapping
-	(*v12.Location)(nil),            // 44: google.v1.Location
-	(*v12.Function)(nil),            // 45: google.v1.Function
-	(v13.HeatmapQueryType)(0),       // 46: querier.v1.HeatmapQueryType
+	nil,                             // 38: query.v1.TreeReport.MappingNamesEntry
+	(*v1.BlockMeta)(nil),            // 39: metastore.v1.BlockMeta
+	(*v11.Labels)(nil),              // 40: types.v1.Labels
+	(v11.ExemplarType)(0),           // 41: types.v1.ExemplarType
+	(*v11.Series)(nil),              // 42: types.v1.Series
+	(*v11.StackTraceSelector)(nil),  // 43: types.v1.StackTraceSelector
+	(*v12.Mapping)(nil),             // 44: google.v1.Mapping
+	(*v12.Location)(nil),            // 45: google.v1.Location
+	(*v12.Function)(nil),            // 46: google.v1.Function
+	(v13.HeatmapQueryType)(0),       // 47: querier.v1.HeatmapQueryType
 }
 var file_query_v1_query_proto_depIdxs = []int32{
 	9,  // 0: query.v1.QueryRequest.query:type_name -> query.v1.Query
@@ -2768,7 +2781,7 @@ var file_query_v1_query_proto_depIdxs = []int32{
 	8,  // 5: query.v1.QueryPlan.root:type_name -> query.v1.QueryNode
 	2,  // 6: query.v1.QueryNode.type:type_name -> query.v1.QueryNode.Type
 	8,  // 7: query.v1.QueryNode.children:type_name -> query.v1.QueryNode
-	38, // 8: query.v1.QueryNode.blocks:type_name -> metastore.v1.BlockMeta
+	39, // 8: query.v1.QueryNode.blocks:type_name -> metastore.v1.BlockMeta
 	0,  // 9: query.v1.Query.query_type:type_name -> query.v1.QueryType
 	16, // 10: query.v1.Query.label_names:type_name -> query.v1.LabelNamesQuery
 	18, // 11: query.v1.Query.label_values:type_name -> query.v1.LabelValuesQuery
@@ -2798,38 +2811,39 @@ var file_query_v1_query_proto_depIdxs = []int32{
 	16, // 35: query.v1.LabelNamesReport.query:type_name -> query.v1.LabelNamesQuery
 	18, // 36: query.v1.LabelValuesReport.query:type_name -> query.v1.LabelValuesQuery
 	20, // 37: query.v1.SeriesLabelsReport.query:type_name -> query.v1.SeriesLabelsQuery
-	39, // 38: query.v1.SeriesLabelsReport.series_labels:type_name -> types.v1.Labels
-	40, // 39: query.v1.TimeSeriesQuery.exemplar_type:type_name -> types.v1.ExemplarType
+	40, // 38: query.v1.SeriesLabelsReport.series_labels:type_name -> types.v1.Labels
+	41, // 39: query.v1.TimeSeriesQuery.exemplar_type:type_name -> types.v1.ExemplarType
 	22, // 40: query.v1.TimeSeriesReport.query:type_name -> query.v1.TimeSeriesQuery
-	41, // 41: query.v1.TimeSeriesReport.time_series:type_name -> types.v1.Series
-	42, // 42: query.v1.TreeQuery.stack_trace_selector:type_name -> types.v1.StackTraceSelector
-	43, // 43: query.v1.TreeSymbols.mappings:type_name -> google.v1.Mapping
-	44, // 44: query.v1.TreeSymbols.locations:type_name -> google.v1.Location
-	45, // 45: query.v1.TreeSymbols.functions:type_name -> google.v1.Function
+	42, // 41: query.v1.TimeSeriesReport.time_series:type_name -> types.v1.Series
+	43, // 42: query.v1.TreeQuery.stack_trace_selector:type_name -> types.v1.StackTraceSelector
+	44, // 43: query.v1.TreeSymbols.mappings:type_name -> google.v1.Mapping
+	45, // 44: query.v1.TreeSymbols.locations:type_name -> google.v1.Location
+	46, // 45: query.v1.TreeSymbols.functions:type_name -> google.v1.Function
 	24, // 46: query.v1.TreeReport.query:type_name -> query.v1.TreeQuery
 	25, // 47: query.v1.TreeReport.symbols:type_name -> query.v1.TreeSymbols
-	42, // 48: query.v1.PprofQuery.stack_trace_selector:type_name -> types.v1.StackTraceSelector
-	27, // 49: query.v1.PprofReport.query:type_name -> query.v1.PprofQuery
-	46, // 50: query.v1.HeatmapQuery.query_type:type_name -> querier.v1.HeatmapQueryType
-	40, // 51: query.v1.HeatmapQuery.exemplar_type:type_name -> types.v1.ExemplarType
-	31, // 52: query.v1.HeatmapSeries.points:type_name -> query.v1.HeatmapPoint
-	29, // 53: query.v1.HeatmapReport.query:type_name -> query.v1.HeatmapQuery
-	32, // 54: query.v1.HeatmapReport.heatmap_series:type_name -> query.v1.HeatmapSeries
-	30, // 55: query.v1.HeatmapReport.attribute_table:type_name -> query.v1.AttributeTable
-	34, // 56: query.v1.Point.exemplars:type_name -> query.v1.Exemplar
-	35, // 57: query.v1.Series.points:type_name -> query.v1.Point
-	22, // 58: query.v1.TimeSeriesCompactReport.query:type_name -> query.v1.TimeSeriesQuery
-	36, // 59: query.v1.TimeSeriesCompactReport.time_series:type_name -> query.v1.Series
-	30, // 60: query.v1.TimeSeriesCompactReport.attribute_table:type_name -> query.v1.AttributeTable
-	3,  // 61: query.v1.QueryFrontendService.Query:input_type -> query.v1.QueryRequest
-	6,  // 62: query.v1.QueryBackendService.Invoke:input_type -> query.v1.InvokeRequest
-	4,  // 63: query.v1.QueryFrontendService.Query:output_type -> query.v1.QueryResponse
-	10, // 64: query.v1.QueryBackendService.Invoke:output_type -> query.v1.InvokeResponse
-	63, // [63:65] is the sub-list for method output_type
-	61, // [61:63] is the sub-list for method input_type
-	61, // [61:61] is the sub-list for extension type_name
-	61, // [61:61] is the sub-list for extension extendee
-	0,  // [0:61] is the sub-list for field type_name
+	38, // 48: query.v1.TreeReport.mapping_names:type_name -> query.v1.TreeReport.MappingNamesEntry
+	43, // 49: query.v1.PprofQuery.stack_trace_selector:type_name -> types.v1.StackTraceSelector
+	27, // 50: query.v1.PprofReport.query:type_name -> query.v1.PprofQuery
+	47, // 51: query.v1.HeatmapQuery.query_type:type_name -> querier.v1.HeatmapQueryType
+	41, // 52: query.v1.HeatmapQuery.exemplar_type:type_name -> types.v1.ExemplarType
+	31, // 53: query.v1.HeatmapSeries.points:type_name -> query.v1.HeatmapPoint
+	29, // 54: query.v1.HeatmapReport.query:type_name -> query.v1.HeatmapQuery
+	32, // 55: query.v1.HeatmapReport.heatmap_series:type_name -> query.v1.HeatmapSeries
+	30, // 56: query.v1.HeatmapReport.attribute_table:type_name -> query.v1.AttributeTable
+	34, // 57: query.v1.Point.exemplars:type_name -> query.v1.Exemplar
+	35, // 58: query.v1.Series.points:type_name -> query.v1.Point
+	22, // 59: query.v1.TimeSeriesCompactReport.query:type_name -> query.v1.TimeSeriesQuery
+	36, // 60: query.v1.TimeSeriesCompactReport.time_series:type_name -> query.v1.Series
+	30, // 61: query.v1.TimeSeriesCompactReport.attribute_table:type_name -> query.v1.AttributeTable
+	3,  // 62: query.v1.QueryFrontendService.Query:input_type -> query.v1.QueryRequest
+	6,  // 63: query.v1.QueryBackendService.Invoke:input_type -> query.v1.InvokeRequest
+	4,  // 64: query.v1.QueryFrontendService.Query:output_type -> query.v1.QueryResponse
+	10, // 65: query.v1.QueryBackendService.Invoke:output_type -> query.v1.InvokeResponse
+	64, // [64:66] is the sub-list for method output_type
+	62, // [62:64] is the sub-list for method input_type
+	62, // [62:62] is the sub-list for extension type_name
+	62, // [62:62] is the sub-list for extension extendee
+	0,  // [0:62] is the sub-list for field type_name
 }
 
 func init() { file_query_v1_query_proto_init() }
@@ -2846,7 +2860,7 @@ func file_query_v1_query_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_query_v1_query_proto_rawDesc), len(file_query_v1_query_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   35,
+			NumMessages:   36,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/api/gen/proto/go/query/v1/query_vtproto.pb.go
+++ b/api/gen/proto/go/query/v1/query_vtproto.pb.go
@@ -651,6 +651,13 @@ func (m *TreeReport) CloneVT() *TreeReport {
 		copy(tmpBytes, rhs)
 		r.Tree = tmpBytes
 	}
+	if rhs := m.MappingNames; rhs != nil {
+		tmpContainer := make(map[string]string, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.MappingNames = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -1870,6 +1877,18 @@ func (this *TreeReport) EqualVT(that *TreeReport) bool {
 	}
 	if !this.Symbols.EqualVT(that.Symbols) {
 		return false
+	}
+	if len(this.MappingNames) != len(that.MappingNames) {
+		return false
+	}
+	for i, vx := range this.MappingNames {
+		vy, ok := that.MappingNames[i]
+		if !ok {
+			return false
+		}
+		if vx != vy {
+			return false
+		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -4117,6 +4136,25 @@ func (m *TreeReport) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.MappingNames) > 0 {
+		for k := range m.MappingNames {
+			v := m.MappingNames[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x22
+		}
+	}
 	if m.Symbols != nil {
 		size, err := m.Symbols.MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
@@ -5525,6 +5563,14 @@ func (m *TreeReport) SizeVT() (n int) {
 	if m.Symbols != nil {
 		l = m.Symbols.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.MappingNames) > 0 {
+		for k, v := range m.MappingNames {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
+			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
 	}
 	n += len(m.unknownFields)
 	return n
@@ -9845,6 +9891,133 @@ func (m *TreeReport) UnmarshalVT(dAtA []byte) error {
 			if err := m.Symbols.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MappingNames", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.MappingNames == nil {
+				m.MappingNames = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.MappingNames[mapkey] = mapvalue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/api/querier/v1/querier.proto
+++ b/api/querier/v1/querier.proto
@@ -132,8 +132,9 @@ message SelectMergeStacktracesResponse {
   FlameGraph flamegraph = 1;
   // Pyroscope tree bytes.
   bytes tree = 2;
+  map<string, string> mapping = 3;
   // DOT graph representation.
-  string dot = 3;
+  string dot = 4;
 }
 
 message SelectMergeSpanProfileRequest {
@@ -160,6 +161,7 @@ message SelectMergeSpanProfileResponse {
   FlameGraph flamegraph = 1;
   // Pyroscope tree bytes.
   bytes tree = 2;
+  map<string, string> mapping = 3;
 }
 
 message DiffRequest {
@@ -176,6 +178,7 @@ message FlameGraph {
   repeated Level levels = 2;
   int64 total = 3;
   int64 max_self = 4;
+  repeated string mapping_names = 5;
 }
 
 message FlameGraphDiff {

--- a/api/query/v1/query.proto
+++ b/api/query/v1/query.proto
@@ -232,6 +232,7 @@ message TreeReport {
   TreeQuery query = 1;
   bytes tree = 2;
   optional TreeSymbols symbols = 3;
+  map<string, string> mapping_names = 4;
 }
 
 message PprofQuery {

--- a/pkg/frontend/frontend_diff.go
+++ b/pkg/frontend/frontend_diff.go
@@ -47,12 +47,12 @@ func (f *Frontend) Diff(
 	var left, right *phlaremodel.FunctionNameTree
 	g.Go(func() error {
 		var leftErr error
-		left, leftErr = f.selectMergeStacktracesTree(ctx, connect.NewRequest(c.Msg.Left))
+		left, _, leftErr = f.selectMergeStacktracesTree(ctx, connect.NewRequest(c.Msg.Left))
 		return leftErr
 	})
 	g.Go(func() error {
 		var rightErr error
-		right, rightErr = f.selectMergeStacktracesTree(ctx, connect.NewRequest(c.Msg.Right))
+		right, _, rightErr = f.selectMergeStacktracesTree(ctx, connect.NewRequest(c.Msg.Right))
 		return rightErr
 	})
 	if err = g.Wait(); err != nil {

--- a/pkg/frontend/frontend_diff_test.go
+++ b/pkg/frontend/frontend_diff_test.go
@@ -117,7 +117,7 @@ func Test_Frontend_Diff(t *testing.T) {
 				}
 
 				return connect.NewResponse(&querierv1.SelectMergeStacktracesResponse{
-					Flamegraph: model.NewFlameGraph(s, -1),
+					Flamegraph: model.NewFlameGraph(s, map[string]string{}, -1),
 				}), nil
 			})
 		}}

--- a/pkg/frontend/frontend_select_merge_span_profile.go
+++ b/pkg/frontend/frontend_select_merge_span_profile.go
@@ -48,6 +48,7 @@ func (f *Frontend) SelectMergeSpanProfile(
 	interval := validationutil.MaxDurationOrZeroPerTenant(tenantIDs, f.limits.QuerySplitDuration)
 	intervals := NewTimeIntervalIterator(time.UnixMilli(int64(validated.Start)), time.UnixMilli(int64(validated.End)), interval)
 
+    mapping := map[string]string{}
 	for intervals.Next() {
 		r := intervals.At()
 		g.Go(func() error {
@@ -66,6 +67,11 @@ func (f *Frontend) SelectMergeSpanProfile(
 			if err != nil {
 				return err
 			}
+            if resp.Msg.Mapping != nil {
+                for k, v := range resp.Msg.Mapping {
+                    mapping[k] = v
+                }
+            }
 			if len(resp.Msg.Tree) > 0 {
 				err = m.MergeTreeBytes(resp.Msg.Tree)
 			} else if resp.Msg.Flamegraph != nil {
@@ -84,9 +90,10 @@ func (f *Frontend) SelectMergeSpanProfile(
 	var resp querierv1.SelectMergeSpanProfileResponse
 	switch c.Msg.Format {
 	default:
-		resp.Flamegraph = phlaremodel.NewFlameGraph(t, c.Msg.GetMaxNodes())
+		resp.Flamegraph = phlaremodel.NewFlameGraph(t, mapping, c.Msg.GetMaxNodes())
 	case querierv1.ProfileFormat_PROFILE_FORMAT_TREE:
 		resp.Tree = t.Bytes(c.Msg.GetMaxNodes(), nil)
+		resp.Mapping = mapping
 	}
 	return connect.NewResponse(&resp), nil
 }

--- a/pkg/frontend/frontend_select_merge_stacktraces.go
+++ b/pkg/frontend/frontend_select_merge_stacktraces.go
@@ -25,16 +25,17 @@ func (f *Frontend) SelectMergeStacktraces(
 	if c.Msg.Format == querierv1.ProfileFormat_PROFILE_FORMAT_DOT {
 		return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dot format is only supported with the v2 query backend"))
 	}
-	t, err := f.selectMergeStacktracesTree(ctx, c)
+	t, mapping, err := f.selectMergeStacktracesTree(ctx, c)
 	if err != nil {
 		return nil, err
 	}
 	var resp querierv1.SelectMergeStacktracesResponse
 	switch c.Msg.Format {
 	default:
-		resp.Flamegraph = phlaremodel.NewFlameGraph(t, c.Msg.GetMaxNodes())
+		resp.Flamegraph = phlaremodel.NewFlameGraph(t, mapping, c.Msg.GetMaxNodes())
 	case querierv1.ProfileFormat_PROFILE_FORMAT_TREE:
 		resp.Tree = t.Bytes(c.Msg.GetMaxNodes(), nil)
+		resp.Mapping = mapping
 	}
 	return connect.NewResponse(&resp), nil
 }
@@ -42,23 +43,23 @@ func (f *Frontend) SelectMergeStacktraces(
 func (f *Frontend) selectMergeStacktracesTree(
 	ctx context.Context,
 	c *connect.Request[querierv1.SelectMergeStacktracesRequest],
-) (*phlaremodel.FunctionNameTree, error) {
+) (*phlaremodel.FunctionNameTree, map[string]string, error) {
 	ctx = connectgrpc.WithProcedure(ctx, querierv1connect.QuerierServiceSelectMergeStacktracesProcedure)
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		return nil, nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
 	validated, err := validation.ValidateRangeRequest(f.limits, tenantIDs, model.Interval{Start: model.Time(c.Msg.Start), End: model.Time(c.Msg.End)}, model.Now())
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		return nil, nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	if validated.IsEmpty {
-		return new(phlaremodel.FunctionNameTree), nil
+		return new(phlaremodel.FunctionNameTree), nil, nil
 	}
 	maxNodes, err := validation.ValidateMaxNodes(f.limits, tenantIDs, c.Msg.GetMaxNodes())
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		return nil, nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
 	g, ctx := errgroup.WithContext(ctx)
@@ -70,6 +71,7 @@ func (f *Frontend) selectMergeStacktracesTree(
 	interval := validationutil.MaxDurationOrZeroPerTenant(tenantIDs, f.limits.QuerySplitDuration)
 	intervals := NewTimeIntervalIterator(time.UnixMilli(int64(validated.Start)), time.UnixMilli(int64(validated.End)), interval)
 
+    mapping := map[string]string{}
 	for intervals.Next() {
 		r := intervals.At()
 		g.Go(func() error {
@@ -87,6 +89,11 @@ func (f *Frontend) selectMergeStacktracesTree(
 			if err != nil {
 				return err
 			}
+            if resp.Msg.Mapping != nil {
+                for k, v := range resp.Msg.Mapping {
+                    mapping[k] = v
+                }
+            }
 			if len(resp.Msg.Tree) > 0 {
 				err = m.MergeTreeBytes(resp.Msg.Tree)
 			} else if resp.Msg.Flamegraph != nil {
@@ -98,8 +105,8 @@ func (f *Frontend) selectMergeStacktracesTree(
 	}
 
 	if err = g.Wait(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-
-	return m.Tree(), nil
+    m.MergeMapping(mapping)
+	return m.Tree(), m.Mapping(), nil
 }

--- a/pkg/frontend/readpath/query_service_handler.go
+++ b/pkg/frontend/readpath/query_service_handler.go
@@ -78,13 +78,25 @@ func (r *Router) SelectMergeStacktraces(
 			if err := m.MergeTreeBytes(b.Tree); err != nil {
 				return nil, err
 			}
+            mapping := map[string]string{}
+            for k, v := range a.Mapping {
+                mapping[k] = v
+            }
+            for k, v := range b.Mapping {
+                mapping[k] = v
+            }
 			tree := m.Tree().Bytes(c.Msg.GetMaxNodes(), nil)
-			return &querierv1.SelectMergeStacktracesResponse{Tree: tree}, nil
+			return &querierv1.SelectMergeStacktracesResponse{
+			    Tree: tree,
+			    Mapping: mapping,
+			}, nil
 		},
 	)
+
 	if err == nil && f != c.Msg.Format {
 		resp.Msg.Flamegraph = phlaremodel.NewFlameGraph(
 			phlaremodel.MustUnmarshalTree[phlaremodel.FunctionName, phlaremodel.FunctionNameI](resp.Msg.Tree),
+			resp.Msg.Mapping,
 			c.Msg.GetMaxNodes())
 	}
 	return resp, err
@@ -108,13 +120,24 @@ func (r *Router) SelectMergeSpanProfile(
 			if err := m.MergeTreeBytes(b.Tree); err != nil {
 				return nil, err
 			}
-			tree := m.Tree().Bytes(c.Msg.GetMaxNodes(), nil)
-			return &querierv1.SelectMergeSpanProfileResponse{Tree: tree}, nil
+            mapping := map[string]string{}
+            for k, v := range a.Mapping {
+                mapping[k] = v
+            }
+            for k, v := range b.Mapping {
+                mapping[k] = v
+            }
+            tree := m.Tree().Bytes(c.Msg.GetMaxNodes(), nil)
+			return &querierv1.SelectMergeSpanProfileResponse{
+			    Tree: tree,
+			    Mapping: mapping,
+			}, nil
 		},
 	)
 	if err == nil && f != c.Msg.Format {
 		resp.Msg.Flamegraph = phlaremodel.NewFlameGraph(
 			phlaremodel.MustUnmarshalTree[phlaremodel.FunctionName, phlaremodel.FunctionNameI](resp.Msg.Tree),
+			resp.Msg.Mapping,
 			c.Msg.GetMaxNodes())
 	}
 	return resp, err

--- a/pkg/frontend/readpath/queryfrontend/query_diff.go
+++ b/pkg/frontend/readpath/queryfrontend/query_diff.go
@@ -54,12 +54,12 @@ func (q *QueryFrontend) Diff(
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
 		var leftErr error
-		left, leftErr = q.selectMergeStacktracesTree(ctx, connect.NewRequest(c.Msg.Left))
+		left, _, leftErr = q.selectMergeStacktracesTree(ctx, connect.NewRequest(c.Msg.Left))
 		return leftErr
 	})
 	g.Go(func() error {
 		var rightErr error
-		right, rightErr = q.selectMergeStacktracesTree(ctx, connect.NewRequest(c.Msg.Right))
+		right, _, rightErr = q.selectMergeStacktracesTree(ctx, connect.NewRequest(c.Msg.Right))
 		return rightErr
 	})
 	if err = g.Wait(); err != nil {

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_span_profile.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_span_profile.go
@@ -79,12 +79,13 @@ func (q *QueryFrontend) SelectMergeSpanProfile(
 	switch c.Msg.Format {
 	case querierv1.ProfileFormat_PROFILE_FORMAT_TREE:
 		resp.Tree = report.Tree.Tree
+		resp.Mapping = report.Tree.MappingNames
 	default:
 		t, err := phlaremodel.UnmarshalTree[phlaremodel.FunctionName, phlaremodel.FunctionNameI](report.Tree.Tree)
 		if err != nil {
 			return nil, err
 		}
-		resp.Flamegraph = phlaremodel.NewFlameGraph(t, c.Msg.GetMaxNodes())
+		resp.Flamegraph = phlaremodel.NewFlameGraph(t, report.Tree.MappingNames, c.Msg.GetMaxNodes())
 	}
 	return connect.NewResponse(&resp), nil
 }

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces.go
@@ -18,11 +18,12 @@ func (q *QueryFrontend) SelectMergeStacktraces(
 	ctx context.Context,
 	c *connect.Request[querierv1.SelectMergeStacktracesRequest],
 ) (*connect.Response[querierv1.SelectMergeStacktracesResponse], error) {
+
 	if c.Msg.Format == querierv1.ProfileFormat_PROFILE_FORMAT_DOT {
 		return q.selectMergeStacktracesDot(ctx, c)
 	}
 
-	b, err := q.selectMergeStacktracesTree(ctx, c)
+	b, mapping, err := q.selectMergeStacktracesTree(ctx, c)
 	if err != nil {
 		return nil, err
 	}
@@ -30,12 +31,13 @@ func (q *QueryFrontend) SelectMergeStacktraces(
 	switch c.Msg.Format {
 	case querierv1.ProfileFormat_PROFILE_FORMAT_TREE:
 		resp.Tree = b
+		resp.Mapping = mapping
 	default:
 		t, err := phlaremodel.UnmarshalTree[phlaremodel.FunctionName, phlaremodel.FunctionNameI](b)
 		if err != nil {
 			return nil, err
 		}
-		resp.Flamegraph = phlaremodel.NewFlameGraph(t, c.Msg.GetMaxNodes())
+		resp.Flamegraph = phlaremodel.NewFlameGraph(t, mapping, c.Msg.GetMaxNodes())
 	}
 	return connect.NewResponse(&resp), nil
 }
@@ -84,32 +86,32 @@ func (q *QueryFrontend) selectMergeStacktracesDot(
 func (q *QueryFrontend) selectMergeStacktracesTree(
 	ctx context.Context,
 	c *connect.Request[querierv1.SelectMergeStacktracesRequest],
-) (tree []byte, err error) {
+) (tree []byte, mapping map[string]string, err error) {
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		return nil, nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	empty, err := validation.SanitizeTimeRange(q.limits, tenantIDs, &c.Msg.Start, &c.Msg.End)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		return nil, nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	if empty {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	maxNodes, err := validation.ValidateMaxNodes(q.limits, tenantIDs, c.Msg.GetMaxNodes())
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		return nil, nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
 	_, err = phlaremodel.ParseProfileTypeSelector(c.Msg.ProfileTypeID)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		return nil, nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
 	labelSelector, err := buildLabelSelectorWithProfileType(c.Msg.LabelSelector, c.Msg.ProfileTypeID)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		return nil, nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	report, err := q.querySingle(ctx,
 		&queryv1.QueryRequest{
@@ -137,10 +139,10 @@ func (q *QueryFrontend) selectMergeStacktracesTree(
 		},
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if report == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
-	return report.Tree.Tree, nil
+	return report.Tree.Tree, report.Tree.MappingNames, nil
 }

--- a/pkg/ingester/otlp/convert.go
+++ b/pkg/ingester/otlp/convert.go
@@ -253,6 +253,18 @@ func (p *profileBuilder) convertLocationBack(ol *otelProfile.Location, dictionar
 		Line:      make([]*googleProfile.Line, len(ol.Lines)),
 	}
 
+    frameType, _ := getAttributeValueByKeyOrEmpty(ol.AttributeIndices, dictionary, "profile.frame.type")
+    if frameType == "kernel" {
+        fn := p.dst.StringTable[p.dst.Mapping[mappingId-1].Filename]
+        if !strings.HasPrefix(fn, "[kernel]") {
+            if fn == "" {
+                p.dst.Mapping[mappingId-1].Filename = p.addstr("[kernel]")
+            } else {
+                p.dst.Mapping[mappingId-1].Filename = p.addstr("[kernel] " + fn)
+            }
+        }
+    }
+
 	for i, line := range ol.Lines {
 		gl.Line[i], err = p.convertLineBack(line, dictionary)
 		if err != nil {

--- a/pkg/ingester/otlp/convert_test.go
+++ b/pkg/ingester/otlp/convert_test.go
@@ -1,0 +1,107 @@
+package otlp
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    v1 "go.opentelemetry.io/proto/otlp/common/v1"
+    v1experimental "go.opentelemetry.io/proto/otlp/profiles/v1development"
+)
+
+func TestConvertLocationBackKernelFrameType(t *testing.T) {
+    tests := []struct {
+        name             string
+        frameType        string
+        mappingFilename  string
+        expectedFilename string
+    }{
+        {
+            name:             "kernel frame type adds prefix",
+            frameType:        "kernel",
+            mappingFilename:  "/lib/modules/kernel.ko",
+            expectedFilename: "[kernel] /lib/modules/kernel.ko",
+        },
+        {
+            name:             "kernel prefix not duplicated",
+            frameType:        "kernel",
+            mappingFilename:  "[kernel] /lib/modules/kernel.ko",
+            expectedFilename: "[kernel] /lib/modules/kernel.ko",
+        },
+        {
+            name:             "non-kernel frame type unchanged",
+            frameType:        "native",
+            mappingFilename:  "/usr/bin/app",
+            expectedFilename: "/usr/bin/app",
+        },
+        {
+            name:             "no frame type unchanged",
+            frameType:        "",
+            mappingFilename:  "/usr/bin/app",
+            expectedFilename: "/usr/bin/app",
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            stringTable := []string{
+                "",
+                tt.mappingFilename,
+                "profile.frame.type",
+                tt.frameType,
+                "samples",
+                "count",
+            }
+
+            dictionary := &v1experimental.ProfilesDictionary{
+                StringTable: stringTable,
+                AttributeTable: []*v1experimental.KeyValueAndUnit{
+                    {KeyStrindex: 0},
+                    {
+                        KeyStrindex: 2,
+                        Value: &v1.AnyValue{
+                            Value: &v1.AnyValue_StringValue{
+                                StringValue: tt.frameType,
+                            },
+                        },
+                    },
+                },
+                MappingTable: []*v1experimental.Mapping{
+                    {FilenameStrindex: 0},
+                    {FilenameStrindex: 1},
+                },
+                LocationTable: []*v1experimental.Location{
+                    {},
+                    {
+                        MappingIndex:     1,
+                        AttributeIndices: []int32{1},
+                    },
+                },
+                FunctionTable: []*v1experimental.Function{},
+                StackTable:    []*v1experimental.Stack{},
+            }
+
+            src := &v1experimental.Profile{
+                SampleType: &v1experimental.ValueType{
+                    TypeStrindex: 4,
+                    UnitStrindex: 5,
+                },
+            }
+
+            p, err := newProfileBuilder(src, dictionary)
+            require.NoError(t, err)
+
+            om := dictionary.MappingTable[1]
+            ol := dictionary.LocationTable[1]
+            _, err = p.convertMappingBack([]*v1experimental.Location{ol}, om, dictionary)
+            require.NoError(t, err)
+
+            _, err = p.convertLocationBack(ol, dictionary)
+            require.NoError(t, err)
+
+            require.Len(t, p.dst.Mapping, 1)
+            actualFilename := p.dst.StringTable[p.dst.Mapping[0].Filename]
+            assert.Equal(t, tt.expectedFilename, actualFilename)
+        })
+    }
+}

--- a/pkg/model/flamegraph.go
+++ b/pkg/model/flamegraph.go
@@ -3,6 +3,7 @@ package model
 import (
 	"sort"
 	"sync"
+	"maps"
 
 	"github.com/samber/lo"
 
@@ -13,7 +14,7 @@ import (
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 )
 
-func NewFlameGraph(t *FunctionNameTree, maxNodes int64) *querierv1.FlameGraph {
+func NewFlameGraph(t *FunctionNameTree, nameToMapping map[string]string, maxNodes int64) *querierv1.FlameGraph {
 	var total, max int64
 	for _, node := range t.root {
 		total += node.total
@@ -112,12 +113,18 @@ func NewFlameGraph(t *FunctionNameTree, maxNodes int64) *querierv1.FlameGraph {
 		}
 	}
 
-	return &querierv1.FlameGraph{
-		Names:   names,
-		Levels:  levels,
-		Total:   total,
-		MaxSelf: max,
-	}
+	mappingNames := make([]string, len(names))
+    for i, name := range names {
+        mappingNames[i] = nameToMapping[name]
+    }
+
+    return &querierv1.FlameGraph{
+        Names:        names,
+        Levels:       levels,
+        Total:        total,
+        MaxSelf:      max,
+        MappingNames: mappingNames,
+    }
 }
 
 // ExportToFlamebearer exports the flamegraph to a Flamebearer struct.
@@ -179,10 +186,14 @@ func ExportDiffToFlamebearer(fg *querierv1.FlameGraphDiff, profileType *typesv1.
 type FlameGraphMerger struct {
 	mu sync.Mutex
 	t  *FunctionNameTree
+	mapping map[string]string
 }
 
 func NewFlameGraphMerger() *FlameGraphMerger {
-	return &FlameGraphMerger{t: new(FunctionNameTree)}
+	return &FlameGraphMerger{
+	    t: new(FunctionNameTree),
+	    mapping: make(map[string]string),
+	}
 }
 
 // MergeFlameGraph adds the flame graph stack traces to the resulting
@@ -214,6 +225,16 @@ func (m *FlameGraphMerger) MergeFlameGraph(src *querierv1.FlameGraph) {
 	}
 }
 
+func (m *FlameGraphMerger) MergeMapping(src map[string]string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.mapping = maps.Clone(src)
+}
+
+func (m *FlameGraphMerger) Mapping() map[string]string {
+	return m.mapping
+}
+
 func (m *FlameGraphMerger) MergeTreeBytes(src []byte) error {
 	t, err := UnmarshalTree[FunctionName, FunctionNameI](src)
 	if err != nil {
@@ -232,7 +253,7 @@ func (m *FlameGraphMerger) FlameGraph(maxNodes int64) *querierv1.FlameGraph {
 	if t == nil {
 		t = new(FunctionNameTree)
 	}
-	return NewFlameGraph(t, maxNodes)
+	return NewFlameGraph(t, nil, maxNodes)
 }
 
 func deltaDecoding(levels []*querierv1.Level, start, step int) {

--- a/pkg/model/flamegraph_test.go
+++ b/pkg/model/flamegraph_test.go
@@ -12,6 +12,10 @@ import (
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 )
 
+func emptyMapping() map[string]string {
+    return map[string]string{}
+}
+
 func Test_ExportToFlamebearer(t *testing.T) {
 	pType := &typesv1.ProfileType{
 		ID:         "memory:inuse_space:bytes:space:bytes",
@@ -59,6 +63,7 @@ func Test_ExportToFlamebearer(t *testing.T) {
 					value:     1,
 				},
 			}),
+            emptyMapping(),
 			-1,
 		), pType)
 	require.Equal(t, expected, actual)
@@ -95,7 +100,7 @@ func BenchmarkFlamegraph(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		f = NewFlameGraph(tr, -1)
+		f = NewFlameGraph(tr, emptyMapping(), -1)
 	}
 }
 
@@ -108,7 +113,7 @@ func Test_FlameGraphMerger(t *testing.T) {
 		s.InsertStack(2, "foo", "qux")
 		s.InsertStack(1, "fred", "zoo")
 		s.InsertStack(1, "fred", "other")
-		m.MergeFlameGraph(NewFlameGraph(s, -1))
+		m.MergeFlameGraph(NewFlameGraph(s, emptyMapping(), -1))
 
 		s = new(FunctionNameTree)
 		s.InsertStack(1, "foo", "bar", "baz")
@@ -117,7 +122,7 @@ func Test_FlameGraphMerger(t *testing.T) {
 		s.InsertStack(1, "func", "other")
 		s.InsertStack(1, "func")
 		s.InsertStack(1, "other")
-		m.MergeFlameGraph(NewFlameGraph(s, -1))
+		m.MergeFlameGraph(NewFlameGraph(s, emptyMapping(), -1))
 
 		expected := new(FunctionNameTree)
 		expected.InsertStack(1, "foo", "bar")
@@ -143,7 +148,7 @@ func Test_FlameGraphMerger(t *testing.T) {
 		s.InsertStack(2, "foo", "qux")
 		s.InsertStack(1, "fred", "zoo")
 		s.InsertStack(1, "fred", "other")
-		m.MergeFlameGraph(NewFlameGraph(s, -1))
+		m.MergeFlameGraph(NewFlameGraph(s, emptyMapping(), -1))
 
 		fg := m.FlameGraph(4)
 		m = NewFlameGraphMerger()
@@ -160,7 +165,7 @@ func Test_FlameGraphMerger(t *testing.T) {
 
 	t.Run("empty flamegraph", func(t *testing.T) {
 		m := NewFlameGraphMerger()
-		m.MergeFlameGraph(NewFlameGraph(new(FunctionNameTree), -1))
+		m.MergeFlameGraph(NewFlameGraph(new(FunctionNameTree), emptyMapping(), -1))
 		require.Equal(t, new(FunctionNameTree).String(), m.Tree().String())
 	})
 
@@ -168,4 +173,71 @@ func Test_FlameGraphMerger(t *testing.T) {
 		m := NewFlameGraphMerger()
 		require.Equal(t, new(FunctionNameTree).String(), m.Tree().String())
 	})
+}
+
+func Test_NewFlameGraph_Mappings(t *testing.T) {
+    t.Run("mappings are correctly assigned to names", func(t *testing.T) {
+        s := new(FunctionNameTree)
+        s.InsertStack(1, "foo", "bar")
+        s.InsertStack(1, "foo", "baz")
+
+        nameToMapping := map[string]string{
+            "foo": "foo_file",
+            "bar": "bar_file",
+            "baz": "baz_file",
+        }
+
+        fg := NewFlameGraph(s, nameToMapping, -1)
+
+        require.Equal(t, len(fg.Names), len(fg.MappingNames))
+        for i, name := range fg.Names {
+            if name == "total" {
+                require.Equal(t, "", fg.MappingNames[i])
+                continue
+            }
+            require.Equal(t, nameToMapping[name], fg.MappingNames[i])
+        }
+    })
+
+    t.Run("empty mapping returns empty strings", func(t *testing.T) {
+        s := new(FunctionNameTree)
+        s.InsertStack(1, "foo", "bar")
+
+        fg := NewFlameGraph(s, emptyMapping(), -1)
+
+        require.Equal(t, len(fg.Names), len(fg.MappingNames))
+        for _, m := range fg.MappingNames {
+            require.Equal(t, "", m)
+        }
+    })
+
+    t.Run("partial mapping leaves missing names as empty string", func(t *testing.T) {
+        s := new(FunctionNameTree)
+        s.InsertStack(1, "foo", "bar")
+
+        nameToMapping := map[string]string{
+            "foo": "foo_file",
+        }
+
+        fg := NewFlameGraph(s, nameToMapping, -1)
+
+        require.Equal(t, len(fg.Names), len(fg.MappingNames))
+        for i, name := range fg.Names {
+            if name == "bar" {
+                require.Equal(t, "", fg.MappingNames[i])
+            }
+        }
+    })
+}
+
+func Test_FlameGraphMerger_Mapping(t *testing.T) {
+    t.Run("merge mapping stores values", func(t *testing.T) {
+        m := NewFlameGraphMerger()
+        src := map[string]string{
+            "foo": "foo_file",
+            "bar": "bar_file",
+        }
+        m.MergeMapping(src)
+        require.Equal(t, src, m.Mapping())
+    })
 }

--- a/pkg/og/structs/flamebearer/convert/convert.go
+++ b/pkg/og/structs/flamebearer/convert/convert.go
@@ -289,7 +289,25 @@ func PprofToProfile(b []byte, name string, limits Limits) ([]*flamebearer.Flameb
 		for i, s := range p.StringTable {
 			names[i] = model.FunctionName(s)
 		}
-		fg := model.NewFlameGraph(t.Tree(int64(limits.MaxNodes), names), int64(limits.MaxNodes))
+
+        nameToMapping := map[string]string{}
+        for _, loc := range p.Location {
+            if loc.MappingId == 0 || int(loc.MappingId-1) >= len(p.Mapping) {
+                continue
+            }
+            mapping := p.Mapping[loc.MappingId-1]
+            mappingFilename := p.StringTable[mapping.Filename]
+            for _, line := range loc.Line {
+                if line.FunctionId == 0 || int(line.FunctionId-1) >= len(p.Function) {
+                    continue
+                }
+                funcNameIdx := p.Function[line.FunctionId-1].Name
+                funcName := p.StringTable[funcNameIdx]
+                nameToMapping[funcName] = mappingFilename
+            }
+        }
+
+		fg := model.NewFlameGraph(t.Tree(int64(limits.MaxNodes), names), nameToMapping, int64(limits.MaxNodes))
 		fbs = append(fbs, model.ExportToFlamebearer(fg, tp))
 	}
 	if len(fbs) == 0 {

--- a/pkg/phlaredb/symdb/resolver.go
+++ b/pkg/phlaredb/symdb/resolver.go
@@ -299,6 +299,41 @@ func (r *Resolver) Tree() (*model.FunctionNameTree, error) {
 	return tree, err
 }
 
+func (r *Resolver) TreeWithMappings() (*model.FunctionNameTree, map[string]string, error) {
+    span, ctx := tracing.StartSpanFromContext(r.ctx, "Resolver.TreeWithMappings")
+    defer span.Finish()
+    var lock sync.Mutex
+
+    tree := new(model.FunctionNameTree)
+    nameToMapping := map[string]string{}
+
+    err := r.withSymbols(ctx, func(symbols *Symbols, appender *SampleAppender) error {
+        for _, loc := range symbols.Locations {
+            if loc.MappingId >= uint32(len(symbols.Mappings)) {
+                continue
+            }
+            mappingFilename := symbols.Strings[symbols.Mappings[loc.MappingId].Filename]
+            for _, line := range loc.Line {
+                funcName := symbols.Strings[symbols.Functions[line.FunctionId].Name]
+                nameToMapping[funcName] = mappingFilename
+            }
+        }
+
+        lookup := func(i int32) model.FunctionName {
+            return model.FunctionName(symbols.Strings[i])
+        }
+        resolved, err := symbols.Tree(ctx, appender, r.maxNodes, SelectStackTraces(symbols, r.sts), lookup)
+        if err != nil {
+            return err
+        }
+        lock.Lock()
+        tree.Merge(resolved)
+        lock.Unlock()
+        return nil
+    })
+    return tree, nameToMapping, err
+}
+
 func (r *Resolver) Pprof() (*googlev1.Profile, error) {
 	span, ctx := tracing.StartSpanFromContext(r.ctx, "Resolver.Pprof")
 	defer span.Finish()

--- a/pkg/phlaredb/symdb/resolver_test.go
+++ b/pkg/phlaredb/symdb/resolver_test.go
@@ -78,6 +78,46 @@ func Test_Resolver_Cancellation(t *testing.T) {
 	wg.Wait()
 }
 
+func Test_Resolver_TreeWithMappings(t *testing.T) {
+    s := newBlockSuite(t, [][]string{{"testdata/profile.pb.gz"}})
+    defer s.teardown()
+
+    r := NewResolver(context.Background(), s.reader)
+    r.AddSamples(0, s.indexed[0][0].Samples)
+    tree, mappings, err := r.TreeWithMappings()
+    r.Release()
+
+    require.NoError(t, err)
+    require.NotNil(t, tree)
+    require.NotNil(t, mappings)
+}
+
+func Test_Resolver_TreeWithMappings_Error_Propagation(t *testing.T) {
+    s := newBlockSuite(t, [][]string{{"testdata/profile.pb.gz"}})
+    defer s.teardown()
+    ctx, cancel := context.WithCancel(context.Background())
+    cancel()
+
+    r := NewResolver(ctx, s.reader)
+    r.AddSamples(0, s.indexed[0][0].Samples)
+    _, _, err := r.TreeWithMappings()
+    r.Release()
+
+    require.ErrorIs(t, err, context.Canceled)
+}
+
+func Test_Resolver_TreeWithMappings_Cancellation(t *testing.T) {
+    m := new(mockSymbolsReader)
+    m.On("Partition", mock.Anything, mock.Anything).Return(nil, io.EOF).Once()
+
+    r := NewResolver(context.Background(), m)
+    r.AddSamples(0, schemav1.Samples{})
+    _, _, err := r.TreeWithMappings()
+    r.Release()
+
+    require.ErrorIs(t, err, io.EOF)
+}
+
 type mockSymbolsReader struct{ mock.Mock }
 
 func (m *mockSymbolsReader) Partition(ctx context.Context, partition uint64) (PartitionReader, error) {

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -640,6 +640,41 @@ func (q *Querier) GetProfileStats(ctx context.Context, req *connect.Request[type
 	return connect.NewResponse(response), nil
 }
 
+func buildMappingFromProfile(p *googlev1.Profile) map[string]string {
+    nameToMapping := map[string]string{}
+    if p == nil {
+        return nameToMapping
+    }
+    for _, loc := range p.Location {
+        if loc.MappingId == 0 || int(loc.MappingId-1) >= len(p.Mapping) {
+            continue
+        }
+        mappingFilename := p.StringTable[p.Mapping[loc.MappingId-1].Filename]
+        for _, line := range loc.Line {
+            if line.FunctionId == 0 || int(line.FunctionId-1) >= len(p.Function) {
+                continue
+            }
+            funcName := p.StringTable[p.Function[line.FunctionId-1].Name]
+            nameToMapping[funcName] = mappingFilename
+        }
+    }
+    return nameToMapping
+}
+
+func (q *Querier) buildMappingFromPprof(ctx context.Context, profileTypeID, labelSelector string, start, end int64, maxNodes *int64) (map[string]string, error) {
+    p, err := q.selectProfile(ctx, &querierv1.SelectMergeProfileRequest{
+        ProfileTypeID: profileTypeID,
+        LabelSelector: labelSelector,
+        Start:         start,
+        End:           end,
+        MaxNodes:      maxNodes,
+    })
+    if err != nil {
+        return nil, err
+    }
+    return buildMappingFromProfile(p), nil
+}
+
 func (q *Querier) SelectMergeStacktraces(ctx context.Context, req *connect.Request[querierv1.SelectMergeStacktracesRequest]) (*connect.Response[querierv1.SelectMergeStacktracesResponse], error) {
 	sp, ctx := tracing.StartSpanFromContext(ctx, "SelectMergeStacktraces")
 	level.Info(spanlogger.FromContext(ctx, q.logger)).Log(
@@ -670,12 +705,26 @@ func (q *Querier) SelectMergeStacktraces(ctx context.Context, req *connect.Reque
 		return nil, err
 	}
 
+    nameToMapping, err := q.buildMappingFromPprof(
+        ctx,
+        req.Msg.ProfileTypeID,
+        req.Msg.LabelSelector,
+        req.Msg.Start,
+        req.Msg.End,
+        req.Msg.MaxNodes,
+    )
+    if err != nil {
+        level.Warn(q.logger).Log("msg", "failed to get mapping names", "err", err)
+        nameToMapping = nil
+    }
+
 	var resp querierv1.SelectMergeStacktracesResponse
 	switch req.Msg.Format {
 	default:
-		resp.Flamegraph = phlaremodel.NewFlameGraph(t, req.Msg.GetMaxNodes())
+		resp.Flamegraph = phlaremodel.NewFlameGraph(t, nameToMapping, req.Msg.GetMaxNodes())
 	case querierv1.ProfileFormat_PROFILE_FORMAT_TREE:
 		resp.Tree = t.Bytes(req.Msg.GetMaxNodes(), nil)
+		resp.Mapping = nameToMapping
 	}
 	return connect.NewResponse(&resp), nil
 }
@@ -702,13 +751,27 @@ func (q *Querier) SelectMergeSpanProfile(ctx context.Context, req *connect.Reque
 		return nil, err
 	}
 
+    nameToMapping, err := q.buildMappingFromPprof(
+        ctx,
+        req.Msg.ProfileTypeID,
+        req.Msg.LabelSelector,
+        req.Msg.Start,
+        req.Msg.End,
+        req.Msg.MaxNodes,
+    )
+    if err != nil {
+        level.Warn(q.logger).Log("msg", "failed to get mapping names", "err", err)
+        nameToMapping = nil
+    }
+
 	var resp querierv1.SelectMergeSpanProfileResponse
 	switch req.Msg.Format {
 	default:
-		resp.Flamegraph = phlaremodel.NewFlameGraph(t, req.Msg.GetMaxNodes())
+		resp.Flamegraph = phlaremodel.NewFlameGraph(t, nameToMapping, req.Msg.GetMaxNodes())
 	case querierv1.ProfileFormat_PROFILE_FORMAT_TREE:
 		resp.Tree = t.Bytes(req.Msg.GetMaxNodes(), nil)
-	}
+		resp.Mapping = nameToMapping
+    }
 	return connect.NewResponse(&resp), nil
 }
 

--- a/pkg/querybackend/query_tree.go
+++ b/pkg/querybackend/query_tree.go
@@ -123,7 +123,7 @@ func queryTree(q *queryContext, query *queryv1.Query) (*queryv1.Report, error) {
 		return resp, nil
 	}
 
-	tree, err := resolver.Tree()
+	tree, nameToMapping, err := resolver.TreeWithMappings()
 	if err != nil {
 		return nil, err
 	}
@@ -132,6 +132,7 @@ func queryTree(q *queryContext, query *queryv1.Query) (*queryv1.Report, error) {
 		Tree: &queryv1.TreeReport{
 			Query: query.Tree.CloneVT(),
 			Tree:  tree.Bytes(query.Tree.GetMaxNodes(), nil),
+			MappingNames: nameToMapping,
 		},
 	}
 	return resp, nil
@@ -141,6 +142,9 @@ type treeAggregator struct {
 	init  sync.Once
 	query *queryv1.TreeQuery
 	tree  *model.TreeMerger[model.FunctionName, model.FunctionNameI]
+
+	mappingLock  sync.Mutex
+    mappingNames map[string]string
 
 	lrTree       *model.TreeMerger[model.LocationRefName, model.LocationRefNameI]
 	symbolLock   sync.Mutex
@@ -166,6 +170,15 @@ func (a *treeAggregator) aggregate(report *queryv1.Report) error {
 		return a.lrTree.MergeTreeBytes(r.Tree, model.WithTreeMergeFormatNodeNames(adder))
 	}
 
+    a.mappingLock.Lock()
+    if a.mappingNames == nil {
+        a.mappingNames = make(map[string]string)
+    }
+    for k, v := range r.MappingNames {
+        a.mappingNames[k] = v
+    }
+    a.mappingLock.Unlock()
+
 	a.init.Do(func() {
 		a.tree = model.NewTreeMerger[model.FunctionName, model.FunctionNameI]()
 		a.query = r.Query.CloneVT()
@@ -189,5 +202,6 @@ func (a *treeAggregator) build() *queryv1.Report {
 	}
 
 	result.Tree.Tree = a.tree.Tree().Bytes(a.query.GetMaxNodes(), nil)
+	result.Tree.MappingNames = a.mappingNames
 	return result
 }


### PR DESCRIPTION
## Summary

Adds filename/mapping information to the Flamegraph response, enabling Grafana to apply custom coloring schemes based on kernel/user space symbols. The mapping data exposes the executable for each symbol, allowing Grafana to identify which binary or library a frame belongs to.

## Changes

**Proto changes:**
- Add `mapping_names` field (`[]string`) to `FlameGraph` and `TreeReport` proto messages
- Add `mapping` field (`map<function_name, filename>`) to `SelectMergeStacktracesResponse` and `SelectMergeSpanProfileResponse` proto messages

**Resolver:**
- Add `TreeWithMappings()` method to `Resolver` that builds a `function name -> filename` mapping from symbol data

**FlameGraph construction:**
- Populate `mapping_names` in `NewFlameGraph()` using the mapping built above
- Propagate mapping through the query path: `queryTree` -> `TreeReport` -> `SelectMergeStacktracesResponse` / `SelectMergeSpanProfileResponse`

**pprof / OTLP:**
- Add `buildMappingFromPprof()` and `buildMappingFromProfile()` helpers to extract mapping from pprof profiles (`pprof` -> `profile` -> `mapping`)
- Use `frameType` to distinguish user vs. kernel space symbols when converting OTLP to Google profile format
- Add `[kernel]` prefix to kernel symbol mapping filenames during OTLP conversion, so that Grafana can correctly classify and color kernel frames

**Tests:**
- Add unit tests covering the new mapping logic

Related PR: [grafana/grafana#125627](https://github.com/grafana/grafana/pull/125627)