### PR TITLE
fix(ci): run helm HTTPRoute e2e only in its workflow

### DIFF
--- a/.github/workflows/helm-integration-httproute.yml
+++ b/.github/workflows/helm-integration-httproute.yml
@@ -42,4 +42,4 @@ jobs:
         run: kubectl version --client
 
       - name: Run HTTPRoute integration tests
-        run: go test ./operations/pyroscope/helm/pyroscope/e2e/... -v -timeout 60m
+        run: go test -tags=helm_integration ./operations/pyroscope/helm/pyroscope/e2e/... -v -timeout 60m

--- a/operations/pyroscope/helm/pyroscope/e2e/httproute_test.go
+++ b/operations/pyroscope/helm/pyroscope/e2e/httproute_test.go
@@ -1,3 +1,5 @@
+//go:build helm_integration
+
 package e2e
 
 import (

--- a/operations/pyroscope/helm/pyroscope/e2e/main_test.go
+++ b/operations/pyroscope/helm/pyroscope/e2e/main_test.go
@@ -1,3 +1,5 @@
+//go:build helm_integration
+
 package e2e
 
 import (


### PR DESCRIPTION
Follow up to https://github.com/grafana/pyroscope/pull/5039, these tests weren't meant to be run as part of ci/*

Sorry about the flakes this caused.
