### PR TITLE
[backport/weekly/f172] ci: publish docker images via GAR + gar-image-mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,8 +163,12 @@ jobs:
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version: 1.25.10
-      - name: Login to DockerHub (from vault)
-        uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+      - name: Log into GAR
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+        with:
+          registry: us-docker.pkg.dev
       - name: Pyroscope Build & push multi-arch image
         id: build-push
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,12 @@ jobs:
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - name: Login to DockerHub (from vault)
-        uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+      - name: Log into GAR
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+        with:
+          registry: us-docker.pkg.dev
       - id: get-github-app-token
         uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
         with:

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -46,8 +46,12 @@ jobs:
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
-      - name: Login to DockerHub (from vault)
-        uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+      - name: Log into GAR
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+        with:
+          registry: us-docker.pkg.dev
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,8 +7,9 @@ before:
 env:
   # Strip debug information from the binary by default, weekly builds will have debug information
   - GORELEASER_DEBUG_INFO_FLAGS={{ if and (index .Env "GORELEASER_STRIP_DEBUG_INFO") (eq .Env.GORELEASER_STRIP_DEBUG_INFO "false")  }}{{ else }}-s -w{{ end }}
-  # Use a custom image prefix (registry) or fallback to docker.io/grafana/
-  - IMAGE_PREFIX={{ or (index .Env "IMAGE_PREFIX") "docker.io/grafana/" }}
+  # Use a custom image prefix (registry) or fallback to the GAR mirror staging repo.
+  # The gar-image-mirror service copies images from there to docker.io/grafana/pyroscope.
+  - IMAGE_PREFIX={{ or (index .Env "IMAGE_PREFIX") "us-docker.pkg.dev/grafanalabs-global/dockerhub-pyroscope-prod-mirror/" }}
   # Allow a custom image tag to be used (must be set by workflow)
   - IMAGE_TAG={{ .Env.IMAGE_TAG }}
   # Publish latest image tag
@@ -232,7 +233,7 @@ release:
     - [grafana/pyroscope](https://hub.docker.com/r/grafana/pyroscope/tags)
 
     ```bash
-      docker pull {{ .Env.IMAGE_PREFIX }}{{ .ProjectName }}:{{ .Env.IMAGE_TAG }}
+      docker pull grafana/{{ .ProjectName }}:{{ .Env.IMAGE_TAG }}
     ```
 
   ids:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GOPRIVATE=github.com/grafana/frostdb
 
 # Boiler plate for building Docker containers.
 # All this must go at top of file I'm afraid.
-IMAGE_PREFIX ?= docker.io/grafana/
+IMAGE_PREFIX ?= us-docker.pkg.dev/grafanalabs-global/dockerhub-pyroscope-prod-mirror/
 
 IMAGE_TAG ?= $(shell ./tools/image-tag)
 GIT_REVISION := $(shell git rev-parse --short HEAD)


### PR DESCRIPTION
Backport of #5193 onto weekly/f172.

Required so weekly publishes use login-to-gar instead of the disabled dockerhub-login. Depends on grafana/deployment_tools#596772 (WIF exclusion) being merged + applied first.