### PR TITLE
fix: close files properly in extractZip and extractTarGz

### DIFF
--- a/pkg/embedded/grafana/assets.go
+++ b/pkg/embedded/grafana/assets.go
@@ -201,22 +201,44 @@ func extractZip(zipStream io.ReaderAt, size int64, destPath string, stripCompone
 			}
 		}
 
-		fileInArchive, err := f.Open()
-		if err != nil {
-			return fmt.Errorf("ExtractZip: Open() failed: %s", err.Error())
-		}
-
-		outFile, err := os.OpenFile(p, os.O_RDWR|os.O_CREATE|os.O_TRUNC, f.FileInfo().Mode())
-		if err != nil {
-			return fmt.Errorf("ExtractZip: OpenFile() failed: %s", err.Error())
-		}
-		if _, err := io.Copy(outFile, fileInArchive); err != nil {
-			return fmt.Errorf("ExtractZip: Copy() failed: %s", err.Error())
+		if err := extractZipFile(f, p); err != nil {
+			return fmt.Errorf("ExtractZip: %w", err)
 		}
 	}
 
 	return nil
 
+}
+
+func extractTarGzFile(p string, src io.Reader, mode fs.FileMode) error {
+	outFile, err := os.OpenFile(p, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("OpenFile() failed: %s", err.Error())
+	}
+	defer outFile.Close()
+	if _, err := io.Copy(outFile, src); err != nil {
+		return fmt.Errorf("Copy() failed: %s", err.Error())
+	}
+	return nil
+}
+
+func extractZipFile(f *zip.File, p string) error {
+	fileInArchive, err := f.Open()
+	if err != nil {
+		return fmt.Errorf("Open() failed: %s", err.Error())
+	}
+	defer fileInArchive.Close()
+
+	outFile, err := os.OpenFile(p, os.O_RDWR|os.O_CREATE|os.O_TRUNC, f.FileInfo().Mode())
+	if err != nil {
+		return fmt.Errorf("OpenFile() failed: %s", err.Error())
+	}
+	defer outFile.Close()
+
+	if _, err := io.Copy(outFile, fileInArchive); err != nil {
+		return fmt.Errorf("Copy() failed: %s", err.Error())
+	}
+	return nil
 }
 
 func extractTarGz(gzipStream io.Reader, destPath string, stripComponents int) error {
@@ -254,14 +276,9 @@ func extractTarGz(gzipStream io.Reader, destPath string, stripComponents int) er
 					return fmt.Errorf("ExtractTarGz: MkdirAll() failed: %s", err.Error())
 				}
 			}
-			outFile, err := os.OpenFile(p, os.O_RDWR|os.O_CREATE|os.O_TRUNC, fs.FileMode(header.Mode))
-			if err != nil {
-				return fmt.Errorf("ExtractTarGz: OpenFile() failed: %s", err.Error())
+			if err := extractTarGzFile(p, tarReader, fs.FileMode(header.Mode)); err != nil {
+				return fmt.Errorf("ExtractTarGz: %w", err)
 			}
-			if _, err := io.Copy(outFile, tarReader); err != nil {
-				return fmt.Errorf("ExtractTarGz: Copy() failed: %s", err.Error())
-			}
-			outFile.Close()
 
 		default:
 			return fmt.Errorf(


### PR DESCRIPTION
## Summary

extractZip and extractTarGz in pkg/embedded/grafana/assets.go leak file descriptors every time grafana assets are extracted.

In extractZip, both fileInArchive (the zip entry reader) and outFile are opened but never get closed on any code path. In extractTarGz, outFile has an explicit Close() on the happy path but if io.Copy fails the fd is just... gone.

The fix pulls the open/copy/close logic into small helper fns so defer handles cleanup properly on all paths.

## How to reproduce

Run pyroscope with `--target all,embedded-grafana` on a fresh setup and lsof/strace the pid while grafana assets are being extracted. You'll see unclosed fds piling up for each file in the archive. A typical grafana release has a few hundred files, so this ain't trivial.

You can also just read the code: extractZip opens fileInArchive and outFile in a loop with no defer and no explicit Close anywhere.

Related: #5195 touched this same file and code path.