### PR TITLE
chore(examples): move TypeScript to devDependencies

### DIFF
--- a/examples/language-sdk-instrumentation/nodejs/express-ts-inline/package.json
+++ b/examples/language-sdk-instrumentation/nodejs/express-ts-inline/package.json
@@ -16,12 +16,12 @@
     "@pyroscope/nodejs": "v0.4.11",
     "axios": "^1.15.2",
     "express": "^4.20.0",
-    "morgan": "^1.10.0",
-    "typescript": "^4.6.2"
+    "morgan": "^1.10.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
-    "@types/morgan": "^1.9.3"
+    "@types/morgan": "^1.9.3",
+    "typescript": "^4.6.2"
   },
   "resolutions": {
     "protobufjs": "^7.5.8",

--- a/examples/language-sdk-instrumentation/nodejs/express-ts/package.json
+++ b/examples/language-sdk-instrumentation/nodejs/express-ts/package.json
@@ -16,12 +16,12 @@
     "@pyroscope/nodejs": "v0.4.11",
     "axios": "^1.15.0",
     "express": "^4.19.2",
-    "morgan": "^1.10.0",
-    "typescript": "^4.6.2"
+    "morgan": "^1.10.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
-    "@types/morgan": "^1.9.3"
+    "@types/morgan": "^1.9.3",
+    "typescript": "^4.6.2"
   },
   "resolutions": {
     "protobufjs": "^7.5.5",


### PR DESCRIPTION
## Summary

Moves `typescript` from runtime `dependencies` to `devDependencies` in the TypeScript Node.js example packages.

This is a canary remediation for the `dependency-reduction.node-tooling-in-prod-dependencies` finding from the draft security-hardening skill. The Dockerfiles run a full `yarn` install before `yarn build`, so TypeScript remains available for the example build while no longer being declared as a runtime dependency.

## Validation

- `security_hardening.py detect --repo . --repo-name grafana/pyroscope --modules dependency-reduction --jsonl /tmp/pyroscope-dependency-reduction.jsonl`