### PR TITLE
fix: nil dereference in embedded grafana download + drop deprecated ioutil

### DIFF
--- a/pkg/embedded/grafana/assets.go
+++ b/pkg/embedded/grafana/assets.go
@@ -77,10 +77,10 @@ func (release *releaseArtifact) download(ctx context.Context, logger log.Logger,
 
 	level.Info(logger).Log("msg", "download new release", "url", release.URL)
 	req, err := http.NewRequestWithContext(ctx, "GET", release.URL, nil)
-	req.Header.Set("User-Agent", "pyroscope/embedded-grafana")
 	if err != nil {
 		return "", err
 	}
+	req.Header.Set("User-Agent", "pyroscope/embedded-grafana")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/pkg/util/copy.go
+++ b/pkg/util/copy.go
@@ -32,7 +32,6 @@ package util
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -108,7 +107,7 @@ func CopyDir(src string, dst string) (err error) {
 		return
 	}
 
-	entries, err := ioutil.ReadDir(src)
+	entries, err := os.ReadDir(src)
 	if err != nil {
 		return
 	}
@@ -124,7 +123,7 @@ func CopyDir(src string, dst string) (err error) {
 			}
 		} else {
 			// Skip symlinks.
-			if entry.Mode()&os.ModeSymlink != 0 {
+			if entry.Type()&os.ModeSymlink != 0 {
 				continue
 			}
 


### PR DESCRIPTION
Two small fixes in unrelated files, both pretty straightforward.

`pkg/embedded/grafana/assets.go` - nil deref in download

`req.Header.Set(...)` was called before checking the error from `http.NewRequestWithContext`. If the URL fails to parse, `req` is nil and the call panics instead of returning a clean error.

Reproduce:
```go
req, err := http.NewRequestWithContext(ctx, "GET", "://bad-url", nil)
req.Header.Set("User-Agent", "test") // panics here, req is nil
if err != nil { ... }
```

Every other `NewRequestWithContext` callsite in the codebase checks `err` first - this one slipped thru. Fix swaps the two lines.

`pkg/util/copy.go` - deprecated ioutil

`ioutil.ReadDir` has been deprecated since Go 1.16, replaced by `os.ReadDir`. Updated the call and switched `entry.Mode()` to `entry.Type()` since `os.DirEntry` exposes type bits via `Type()`.