### PR TITLE
chore(ci): bump stale action pins in weekly-release.yml

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -37,15 +37,15 @@ jobs:
         run: |
           git tag "$GORELEASER_CURRENT_TAG"
           git tag "$IMAGE_TAG"
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version: "1.25.10"
           cache: false
       # setup docker buildx
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
       - name: Log into GAR


### PR DESCRIPTION
## What

Bumps three GitHub Actions in `weekly-release.yml` that had drifted behind the rest of the repo:

| Action | Before | After |
| --- | --- | --- |
| `docker/setup-qemu-action` | `2b82ce8` (v2, 2023-06-07) | `c7c5346` (v3.7.0, 2025-11-05) |
| `docker/setup-buildx-action` | `885d146` (v2, 2023-08-28) | `8d2750c` (v3.12.0, 2025-12-16) |
| `actions/setup-go` | `40f1582` (v5) | `7a3fe6c` (v6.2.0) |

## Why

`ci.yml` and `release.yml` already use these newer pins; `weekly-release.yml` was left on ~2.5-year-old v2 docker actions. This aligns it with the other release/CI workflows. No functional behavior change expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)