### PR TITLE
chore(ci): bump goreleaser/goreleaser-action to v7.2.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           github_app: grafana-pyroscope-bot
       - run: make frontend/build
-      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+      - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           # ensure this aligns with the version specified in the /Makefile
           version: v2.13.2

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -57,7 +57,7 @@ jobs:
           node-version: 20
           package-manager-cache: false
       - run: make frontend/build
-      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
+      - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           # ensure this aligns with the version specified in the /Makefile
           version: v2.13.2


### PR DESCRIPTION
## What

Bumps `goreleaser/goreleaser-action` from v6.4.0 (`e435ccd`, Aug 2025) to **v7.2.2** (`5daf1e9`, 2026-05-19) in both `release.yml` and `weekly-release.yml`.

## Why it's safe despite being a major bump

The v6→v7 break is **internal to the action's own runtime** (Node 24, ESM, dropped yarn — goreleaser/goreleaser-action#533). It does **not** change the GoReleaser binary that runs:

- We pin the GoReleaser binary explicitly (`version: v2.13.2`), so v7's changed default (`~> v2`) is irrelevant.
- The only inputs we use — `version` and `args` — are unchanged in v7.2.2 (verified against the v7.2.2 `action.yml`). No removed/renamed inputs affect us.
- Node 24 runs fine on GitHub-hosted runners.

No `.goreleaser.yaml` or Makefile changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)