### PR TITLE
chore(ci): drop redundant setup-gcloud step before login-to-gar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,8 +163,6 @@ jobs:
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version: 1.25.10
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
       - name: Log into GAR
         uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,6 @@ jobs:
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
       - name: Log into GAR
         uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
         with:

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -46,8 +46,6 @@ jobs:
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
       - name: Log into GAR
         uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
         with:


### PR DESCRIPTION
## What

Removes the standalone `Set up Cloud SDK` (`google-github-actions/setup-gcloud`) step that runs immediately before `login-to-gar` in `ci.yml`, `release.yml`, and `weekly-release.yml`.

## Why it's redundant

The explicit step is a bare `setup-gcloud` — **no `with:` (no version/project) and no preceding `google-github-actions/auth`** — so it only drops an unauthenticated gcloud CLI on the runner.

`grafana/shared-workflows/actions/login-to-gar@v1.0.1` already does all of this internally:

1. `google-github-actions/auth` — WIF authentication
2. `setup-gcloud` — installs the gcloud CLI
3. `gcloud auth configure-docker` — configures the Docker credential helper (this is what the later `docker push` actually relies on)

## Risk

None expected: gcloud install + Docker config become solely login-to-gar's responsibility, which it already performs unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)