### PR TITLE
examples: bump to 2.0 otel-profiling-java for the wall profiling example

### DIFF
--- a/examples/tracing/java-wall/Dockerfile
+++ b/examples/tracing/java-wall/Dockerfile
@@ -42,7 +42,7 @@ COPY --from=builder /opt/app/build/libs/rideshare-1.0-SNAPSHOT.jar /opt/app/buil
 WORKDIR /opt/app
 
 ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.15.0/opentelemetry-javaagent.jar opentelemetry-javaagent.jar
-ADD https://github.com/grafana/otel-profiling-java/releases/download/v1.1.0/pyroscope-otel.jar pyroscope-otel.jar
+ADD https://github.com/grafana/otel-profiling-java/releases/download/v2.0.4/pyroscope-otel-javaagent-extension.jar pyroscope-otel.jar
 
 EXPOSE 5000
 


### PR DESCRIPTION
Bumps otel-profiling-java to 2.0.4 (latest) for the java-wall tracing example. Switches to `pyroscope-otel-javaagent-extension.jar` because from 2.0 onwards `pyroscope-otel.jar` is a thin library and doesn't contain the profiler, but this example relies solely on the OTEL extension unlike the regular (cpu) java example that also adds the profiler via`-javaagent`.