### PR TITLE
fix: include remote write URL in error messages

### DIFF
--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -29,6 +29,7 @@ type StaticExporter struct {
 	wg     sync.WaitGroup
 
 	logger log.Logger
+	url    string
 
 	metrics *clientMetrics
 }
@@ -47,6 +48,7 @@ func NewExporter(remoteWriteAddress string, logger log.Logger, reg prometheus.Re
 		client:  client,
 		wg:      sync.WaitGroup{},
 		logger:  logger,
+		url:     remoteWriteAddress,
 		metrics: metrics,
 	}, nil
 }
@@ -65,7 +67,7 @@ func (e *StaticExporter) Send(tenantId string, data []prompb.TimeSeries) error {
 		ctx := tenant.InjectTenantID(context.Background(), tenantId)
 		_, err := e.client.Store(ctx, snappy.Encode(nil, buf.Bytes()), 0)
 		if err != nil {
-			level.Error(e.logger).Log("msg", "unable to store prompb.WriteRequest", "err", err)
+			level.Error(e.logger).Log("msg", "unable to store prompb.WriteRequest", "url", e.url, "err", err)
 			return
 		}
 		seriesByRuleID := make(map[string]int)


### PR DESCRIPTION
Fixes #1961

When remote write fails, the error message only shows the status code but not the URL being hit. This makes debugging difficult when multiple remote targets are configured.

Added the remote write URL to the error log message so operators can immediately identify which target is failing.

Before:
```
level=error msg="unable to store prompb.WriteRequest" err="response not ok: status code: '404'"
```

After:
```
level=error msg="unable to store prompb.WriteRequest" url="http://localhost:9009/api/v1/write" err="response not ok: status code: '404'"
```
