### PR TITLE
examples: expanded ci checks

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -40,9 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       examples: ${{ steps.select.outputs.examples }}
-      tracing_examples: ${{ steps.select.outputs.tracing_examples }}
       any: ${{ steps.select.outputs.any }}
-      any_tracing: ${{ steps.select.outputs.any_tracing }}
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -63,21 +61,20 @@ jobs:
             export TARGET="$TARGET_INPUT"
           fi
           selected="$(bash tools/examples/select-examples.sh)"
-          tracing="$(printf '%s\n' "$selected" | { grep '^examples/tracing/' || true; })"
 
           echo "Selected examples:"
           printf '%s\n' "$selected"
 
           {
             echo "examples=$(printf '%s\n' "$selected" | paste -sd, -)"
-            echo "tracing_examples=$(printf '%s\n' "$tracing" | paste -sd, -)"
             echo "any=$([ -n "$selected" ] && echo true || echo false)"
-            echo "any_tracing=$([ -n "$tracing" ] && echo true || echo false)"
           } >> "$GITHUB_OUTPUT"
 
-  # Check 1: profiles can be queried from Pyroscope (Series + SelectSeries) for
-  # every selected example.
-  profiles:
+  # Bring each selected example up once and verify it: profiles are queried for
+  # every example (Series + SelectSeries); tracing examples additionally get the
+  # trace-to-profile link checked (SelectMergeSpanProfile). The profiles and
+  # trace-link results show up as subtests in this job's output.
+  test:
     needs: detect
     if: needs.detect.outputs.any == 'true'
     runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
@@ -90,28 +87,7 @@ jobs:
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version: 1.25.10
-      - name: Query profiles for selected examples
+      - name: Query profiles (and span profiles) for selected examples
         env:
           PYROSCOPE_TEST_EXAMPLES: ${{ needs.detect.outputs.examples }}
-        run: make examples/test/profiles
-
-  # Check 2: the trace-to-profile link works (find a trace, find its
-  # pyroscope.profile.id span attribute, query SelectMergeSpanProfile) for every
-  # selected example under examples/tracing.
-  tracing:
-    needs: detect
-    if: needs.detect.outputs.any_tracing == 'true'
-    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        with:
-          persist-credentials: 'false'
-      - name: Install Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
-        with:
-          go-version: 1.25.10
-      - name: Query span profiles for selected tracing examples
-        env:
-          PYROSCOPE_TEST_EXAMPLES: ${{ needs.detect.outputs.tracing_examples }}
-        run: make examples/test/tracing
+        run: make examples/test

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -1,18 +1,85 @@
 name: Test Examples
+
+# Builds and runs the examples and verifies that profiling data (and, for tracing
+# examples, span-linked profiling data) can be queried back from Pyroscope.
+#
+# Runs nightly, on manual dispatch, and on the automated examples-update PRs
+# (head branch gh_bot_examples_update). These checks are intentionally NOT part
+# of the required status checks and should not block merging.
 on:
   schedule:
     - cron: '13 1 * * *'
   workflow_dispatch:
+    inputs:
+      target:
+        description: 'Example dir or path prefix to test (e.g. examples/tracing/java or examples/language-sdk-instrumentation/java). Empty = all examples.'
+        required: false
+        default: ''
+  pull_request:
+    paths:
+      - 'examples/**'
+
 concurrency:
   # Cancel any running workflow for the same branch when new commits are pushed.
-  # We group both by ref_name (available when CI is triggered by a push to a branch/tag)
-  # and head_ref (available when CI is triggered by a PR).
-  group: "${{ github.ref_name }}-${{ github.head_ref }}"
+  group: "test-examples-${{ github.ref_name }}-${{ github.head_ref }}"
   cancel-in-progress: true
+
 permissions:
   contents: read
+
 jobs:
-  test:
+  # Determine which examples to test: the ones changed by the PR, the ones under
+  # the manually dispatched target prefix, or all of them (scheduled runs).
+  detect:
+    # On PRs, only run for the automated examples-update branch in this repo
+    # (a fork can name its branch the same, so also require a same-repo PR).
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.head_ref == 'gh_bot_examples_update' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    outputs:
+      examples: ${{ steps.select.outputs.examples }}
+      tracing_examples: ${{ steps.select.outputs.tracing_examples }}
+      any: ${{ steps.select.outputs.any }}
+      any_tracing: ${{ steps.select.outputs.any_tracing }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: 'false'
+          fetch-depth: 0
+      - name: Select examples
+        id: select
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          TARGET_INPUT: ${{ github.event.inputs.target }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            export BASE_REF="$BASE_SHA"
+          else
+            export TARGET="$TARGET_INPUT"
+          fi
+          selected="$(bash tools/examples/select-examples.sh)"
+          tracing="$(printf '%s\n' "$selected" | { grep '^examples/tracing/' || true; })"
+
+          echo "Selected examples:"
+          printf '%s\n' "$selected"
+
+          {
+            echo "examples=$(printf '%s\n' "$selected" | paste -sd, -)"
+            echo "tracing_examples=$(printf '%s\n' "$tracing" | paste -sd, -)"
+            echo "any=$([ -n "$selected" ] && echo true || echo false)"
+            echo "any_tracing=$([ -n "$tracing" ] && echo true || echo false)"
+          } >> "$GITHUB_OUTPUT"
+
+  # Check 1: profiles can be queried from Pyroscope (Series + SelectSeries) for
+  # every selected example.
+  profiles:
+    needs: detect
+    if: needs.detect.outputs.any == 'true'
     runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
     steps:
       - name: Checkout code
@@ -23,5 +90,28 @@ jobs:
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version: 1.25.10
-      - name: Run tests
-        run: make examples/test
+      - name: Query profiles for selected examples
+        env:
+          PYROSCOPE_TEST_EXAMPLES: ${{ needs.detect.outputs.examples }}
+        run: make examples/test/profiles
+
+  # Check 2: the trace-to-profile link works (find a trace, find its
+  # pyroscope.profile.id span attribute, query SelectMergeSpanProfile) for every
+  # selected example under examples/tracing.
+  tracing:
+    needs: detect
+    if: needs.detect.outputs.any_tracing == 'true'
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: 'false'
+      - name: Install Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version: 1.25.10
+      - name: Query span profiles for selected tracing examples
+        env:
+          PYROSCOPE_TEST_EXAMPLES: ${{ needs.detect.outputs.tracing_examples }}
+        run: make examples/test/tracing

--- a/Makefile
+++ b/Makefile
@@ -92,12 +92,13 @@ go/test-integration: $(BIN)/gotestsum
 	$(BIN)/gotestsum --rerun-fails=2 --packages './pkg/test/integration/...' -- $(GO_TEST_FLAGS)
 
 # Run tests on examples. These build and run each example via docker-compose,
-# verify the containers stay up, and query the ingested profiling data back.
+# verify the containers stay up, and query the ingested profiling data back
+# (profiles for every example; the trace-to-profile link for tracing examples).
 #
 # Scope to specific examples with PYROSCOPE_TEST_EXAMPLES (comma-separated,
 # repository-relative dirs), and/or to specific tests with RUN. For example:
 # $ make examples/test PYROSCOPE_TEST_EXAMPLES=examples/tracing/java
-# $ make examples/test RUN=TestExampleProfiles/examples/language-sdk-instrumentation/rust/basic
+# $ make examples/test RUN=TestExamples/examples/language-sdk-instrumentation/rust/basic
 #
 # The default verbose format surfaces what each check verified (discovered
 # services, profile types, point/sample counts). Override with
@@ -107,18 +108,6 @@ GOTESTSUM_FORMAT ?= standard-verbose
 examples/test: RUN := .*
 examples/test: $(BIN)/gotestsum
 	$(BIN)/gotestsum --format $(GOTESTSUM_FORMAT) --rerun-fails=2 --packages ./examples -- --count 1 --parallel 2 --timeout 1h --tags examples -run "$(RUN)"
-
-# Check that profiles can be queried from Pyroscope (Series + SelectSeries) for
-# the selected examples (see PYROSCOPE_TEST_EXAMPLES above).
-.PHONY: examples/test/profiles
-examples/test/profiles:
-	$(MAKE) examples/test RUN=TestExampleProfiles
-
-# Check that the trace-to-profile link works (SelectMergeSpanProfile) for the
-# selected tracing examples.
-.PHONY: examples/test/tracing
-examples/test/tracing:
-	$(MAKE) examples/test RUN=TestExampleTracingSpanProfiles
 
 .PHONY: build
 build: frontend/build go/bin ## Do a production build (requiring the frontend build to be present)

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ GOTESTSUM_FORMAT ?= standard-verbose
 .PHONY: examples/test
 examples/test: RUN := .*
 examples/test: $(BIN)/gotestsum
-	$(BIN)/gotestsum --format $(GOTESTSUM_FORMAT) --rerun-fails=2 --packages ./examples -- --count 1 --parallel 2 --timeout 1h --tags examples -run "$(RUN)"
+	$(BIN)/gotestsum --format $(GOTESTSUM_FORMAT) --packages ./examples -- --count 1 --parallel 2 --timeout 1h --tags examples -run "$(RUN)"
 
 .PHONY: build
 build: frontend/build go/bin ## Do a production build (requiring the frontend build to be present)

--- a/Makefile
+++ b/Makefile
@@ -91,13 +91,34 @@ go/test: $(BIN)/gotestsum
 go/test-integration: $(BIN)/gotestsum
 	$(BIN)/gotestsum --rerun-fails=2 --packages './pkg/test/integration/...' -- $(GO_TEST_FLAGS)
 
-# Run test on examples
-# This can also be used to run it on a subset of tests
-# $ make examples/test RUN=TestDockerComposeBuildRun/tracing/java
+# Run tests on examples. These build and run each example via docker-compose,
+# verify the containers stay up, and query the ingested profiling data back.
+#
+# Scope to specific examples with PYROSCOPE_TEST_EXAMPLES (comma-separated,
+# repository-relative dirs), and/or to specific tests with RUN. For example:
+# $ make examples/test PYROSCOPE_TEST_EXAMPLES=examples/tracing/java
+# $ make examples/test RUN=TestExampleProfiles/examples/language-sdk-instrumentation/rust/basic
+#
+# The default verbose format surfaces what each check verified (discovered
+# services, profile types, point/sample counts). Override with
+# GOTESTSUM_FORMAT=testname for terse one-line-per-test output.
+GOTESTSUM_FORMAT ?= standard-verbose
 .PHONY: examples/test
 examples/test: RUN := .*
 examples/test: $(BIN)/gotestsum
-	$(BIN)/gotestsum --format testname --rerun-fails=2 --packages ./examples -- --count 1 --parallel 2 --timeout 1h --tags examples -run "$(RUN)"
+	$(BIN)/gotestsum --format $(GOTESTSUM_FORMAT) --rerun-fails=2 --packages ./examples -- --count 1 --parallel 2 --timeout 1h --tags examples -run "$(RUN)"
+
+# Check that profiles can be queried from Pyroscope (Series + SelectSeries) for
+# the selected examples (see PYROSCOPE_TEST_EXAMPLES above).
+.PHONY: examples/test/profiles
+examples/test/profiles:
+	$(MAKE) examples/test RUN=TestExampleProfiles
+
+# Check that the trace-to-profile link works (SelectMergeSpanProfile) for the
+# selected tracing examples.
+.PHONY: examples/test/tracing
+examples/test/tracing:
+	$(MAKE) examples/test RUN=TestExampleTracingSpanProfiles
 
 .PHONY: build
 build: frontend/build go/bin ## Do a production build (requiring the frontend build to be present)

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -12,10 +12,13 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -36,9 +39,6 @@ const (
 	pollInterval       = 3 * time.Second
 )
 
-// pyroscopeService and tempoService are the docker-compose service names every
-// example uses. We publish their ports on random host ports so the tests can
-// query them directly over localhost.
 const (
 	pyroscopeService = "pyroscope"
 	pyroscopePort    = "4040"
@@ -46,14 +46,49 @@ const (
 	tempoPort        = "3200"
 )
 
+// activeStacks tracks the compose stacks that are currently up, so they can be
+// torn down on an interrupt (where t.Cleanup does not run).
+var (
+	activeMu     sync.Mutex
+	activeStacks = map[string]*env{}
+)
+
+func registerActive(e *env) { activeMu.Lock(); activeStacks[e.projectName()] = e; activeMu.Unlock() }
+func unregisterActive(e *env) {
+	activeMu.Lock()
+	delete(activeStacks, e.projectName())
+	activeMu.Unlock()
+}
+
+// TestMain installs a signal handler so that an interrupted run (Ctrl+C) still
+// tears down the docker-compose stacks it started. t.Cleanup does not run when
+// the test process is killed by a signal, which would otherwise leak containers.
+func TestMain(m *testing.M) {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sig
+		activeMu.Lock()
+		envs := make([]*env, 0, len(activeStacks))
+		for _, e := range activeStacks {
+			envs = append(envs, e)
+		}
+		activeMu.Unlock()
+		for _, e := range envs {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			_ = e.newCmd(ctx, "down", "--volumes").Run()
+			cancel()
+		}
+		os.Exit(1)
+	}()
+	os.Exit(m.Run())
+}
+
 type env struct {
 	dir  string // project dir of docker-compose, relative to the test working directory
 	path string // path to docker-compose file
 }
 
-// repoDir returns the repository-relative path of the example (e.g.
-// "examples/tracing/java"). The test runs with its working directory set to the
-// examples package, so the discovered dir is relative to that.
 func (e *env) repoDir() string {
 	return filepath.Join("examples", e.dir)
 }
@@ -196,8 +231,7 @@ func containerPortOf(p interface{}) int {
 }
 
 // localhostPort is a long-form ports entry that binds the container port to a
-// random host port on the loopback interface only, so the (unauthenticated)
-// test services are never exposed on the runner's external interfaces.
+// random host port on the loopback interface only.
 func localhostPort(containerPort int) map[string]any {
 	return map[string]any{"target": containerPort, "host_ip": "127.0.0.1"}
 }
@@ -240,11 +274,13 @@ func (e *env) hostPort(t testing.TB, ctx context.Context, service, containerPort
 	return line[idx+1:]
 }
 
-// bringUp builds, pulls and starts the example detached. Teardown is registered
-// with t.Cleanup before anything is started, so containers are removed even if
-// build or up fails partway through.
+// bringUp builds, pulls and starts the example detached.
 func (e *env) bringUp(t *testing.T, ctx context.Context) {
+	// Register before starting and tear down on cleanup, so the stack is removed
+	// both on normal completion (t.Cleanup) and on interrupt (see TestMain).
+	registerActive(e)
 	t.Cleanup(func() {
+		unregisterActive(e)
 		if err := e.run(t, context.Background(), "down", "--volumes"); err != nil {
 			t.Logf("cleanup error=%v", err)
 		}
@@ -276,13 +312,8 @@ func (e *env) waitRunning(t testing.TB, ctx context.Context) {
 // Each distinct message is logged once across the whole poll, so steps show up
 // as they are first reached without spamming a line on every retry.
 func poll(t testing.TB, ctx context.Context, timeout time.Duration, fn func(progress func(string, ...any)) error) {
-	seen := map[string]struct{}{}
 	progress := func(format string, args ...any) {
 		msg := fmt.Sprintf(format, args...)
-		if _, ok := seen[msg]; ok {
-			return
-		}
-		seen[msg] = struct{}{}
 		t.Log(msg)
 	}
 	deadline := time.Now().Add(timeout)
@@ -358,8 +389,9 @@ func labelValue(labels []labelPair, name string) string {
 	return ""
 }
 
-// seriesData maps a service name to the profile types ingested for it. CPU-like
-// types (those span profiles are attached to) are ordered first.
+// seriesData maps a service name to its ingested CPU/wall profile types. Those
+// are the types span profiles are attached to; other types (memory, lock, etc.)
+// are not useful for these checks and are dropped.
 type seriesData map[string][]string
 
 func sortedKeys(d seriesData) []string {
@@ -376,8 +408,14 @@ func sortedKeys(d seriesData) []string {
 // the checks validate the example's application rather than the server.
 const selfProfilingService = "pyroscope"
 
+// isCPUOrWallType reports whether a profile type is a CPU or wall-clock type.
+func isCPUOrWallType(profileType string) bool {
+	return strings.HasPrefix(profileType, "process_cpu:") || strings.HasPrefix(profileType, "wall:")
+}
+
 // discoverSeries queries the Series API and returns the application services and
-// their ingested profile types. The self-profiling series are excluded.
+// their ingested CPU/wall profile types. Self-profiling series and non-CPU/wall
+// types are excluded.
 func (e *env) discoverSeries(ctx context.Context, host string) (seriesData, error) {
 	start, end := nowWindowMillis()
 	var resp seriesResponse
@@ -394,18 +432,13 @@ func (e *env) discoverSeries(ctx context.Context, host string) (seriesData, erro
 	for _, ls := range resp.LabelsSet {
 		svc := labelValue(ls.Labels, "service_name")
 		pt := labelValue(ls.Labels, "__profile_type__")
-		if svc == "" || pt == "" || svc == selfProfilingService {
+		if svc == "" || svc == selfProfilingService || !isCPUOrWallType(pt) {
 			continue
 		}
-		// CPU-like types first so callers prefer them.
-		if strings.Contains(pt, ":cpu:") || strings.HasPrefix(pt, "wall:") {
-			data[svc] = append([]string{pt}, data[svc]...)
-		} else {
-			data[svc] = append(data[svc], pt)
-		}
+		data[svc] = append(data[svc], pt)
 	}
 	if len(data) == 0 {
-		return nil, errors.New("no application series ingested yet")
+		return nil, errors.New("no CPU or wall profile series ingested yet")
 	}
 	return data, nil
 }
@@ -618,8 +651,7 @@ func (e *env) isTracing() bool {
 
 // TestExamples brings each selected example up once and verifies it: profiles
 // are always checked (Series + SelectSeries); tracing examples additionally get
-// the trace-to-profile link checked (SelectMergeSpanProfile). Bringing the stack
-// up once and branching keeps tracing examples from being built and run twice.
+// the trace-to-profile link checked (SelectMergeSpanProfile).
 func TestExamples(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
@@ -650,8 +682,6 @@ func TestExamples(t *testing.T) {
 				})
 			}
 
-			// All containers should still be up after the workload, not just at
-			// startup (catches a container that crashed during the run).
 			require.NoError(t, e.containersAllRunning(ctx), "containers must stay running through the run")
 		})
 	}

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -613,18 +613,21 @@ func (e *env) profileIDsFromTrace(ctx context.Context, host, traceID string) ([]
 // examplesToTest discovers the docker-compose examples and filters them by the
 // PYROSCOPE_TEST_EXAMPLES environment variable (a comma/newline/space separated
 // list of repository-relative example dirs, e.g. "examples/tracing/java"). When
-// the variable is empty, all examples are returned.
+// the variable is empty, all examples are returned. It fails the test if the
+// variable names an example that does not exist, so a typo cannot silently pass
+// by selecting (and testing) nothing.
 func examplesToTest(t *testing.T) []*env {
 	out, err := exec.Command("git", "ls-files", "**/docker-compose.yml", "**/docker-compose.yaml").Output()
 	require.NoError(t, err)
 
-	var selected map[string]struct{}
+	// requested maps each requested dir to whether a matching example was found.
+	var requested map[string]bool
 	if raw := strings.TrimSpace(os.Getenv("PYROSCOPE_TEST_EXAMPLES")); raw != "" {
-		selected = map[string]struct{}{}
+		requested = map[string]bool{}
 		for _, f := range strings.FieldsFunc(raw, func(r rune) bool {
 			return r == ',' || r == '\n' || r == ' ' || r == '\t'
 		}) {
-			selected[strings.TrimRight(f, "/")] = struct{}{}
+			requested[strings.TrimRight(f, "/")] = false
 		}
 	}
 
@@ -634,12 +637,24 @@ func examplesToTest(t *testing.T) []*env {
 			continue
 		}
 		e := &env{dir: filepath.Dir(path), path: path}
-		if selected != nil {
-			if _, ok := selected[e.repoDir()]; !ok {
+		if requested != nil {
+			if _, ok := requested[e.repoDir()]; !ok {
 				continue
 			}
+			requested[e.repoDir()] = true
 		}
 		envs = append(envs, e)
+	}
+
+	var unmatched []string
+	for dir, matched := range requested {
+		if !matched {
+			unmatched = append(unmatched, dir)
+		}
+	}
+	if len(unmatched) > 0 {
+		sort.Strings(unmatched)
+		t.Fatalf("PYROSCOPE_TEST_EXAMPLES references unknown example(s): %s", strings.Join(unmatched, ", "))
 	}
 	return envs
 }

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -240,9 +240,15 @@ func (e *env) hostPort(t testing.TB, ctx context.Context, service, containerPort
 	return line[idx+1:]
 }
 
-// bringUp builds, pulls and starts the example detached. The returned function
-// tears the stack down and must always be called.
-func (e *env) bringUp(t *testing.T, ctx context.Context) func() {
+// bringUp builds, pulls and starts the example detached. Teardown is registered
+// with t.Cleanup before anything is started, so containers are removed even if
+// build or up fails partway through.
+func (e *env) bringUp(t *testing.T, ctx context.Context) {
+	t.Cleanup(func() {
+		if err := e.run(t, context.Background(), "down", "--volumes"); err != nil {
+			t.Logf("cleanup error=%v", err)
+		}
+	})
 	t.Run("build", func(t *testing.T) {
 		require.NoError(t, e.run(t, ctx, "build"))
 	})
@@ -251,12 +257,6 @@ func (e *env) bringUp(t *testing.T, ctx context.Context) func() {
 		require.NoError(t, e.run(t, ctx, "pull"))
 	})
 	require.NoError(t, e.run(t, ctx, "up", "--detach"))
-
-	return func() {
-		if err := e.run(t, context.Background(), "down", "--volumes"); err != nil {
-			t.Logf("cleanup error=%v", err)
-		}
-	}
 }
 
 // waitRunning waits until all containers report a running state, failing the
@@ -582,7 +582,7 @@ func (e *env) profileIDsFromTrace(ctx context.Context, host, traceID string) ([]
 // list of repository-relative example dirs, e.g. "examples/tracing/java"). When
 // the variable is empty, all examples are returned.
 func examplesToTest(t *testing.T) []*env {
-	out, err := exec.Command("git", "ls-files", "**/docker-compose.yml").Output()
+	out, err := exec.Command("git", "ls-files", "**/docker-compose.yml", "**/docker-compose.yaml").Output()
 	require.NoError(t, err)
 
 	var selected map[string]struct{}
@@ -611,10 +611,16 @@ func examplesToTest(t *testing.T) []*env {
 	return envs
 }
 
-// TestExampleProfiles brings up each selected example, verifies all containers
-// stay running, and then verifies that profiles are queryable from Pyroscope via
-// the Series and SelectSeries APIs.
-func TestExampleProfiles(t *testing.T) {
+// isTracing reports whether the example lives under examples/tracing/.
+func (e *env) isTracing() bool {
+	return strings.HasPrefix(e.repoDir(), filepath.Join("examples", "tracing")+string(filepath.Separator))
+}
+
+// TestExamples brings each selected example up once and verifies it: profiles
+// are always checked (Series + SelectSeries); tracing examples additionally get
+// the trace-to-profile link checked (SelectMergeSpanProfile). Bringing the stack
+// up once and branching keeps tracing examples from being built and run twice.
+func TestExamples(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -627,121 +633,112 @@ func TestExampleProfiles(t *testing.T) {
 			defer cancel()
 
 			e := e.prepareCompose(t)
-			defer e.bringUp(t, ctx)()
+			e.bringUp(t, ctx)
 			e.waitRunning(t, ctx)
 
-			host := "127.0.0.1:" + e.hostPort(t, ctx, pyroscopeService, pyroscopePort)
-			t.Logf("[%s] all containers running; pyroscope on %s, waiting for profiles to be queryable", e.repoDir(), host)
+			pyroHost := "127.0.0.1:" + e.hostPort(t, ctx, pyroscopeService, pyroscopePort)
+			t.Logf("[%s] all containers running; pyroscope on %s", e.repoDir(), pyroHost)
 
-			dir := e.repoDir()
-			var summary string
-			poll(t, ctx, profilesQueryTimeout, func(progress func(string, ...any)) error {
-				progress("[%s] querying Series for ingested profiles...", dir)
-				data, err := e.discoverSeries(ctx, host)
-				if err != nil {
-					return err
-				}
-				progress("[%s] Series found %d service(s): %s; querying SelectSeries...", dir, len(data), strings.Join(sortedKeys(data), ", "))
-				for svc, types := range data {
-					for _, pt := range types {
-						nSeries, nPoints, err := e.selectSeries(ctx, host, svc, pt)
-						if err != nil {
-							return err
-						}
-						if nPoints > 0 {
-							summary = fmt.Sprintf("service=%q profileType=%q -> %d series, %d points (%d service(s) ingesting)",
-								svc, pt, nSeries, nPoints, len(data))
-							return nil
-						}
-						progress("[%s] SelectSeries service=%q type=%q -> 0 points (waiting for data)", dir, svc, pt)
-					}
-				}
-				return fmt.Errorf("no data points for any of %d discovered series yet", len(data))
+			t.Run("profiles", func(t *testing.T) {
+				e.checkProfilesQueryable(t, ctx, pyroHost)
 			})
-			t.Logf("[%s] PASS profiles queryable via Series+SelectSeries: %s", dir, summary)
+
+			if e.isTracing() {
+				tempoHost := "127.0.0.1:" + e.hostPort(t, ctx, tempoService, tempoPort)
+				t.Run("trace-link", func(t *testing.T) {
+					e.checkSpanProfilesQueryable(t, ctx, pyroHost, tempoHost)
+				})
+			}
+
+			// All containers should still be up after the workload, not just at
+			// startup (catches a container that crashed during the run).
+			require.NoError(t, e.containersAllRunning(ctx), "containers must stay running through the run")
 		})
 	}
 }
 
-// TestExampleTracingSpanProfiles brings up each selected tracing example and
-// verifies the trace-to-profile link end to end: a trace is found in Tempo, a
-// span carries a pyroscope.profile.id attribute, and SelectMergeSpanProfile
-// returns span-scoped profiling data for it.
-func TestExampleTracingSpanProfiles(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
-	}
-
-	for _, e := range examplesToTest(t) {
-		e := e
-		if !strings.HasPrefix(e.repoDir(), filepath.Join("examples", "tracing")+string(filepath.Separator)) {
-			continue
+// checkProfilesQueryable verifies profiles are queryable from Pyroscope via the
+// Series and SelectSeries APIs.
+func (e *env) checkProfilesQueryable(t *testing.T, ctx context.Context, host string) {
+	dir := e.repoDir()
+	var summary string
+	poll(t, ctx, profilesQueryTimeout, func(progress func(string, ...any)) error {
+		progress("[%s] querying Series for ingested profiles...", dir)
+		data, err := e.discoverSeries(ctx, host)
+		if err != nil {
+			return err
 		}
-		t.Run(e.repoDir(), func(t *testing.T) {
-			t.Parallel()
-			ctx, cancel := context.WithTimeout(context.Background(), timeoutPerExample)
-			defer cancel()
-
-			e := e.prepareCompose(t)
-			defer e.bringUp(t, ctx)()
-			e.waitRunning(t, ctx)
-
-			pyroHost := "127.0.0.1:" + e.hostPort(t, ctx, pyroscopeService, pyroscopePort)
-			tempoHost := "127.0.0.1:" + e.hostPort(t, ctx, tempoService, tempoPort)
-			t.Logf("[%s] all containers running; pyroscope on %s, tempo on %s, waiting for traces + span profiles", e.repoDir(), pyroHost, tempoHost)
-
-			// Find a trace whose span carries a pyroscope.profile.id, then verify
-			// span-scoped profiling data can be fetched for it. The (service,
-			// profile type) carrying span data is discovered from Pyroscope.
-			dir := e.repoDir()
-			var summary string
-			poll(t, ctx, tracesQueryTimeout, func(progress func(string, ...any)) error {
-				progress("[%s] querying Series for ingested profiles...", dir)
-				data, err := e.discoverSeries(ctx, pyroHost)
+		progress("[%s] Series found %d service(s): %s; querying SelectSeries...", dir, len(data), strings.Join(sortedKeys(data), ", "))
+		for svc, types := range data {
+			for _, pt := range types {
+				nSeries, nPoints, err := e.selectSeries(ctx, host, svc, pt)
 				if err != nil {
 					return err
 				}
-				progress("[%s] Series found %d service(s): %s; searching Tempo for traces...", dir, len(data), strings.Join(sortedKeys(data), ", "))
+				if nPoints > 0 {
+					summary = fmt.Sprintf("service=%q profileType=%q -> %d series, %d points (%d service(s) ingesting)",
+						svc, pt, nSeries, nPoints, len(data))
+					return nil
+				}
+				progress("[%s] SelectSeries service=%q type=%q -> 0 points (waiting for data)", dir, svc, pt)
+			}
+		}
+		return fmt.Errorf("no data points for any of %d discovered series yet", len(data))
+	})
+	t.Logf("[%s] PASS profiles queryable via Series+SelectSeries: %s", dir, summary)
+}
 
-				traceIDs, err := e.tempoSearch(ctx, tempoHost)
+// checkSpanProfilesQueryable verifies the trace-to-profile link end to end: a
+// trace is found in Tempo, a span carries a pyroscope.profile.id attribute, and
+// SelectMergeSpanProfile returns span-scoped profiling data for it.
+func (e *env) checkSpanProfilesQueryable(t *testing.T, ctx context.Context, pyroHost, tempoHost string) {
+	dir := e.repoDir()
+	var summary string
+	poll(t, ctx, tracesQueryTimeout, func(progress func(string, ...any)) error {
+		progress("[%s] querying Series for ingested profiles...", dir)
+		data, err := e.discoverSeries(ctx, pyroHost)
+		if err != nil {
+			return err
+		}
+		progress("[%s] Series found %d service(s): %s; searching Tempo for traces...", dir, len(data), strings.Join(sortedKeys(data), ", "))
+
+		traceIDs, err := e.tempoSearch(ctx, tempoHost)
+		if err != nil {
+			return err
+		}
+		if len(traceIDs) == 0 {
+			return errors.New("no traces found in tempo yet")
+		}
+		progress("[%s] found %d trace(s); scanning spans for %s attribute...", dir, len(traceIDs), pyroscopeProfileIDAttr)
+
+		var spanIDs []string
+		for _, id := range traceIDs {
+			ids, err := e.profileIDsFromTrace(ctx, tempoHost, id)
+			if err != nil {
+				return err
+			}
+			spanIDs = append(spanIDs, ids...)
+		}
+		if len(spanIDs) == 0 {
+			return fmt.Errorf("found %d traces in tempo but no span carried a %s attribute", len(traceIDs), pyroscopeProfileIDAttr)
+		}
+		progress("[%s] found %d span(s) with %s; querying SelectMergeSpanProfile...", dir, len(spanIDs), pyroscopeProfileIDAttr)
+
+		for svc, types := range data {
+			for _, pt := range types {
+				total, err := e.selectMergeSpanProfile(ctx, pyroHost, svc, pt, spanIDs)
 				if err != nil {
 					return err
 				}
-				if len(traceIDs) == 0 {
-					return errors.New("no traces found in tempo yet")
+				if total > 0 {
+					summary = fmt.Sprintf("service=%q profileType=%q -> %d span id(s) from %d trace(s), %d samples",
+						svc, pt, len(spanIDs), len(traceIDs), total)
+					return nil
 				}
-				progress("[%s] found %d trace(s); scanning spans for %s attribute...", dir, len(traceIDs), pyroscopeProfileIDAttr)
-
-				var spanIDs []string
-				for _, id := range traceIDs {
-					ids, err := e.profileIDsFromTrace(ctx, tempoHost, id)
-					if err != nil {
-						return err
-					}
-					spanIDs = append(spanIDs, ids...)
-				}
-				if len(spanIDs) == 0 {
-					return fmt.Errorf("found %d traces in tempo but no span carried a %s attribute", len(traceIDs), pyroscopeProfileIDAttr)
-				}
-				progress("[%s] found %d span(s) with %s; querying SelectMergeSpanProfile...", dir, len(spanIDs), pyroscopeProfileIDAttr)
-
-				for svc, types := range data {
-					for _, pt := range types {
-						total, err := e.selectMergeSpanProfile(ctx, pyroHost, svc, pt, spanIDs)
-						if err != nil {
-							return err
-						}
-						if total > 0 {
-							summary = fmt.Sprintf("service=%q profileType=%q -> %d span id(s) from %d trace(s), %d samples",
-								svc, pt, len(spanIDs), len(traceIDs), total)
-							return nil
-						}
-						progress("[%s] SelectMergeSpanProfile service=%q type=%q -> 0 samples", dir, svc, pt)
-					}
-				}
-				return fmt.Errorf("found %d span ids but SelectMergeSpanProfile returned no samples across %d service(s)", len(spanIDs), len(data))
-			})
-			t.Logf("[%s] PASS trace->profile link via SelectMergeSpanProfile: %s", dir, summary)
-		})
-	}
+				progress("[%s] SelectMergeSpanProfile service=%q type=%q -> 0 samples", dir, svc, pt)
+			}
+		}
+		return fmt.Errorf("found %d span ids but SelectMergeSpanProfile returned no samples across %d service(s)", len(spanIDs), len(data))
+	})
+	t.Logf("[%s] PASS trace->profile link via SelectMergeSpanProfile: %s", dir, summary)
 }

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -3,7 +3,6 @@
 package examples
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"crypto/sha256"
@@ -11,10 +10,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -25,13 +26,36 @@ import (
 )
 
 const (
-	timeoutPerExample     = 10 * time.Minute
-	durationToStayRunning = 5 * time.Second
+	timeoutPerExample = 20 * time.Minute
+	// How long to wait for all containers to come up and stay running.
+	runningTimeout = 90 * time.Second
+	// How long to wait for profiles to be ingested and become queryable.
+	profilesQueryTimeout = 3 * time.Minute
+	// How long to wait for traces to be ingested and become searchable.
+	tracesQueryTimeout = 3 * time.Minute
+	pollInterval       = 3 * time.Second
+)
+
+// pyroscopeService and tempoService are the docker-compose service names every
+// example uses. We publish their ports on random host ports so the tests can
+// query them directly over localhost.
+const (
+	pyroscopeService = "pyroscope"
+	pyroscopePort    = "4040"
+	tempoService     = "tempo"
+	tempoPort        = "3200"
 )
 
 type env struct {
-	dir  string // project dir of docker-compose
+	dir  string // project dir of docker-compose, relative to the test working directory
 	path string // path to docker-compose file
+}
+
+// repoDir returns the repository-relative path of the example (e.g.
+// "examples/tracing/java"). The test runs with its working directory set to the
+// examples package, so the discovered dir is relative to that.
+func (e *env) repoDir() string {
+	return filepath.Join("examples", e.dir)
 }
 
 type status struct {
@@ -58,27 +82,15 @@ func (e *env) newCmd(ctx context.Context, args ...string) *exec.Cmd {
 	return c
 }
 
-func (e *env) newCmdWithOutputCapture(t testing.TB, ctx context.Context, args ...string) *exec.Cmd {
-	c := e.newCmd(ctx, args...)
-	stdout, err := c.StdoutPipe()
-	require.NoError(t, err)
-	go func() {
-		scanner := bufio.NewScanner(stdout)
-		for scanner.Scan() {
-			t.Log(scanner.Text())
-		}
-	}()
-
-	stderr, err := c.StderrPipe()
-	require.NoError(t, err)
-	go func() {
-		scanner := bufio.NewScanner(stderr)
-		for scanner.Scan() {
-			t.Log("STDERR: " + scanner.Text())
-		}
-	}()
-
-	return c
+// run executes a docker compose command, buffering its output and surfacing it
+// only when the command fails. This keeps successful runs readable under -v,
+// while still capturing full logs for debugging failures.
+func (e *env) run(t testing.TB, ctx context.Context, args ...string) error {
+	out, err := e.newCmd(ctx, args...).CombinedOutput()
+	if err != nil {
+		t.Logf("$ docker compose %s\n%s", strings.Join(args, " "), string(out))
+	}
+	return err
 }
 
 func (e *env) containerStatus(ctx context.Context) ([]status, error) {
@@ -109,163 +121,627 @@ func (e *env) containersAllRunning(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if len(status) == 0 {
+		return errors.New("no containers found")
+	}
 
 	var errs []error
 	for _, s := range status {
 		if s.State != "running" {
-			errs = append(errs, fmt.Errorf("container %s is not running", s.Name))
+			errs = append(errs, fmt.Errorf("container %s is not running (state=%s)", s.Name, s.State))
 		}
 	}
 
 	return errors.Join(errs...)
 }
 
-// removeExposedPorts removes ports from services which expose fixed ports. This will break once there is an overlap of ports. This will instead use random ports allocated by docker-compose.
-func (e *env) removeExposedPorts(t testing.TB) *env {
-
-	var obj map[interface{}]interface{}
+// prepareCompose rewrites the docker-compose file into a temporary copy so that:
+//   - every published port is bound to a random host port on localhost only
+//     (avoids conflicts when running examples in parallel and keeps the
+//     unauthenticated test services off the runner's external interfaces), and
+//   - the pyroscope (and, when present, tempo) services always publish their
+//     API ports so the test can query them over localhost.
+func (e *env) prepareCompose(t testing.TB) *env {
+	var obj map[string]interface{}
 
 	body, err := os.ReadFile(e.path)
-	if err != nil {
-		require.NoError(t, err)
-	}
+	require.NoError(t, err)
+	require.NoError(t, yaml.Unmarshal(body, &obj))
 
-	if err := yaml.Unmarshal(body, &obj); err != nil {
-		require.NoError(t, err)
-	}
+	services, ok := obj["services"].(map[string]interface{})
+	require.True(t, ok, "docker-compose file has no services map")
 
-	changed := false
-
-	for key, value := range obj {
-		if key.(string) == "services" {
-			services, ok := value.(map[string]interface{})
-			if !ok {
-				require.NoError(t, fmt.Errorf("services is not a map[string]interface{}"))
-			}
-			for serviceName, service := range services {
-				params, ok := service.(map[string]interface{})
-				if !ok {
-					require.NoError(t, fmt.Errorf("service '%s' is not a map[string]interface{}", serviceName))
-				}
-
-				// check for ports
-				ports, ok := params["ports"]
-				if !ok {
-					continue
-				}
-
-				portsSlice, ok := ports.([]interface{})
-				if !ok {
-					continue
-				}
-				for i := range portsSlice {
-					port, ok := portsSlice[i].(string)
-					if !ok {
-						continue
-					}
-
-					portSplitted := strings.Split(port, ":")
-					if len(portSplitted) < 2 {
-						continue
-					}
-
-					portsSlice[i] = portSplitted[len(portSplitted)-1]
-					changed = true
-				}
-			}
+	for serviceName, service := range services {
+		params, ok := service.(map[string]interface{})
+		if !ok {
+			require.NoError(t, fmt.Errorf("service '%s' is not a map", serviceName))
 		}
-
+		localhostBindPorts(params)
 	}
-	if !changed {
-		return e
+
+	// Ensure the API ports we need to query are published (on localhost).
+	pp, _ := strconv.Atoi(pyroscopePort)
+	tp, _ := strconv.Atoi(tempoPort)
+	if svc, ok := services[pyroscopeService].(map[string]interface{}); ok {
+		ensurePublished(svc, pp)
+	}
+	if svc, ok := services[tempoService].(map[string]interface{}); ok {
+		ensurePublished(svc, tp)
 	}
 
 	path := filepath.Join(t.TempDir(), "docker-compose.yml")
 	data, err := yaml.Marshal(obj)
-	if err != nil {
-		require.NoError(t, err)
-	}
-
+	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(path, data, 0644))
 
-	return &env{
-		dir:  e.dir,
-		path: path,
+	return &env{dir: e.dir, path: path}
+}
+
+// containerPortOf returns the container-side port of a docker-compose ports
+// entry, handling short ("3000", "3000:3000", "127.0.0.1:80:8080"), numeric
+// (4040) and long-form ({target: 4040, ...}) syntaxes. Returns 0 if unknown.
+func containerPortOf(p interface{}) int {
+	switch v := p.(type) {
+	case int:
+		return v
+	case string:
+		parts := strings.Split(v, ":")
+		n, _ := strconv.Atoi(parts[len(parts)-1])
+		return n
+	case map[string]interface{}:
+		return containerPortOf(v["target"])
+	default:
+		return 0
 	}
 }
 
-// This test is meant to catch very fundamental errors in the examples. It could be extened to be more comprehensive. For now it will just run the examples and check that they don't crash, within 5 seconds.
-func TestDockerComposeBuildRun(t *testing.T) {
+// localhostPort is a long-form ports entry that binds the container port to a
+// random host port on the loopback interface only, so the (unauthenticated)
+// test services are never exposed on the runner's external interfaces.
+func localhostPort(containerPort int) map[string]any {
+	return map[string]any{"target": containerPort, "host_ip": "127.0.0.1"}
+}
+
+// localhostBindPorts rewrites every published port of a service to a random
+// loopback-only binding. This both avoids host port conflicts when examples run
+// in parallel and prevents exposing services on external interfaces.
+func localhostBindPorts(params map[string]interface{}) {
+	ports, ok := params["ports"].([]interface{})
+	if !ok {
+		return
+	}
+	for i := range ports {
+		if cp := containerPortOf(ports[i]); cp != 0 {
+			ports[i] = localhostPort(cp)
+		}
+	}
+}
+
+func ensurePublished(params map[string]interface{}, containerPort int) {
+	ports, _ := params["ports"].([]interface{})
+	for _, p := range ports {
+		if containerPortOf(p) == containerPort {
+			return
+		}
+	}
+	params["ports"] = append(ports, localhostPort(containerPort))
+}
+
+// hostPort resolves the random host port that the given service's container port
+// has been published on.
+func (e *env) hostPort(t testing.TB, ctx context.Context, service, containerPort string) string {
+	out, err := e.newCmd(ctx, "port", service, containerPort).Output()
+	require.NoError(t, err, "resolving host port for %s:%s", service, containerPort)
+	line := strings.TrimSpace(string(out))
+	require.NotEmpty(t, line, "no published host port for %s:%s", service, containerPort)
+	line = strings.SplitN(line, "\n", 2)[0]
+	idx := strings.LastIndex(line, ":")
+	require.GreaterOrEqual(t, idx, 0, "unexpected docker compose port output: %q", line)
+	return line[idx+1:]
+}
+
+// bringUp builds, pulls and starts the example detached. The returned function
+// tears the stack down and must always be called.
+func (e *env) bringUp(t *testing.T, ctx context.Context) func() {
+	t.Run("build", func(t *testing.T) {
+		require.NoError(t, e.run(t, ctx, "build"))
+	})
+	// pull first so containers can start immediately
+	t.Run("pull", func(t *testing.T) {
+		require.NoError(t, e.run(t, ctx, "pull"))
+	})
+	require.NoError(t, e.run(t, ctx, "up", "--detach"))
+
+	return func() {
+		if err := e.run(t, context.Background(), "down", "--volumes"); err != nil {
+			t.Logf("cleanup error=%v", err)
+		}
+	}
+}
+
+// waitRunning waits until all containers report a running state, failing the
+// test if they don't within runningTimeout. A container that exits during this
+// window (e.g. a crash on startup) is caught here.
+func (e *env) waitRunning(t testing.TB, ctx context.Context) {
+	poll(t, ctx, runningTimeout, func(progress func(string, ...any)) error {
+		progress("[%s] waiting for all containers to be running...", e.repoDir())
+		return e.containersAllRunning(ctx)
+	})
+}
+
+// poll calls fn until it returns nil, the timeout elapses, or the context is
+// cancelled. On timeout it fails the test with the last error fn returned.
+//
+// fn receives a progress reporter it should use to announce what it is doing.
+// Each distinct message is logged once across the whole poll, so steps show up
+// as they are first reached without spamming a line on every retry.
+func poll(t testing.TB, ctx context.Context, timeout time.Duration, fn func(progress func(string, ...any)) error) {
+	seen := map[string]struct{}{}
+	progress := func(format string, args ...any) {
+		msg := fmt.Sprintf(format, args...)
+		if _, ok := seen[msg]; ok {
+			return
+		}
+		seen[msg] = struct{}{}
+		t.Log(msg)
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		err := fn(progress)
+		if err == nil {
+			return
+		}
+		progress("waiting: %s", err.Error())
+		if time.Now().After(deadline) {
+			require.NoError(t, err, "condition not met within %s", timeout)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			require.NoError(t, ctx.Err())
+			return
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+// --- Pyroscope query helpers -------------------------------------------------
+
+func nowWindowMillis() (start, end int64) {
+	now := time.Now()
+	return now.Add(-1 * time.Hour).UnixMilli(), now.Add(1 * time.Minute).UnixMilli()
+}
+
+func (e *env) pyroscopePost(ctx context.Context, host, apiPath string, reqBody any, out any) error {
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("http://%s/%s", host, apiPath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s returned %d: %s", apiPath, resp.StatusCode, string(data))
+	}
+	return json.Unmarshal(data, out)
+}
+
+type labelPair struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type seriesResponse struct {
+	LabelsSet []struct {
+		Labels []labelPair `json:"labels"`
+	} `json:"labelsSet"`
+}
+
+func labelValue(labels []labelPair, name string) string {
+	for _, l := range labels {
+		if l.Name == name {
+			return l.Value
+		}
+	}
+	return ""
+}
+
+// seriesData maps a service name to the profile types ingested for it. CPU-like
+// types (those span profiles are attached to) are ordered first.
+type seriesData map[string][]string
+
+func sortedKeys(d seriesData) []string {
+	keys := make([]string, 0, len(d))
+	for k := range d {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// selfProfilingService is the service name Pyroscope uses for its own profiles.
+// Examples that don't disable self-profiling will surface it; we exclude it so
+// the checks validate the example's application rather than the server.
+const selfProfilingService = "pyroscope"
+
+// discoverSeries queries the Series API and returns the application services and
+// their ingested profile types. The self-profiling series are excluded.
+func (e *env) discoverSeries(ctx context.Context, host string) (seriesData, error) {
+	start, end := nowWindowMillis()
+	var resp seriesResponse
+	err := e.pyroscopePost(ctx, host, "querier.v1.QuerierService/Series", map[string]any{
+		"start":      start,
+		"end":        end,
+		"labelNames": []string{"service_name", "__profile_type__"},
+	}, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	data := seriesData{}
+	for _, ls := range resp.LabelsSet {
+		svc := labelValue(ls.Labels, "service_name")
+		pt := labelValue(ls.Labels, "__profile_type__")
+		if svc == "" || pt == "" || svc == selfProfilingService {
+			continue
+		}
+		// CPU-like types first so callers prefer them.
+		if strings.Contains(pt, ":cpu:") || strings.HasPrefix(pt, "wall:") {
+			data[svc] = append([]string{pt}, data[svc]...)
+		} else {
+			data[svc] = append(data[svc], pt)
+		}
+	}
+	if len(data) == 0 {
+		return nil, errors.New("no application series ingested yet")
+	}
+	return data, nil
+}
+
+type selectSeriesResponse struct {
+	Series []struct {
+		Labels []labelPair `json:"labels"`
+		Points []struct {
+			Value     float64 `json:"value"`
+			Timestamp string  `json:"timestamp"`
+		} `json:"points"`
+	} `json:"series"`
+}
+
+// selectSeries fetches a time series for the given service and profile type and
+// returns the number of series and the total number of data points found.
+func (e *env) selectSeries(ctx context.Context, host, service, profileType string) (nSeries, nPoints int, err error) {
+	start, end := nowWindowMillis()
+	var resp selectSeriesResponse
+	err = e.pyroscopePost(ctx, host, "querier.v1.QuerierService/SelectSeries", map[string]any{
+		"profileTypeID": profileType,
+		"labelSelector": fmt.Sprintf("{service_name=%q}", service),
+		"start":         start,
+		"end":           end,
+		"step":          60,
+	}, &resp)
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, s := range resp.Series {
+		nPoints += len(s.Points)
+	}
+	return len(resp.Series), nPoints, nil
+}
+
+type flamegraphResponse struct {
+	Flamegraph struct {
+		Names  []string `json:"names"`
+		Levels []struct {
+			Values []json.Number `json:"values"`
+		} `json:"levels"`
+	} `json:"flamegraph"`
+}
+
+// selectMergeSpanProfile fetches a span-scoped profile for the given span IDs and
+// returns the total number of samples at the root of the flame graph.
+func (e *env) selectMergeSpanProfile(ctx context.Context, host, service, profileType string, spanIDs []string) (int64, error) {
+	start, end := nowWindowMillis()
+	var resp flamegraphResponse
+	err := e.pyroscopePost(ctx, host, "querier.v1.QuerierService/SelectMergeSpanProfile", map[string]any{
+		"profileTypeID": profileType,
+		"labelSelector": fmt.Sprintf("{service_name=%q}", service),
+		"spanSelector":  spanIDs,
+		"start":         start,
+		"end":           end,
+	}, &resp)
+	if err != nil {
+		return 0, err
+	}
+	if len(resp.Flamegraph.Levels) == 0 || len(resp.Flamegraph.Levels[0].Values) < 2 {
+		return 0, nil
+	}
+	// levels[0].values = [offset, total, self, nameIndex]; index 1 is the total.
+	total, err := resp.Flamegraph.Levels[0].Values[1].Int64()
+	if err != nil {
+		return 0, err
+	}
+	return total, nil
+}
+
+// --- Tempo query helpers -----------------------------------------------------
+
+type tempoSearchResponse struct {
+	Traces []struct {
+		TraceID string `json:"traceID"`
+	} `json:"traces"`
+}
+
+func (e *env) tempoSearch(ctx context.Context, host string) ([]string, error) {
+	start := time.Now().Add(-1 * time.Hour).Unix()
+	end := time.Now().Add(1 * time.Minute).Unix()
+	url := fmt.Sprintf("http://%s/api/search?start=%d&end=%d&limit=20", host, start, end)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("tempo search returned %d: %s", resp.StatusCode, string(data))
+	}
+	var sr tempoSearchResponse
+	if err := json.Unmarshal(data, &sr); err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(sr.Traces))
+	for _, tr := range sr.Traces {
+		ids = append(ids, tr.TraceID)
+	}
+	return ids, nil
+}
+
+type otlpAttr struct {
+	Key   string `json:"key"`
+	Value struct {
+		StringValue string `json:"stringValue"`
+	} `json:"value"`
+}
+
+type tempoTrace struct {
+	Batches []struct {
+		ScopeSpans []struct {
+			Spans []struct {
+				Name       string     `json:"name"`
+				Attributes []otlpAttr `json:"attributes"`
+			} `json:"spans"`
+		} `json:"scopeSpans"`
+	} `json:"batches"`
+}
+
+const pyroscopeProfileIDAttr = "pyroscope.profile.id"
+
+// profileIDsFromTrace fetches a trace and returns the values of every
+// pyroscope.profile.id span attribute it contains.
+func (e *env) profileIDsFromTrace(ctx context.Context, host, traceID string) ([]string, error) {
+	url := fmt.Sprintf("http://%s/api/traces/%s", host, traceID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("tempo trace returned %d: %s", resp.StatusCode, string(data))
+	}
+	var tr tempoTrace
+	if err := json.Unmarshal(data, &tr); err != nil {
+		return nil, err
+	}
+	var ids []string
+	for _, b := range tr.Batches {
+		for _, ss := range b.ScopeSpans {
+			for _, sp := range ss.Spans {
+				for _, a := range sp.Attributes {
+					if a.Key == pyroscopeProfileIDAttr && a.Value.StringValue != "" {
+						ids = append(ids, a.Value.StringValue)
+					}
+				}
+			}
+		}
+	}
+	return ids, nil
+}
+
+// --- Tests -------------------------------------------------------------------
+
+// examplesToTest discovers the docker-compose examples and filters them by the
+// PYROSCOPE_TEST_EXAMPLES environment variable (a comma/newline/space separated
+// list of repository-relative example dirs, e.g. "examples/tracing/java"). When
+// the variable is empty, all examples are returned.
+func examplesToTest(t *testing.T) []*env {
+	out, err := exec.Command("git", "ls-files", "**/docker-compose.yml").Output()
+	require.NoError(t, err)
+
+	var selected map[string]struct{}
+	if raw := strings.TrimSpace(os.Getenv("PYROSCOPE_TEST_EXAMPLES")); raw != "" {
+		selected = map[string]struct{}{}
+		for _, f := range strings.FieldsFunc(raw, func(r rune) bool {
+			return r == ',' || r == '\n' || r == ' ' || r == '\t'
+		}) {
+			selected[strings.TrimRight(f, "/")] = struct{}{}
+		}
+	}
+
+	var envs []*env
+	for _, path := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if path == "" {
+			continue
+		}
+		e := &env{dir: filepath.Dir(path), path: path}
+		if selected != nil {
+			if _, ok := selected[e.repoDir()]; !ok {
+				continue
+			}
+		}
+		envs = append(envs, e)
+	}
+	return envs
+}
+
+// TestExampleProfiles brings up each selected example, verifies all containers
+// stay running, and then verifies that profiles are queryable from Pyroscope via
+// the Series and SelectSeries APIs.
+func TestExampleProfiles(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
 
-	ctx := context.Background()
-
-	// find docker compose files
-	out, err := exec.Command("git", "ls-files", "**/docker-compose.yml").Output()
-	require.NoError(t, err)
-
-	var envs []*env
-	for _, path := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		e := &env{dir: filepath.Dir(path), path: path}
-		envs = append(envs, e)
-	}
-
-	for i := range envs {
-		t.Run(envs[i].dir, func(t *testing.T) {
-			e := envs[i]
+	for _, e := range examplesToTest(t) {
+		e := e
+		t.Run(e.repoDir(), func(t *testing.T) {
 			t.Parallel()
-			ctx, cancel := context.WithTimeout(ctx, timeoutPerExample)
+			ctx, cancel := context.WithTimeout(context.Background(), timeoutPerExample)
 			defer cancel()
-			t.Run("build", func(t *testing.T) {
-				cmd := e.newCmdWithOutputCapture(t, ctx, "build")
-				require.NoError(t, cmd.Run())
-			})
-			// run pull first so lcontainers can start immediately
-			t.Run("pull", func(t *testing.T) {
-				cmd := e.newCmdWithOutputCapture(t, ctx, "pull")
-				require.NoError(t, cmd.Run())
-			})
-			// now run the docker-compose containers, run them for 5 seconds, it would abort if one of the containers exits
-			t.Run("run", func(t *testing.T) {
-				ctx, cancel := context.WithCancel(ctx)
-				defer cancel()
-				e = e.removeExposedPorts(t)
-				cmd := e.newCmdWithOutputCapture(t, ctx, "up", "--abort-on-container-exit")
-				require.NoError(t, cmd.Start())
 
-				// cleanup what ever happens
-				defer func() {
-					err := e.newCmdWithOutputCapture(t, context.Background(), "down", "--volumes").Run()
-					if err != nil {
-						t.Logf("cleanup error=%v\n", err)
-					}
-				}()
+			e := e.prepareCompose(t)
+			defer e.bringUp(t, ctx)()
+			e.waitRunning(t, ctx)
 
-				// check if all containers are still running after 5 seconds
-				go func() {
-					<-time.After(durationToStayRunning)
-					err := e.containersAllRunning(ctx)
-					if err != nil {
-						t.Logf("do nothing, as not all containers are running: %v\n", err)
-						return
-					}
-					t.Log("all healthy, start graceful shutdown")
-					err = cmd.Process.Signal(syscall.SIGTERM)
-					if err != nil {
-						t.Log("error sending terminate signal", err)
-					}
-				}()
+			host := "127.0.0.1:" + e.hostPort(t, ctx, pyroscopeService, pyroscopePort)
+			t.Logf("[%s] all containers running; pyroscope on %s, waiting for profiles to be queryable", e.repoDir(), host)
 
-				err := cmd.Wait()
-				var exitError *exec.ExitError
-				if !errors.As(err, &exitError) || exitError.ExitCode() != 130 {
-					require.NoError(t, err)
+			dir := e.repoDir()
+			var summary string
+			poll(t, ctx, profilesQueryTimeout, func(progress func(string, ...any)) error {
+				progress("[%s] querying Series for ingested profiles...", dir)
+				data, err := e.discoverSeries(ctx, host)
+				if err != nil {
+					return err
 				}
-
+				progress("[%s] Series found %d service(s): %s; querying SelectSeries...", dir, len(data), strings.Join(sortedKeys(data), ", "))
+				for svc, types := range data {
+					for _, pt := range types {
+						nSeries, nPoints, err := e.selectSeries(ctx, host, svc, pt)
+						if err != nil {
+							return err
+						}
+						if nPoints > 0 {
+							summary = fmt.Sprintf("service=%q profileType=%q -> %d series, %d points (%d service(s) ingesting)",
+								svc, pt, nSeries, nPoints, len(data))
+							return nil
+						}
+						progress("[%s] SelectSeries service=%q type=%q -> 0 points (waiting for data)", dir, svc, pt)
+					}
+				}
+				return fmt.Errorf("no data points for any of %d discovered series yet", len(data))
 			})
+			t.Logf("[%s] PASS profiles queryable via Series+SelectSeries: %s", dir, summary)
 		})
 	}
+}
 
+// TestExampleTracingSpanProfiles brings up each selected tracing example and
+// verifies the trace-to-profile link end to end: a trace is found in Tempo, a
+// span carries a pyroscope.profile.id attribute, and SelectMergeSpanProfile
+// returns span-scoped profiling data for it.
+func TestExampleTracingSpanProfiles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	for _, e := range examplesToTest(t) {
+		e := e
+		if !strings.HasPrefix(e.repoDir(), filepath.Join("examples", "tracing")+string(filepath.Separator)) {
+			continue
+		}
+		t.Run(e.repoDir(), func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithTimeout(context.Background(), timeoutPerExample)
+			defer cancel()
+
+			e := e.prepareCompose(t)
+			defer e.bringUp(t, ctx)()
+			e.waitRunning(t, ctx)
+
+			pyroHost := "127.0.0.1:" + e.hostPort(t, ctx, pyroscopeService, pyroscopePort)
+			tempoHost := "127.0.0.1:" + e.hostPort(t, ctx, tempoService, tempoPort)
+			t.Logf("[%s] all containers running; pyroscope on %s, tempo on %s, waiting for traces + span profiles", e.repoDir(), pyroHost, tempoHost)
+
+			// Find a trace whose span carries a pyroscope.profile.id, then verify
+			// span-scoped profiling data can be fetched for it. The (service,
+			// profile type) carrying span data is discovered from Pyroscope.
+			dir := e.repoDir()
+			var summary string
+			poll(t, ctx, tracesQueryTimeout, func(progress func(string, ...any)) error {
+				progress("[%s] querying Series for ingested profiles...", dir)
+				data, err := e.discoverSeries(ctx, pyroHost)
+				if err != nil {
+					return err
+				}
+				progress("[%s] Series found %d service(s): %s; searching Tempo for traces...", dir, len(data), strings.Join(sortedKeys(data), ", "))
+
+				traceIDs, err := e.tempoSearch(ctx, tempoHost)
+				if err != nil {
+					return err
+				}
+				if len(traceIDs) == 0 {
+					return errors.New("no traces found in tempo yet")
+				}
+				progress("[%s] found %d trace(s); scanning spans for %s attribute...", dir, len(traceIDs), pyroscopeProfileIDAttr)
+
+				var spanIDs []string
+				for _, id := range traceIDs {
+					ids, err := e.profileIDsFromTrace(ctx, tempoHost, id)
+					if err != nil {
+						return err
+					}
+					spanIDs = append(spanIDs, ids...)
+				}
+				if len(spanIDs) == 0 {
+					return fmt.Errorf("found %d traces in tempo but no span carried a %s attribute", len(traceIDs), pyroscopeProfileIDAttr)
+				}
+				progress("[%s] found %d span(s) with %s; querying SelectMergeSpanProfile...", dir, len(spanIDs), pyroscopeProfileIDAttr)
+
+				for svc, types := range data {
+					for _, pt := range types {
+						total, err := e.selectMergeSpanProfile(ctx, pyroHost, svc, pt, spanIDs)
+						if err != nil {
+							return err
+						}
+						if total > 0 {
+							summary = fmt.Sprintf("service=%q profileType=%q -> %d span id(s) from %d trace(s), %d samples",
+								svc, pt, len(spanIDs), len(traceIDs), total)
+							return nil
+						}
+						progress("[%s] SelectMergeSpanProfile service=%q type=%q -> 0 samples", dir, svc, pt)
+					}
+				}
+				return fmt.Errorf("found %d span ids but SelectMergeSpanProfile returned no samples across %d service(s)", len(spanIDs), len(data))
+			})
+			t.Logf("[%s] PASS trace->profile link via SelectMergeSpanProfile: %s", dir, summary)
+		})
+	}
 }

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -612,15 +612,12 @@ func (e *env) profileIDsFromTrace(ctx context.Context, host, traceID string) ([]
 
 // examplesToTest discovers the docker-compose examples and filters them by the
 // PYROSCOPE_TEST_EXAMPLES environment variable (a comma/newline/space separated
-// list of repository-relative example dirs, e.g. "examples/tracing/java"). When
-// the variable is empty, all examples are returned. It fails the test if the
-// variable names an example that does not exist, so a typo cannot silently pass
-// by selecting (and testing) nothing.
+// list of repository-relative paths).
 func examplesToTest(t *testing.T) []*env {
 	out, err := exec.Command("git", "ls-files", "**/docker-compose.yml", "**/docker-compose.yaml").Output()
 	require.NoError(t, err)
 
-	// requested maps each requested dir to whether a matching example was found.
+	// requested maps each requested path to whether it matched an example.
 	var requested map[string]bool
 	if raw := strings.TrimSpace(os.Getenv("PYROSCOPE_TEST_EXAMPLES")); raw != "" {
 		requested = map[string]bool{}
@@ -638,18 +635,24 @@ func examplesToTest(t *testing.T) []*env {
 		}
 		e := &env{dir: filepath.Dir(path), path: path}
 		if requested != nil {
-			if _, ok := requested[e.repoDir()]; !ok {
+			matched := false
+			for p := range requested {
+				if e.repoDir() == p || strings.HasPrefix(e.repoDir(), p+"/") {
+					requested[p] = true
+					matched = true
+				}
+			}
+			if !matched {
 				continue
 			}
-			requested[e.repoDir()] = true
 		}
 		envs = append(envs, e)
 	}
 
 	var unmatched []string
-	for dir, matched := range requested {
+	for p, matched := range requested {
 		if !matched {
-			unmatched = append(unmatched, dir)
+			unmatched = append(unmatched, p)
 		}
 	}
 	if len(unmatched) > 0 {

--- a/tools/examples/select-examples.sh
+++ b/tools/examples/select-examples.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Prints the repository-relative directories of the docker-compose examples that
+# should be tested, one per line.
+#
+# Selection logic:
+#   - If TARGET is set, select every example at or under that path prefix
+#     (e.g. TARGET=examples/tracing selects all tracing examples).
+#   - Else if BASE_REF is set, select every example that has a changed file in
+#     the diff against BASE_REF (used for pull requests).
+#   - Else select all examples.
+#
+# Environment:
+#   TARGET    Optional path prefix to scope the selection to.
+#   BASE_REF  Optional git ref to diff against (e.g. origin/main).
+
+set -euo pipefail
+
+# All example directories (those containing a docker-compose.yml).
+mapfile -t all_dirs < <(git ls-files 'examples/**/docker-compose.yml' | xargs -n1 dirname | sort -u)
+
+emit_under_prefix() {
+  local prefix="${1%/}"
+  local d
+  for d in "${all_dirs[@]}"; do
+    if [[ "$d" == "$prefix" || "$d" == "$prefix"/* ]]; then
+      echo "$d"
+    fi
+  done
+}
+
+if [[ -n "${TARGET:-}" ]]; then
+  emit_under_prefix "$TARGET"
+  exit 0
+fi
+
+if [[ -n "${BASE_REF:-}" ]]; then
+  mapfile -t changed < <(git diff --name-only "${BASE_REF}"...HEAD -- examples)
+  for d in "${all_dirs[@]}"; do
+    for f in "${changed[@]:-}"; do
+      if [[ "$f" == "$d"/* ]]; then
+        echo "$d"
+        break
+      fi
+    done
+  done
+  exit 0
+fi
+
+printf '%s\n' "${all_dirs[@]}"

--- a/tools/examples/select-examples.sh
+++ b/tools/examples/select-examples.sh
@@ -17,7 +17,7 @@
 set -euo pipefail
 
 # All example directories (those containing a docker-compose.yml).
-mapfile -t all_dirs < <(git ls-files 'examples/**/docker-compose.yml' | xargs -n1 dirname | sort -u)
+mapfile -t all_dirs < <(git ls-files 'examples/**/docker-compose.yml' 'examples/**/docker-compose.yaml' | xargs -n1 dirname | sort -u)
 
 emit_under_prefix() {
   local prefix="${1%/}"


### PR DESCRIPTION
The current CI for testing examples runs on a cron and manually, and only verifies that the containers stand up. Regressions in SDKs or the way examples are structured are therefore not caught - examples/tracing/java is currently broken.

This change expands the current check to do a full test. 

Triggers:
- cron, like today
- manual, like today but can be scoped to a test or a test directory (e.g. all dotnet)
- PRs like https://github.com/grafana/pyroscope/pull/5210

Checks:
- the containers are up
- profiling data is coming in (can be queried)
- trace-profile linking works for tracing examples

