### PR TITLE
examples(java): fix wrong jar usage and outdated base image

### DIFF
--- a/docs/sources/configure-client/trace-span-profiles/java-span-profiles.md
+++ b/docs/sources/configure-client/trace-span-profiles/java-span-profiles.md
@@ -71,7 +71,7 @@ EXPOSE 5000
 
 ## Add required libraries
 ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.17.0/opentelemetry-javaagent.jar opentelemetry-javaagent.jar
-ADD https://github.com/grafana/otel-profiling-java/releases/download/v2.0.3/pyroscope-otel.jar pyroscope-otel.jar
+ADD https://github.com/grafana/otel-profiling-java/releases/download/v2.0.5/pyroscope-otel-javaagent-extension.jar pyroscope-otel-javaagent-extension.jar
 
 ENV PYROSCOPE_APPLICATION_NAME=my-app
 ENV PYROSCOPE_FORMAT=jfr
@@ -80,7 +80,7 @@ ENV PYROSCOPE_PROFILER_EVENT=itimer
 ENV PYROSCOPE_PROFILER_LOCK=10ms
 ENV PYROSCOPE_PROFILER_ALLOC=512k
 ENV PYROSCOPE_UPLOAD_INTERVAL=15s
-ENV OTEL_JAVAAGENT_EXTENSIONS=./pyroscope-otel.jar
+ENV OTEL_JAVAAGENT_EXTENSIONS=./pyroscope-otel-javaagent-extension.jar
 ENV OTEL_PYROSCOPE_ADD_PROFILE_URL=false
 ENV OTEL_PYROSCOPE_ADD_PROFILE_BASELINE_URL=false
 ENV OTEL_PYROSCOPE_START_PROFILING=true

--- a/examples/language-sdk-instrumentation/java/simple/Dockerfile
+++ b/examples/language-sdk-instrumentation/java/simple/Dockerfile
@@ -1,4 +1,4 @@
-FROM sapmachine:11-jdk-headless
+FROM eclipse-temurin:11.0.31_11-jdk-jammy
 
 WORKDIR /opt/app
 

--- a/examples/tracing/java-wall/Dockerfile
+++ b/examples/tracing/java-wall/Dockerfile
@@ -31,7 +31,7 @@ ENV PYROSCOPE_UPLOAD_INTERVAL=15s
 ENV PYROSCOPE_LOG_LEVEL=debug
 ENV PYROSCOPE_SERVER_ADDRESS=http://localhost:4040
 
-ENV OTEL_JAVAAGENT_EXTENSIONS=./pyroscope-otel.jar
+ENV OTEL_JAVAAGENT_EXTENSIONS=./pyroscope-otel-javaagent-extension.jar
 
 ENV OTEL_PYROSCOPE_ADD_PROFILE_URL=false
 ENV OTEL_PYROSCOPE_ADD_PROFILE_BASELINE_URL=false
@@ -42,7 +42,7 @@ COPY --from=builder /opt/app/build/libs/rideshare-1.0-SNAPSHOT.jar /opt/app/buil
 WORKDIR /opt/app
 
 ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.15.0/opentelemetry-javaagent.jar opentelemetry-javaagent.jar
-ADD https://github.com/grafana/otel-profiling-java/releases/download/v2.0.4/pyroscope-otel-javaagent-extension.jar pyroscope-otel.jar
+ADD https://github.com/grafana/otel-profiling-java/releases/download/v2.0.5/pyroscope-otel-javaagent-extension.jar pyroscope-otel-javaagent-extension.jar
 
 EXPOSE 5000
 

--- a/examples/tracing/java/Dockerfile
+++ b/examples/tracing/java/Dockerfile
@@ -31,7 +31,7 @@ ENV PYROSCOPE_UPLOAD_INTERVAL=15s
 ENV PYROSCOPE_LOG_LEVEL=debug
 ENV PYROSCOPE_SERVER_ADDRESS=http://localhost:4040
 
-ENV OTEL_JAVAAGENT_EXTENSIONS=./pyroscope-otel.jar
+ENV OTEL_JAVAAGENT_EXTENSIONS=./pyroscope-otel-javaagent-extension.jar
 
 ENV OTEL_PYROSCOPE_ADD_PROFILE_URL=false
 ENV OTEL_PYROSCOPE_ADD_PROFILE_BASELINE_URL=false
@@ -42,9 +42,8 @@ COPY --from=builder /opt/app/build/libs/rideshare-1.0-SNAPSHOT.jar /opt/app/buil
 WORKDIR /opt/app
 
 ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.15.0/opentelemetry-javaagent.jar opentelemetry-javaagent.jar
-ADD https://github.com/grafana/pyroscope-java/releases/download/v2.5.2/pyroscope.jar pyroscope.jar
-ADD https://github.com/grafana/otel-profiling-java/releases/download/v2.0.3/pyroscope-otel.jar pyroscope-otel.jar
+ADD https://github.com/grafana/otel-profiling-java/releases/download/v2.0.5/pyroscope-otel-javaagent-extension.jar pyroscope-otel-javaagent-extension.jar
 
 EXPOSE 5000
 
-CMD ["java", "-Dserver.port=5000", "-javaagent:./pyroscope.jar", "-javaagent:./opentelemetry-javaagent.jar", "-jar", "./build/libs/rideshare-1.0-SNAPSHOT.jar" ]
+CMD ["java", "-Dserver.port=5000", "-javaagent:./opentelemetry-javaagent.jar", "-jar", "./build/libs/rideshare-1.0-SNAPSHOT.jar" ]

--- a/tools/update_examples.go
+++ b/tools/update_examples.go
@@ -238,8 +238,8 @@ func updateJava() {
 func updateOtelProfilingJava() {
 	tags := getTagsV("grafana/otel-profiling-java", extractGoVersion(""))
 	last := tags[len(tags)-1]
-	reJarURL := regexp.MustCompile(`https://github\.com/grafana/otel-profiling-java/releases/download/(v\d+\.\d+\.\d+)/pyroscope-otel\.jar`)
-	lastJarURL := "https://github.com/grafana/otel-profiling-java/releases/download/" + last.versionV() + "/pyroscope-otel.jar"
+	reJarURL := regexp.MustCompile(`https://github\.com/grafana/otel-profiling-java/releases/download/(v\d+\.\d+\.\d+)/pyroscope-otel-javaagent-extension\.jar`)
+	lastJarURL := "https://github.com/grafana/otel-profiling-java/releases/download/" + last.versionV() + "/pyroscope-otel-javaagent-extension.jar"
 	replaceInplace(reJarURL, "docs/sources/configure-client/trace-span-profiles/java-span-profiles.md", lastJarURL)
 	replaceInplace(reJarURL, "examples/tracing/java/Dockerfile", lastJarURL)
 }


### PR DESCRIPTION
addresses the java example failures reported in https://github.com/grafana/pyroscope/actions/runs/26817239342/job/79062083457