### PR TITLE
examples(dotnet): switch to GH releases, improve update script

### DIFF
--- a/docs/sources/configure-client/language-sdks/dotnet.md
+++ b/docs/sources/configure-client/language-sdks/dotnet.md
@@ -48,7 +48,7 @@ The Pyroscope server can be a local server for development or a remote server fo
 1. Obtain `Pyroscope.Profiler.Native.so` and `Pyroscope.Linux.ApiWrapper.x64.so` from the [latest tarball](https://github.com/grafana/pyroscope-dotnet/releases/):
 
 ```bash
-curl -s -L https://github.com/grafana/pyroscope-dotnet/releases/download/v0.15.0-pyroscope/pyroscope.0.15.0-glibc-x86_64.tar.gz  | tar xvz -C .
+curl -s -L https://github.com/grafana/pyroscope-dotnet/releases/download/pyroscope-1.0.0/pyroscope.1.0.0-glibc-x86_64.tar.gz  | tar xvz -C .
 ```
 
 `glibc` and `musl` builds are published for both `x86_64` and `aarch64`; pick the tarball that matches your base image.

--- a/docs/sources/configure-client/language-sdks/dotnet.md
+++ b/docs/sources/configure-client/language-sdks/dotnet.md
@@ -51,11 +51,7 @@ The Pyroscope server can be a local server for development or a remote server fo
 curl -s -L https://github.com/grafana/pyroscope-dotnet/releases/download/v0.15.0-pyroscope/pyroscope.0.15.0-glibc-x86_64.tar.gz  | tar xvz -C .
 ```
 
-Or copy them from the [latest docker image](https://hub.docker.com/r/pyroscope/pyroscope-dotnet/tags). We have `glibc` and `musl` versions:
-```dockerfile
-COPY --from=pyroscope/pyroscope-dotnet:0.15.0-glibc /Pyroscope.Profiler.Native.so /dotnet/Pyroscope.Profiler.Native.so
-COPY --from=pyroscope/pyroscope-dotnet:0.15.0-glibc /Pyroscope.Linux.ApiWrapper.x64.so /dotnet/Pyroscope.Linux.ApiWrapper.x64.so
-````
+`glibc` and `musl` builds are published for both `x86_64` and `aarch64`; pick the tarball that matches your base image.
 
 2. Set the following required environment variables to enable profiler
 ```shell

--- a/examples/language-sdk-instrumentation/dotnet/fast-slow/Dockerfile
+++ b/examples/language-sdk-instrumentation/dotnet/fast-slow/Dockerfile
@@ -1,4 +1,4 @@
-ARG PROFILER_VERSION=0.15.0
+ARG PROFILER_VERSION=1.0.0
 
 FROM alpine:3 AS sdk
 ARG PROFILER_VERSION
@@ -10,7 +10,7 @@ RUN case "$TARGETARCH" in \
       *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
     esac \
     && curl -fsSL -o /tmp/pyroscope.tar.gz \
-      "https://github.com/grafana/pyroscope-dotnet/releases/download/v${PROFILER_VERSION}-pyroscope/pyroscope.${PROFILER_VERSION}-glibc-${PROFILER_ARCH}.tar.gz" \
+      "https://github.com/grafana/pyroscope-dotnet/releases/download/pyroscope-${PROFILER_VERSION}/pyroscope.${PROFILER_VERSION}-glibc-${PROFILER_ARCH}.tar.gz" \
     && mkdir -p /pyroscope \
     && tar -xzf /tmp/pyroscope.tar.gz -C /pyroscope
 

--- a/examples/language-sdk-instrumentation/dotnet/fast-slow/Dockerfile
+++ b/examples/language-sdk-instrumentation/dotnet/fast-slow/Dockerfile
@@ -1,9 +1,25 @@
+ARG PROFILER_VERSION=0.15.0
+
+FROM alpine:3 AS sdk
+ARG PROFILER_VERSION
+ARG TARGETARCH
+RUN apk add --no-cache curl tar
+RUN case "$TARGETARCH" in \
+      amd64) PROFILER_ARCH=x86_64 ;; \
+      arm64) PROFILER_ARCH=aarch64 ;; \
+      *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL -o /tmp/pyroscope.tar.gz \
+      "https://github.com/grafana/pyroscope-dotnet/releases/download/v${PROFILER_VERSION}-pyroscope/pyroscope.${PROFILER_VERSION}-glibc-${PROFILER_ARCH}.tar.gz" \
+    && mkdir -p /pyroscope \
+    && tar -xzf /tmp/pyroscope.tar.gz -C /pyroscope
+
 FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 WORKDIR /dotnet
 
-COPY --from=grafana/pyroscope-dotnet:0.15.0-glibc /Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
-COPY --from=grafana/pyroscope-dotnet:0.15.0-glibc /Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
+COPY --from=sdk /pyroscope/Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
+COPY --from=sdk /pyroscope/Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
 
 ADD example .
 

--- a/examples/language-sdk-instrumentation/dotnet/fast-slow/musl.Dockerfile
+++ b/examples/language-sdk-instrumentation/dotnet/fast-slow/musl.Dockerfile
@@ -1,4 +1,4 @@
-ARG PROFILER_VERSION=0.15.0
+ARG PROFILER_VERSION=1.0.0
 
 # Fetch the profiler artifacts from the GitHub release.
 FROM alpine:3 AS sdk
@@ -11,7 +11,7 @@ RUN case "$TARGETARCH" in \
       *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
     esac \
     && curl -fsSL -o /tmp/pyroscope.tar.gz \
-      "https://github.com/grafana/pyroscope-dotnet/releases/download/v${PROFILER_VERSION}-pyroscope/pyroscope.${PROFILER_VERSION}-musl-${PROFILER_ARCH}.tar.gz" \
+      "https://github.com/grafana/pyroscope-dotnet/releases/download/pyroscope-${PROFILER_VERSION}/pyroscope.${PROFILER_VERSION}-musl-${PROFILER_ARCH}.tar.gz" \
     && mkdir -p /pyroscope \
     && tar -xzf /tmp/pyroscope.tar.gz -C /pyroscope
 

--- a/examples/language-sdk-instrumentation/dotnet/fast-slow/musl.Dockerfile
+++ b/examples/language-sdk-instrumentation/dotnet/fast-slow/musl.Dockerfile
@@ -1,9 +1,26 @@
+ARG PROFILER_VERSION=0.15.0
+
+# Fetch the profiler artifacts from the GitHub release.
+FROM alpine:3 AS sdk
+ARG PROFILER_VERSION
+ARG TARGETARCH
+RUN apk add --no-cache curl tar
+RUN case "$TARGETARCH" in \
+      amd64) PROFILER_ARCH=x86_64 ;; \
+      arm64) PROFILER_ARCH=aarch64 ;; \
+      *) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL -o /tmp/pyroscope.tar.gz \
+      "https://github.com/grafana/pyroscope-dotnet/releases/download/v${PROFILER_VERSION}-pyroscope/pyroscope.${PROFILER_VERSION}-musl-${PROFILER_ARCH}.tar.gz" \
+    && mkdir -p /pyroscope \
+    && tar -xzf /tmp/pyroscope.tar.gz -C /pyroscope
+
 FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine
 
 WORKDIR /dotnet
 
-COPY --from=grafana/pyroscope-dotnet:0.15.0-musl /Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
-COPY --from=grafana/pyroscope-dotnet:0.15.0-musl /Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
+COPY --from=sdk /pyroscope/Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
+COPY --from=sdk /pyroscope/Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
 
 ADD example .
 

--- a/examples/language-sdk-instrumentation/dotnet/rideshare/Dockerfile
+++ b/examples/language-sdk-instrumentation/dotnet/rideshare/Dockerfile
@@ -1,5 +1,5 @@
 ARG SDK_VERSION=8.0
-ARG PROFILER_VERSION=0.15.0
+ARG PROFILER_VERSION=1.0.0
 # The build images takes an SDK image of the buildplatform, so the platform the build is running on.
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:$SDK_VERSION-bookworm-slim AS build
 
@@ -27,7 +27,7 @@ FROM --platform=linux/amd64 alpine:3 AS sdk
 ARG PROFILER_VERSION
 RUN apk add --no-cache curl tar
 RUN curl -fsSL -o /tmp/pyroscope.tar.gz \
-      "https://github.com/grafana/pyroscope-dotnet/releases/download/v${PROFILER_VERSION}-pyroscope/pyroscope.${PROFILER_VERSION}-glibc-x86_64.tar.gz" \
+      "https://github.com/grafana/pyroscope-dotnet/releases/download/pyroscope-${PROFILER_VERSION}/pyroscope.${PROFILER_VERSION}-glibc-x86_64.tar.gz" \
     && mkdir -p /pyroscope \
     && tar -xzf /tmp/pyroscope.tar.gz -C /pyroscope
 

--- a/examples/language-sdk-instrumentation/dotnet/rideshare/Dockerfile
+++ b/examples/language-sdk-instrumentation/dotnet/rideshare/Dockerfile
@@ -1,4 +1,5 @@
 ARG SDK_VERSION=8.0
+ARG PROFILER_VERSION=0.15.0
 # The build images takes an SDK image of the buildplatform, so the platform the build is running on.
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:$SDK_VERSION-bookworm-slim AS build
 
@@ -21,8 +22,14 @@ RUN sed -i -E 's|<TargetFramework>.*</TargetFramework>|<TargetFramework>net'$SDK
 # We hardcode linux-x64 here, as the profiler doesn't support any other platform
 RUN dotnet publish -o . --framework net$SDK_VERSION --runtime linux-x64 --no-self-contained
 
-# This fetches the SDK
-FROM --platform=linux/amd64 grafana/pyroscope-dotnet:0.15.0-glibc AS sdk
+# Fetch the profiler artifacts from the GitHub release.
+FROM --platform=linux/amd64 alpine:3 AS sdk
+ARG PROFILER_VERSION
+RUN apk add --no-cache curl tar
+RUN curl -fsSL -o /tmp/pyroscope.tar.gz \
+      "https://github.com/grafana/pyroscope-dotnet/releases/download/v${PROFILER_VERSION}-pyroscope/pyroscope.${PROFILER_VERSION}-glibc-x86_64.tar.gz" \
+    && mkdir -p /pyroscope \
+    && tar -xzf /tmp/pyroscope.tar.gz -C /pyroscope
 
 # Runtime only image of the targetplatfrom, so the platform the image will be running on.
 FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:$SDK_VERSION-noble-chiseled-extra
@@ -32,8 +39,8 @@ WORKDIR /dotnet
 # chiseled images don't include CA certs by default
 COPY --from=build /etc/ssl/certs /etc/ssl/certs
 
-COPY --from=sdk /Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
-COPY --from=sdk /Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
+COPY --from=sdk /pyroscope/Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
+COPY --from=sdk /pyroscope/Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
 COPY --from=build /dotnet/ ./
 
 

--- a/examples/language-sdk-instrumentation/dotnet/rideshare/musl.Dockerfile
+++ b/examples/language-sdk-instrumentation/dotnet/rideshare/musl.Dockerfile
@@ -1,5 +1,5 @@
 ARG SDK_VERSION=8.0
-ARG PROFILER_VERSION=0.15.0
+ARG PROFILER_VERSION=1.0.0
 # The build images takes an SDK image of the buildplatform, so the platform the build is running on.
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:$SDK_VERSION-alpine AS build
 
@@ -27,7 +27,7 @@ FROM --platform=linux/amd64 alpine:3 AS sdk
 ARG PROFILER_VERSION
 RUN apk add --no-cache curl tar
 RUN curl -fsSL -o /tmp/pyroscope.tar.gz \
-      "https://github.com/grafana/pyroscope-dotnet/releases/download/v${PROFILER_VERSION}-pyroscope/pyroscope.${PROFILER_VERSION}-musl-x86_64.tar.gz" \
+      "https://github.com/grafana/pyroscope-dotnet/releases/download/pyroscope-${PROFILER_VERSION}/pyroscope.${PROFILER_VERSION}-musl-x86_64.tar.gz" \
     && mkdir -p /pyroscope \
     && tar -xzf /tmp/pyroscope.tar.gz -C /pyroscope
 

--- a/examples/language-sdk-instrumentation/dotnet/rideshare/musl.Dockerfile
+++ b/examples/language-sdk-instrumentation/dotnet/rideshare/musl.Dockerfile
@@ -1,4 +1,5 @@
 ARG SDK_VERSION=8.0
+ARG PROFILER_VERSION=0.15.0
 # The build images takes an SDK image of the buildplatform, so the platform the build is running on.
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:$SDK_VERSION-alpine AS build
 
@@ -21,16 +22,22 @@ RUN sed -i -E 's|<TargetFramework>.*</TargetFramework>|<TargetFramework>net'$SDK
 # We hardcode linux-x64 here, as the profiler doesn't support any other platform
 RUN dotnet publish -o . --framework net$SDK_VERSION --runtime linux-musl-x64 --no-self-contained
 
-# This fetches the SDK
-FROM --platform=linux/amd64 grafana/pyroscope-dotnet:0.15.0-musl AS sdk
+# Fetch the profiler artifacts from the GitHub release.
+FROM --platform=linux/amd64 alpine:3 AS sdk
+ARG PROFILER_VERSION
+RUN apk add --no-cache curl tar
+RUN curl -fsSL -o /tmp/pyroscope.tar.gz \
+      "https://github.com/grafana/pyroscope-dotnet/releases/download/v${PROFILER_VERSION}-pyroscope/pyroscope.${PROFILER_VERSION}-musl-x86_64.tar.gz" \
+    && mkdir -p /pyroscope \
+    && tar -xzf /tmp/pyroscope.tar.gz -C /pyroscope
 
 # Runtime only image of the targetplatfrom, so the platform the image will be running on.
 FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:$SDK_VERSION-alpine
 
 WORKDIR /dotnet
 
-COPY --from=sdk /Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
-COPY --from=sdk /Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
+COPY --from=sdk /pyroscope/Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
+COPY --from=sdk /pyroscope/Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
 COPY --from=build /dotnet/ ./
 
 

--- a/examples/language-sdk-instrumentation/dotnet/web-new/Dockerfile
+++ b/examples/language-sdk-instrumentation/dotnet/web-new/Dockerfile
@@ -1,11 +1,11 @@
-ARG PROFILER_VERSION=0.15.0
+ARG PROFILER_VERSION=1.0.0
 
 # Fetch the profiler artifacts from the GitHub release.
 FROM --platform=linux/amd64 alpine:3 AS sdk
 ARG PROFILER_VERSION
 RUN apk add --no-cache curl tar
 RUN curl -fsSL -o /tmp/pyroscope.tar.gz \
-      "https://github.com/grafana/pyroscope-dotnet/releases/download/v${PROFILER_VERSION}-pyroscope/pyroscope.${PROFILER_VERSION}-glibc-x86_64.tar.gz" \
+      "https://github.com/grafana/pyroscope-dotnet/releases/download/pyroscope-${PROFILER_VERSION}/pyroscope.${PROFILER_VERSION}-glibc-x86_64.tar.gz" \
     && mkdir -p /pyroscope \
     && tar -xzf /tmp/pyroscope.tar.gz -C /pyroscope
 

--- a/examples/language-sdk-instrumentation/dotnet/web-new/Dockerfile
+++ b/examples/language-sdk-instrumentation/dotnet/web-new/Dockerfile
@@ -1,10 +1,21 @@
+ARG PROFILER_VERSION=0.15.0
+
+# Fetch the profiler artifacts from the GitHub release.
+FROM --platform=linux/amd64 alpine:3 AS sdk
+ARG PROFILER_VERSION
+RUN apk add --no-cache curl tar
+RUN curl -fsSL -o /tmp/pyroscope.tar.gz \
+      "https://github.com/grafana/pyroscope-dotnet/releases/download/v${PROFILER_VERSION}-pyroscope/pyroscope.${PROFILER_VERSION}-glibc-x86_64.tar.gz" \
+    && mkdir -p /pyroscope \
+    && tar -xzf /tmp/pyroscope.tar.gz -C /pyroscope
+
 FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/sdk:6.0
 # FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/sdk:6.0-alpine
 
 WORKDIR /dotnet
 
-COPY --from=grafana/pyroscope-dotnet:0.15.0-glibc /Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
-COPY --from=grafana/pyroscope-dotnet:0.15.0-glibc /Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
+COPY --from=sdk /pyroscope/Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
+COPY --from=sdk /pyroscope/Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
 
 ADD example .
 

--- a/examples/tracing/dotnet/Dockerfile
+++ b/examples/tracing/dotnet/Dockerfile
@@ -1,4 +1,5 @@
 ARG SDK_VERSION=8.0
+ARG PROFILER_VERSION=0.15.0
 # The build images takes an SDK image of the buildplatform, so the platform the build is running on.
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:$SDK_VERSION AS build
 
@@ -16,16 +17,21 @@ RUN sed -i -E 's|<TargetFramework>.*</TargetFramework>|<TargetFramework>net'$SDK
 # We hardcode linux-x64 here, as the profiler doesn't support any other platform
 RUN dotnet publish -o . --framework net$SDK_VERSION --runtime linux-x64 --no-self-contained
 
-# This fetches the SDK
-FROM --platform=linux/amd64 grafana/pyroscope-dotnet:0.15.0-glibc AS sdk
+FROM --platform=linux/amd64 alpine:3 AS sdk
+ARG PROFILER_VERSION
+RUN apk add --no-cache curl tar
+RUN curl -fsSL -o /tmp/pyroscope.tar.gz \
+      "https://github.com/grafana/pyroscope-dotnet/releases/download/v${PROFILER_VERSION}-pyroscope/pyroscope.${PROFILER_VERSION}-glibc-x86_64.tar.gz" \
+    && mkdir -p /pyroscope \
+    && tar -xzf /tmp/pyroscope.tar.gz -C /pyroscope
 
 # Runtime only image of the targetplatfrom, so the platform the image will be running on.
 FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:$SDK_VERSION
 
 WORKDIR /dotnet
 
-COPY --from=sdk /Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
-COPY --from=sdk /Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
+COPY --from=sdk /pyroscope/Pyroscope.Profiler.Native.so ./Pyroscope.Profiler.Native.so
+COPY --from=sdk /pyroscope/Pyroscope.Linux.ApiWrapper.x64.so ./Pyroscope.Linux.ApiWrapper.x64.so
 COPY --from=build /dotnet/ ./
 
 

--- a/examples/tracing/dotnet/Dockerfile
+++ b/examples/tracing/dotnet/Dockerfile
@@ -1,5 +1,5 @@
 ARG SDK_VERSION=8.0
-ARG PROFILER_VERSION=0.15.0
+ARG PROFILER_VERSION=1.0.0
 # The build images takes an SDK image of the buildplatform, so the platform the build is running on.
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:$SDK_VERSION AS build
 
@@ -21,7 +21,7 @@ FROM --platform=linux/amd64 alpine:3 AS sdk
 ARG PROFILER_VERSION
 RUN apk add --no-cache curl tar
 RUN curl -fsSL -o /tmp/pyroscope.tar.gz \
-      "https://github.com/grafana/pyroscope-dotnet/releases/download/v${PROFILER_VERSION}-pyroscope/pyroscope.${PROFILER_VERSION}-glibc-x86_64.tar.gz" \
+      "https://github.com/grafana/pyroscope-dotnet/releases/download/pyroscope-${PROFILER_VERSION}/pyroscope.${PROFILER_VERSION}-glibc-x86_64.tar.gz" \
     && mkdir -p /pyroscope \
     && tar -xzf /tmp/pyroscope.tar.gz -C /pyroscope
 

--- a/examples/tracing/dotnet/example/Example.csproj
+++ b/examples/tracing/dotnet/example/Example.csproj
@@ -11,6 +11,6 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageReference Include="Pyroscope.OpenTelemetry" Version="0.2.0" />
+    <PackageReference Include="Pyroscope.OpenTelemetry" Version="0.4.0" />
   </ItemGroup>
 </Project>

--- a/tools/update_examples.go
+++ b/tools/update_examples.go
@@ -122,21 +122,29 @@ func updateDotnet() {
 	last := tags[len(tags)-1]
 	fmt.Println(last)
 
-	reDockerGlibc := regexp.MustCompile(`grafana/pyroscope-dotnet:\d+\.\d+\.\d+-glibc`)
-	replDockerGlibc := fmt.Sprintf("grafana/pyroscope-dotnet:%s-glibc", last.version())
-	replaceInplace(reDockerGlibc, "examples/language-sdk-instrumentation/dotnet/fast-slow/Dockerfile", replDockerGlibc)
-	replaceInplace(reDockerGlibc, "examples/language-sdk-instrumentation/dotnet/rideshare/Dockerfile", replDockerGlibc)
-	replaceInplace(reDockerGlibc, "examples/language-sdk-instrumentation/dotnet/web-new/Dockerfile", replDockerGlibc)
-	replaceInplace(reDockerGlibc, "docs/sources/configure-client/language-sdks/dotnet.md", replDockerGlibc)
-
-	reDockerMusl := regexp.MustCompile(`grafana/pyroscope-dotnet:\d+\.\d+\.\d+-musl`)
-	replDockerMusl := fmt.Sprintf("grafana/pyroscope-dotnet:%s-musl", last.version())
-	replaceInplace(reDockerMusl, "examples/language-sdk-instrumentation/dotnet/fast-slow/musl.Dockerfile", replDockerMusl)
-	replaceInplace(reDockerMusl, "examples/language-sdk-instrumentation/dotnet/rideshare/musl.Dockerfile", replDockerMusl)
+	reArg := regexp.MustCompile(`ARG PROFILER_VERSION=\d+\.\d+\.\d+`)
+	replArg := fmt.Sprintf("ARG PROFILER_VERSION=%s", last.version())
+	for _, f := range []string{
+		"examples/tracing/dotnet/Dockerfile",
+		"examples/language-sdk-instrumentation/dotnet/fast-slow/Dockerfile",
+		"examples/language-sdk-instrumentation/dotnet/fast-slow/musl.Dockerfile",
+		"examples/language-sdk-instrumentation/dotnet/rideshare/Dockerfile",
+		"examples/language-sdk-instrumentation/dotnet/rideshare/musl.Dockerfile",
+		"examples/language-sdk-instrumentation/dotnet/web-new/Dockerfile",
+	} {
+		replaceInplace(reArg, f, replArg)
+	}
 
 	reUrl := regexp.MustCompile(`https://github\.com/grafana/pyroscope-dotnet/releases/download/v\d+\.\d+\.\d+-pyroscope/pyroscope.\d+\.\d+\.\d+-glibc-x86_64.tar.gz`)
 	replUrl := fmt.Sprintf("https://github.com/grafana/pyroscope-dotnet/releases/download/v%s-pyroscope/pyroscope.%s-glibc-x86_64.tar.gz", last.version(), last.version())
 	replaceInplace(reUrl, "docs/sources/configure-client/language-sdks/dotnet.md", replUrl)
+
+	otelTags := getTagsV("grafana/pyroscope-dotnet", extractDotnetOtelVersion())
+	lastOtel := otelTags[len(otelTags)-1]
+	fmt.Println("Pyroscope.OpenTelemetry", lastOtel)
+	reOtelPkg := regexp.MustCompile(`<PackageReference Include="Pyroscope.OpenTelemetry" Version="\d+\.\d+\.\d+" />`)
+	replOtelPkg := fmt.Sprintf(`<PackageReference Include="Pyroscope.OpenTelemetry" Version="%s" />`, lastOtel.version())
+	replaceInplace(reOtelPkg, "examples/tracing/dotnet/example/Example.csproj", replOtelPkg)
 }
 
 func updateTempo() {
@@ -342,6 +350,26 @@ func extractDotnetVersion() func(tag Tag) *version {
 
 		}
 		return nil
+	}
+}
+
+// extractDotnetOtelVersion matches the Pyroscope.OpenTelemetry helper release
+// tags (e.g. "v0.4.0-opentelemetry"), which are versioned independently of the
+// native profiler tags.
+func extractDotnetOtelVersion() func(tag Tag) *version {
+	return func(tag Tag) *version {
+		re := regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)-opentelemetry$`)
+		match := re.FindStringSubmatch(tag.Name)
+		if match == nil {
+			return nil
+		}
+		major, err := strconv.Atoi(match[1])
+		requireNoError(err, "strconv")
+		minor, err := strconv.Atoi(match[2])
+		requireNoError(err, "strconv")
+		patch, err := strconv.Atoi(match[3])
+		requireNoError(err, "strconv")
+		return &version{major: major, minor: minor, patch: patch, tag: tag}
 	}
 }
 

--- a/tools/update_examples.go
+++ b/tools/update_examples.go
@@ -118,7 +118,7 @@ func updateRust() {
 }
 
 func updateDotnet() {
-	tags := getTagsV("grafana/pyroscope-dotnet", extractDotnetVersion())
+	tags := getTagsV("grafana/pyroscope-dotnet", extractDotnetComponentVersion("pyroscope"))
 	last := tags[len(tags)-1]
 	fmt.Println(last)
 
@@ -135,11 +135,11 @@ func updateDotnet() {
 		replaceInplace(reArg, f, replArg)
 	}
 
-	reUrl := regexp.MustCompile(`https://github\.com/grafana/pyroscope-dotnet/releases/download/v\d+\.\d+\.\d+-pyroscope/pyroscope.\d+\.\d+\.\d+-glibc-x86_64.tar.gz`)
-	replUrl := fmt.Sprintf("https://github.com/grafana/pyroscope-dotnet/releases/download/v%s-pyroscope/pyroscope.%s-glibc-x86_64.tar.gz", last.version(), last.version())
+	reUrl := regexp.MustCompile(`https://github\.com/grafana/pyroscope-dotnet/releases/download/(?:v\d+\.\d+\.\d+-pyroscope|pyroscope-\d+\.\d+\.\d+)/pyroscope\.\d+\.\d+\.\d+-glibc-x86_64\.tar\.gz`)
+	replUrl := fmt.Sprintf("https://github.com/grafana/pyroscope-dotnet/releases/download/pyroscope-%s/pyroscope.%s-glibc-x86_64.tar.gz", last.version(), last.version())
 	replaceInplace(reUrl, "docs/sources/configure-client/language-sdks/dotnet.md", replUrl)
 
-	otelTags := getTagsV("grafana/pyroscope-dotnet", extractDotnetOtelVersion())
+	otelTags := getTagsV("grafana/pyroscope-dotnet", extractDotnetComponentVersion("opentelemetry"))
 	lastOtel := otelTags[len(otelTags)-1]
 	fmt.Println("Pyroscope.OpenTelemetry", lastOtel)
 	reOtelPkg := regexp.MustCompile(`<PackageReference Include="Pyroscope.OpenTelemetry" Version="\d+\.\d+\.\d+" />`)
@@ -333,33 +333,21 @@ func updateJfrParser() {
 	s.sh(" go get github.com/grafana/jfr-parser@" + parserVersion.versionV())
 }
 
-func extractDotnetVersion() func(tag Tag) *version {
+// extractDotnetComponentVersion matches release tags for a pyroscope-dotnet
+// component (e.g. "pyroscope" or "opentelemetry"), which are versioned
+// independently of each other. The repo migrated to release-please, which tags
+// releases with a component prefix and no leading "v" (e.g. "pyroscope-1.0.0",
+// "opentelemetry-0.4.1"). Older releases used the opposite convention: a "v"
+// prefix and a component suffix (e.g. "v0.15.0-pyroscope"). Both forms are
+// matched so the script keeps working across the transition.
+func extractDotnetComponentVersion(component string) func(tag Tag) *version {
+	prefix := regexp.MustCompile(`^` + component + `-(\d+)\.(\d+)\.(\d+)$`)
+	suffix := regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)-` + component + `$`)
 	return func(tag Tag) *version {
-		re := regexp.MustCompile(`v(\d+).(\d+).(\d+)(-pyroscope)?$`)
-		match := re.FindStringSubmatch(tag.Name)
-		if match != nil {
-			fmt.Println(len(match), match)
-
-			major, err := strconv.Atoi(match[1])
-			requireNoError(err, "strconv")
-			minor, err := strconv.Atoi(match[2])
-			requireNoError(err, "strconv")
-			patch, err := strconv.Atoi(match[3])
-			requireNoError(err, "strconv")
-			return &version{major: major, minor: minor, patch: patch, tag: tag}
-
+		match := prefix.FindStringSubmatch(tag.Name)
+		if match == nil {
+			match = suffix.FindStringSubmatch(tag.Name)
 		}
-		return nil
-	}
-}
-
-// extractDotnetOtelVersion matches the Pyroscope.OpenTelemetry helper release
-// tags (e.g. "v0.4.0-opentelemetry"), which are versioned independently of the
-// native profiler tags.
-func extractDotnetOtelVersion() func(tag Tag) *version {
-	return func(tag Tag) *version {
-		re := regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)-opentelemetry$`)
-		match := re.FindStringSubmatch(tag.Name)
 		if match == nil {
 			return nil
 		}


### PR DESCRIPTION
Two improvements to the .NET examples

- switch away from the grafana/pyroscope-dotnet image for sourcing the profiler binarier, in favour of GitHub releases - to be more consistent with other examples
- fix the tracing example (it was using an incompatible version of the OTEL managed helper)

Also adapts the update examples script so that future updates will respect the binary sources and will also take into account examples/tracing/dotnet