### PR TITLE
ci(release/v2.0): align CI pipeline to main (GATB + GAR)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -29,27 +29,15 @@ jobs:
       - name: Install Actions
         run: npm install --production --prefix ./actions
 
-      - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@c2f1df59dba624b3fd509e5181aa8da5217120c0
+      - id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
         with:
-          repo_secrets: |
-            GITHUB_APP_ID=pyroscope-development-app:app-id
-            GITHUB_APP_PRIVATE_KEY=pyroscope-development-app:private-key
-
-      - name: Generate token
-        id: app-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: |
-            pyroscope
+          github_app: pyroscope-development-app
 
       - name: Run backport
         uses: ./actions/backport
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.get-github-app-token.outputs.token }}
           labelsToAdd: backport
           # The provided token needs read permissions for organization members if you want to remove the default reviewers.
           removeDefaultReviewers: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,31 +43,16 @@ jobs:
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-      # login to docker hub
-      - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@c2f1df59dba624b3fd509e5181aa8da5217120c0
+      - name: Log into GAR
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
         with:
-          common_secrets: |
-            DOCKERHUB_USERNAME=dockerhub:username
-            DOCKERHUB_PASSWORD=dockerhub:password
-          repo_secrets: |
-            GRAFANA_PYROSCOPE_BOT_APP_APP_ID=grafana-pyroscope-bot:app-id
-            GRAFANA_PYROSCOPE_BOT_APP_PRIVATE_KEY=grafana-pyroscope-bot:app-private-key
-      - name: Get github app token (valid for an hour)
-        id: brew-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+          registry: us-docker.pkg.dev
+      - id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
         with:
-          app-id: ${{ env.GRAFANA_PYROSCOPE_BOT_APP_APP_ID }}
-          private-key: ${{ env.GRAFANA_PYROSCOPE_BOT_APP_PRIVATE_KEY }}
-          owner: pyroscope-io
-          repositories: homebrew-brew
-      - uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
-        name: Login to Docker Hub
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_PASSWORD }}
+          github_app: grafana-pyroscope-bot
       - run: make frontend/build
-      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+      - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           # ensure this aligns with the version specified in the /Makefile
           version: v2.13.2
@@ -82,12 +67,12 @@ jobs:
       - if: env.IMAGE_PUBLISH_LATEST == 'true'
         name: Update homebrew formulas
         run: |
-          git config --global url."https://x-access-token:$(echo "${HOMEBREW_GITHUB_TOKEN}" | xargs)@github.com/pyroscope-io/homebrew-brew".insteadOf "https://github.com/pyroscope-io/homebrew-brew" 2> /dev/null
+          git config --global url."https://x-access-token:$(echo "${HOMEBREW_GITHUB_TOKEN}" | xargs)@github.com/grafana/homebrew-pyroscope".insteadOf "https://github.com/grafana/homebrew-pyroscope" 2> /dev/null
           git config --global user.email "dmitry+bot@pyroscope.io"
           git config --global user.name "Pyroscope Bot <dmitry+bot@pyroscope.io>"
-          git clone https://github.com/pyroscope-io/homebrew-brew ../homebrew-brew
-          cd ../homebrew-brew
+          git clone https://github.com/grafana/homebrew-pyroscope ../homebrew-pyroscope
+          cd ../homebrew-pyroscope
           make generate-formulas && git add Formula && git commit -m "chore: update formulas" && git push origin main
         env:
-          HOMEBREW_GITHUB_TOKEN: ${{ steps.brew-token.outputs.token }}
+          HOMEBREW_GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,8 +7,9 @@ before:
 env:
   # Strip debug information from the binary by default, weekly builds will have debug information
   - GORELEASER_DEBUG_INFO_FLAGS={{ if and (index .Env "GORELEASER_STRIP_DEBUG_INFO") (eq .Env.GORELEASER_STRIP_DEBUG_INFO "false")  }}{{ else }}-s -w{{ end }}
-  # Use a custom image prefix (registry) or fallback to docker.io/grafana/
-  - IMAGE_PREFIX={{ or (index .Env "IMAGE_PREFIX") "docker.io/grafana/" }}
+  # Use a custom image prefix (registry) or fallback to the GAR mirror staging repo.
+  # The gar-image-mirror service copies images from there to docker.io/grafana/pyroscope.
+  - IMAGE_PREFIX={{ or (index .Env "IMAGE_PREFIX") "us-docker.pkg.dev/grafanalabs-global/dockerhub-pyroscope-prod-mirror/" }}
   # Allow a custom image tag to be used (must be set by workflow)
   - IMAGE_TAG={{ .Env.IMAGE_TAG }}
   # Publish latest image tag
@@ -232,7 +233,7 @@ release:
     - [grafana/pyroscope](https://hub.docker.com/r/grafana/pyroscope/tags)
 
     ```bash
-      docker pull {{ .Env.IMAGE_PREFIX }}{{ .ProjectName }}:{{ .Env.IMAGE_TAG }}
+      docker pull grafana/{{ .ProjectName }}:{{ .Env.IMAGE_TAG }}
     ```
 
   ids:


### PR DESCRIPTION
Aligns `release/v2.0`'s CI to `main`'s GATB + GAR pipeline. **This is required before tagging v2.0.3** the release pipeline on `release/v2.0` is stale and would fail or mispublish.

### Background
`main` migrated CI auth/registry after v2.0.2 was cut (May 7); `release/v2.0` was never updated. We already saw the failure mode: the Backport PR Creator returned `401: JWT could not be decoded` on the #5231 merge, because the old Vault token method (`pyroscope-development-app:app-id/private-key`) was decommissioned in favor of GATB. `release.yml` uses the **same** old method for `grafana-pyroscope-bot`, so a `v2.0.3` tag would hit the same 401.

### Changes
**`backport.yml`**: migrate to GATB (backports #5169). Fixes the recurring 401 on merges into `release/v2.0`.

**`release.yml` + `.goreleaser.yaml`**: align to `main` (backports #5170, #5193, #5212):
- Token via GATB `create-github-app-token` (`github_app: grafana-pyroscope-bot`) instead of decommissioned Vault secrets.
- Publish Docker images via the **GAR mirror** (`us-docker.pkg.dev/grafanalabs-global/dockerhub-pyroscope-prod-mirror/`) using `login-to-gar`, replacing the Docker Hub login.
- Move Homebrew tap from `pyroscope-io/homebrew-brew` → `grafana/homebrew-pyroscope`.
- Bump `goreleaser-action` v6.4.0 → v7.2.2.

Both files are now byte-identical to `main`. The `.goreleaser.yaml` go-version assertion remains `1.25.11` (from #5231).

### Scope notes
- `helm-release.yml` also drifted (Vault→GATB) but is **out of scope**: it triggers on `main`/`release-[0-9]+.[0-9]+` (dash), which doesn't match `release/v2.0`; the chart is published from `main`.
- `update-contributors.yml` / `update-examples-cron.yml` still use the old pattern but are `schedule`/`workflow_dispatch` only scheduled workflows run only on the default branch, so they never fire on `release/v2.0`. Left as-is to keep this minimal.

### Infra dependency to confirm
The `gar-image-mirror` service (configured in `deployment_tools`) must mirror `v2.0.3` tag images from the GAR staging repo to `docker.io/grafana/pyroscope`.
