### PR TITLE
docs: add v2.0.3 release notes

### DIFF
--- a/docs/sources/release-notes/v2-0.md
+++ b/docs/sources/release-notes/v2-0.md
@@ -5,6 +5,21 @@ description: Release notes for Grafana Pyroscope 2.0
 weight: 680
 ---
 
+## Version 2.0.3 release notes
+
+### Fixes
+* **store-gateway**: Validate `tenantID` ([#5194](https://github.com/grafana/pyroscope/pull/5194))
+* **query-backend**: Don't panic on unknown `QueryNode` type ([#5196](https://github.com/grafana/pyroscope/pull/5196))
+* **embedded grafana**: Clean up zip-slip/tar-slip in archive extraction ([#5195](https://github.com/grafana/pyroscope/pull/5195))
+* **embedded grafana**: Close files properly in `extractZip` and `extractTarGz` ([#5206](https://github.com/grafana/pyroscope/pull/5206))
+
+### Security fixes
+* Update Go toolchain to 1.25.11, addressing CVE-2026-27145, CVE-2026-42504, and CVE-2026-42507 (security) ([#5228](https://github.com/grafana/pyroscope/pull/5228))
+* Update `golang.org/x/crypto` to v0.52.0 (security) ([#5197](https://github.com/grafana/pyroscope/pull/5197))
+* Update `golang.org/x/net` to v0.55.0 (security) ([#5131](https://github.com/grafana/pyroscope/pull/5131))
+* Update `golang.org/x/image` to v0.41.0 (security) ([#5216](https://github.com/grafana/pyroscope/pull/5216))
+* Patch CVE-2026-45149 and CVE-2026-46625 in `/ui` yarn dependencies ([#5181](https://github.com/grafana/pyroscope/pull/5181))
+
 ## Version 2.0.2 release notes
 
 ### Fixes


### PR DESCRIPTION
Adds the website release notes for **v2.0.3** documenting the fixes backported to `release/v2.0` in #5231.

### Contents
- **Fixes**: #5194, #5196, #5195, #5206
- **Security fixes**: Go toolchain 1.25.11 (CVE-2026-27145/42504/42507, #5228), `x/crypto` v0.52.0 (#5197), `x/net` v0.55.0 (#5131), `x/image` v0.41.0 (#5216), UI yarn CVE-2026-45149/46625 (#5181) 
