### PR TITLE
fix(tools): read python/ruby SDK versions from their own repos

### DIFF
--- a/tools/update_examples.go
+++ b/tools/update_examples.go
@@ -183,21 +183,21 @@ func extractTempoVersion(major int) func(tag Tag) *version {
 }
 
 func updatePython() {
-	tags := getTagsV("grafana/pyroscope-rs", extractRSVersion("python"))
+	tags := getTagsV("grafana/pyroscope-python", extractRSVersion("python"))
 	last := tags[len(tags)-1]
 	fmt.Println(last)
 
 	re := regexp.MustCompile(`pyroscope-io==\d+\.\d+\.\d+`)
 	repl := fmt.Sprintf("pyroscope-io==%s", last.version())
 	replaceInplace(re, "examples/language-sdk-instrumentation/python/simple/requirements.txt", repl)
-	replaceInplace(re, "examples/language-sdk-instrumentation/python/rideshare/flask/Dockerfile", repl)
-	replaceInplace(re, "examples/language-sdk-instrumentation/python/rideshare/fastapi/Dockerfile", repl)
+	replaceInplace(re, "examples/language-sdk-instrumentation/python/rideshare/flask/requirements.txt", repl)
+	replaceInplace(re, "examples/language-sdk-instrumentation/python/rideshare/fastapi/requirements.txt", repl)
 	replaceInplace(re, "examples/language-sdk-instrumentation/python/rideshare/django/app/requirements.txt", repl)
 
 }
 
 func updateRuby() {
-	tags := getTagsV("grafana/pyroscope-rs", extractRSVersion("ruby"))
+	tags := getTagsV("grafana/pyroscope-ruby", extractRSVersion("ruby"))
 	last := tags[len(tags)-1]
 	fmt.Println(last)
 


### PR DESCRIPTION
## What

The example updater (`tools/update_examples.go`) read the python (`pyroscope-io`) and ruby (`pyroscope`) SDK versions from git tags in `grafana/pyroscope-rs`.

Both SDKs have since moved to their own repos:
- python -> `grafana/pyroscope-python` (latest `python-1.0.11`)
- ruby -> `grafana/pyroscope-ruby` (latest `ruby-1.0.7`)

The tags left in `pyroscope-rs` are stale (python tops out at `python-1.0.4`), so the bot generated **downgrades**, e.g. #5239 dropped `pyroscope-io` from `1.0.5` to `1.0.4`.

## Changes

- `updatePython`: read tags from `grafana/pyroscope-python`.
- `updateRuby`: read tags from `grafana/pyroscope-ruby`.
- Fix the python file targets: flask/fastapi no longer pin the version in their `Dockerfile`; the pins live in `requirements.txt`.

The tag naming is unchanged (`python-X.Y.Z` / `ruby-X.Y.Z`), so the existing version extractors still apply.

## Notes

This PR only fixes the generator script. Running the actual example update (`make tools/update_examples`) is left to the bot / a follow-up so the SDK bumps land in their own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)