### PR TITLE
chore: Release helm chart for v2.0.3

### DIFF
--- a/operations/pyroscope/helm/pyroscope/Chart.yaml
+++ b/operations/pyroscope/helm/pyroscope/Chart.yaml
@@ -3,8 +3,8 @@ name: pyroscope
 description: horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 home: https://grafana.com/oss/pyroscope/
 type: application
-version: 2.0.2
-appVersion: 2.0.2
+version: 2.0.3
+appVersion: 2.0.3
 dependencies:
   - name: grafana-agent
     alias: agent

--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -1,6 +1,6 @@
 # pyroscope
 
-![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.2](https://img.shields.io/badge/AppVersion-2.0.2-informational?style=flat-square)
+![Version: 2.0.3](https://img.shields.io/badge/Version-2.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.3](https://img.shields.io/badge/AppVersion-2.0.3-informational?style=flat-square)
 
 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -27,10 +27,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -48,10 +48,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -69,10 +69,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -90,10 +90,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -111,10 +111,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -132,10 +132,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -176,10 +176,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -523,10 +523,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1381,10 +1381,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1398,10 +1398,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1556,10 +1556,10 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -1581,10 +1581,10 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1728,10 +1728,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1755,10 +1755,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1784,10 +1784,10 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1814,10 +1814,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1843,10 +1843,10 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1873,10 +1873,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1902,10 +1902,10 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1932,10 +1932,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1961,10 +1961,10 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1991,10 +1991,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2020,10 +2020,10 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2050,10 +2050,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2079,10 +2079,10 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2109,10 +2109,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2138,10 +2138,10 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2168,10 +2168,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2183,9 +2183,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2208,7 +2208,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2278,10 +2278,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2293,9 +2293,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2318,7 +2318,7 @@ spec:
         - name: "querier"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -2388,10 +2388,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2403,9 +2403,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2428,7 +2428,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2498,10 +2498,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2513,9 +2513,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2538,7 +2538,7 @@ spec:
         - name: "query-scheduler"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-scheduler"
@@ -2608,10 +2608,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2636,10 +2636,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2667,10 +2667,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2695,10 +2695,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2906,10 +2906,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -2924,9 +2924,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2949,7 +2949,7 @@ spec:
         - name: "compactor"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -3024,10 +3024,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -3042,9 +3042,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3067,7 +3067,7 @@ spec:
         - name: "ingester"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -3138,10 +3138,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -3156,9 +3156,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3181,7 +3181,7 @@ spec:
         - name: "store-gateway"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -27,10 +27,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -48,10 +48,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -69,10 +69,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -90,10 +90,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -111,10 +111,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -132,10 +132,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -153,10 +153,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -174,10 +174,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -218,10 +218,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -565,10 +565,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1423,10 +1423,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1440,10 +1440,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1598,10 +1598,10 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -1623,10 +1623,10 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1770,10 +1770,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1797,10 +1797,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1826,10 +1826,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1856,10 +1856,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1885,10 +1885,10 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1915,10 +1915,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1944,10 +1944,10 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1974,10 +1974,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -2003,10 +2003,10 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -2033,10 +2033,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2062,10 +2062,10 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2092,10 +2092,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2121,10 +2121,10 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2151,10 +2151,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2180,10 +2180,10 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2210,10 +2210,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2239,10 +2239,10 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2269,10 +2269,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2298,10 +2298,10 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2328,10 +2328,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -2344,9 +2344,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2369,7 +2369,7 @@ spec:
         - name: "ad-hoc-profiles"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ad-hoc-profiles"
@@ -2439,10 +2439,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2455,9 +2455,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2480,7 +2480,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2550,10 +2550,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2566,9 +2566,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2591,7 +2591,7 @@ spec:
         - name: "querier"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -2661,10 +2661,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2677,9 +2677,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2702,7 +2702,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2772,10 +2772,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2788,9 +2788,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2813,7 +2813,7 @@ spec:
         - name: "query-scheduler"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-scheduler"
@@ -2883,10 +2883,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2899,9 +2899,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2924,7 +2924,7 @@ spec:
         - name: "tenant-settings"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tenant-settings"
@@ -3177,10 +3177,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -3195,9 +3195,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3220,7 +3220,7 @@ spec:
         - name: "compactor"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -3295,10 +3295,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -3313,9 +3313,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3338,7 +3338,7 @@ spec:
         - name: "ingester"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -3409,10 +3409,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -3427,9 +3427,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3452,7 +3452,7 @@ spec:
         - name: "store-gateway"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -27,10 +27,10 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -48,10 +48,10 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -69,10 +69,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -90,10 +90,10 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -111,10 +111,10 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -132,10 +132,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -153,10 +153,10 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -174,10 +174,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -218,10 +218,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -565,10 +565,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1423,10 +1423,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1440,10 +1440,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1598,10 +1598,10 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -1623,10 +1623,10 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1770,10 +1770,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1797,10 +1797,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1826,10 +1826,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1856,10 +1856,10 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -1885,10 +1885,10 @@ metadata:
   name: pyroscope-dev-admin-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -1915,10 +1915,10 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -1944,10 +1944,10 @@ metadata:
   name: pyroscope-dev-compaction-worker-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -1974,10 +1974,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2003,10 +2003,10 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2033,10 +2033,10 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -2066,10 +2066,10 @@ metadata:
   name: pyroscope-dev-metastore-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -2101,10 +2101,10 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2130,10 +2130,10 @@ metadata:
   name: pyroscope-dev-query-backend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2160,10 +2160,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2189,10 +2189,10 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2219,10 +2219,10 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -2248,10 +2248,10 @@ metadata:
   name: pyroscope-dev-segment-writer-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -2278,10 +2278,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2307,10 +2307,10 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2337,10 +2337,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -2353,9 +2353,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2378,7 +2378,7 @@ spec:
         - name: "ad-hoc-profiles"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ad-hoc-profiles"
@@ -2447,10 +2447,10 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -2463,9 +2463,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2488,7 +2488,7 @@ spec:
         - name: "admin"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=admin"
@@ -2557,10 +2557,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2573,9 +2573,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2598,7 +2598,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2667,10 +2667,10 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2683,9 +2683,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2708,7 +2708,7 @@ spec:
         - name: "query-backend"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-backend"
@@ -2777,10 +2777,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2793,9 +2793,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2818,7 +2818,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2887,10 +2887,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2903,9 +2903,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2928,7 +2928,7 @@ spec:
         - name: "tenant-settings"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tenant-settings"
@@ -3180,10 +3180,10 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -3198,9 +3198,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3223,7 +3223,7 @@ spec:
         - name: "compaction-worker"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compaction-worker"
@@ -3293,10 +3293,10 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -3311,9 +3311,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3336,7 +3336,7 @@ spec:
         - name: "metastore"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=metastore"
@@ -3422,10 +3422,10 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -3440,9 +3440,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3465,7 +3465,7 @@ spec:
         - name: "segment-writer"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=segment-writer"

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -27,10 +27,10 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -48,10 +48,10 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -69,10 +69,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -90,10 +90,10 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -111,10 +111,10 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -132,10 +132,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -153,10 +153,10 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -174,10 +174,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -218,10 +218,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -565,10 +565,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1423,10 +1423,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1440,10 +1440,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1598,10 +1598,10 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -1623,10 +1623,10 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1770,10 +1770,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1797,10 +1797,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1826,10 +1826,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1856,10 +1856,10 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -1885,10 +1885,10 @@ metadata:
   name: pyroscope-dev-admin-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -1915,10 +1915,10 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -1944,10 +1944,10 @@ metadata:
   name: pyroscope-dev-compaction-worker-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -1974,10 +1974,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2003,10 +2003,10 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2033,10 +2033,10 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -2066,10 +2066,10 @@ metadata:
   name: pyroscope-dev-metastore-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -2101,10 +2101,10 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2130,10 +2130,10 @@ metadata:
   name: pyroscope-dev-query-backend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2160,10 +2160,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2189,10 +2189,10 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2219,10 +2219,10 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -2248,10 +2248,10 @@ metadata:
   name: pyroscope-dev-segment-writer-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -2278,10 +2278,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2307,10 +2307,10 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2337,10 +2337,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -2353,9 +2353,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2378,7 +2378,7 @@ spec:
         - name: "ad-hoc-profiles"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ad-hoc-profiles"
@@ -2447,10 +2447,10 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -2463,9 +2463,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2488,7 +2488,7 @@ spec:
         - name: "admin"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=admin"
@@ -2557,10 +2557,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2573,9 +2573,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2598,7 +2598,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2667,10 +2667,10 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2683,9 +2683,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2708,7 +2708,7 @@ spec:
         - name: "query-backend"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-backend"
@@ -2777,10 +2777,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2793,9 +2793,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2818,7 +2818,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2887,10 +2887,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2903,9 +2903,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2928,7 +2928,7 @@ spec:
         - name: "tenant-settings"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tenant-settings"
@@ -3180,10 +3180,10 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -3198,9 +3198,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3223,7 +3223,7 @@ spec:
         - name: "compaction-worker"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compaction-worker"
@@ -3293,10 +3293,10 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -3311,9 +3311,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3336,7 +3336,7 @@ spec:
         - name: "metastore"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=metastore"
@@ -3422,10 +3422,10 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -3440,9 +3440,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4c02c3b7e8305a59c75c320388fb407300053f09f0d5a9067b8943bdc32049ce
+        checksum/config: 72895871fa49be91ddbab6f1cad92d557c0818266f0f2c3213d2aa5c52795b36
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3465,7 +3465,7 @@ spec:
         - name: "segment-writer"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=segment-writer"

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -43,10 +43,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/templates/configmap-alloy.yaml
@@ -56,10 +56,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -914,10 +914,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -931,10 +931,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1082,10 +1082,10 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -1107,10 +1107,10 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1186,10 +1186,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1213,10 +1213,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1246,10 +1246,10 @@ metadata:
   name: pyroscope-dev-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1371,10 +1371,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1389,9 +1389,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 753348e68675509482b48ba79580501d9190bec211b691085df540c1bd087139
+        checksum/config: 90ffb40ccbed1a9e96f3d75605e4531e37cac2785454633accc67137621655d6
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -1414,7 +1414,7 @@ spec:
         - name: "pyroscope"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=all"

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -43,10 +43,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/templates/configmap-alloy.yaml
@@ -56,10 +56,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -914,10 +914,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -931,10 +931,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1082,10 +1082,10 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -1107,10 +1107,10 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1186,10 +1186,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1213,10 +1213,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1246,10 +1246,10 @@ metadata:
   name: pyroscope-dev-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1371,10 +1371,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.0.2
+    helm.sh/chart: pyroscope-2.0.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/version: "2.0.3"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1389,9 +1389,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 753348e68675509482b48ba79580501d9190bec211b691085df540c1bd087139
+        checksum/config: 90ffb40ccbed1a9e96f3d75605e4531e37cac2785454633accc67137621655d6
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.0.2"
+        profiles.grafana.com/service_git_ref: "v2.0.3"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -1414,7 +1414,7 @@ spec:
         - name: "pyroscope"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.0.2"
+          image: "grafana/pyroscope:2.0.3"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=all"


### PR DESCRIPTION
Releases the Helm chart for **v2.0.3**: bumps `version` and `appVersion` `2.0.2 → 2.0.3` and regenerates the docs + rendered manifests.
