### PR TITLE
fix: allow fixed delays in delayed bucket client

### DIFF
--- a/pkg/objstore/delayed_bucket_client.go
+++ b/pkg/objstore/delayed_bucket_client.go
@@ -112,5 +112,10 @@ func (m *DelayedBucketClient) Provider() objstore.ObjProvider {
 }
 
 func (m *DelayedBucketClient) delay() {
-	time.Sleep(m.minDelay + time.Duration(rand.Int63n(m.maxDelay.Nanoseconds()-m.minDelay.Nanoseconds())))
+	if m.minDelay == m.maxDelay {
+		time.Sleep(m.minDelay)
+		return
+	}
+
+	time.Sleep(m.minDelay + time.Duration(rand.Int63n(int64(m.maxDelay-m.minDelay))))
 }

--- a/pkg/objstore/delayed_bucket_client_test.go
+++ b/pkg/objstore/delayed_bucket_client_test.go
@@ -1,0 +1,53 @@
+package objstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/pyroscope/v2/pkg/objstore/providers/memory"
+)
+
+func TestDelayedBucketClient_EqualDelaysDoNotPanic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		minDelay time.Duration
+		maxDelay time.Duration
+	}{
+		{
+			name:     "zero delay",
+			minDelay: 0,
+			maxDelay: 0,
+		},
+		{
+			name:     "fixed non-zero delay",
+			minDelay: time.Millisecond,
+			maxDelay: time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			bucket := NewDelayedBucketClient(memory.NewInMemBucket(), tt.minDelay, tt.maxDelay)
+
+			require.NotPanics(t, func() {
+				_, err := bucket.Exists(context.Background(), "missing")
+				require.NoError(t, err)
+			})
+		})
+	}
+}
+
+func TestNewDelayedBucketClient_InvalidConfigurationPanics(t *testing.T) {
+	t.Parallel()
+
+	require.Panics(t, func() {
+		NewDelayedBucketClient(memory.NewInMemBucket(), time.Second, 0)
+	})
+}


### PR DESCRIPTION
`DelayedBucketClient` blows up when `minDelay == maxDelay`.

That config is legit for tests. `0,0` means no delay, `1ms,1ms` means fixed delay. Right now it hits `rand.Int63n(0)` and panics, kinda rough.

This patch uses a plain sleep when both bounds are equal, and adds a regression test.

Repro:
1. `b := objstore.NewDelayedBucketClient(memory.NewInMemBucket(), 0, 0)`
2. `b.Exists(context.Background(), "x")`
3. before: panic `invalid argument to Int63n`
4. after: returns `ok=false err=<nil>`

Test:
`go test ./pkg/objstore/... -count=1`
