### PR TITLE
fix OOB panic in clearAddresses

### DIFF
--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -557,6 +557,9 @@ func (p *Profile) clearAddresses() {
 		}
 	}
 	for _, l := range p.Location {
+		if l.MappingId == 0 || int(l.MappingId) > len(p.Mapping) {
+			continue
+		}
 		if p.Mapping[l.MappingId-1].HasFunctions {
 			l.Address = 0
 		}

--- a/pkg/pprof/pprof_test.go
+++ b/pkg/pprof/pprof_test.go
@@ -685,6 +685,34 @@ func TestEmptyMappingJava(t *testing.T) {
 	}
 }
 
+func TestClearAddresses_InvalidMappingIDsDoNotPanic(t *testing.T) {
+	p := &Profile{Profile: &profilev1.Profile{
+		Mapping: []*profilev1.Mapping{{
+			Id:           1,
+			HasFunctions: true,
+			MemoryStart:  0x1000,
+			MemoryLimit:  0x2000,
+			FileOffset:   0x3000,
+		}},
+		Location: []*profilev1.Location{
+			{Id: 1, MappingId: 1, Address: 0x10},
+			{Id: 2, MappingId: 0, Address: 0x20},
+			{Id: 3, MappingId: 5, Address: 0x30},
+		},
+	}}
+
+	require.NotPanics(t, func() {
+		p.clearAddresses()
+	})
+
+	require.Equal(t, uint64(0), p.Mapping[0].MemoryStart)
+	require.Equal(t, uint64(0), p.Mapping[0].MemoryLimit)
+	require.Equal(t, uint64(0), p.Mapping[0].FileOffset)
+	require.Equal(t, uint64(0), p.Location[0].Address)
+	require.Equal(t, uint64(0x20), p.Location[1].Address)
+	require.Equal(t, uint64(0x30), p.Location[2].Address)
+}
+
 func countSampleDuplicates(p *Profile) int {
 	hashes := p.hasher.Hashes(p.Sample)
 	uniq := map[uint64][]*profilev1.Sample{}


### PR DESCRIPTION
## Summary

Adds a bounds check in `pkg/pprof/pprof.go` before accessing `p.Mapping[l.MappingId-1]` in `clearAddresses`.

### Problem

Two cases could cause an out-of-bounds panic:
- `MappingId == 0`: would produce index `-1`
- `MappingId > len(p.Mapping)`: index beyond slice bounds

### Fix

Skip locations with an invalid `MappingId` rather than panicking.

### Tests

Added `TestClearAddresses_InvalidMappingIDsDoNotPanic` covering both invalid cases (`MappingId=0` and `MappingId=5` with only 1 mapping entry).