### PR TITLE
fix: enforce tenant header extraction in auth interceptor

### DIFF
--- a/pkg/tenant/interceptor.go
+++ b/pkg/tenant/interceptor.go
@@ -75,7 +75,10 @@ func (i *authInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc
 		if !i.enabled {
 			return next(InjectTenantID(ctx, DefaultTenantID), conn)
 		}
-		_, ctx, _ = ExtractTenantIDFromHeaders(ctx, conn.RequestHeader())
+		_, ctx, err := ExtractTenantIDFromHeaders(ctx, conn.RequestHeader())
+		if err != nil {
+			return connect.NewError(connect.CodeUnauthenticated, err)
+		}
 		if err := next(ctx, conn); err != nil {
 			if errors.Is(err, ErrNoTenantID) {
 				return connect.NewError(connect.CodeUnauthenticated, err)
@@ -105,12 +108,7 @@ func ExtractTenantIDFromHeaders(ctx context.Context, headers http.Header) (strin
 		return "", ctx, err
 	}
 
-	// Single tenant — already injected above, nothing more to do.
-	if len(tenantIDs) == 1 {
-		return orgID, ctx, nil
-	}
-
-	// Multi-tenant: re-inject the normalised (deduped, sorted) string only
+	// Re-inject the normalized (deduped, sorted) string only
 	// when it differs from the raw header value.
 	normalized := tenant.JoinTenantIDs(tenantIDs)
 	if normalized != orgID {

--- a/pkg/tenant/interceptor.go
+++ b/pkg/tenant/interceptor.go
@@ -46,7 +46,10 @@ func (i *authInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 		if !i.enabled {
 			return next(InjectTenantID(ctx, DefaultTenantID), req)
 		}
-		_, ctx, _ = ExtractTenantIDFromHeaders(ctx, req.Header())
+		_, ctx, err := ExtractTenantIDFromHeaders(ctx, req.Header())
+		if err != nil {
+			return nil, connect.NewError(connect.CodeUnauthenticated, err)
+		}
 
 		resp, err := next(ctx, req)
 		if err != nil && errors.Is(err, ErrNoTenantID) {
@@ -85,7 +88,11 @@ func (i *authInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc
 
 var defaultResolver tenant.Resolver = tenant.NewMultiResolver()
 
-// ExtractTenantIDFromHeaders extracts a single TenantID from http headers.
+// ExtractTenantIDFromHeaders extracts the tenant ID(s) from http headers and
+// injects them into the context. It supports both single and multi-tenant
+// requests (pipe-separated org IDs such as "tenant-a|tenant-b").
+// Tenant IDs are deduplicated and sorted before being injected back into the
+// context, so downstream handlers always see a canonical representation.
 func ExtractTenantIDFromHeaders(ctx context.Context, headers http.Header) (string, context.Context, error) {
 	orgID := headers.Get(user.OrgIDHeaderName)
 	if orgID == "" {
@@ -93,12 +100,24 @@ func ExtractTenantIDFromHeaders(ctx context.Context, headers http.Header) (strin
 	}
 	ctx = InjectTenantID(ctx, orgID)
 
-	tenantID, err := defaultResolver.TenantID(ctx)
+	tenantIDs, err := defaultResolver.TenantIDs(ctx)
 	if err != nil {
 		return "", ctx, err
 	}
 
-	return tenantID, ctx, nil
+	// Single tenant — already injected above, nothing more to do.
+	if len(tenantIDs) == 1 {
+		return orgID, ctx, nil
+	}
+
+	// Multi-tenant: re-inject the normalised (deduped, sorted) string only
+	// when it differs from the raw header value.
+	normalized := tenant.JoinTenantIDs(tenantIDs)
+	if normalized != orgID {
+		ctx = InjectTenantID(ctx, normalized)
+	}
+
+	return normalized, ctx, nil
 }
 
 // ExtractTenantIDFromContext extracts a single TenantID from the context.

--- a/pkg/tenant/interceptor_test.go
+++ b/pkg/tenant/interceptor_test.go
@@ -84,6 +84,24 @@ func Test_AuthInterceptor(t *testing.T) {
 			require.NoError(t, err)
 			require.True(t, nextCalled, "multi-tenant request must reach the handler")
 		},
+		"server: enable, canonicalize duplicate tenant header": func(t *testing.T) {
+			i := NewAuthInterceptor(true)
+			req := newFakeReqWithHeader("tenant-a|tenant-a")
+
+			resp, err := i.WrapUnary(func(ctx context.Context, ar connect.AnyRequest) (connect.AnyResponse, error) {
+				tenantID, tenantErr := ExtractTenantIDFromContext(ctx)
+				require.NoError(t, tenantErr)
+				require.Equal(t, "tenant-a", tenantID)
+
+				orgID, orgErr := user.ExtractOrgID(ctx)
+				require.NoError(t, orgErr)
+				require.Equal(t, "tenant-a", orgID)
+				return nil, nil
+			})(context.Background(), req)
+
+			require.Nil(t, resp)
+			require.NoError(t, err)
+		},
 		"server: enable, reject inherited tenant when header missing": func(t *testing.T) {
 			i := NewAuthInterceptor(true)
 			req := newFakeReq(false)
@@ -116,22 +134,38 @@ func Test_AuthInterceptor(t *testing.T) {
 			i := NewAuthInterceptor(true)
 			shc := newFakeClientStreamingConn()
 			shc.requestHeaders.Set("X-Scope-OrgID", "foo")
-			_ = i.WrapStreamingHandler(func(ctx context.Context, shc connect.StreamingHandlerConn) error {
+			err := i.WrapStreamingHandler(func(ctx context.Context, shc connect.StreamingHandlerConn) error {
 				tenantID, err := ExtractTenantIDFromContext(ctx)
 				require.NoError(t, err)
 				require.Equal(t, tenantID, "foo")
 				return nil
 			})(context.Background(), shc)
+			require.NoError(t, err)
+		},
+		"streaming server should reject inherited tenant when header missing": func(t *testing.T) {
+			i := NewAuthInterceptor(true)
+			shc := newFakeClientStreamingConn()
+			nextCalled := false
+
+			err := i.WrapStreamingHandler(func(ctx context.Context, shc connect.StreamingHandlerConn) error {
+				nextCalled = true
+				return nil
+			})(InjectTenantID(context.Background(), "attacker"), shc)
+
+			require.ErrorIs(t, err, ErrNoTenantID)
+			require.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+			require.False(t, nextCalled, "missing tenant header must stop the request before the handler runs")
 		},
 		"streaming server should forward default tenant to context if disable": func(t *testing.T) {
 			i := NewAuthInterceptor(false)
 			shc := newFakeClientStreamingConn()
-			_ = i.WrapStreamingHandler(func(ctx context.Context, shc connect.StreamingHandlerConn) error {
+			err := i.WrapStreamingHandler(func(ctx context.Context, shc connect.StreamingHandlerConn) error {
 				tenantID, err := ExtractTenantIDFromContext(ctx)
 				require.NoError(t, err)
 				require.Equal(t, tenantID, DefaultTenantID)
 				return nil
 			})(context.Background(), shc)
+			require.NoError(t, err)
 		},
 	} {
 		t.Run(testName, testCase)

--- a/pkg/tenant/interceptor_test.go
+++ b/pkg/tenant/interceptor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
+	"github.com/grafana/dskit/user"
 	"github.com/stretchr/testify/require"
 )
 
@@ -59,6 +60,50 @@ func Test_AuthInterceptor(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, resp)
 		},
+		"server: enable, allow multi-tenant header": func(t *testing.T) {
+			i := NewAuthInterceptor(true)
+			// Supply tenants out of order and with a duplicate to verify
+			// that the context receives the canonical (sorted, deduped) form.
+			req := newFakeReqWithHeader("tenant-b|tenant-a|tenant-b")
+			nextCalled := false
+
+			resp, err := i.WrapUnary(func(ctx context.Context, ar connect.AnyRequest) (connect.AnyResponse, error) {
+				nextCalled = true
+				// The context must carry the normalised tenant string.
+				tenantID, tenantErr := ExtractTenantIDFromContext(ctx)
+				require.ErrorContains(t, tenantErr, "multiple org IDs")
+				_ = tenantID
+				// Use the raw org-ID to verify dedup+sort.
+				orgID, orgErr := user.ExtractOrgID(ctx)
+				require.NoError(t, orgErr)
+				require.Equal(t, "tenant-a|tenant-b", orgID, "tenants must be sorted and deduplicated")
+				return nil, nil
+			})(context.Background(), req)
+
+			require.Nil(t, resp)
+			require.NoError(t, err)
+			require.True(t, nextCalled, "multi-tenant request must reach the handler")
+		},
+		"server: enable, reject inherited tenant when header missing": func(t *testing.T) {
+			i := NewAuthInterceptor(true)
+			req := newFakeReq(false)
+			nextCalled := false
+
+			resp, err := i.WrapUnary(func(ctx context.Context, ar connect.AnyRequest) (connect.AnyResponse, error) {
+				nextCalled = true
+
+				tenantID, tenantErr := ExtractTenantIDFromContext(ctx)
+				require.NoError(t, tenantErr)
+				require.Equal(t, "attacker", tenantID)
+
+				return nil, nil
+			})(InjectTenantID(context.Background(), "attacker"), req)
+
+			require.Nil(t, resp)
+			require.ErrorIs(t, err, ErrNoTenantID)
+			require.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+			require.False(t, nextCalled, "missing tenant header must stop the request before the handler runs")
+		},
 		"streaming client should forward from context": func(t *testing.T) {
 			i := NewAuthInterceptor(false)
 			inConn := newFakeClientStreamingConn()
@@ -103,6 +148,16 @@ func newFakeReq(isClient bool) fakeReq {
 	return fakeReq{
 		isClient:   isClient,
 		headers:    http.Header{},
+		AnyRequest: connect.NewRequest(&http.Request{}),
+	}
+}
+
+func newFakeReqWithHeader(orgID string) fakeReq {
+	h := http.Header{}
+	h.Set("X-Scope-OrgID", orgID)
+	return fakeReq{
+		isClient:   false,
+		headers:    h,
 		AnyRequest: connect.NewRequest(&http.Request{}),
 	}
 }


### PR DESCRIPTION
## Summary

The server-side auth interceptor ignored errors from `ExtractTenantIDFromHeaders` in unary and streaming handlers. If the tenant header was missing or invalid, the request could continue with an inherited tenant already present in the context.

A remote client cannot directly inject context values, so this is primarily a fail-early hardening fix that prevents handlers from observing stale or pre-populated tenant context when header-based tenant auth fails.

## Changes

- Return `CodeUnauthenticated` immediately when tenant extraction from request headers fails in `WrapUnary`.
- Apply the same fail-early behavior to `WrapStreamingHandler`.
- Validate tenant headers with `TenantIDs` so legitimate pipe-separated multi-tenant headers are accepted.
- Canonicalize resolved tenant IDs before reinjecting them into context, including duplicate-only headers like `tenant-a|tenant-a`.

## Tests

- Rejects unary requests with an inherited tenant when `X-Scope-OrgID` is missing.
- Rejects streaming requests with an inherited tenant when `X-Scope-OrgID` is missing.
- Allows multi-tenant headers and canonicalizes them to sorted, deduplicated form.
- Canonicalizes duplicate-only tenant headers.