### PR TITLE
feat(queryfrontend): add estimation accuracy histogram and log ratio

### DIFF
--- a/pkg/frontend/readpath/queryfrontend/query_frontend.go
+++ b/pkg/frontend/readpath/queryfrontend/query_frontend.go
@@ -63,7 +63,8 @@ type QueryFrontend struct {
 }
 
 type queryFrontendMetrics struct {
-	fetchedBytesTotal *prometheus.CounterVec
+	fetchedBytesTotal       *prometheus.CounterVec
+	estimationAccuracyRatio prometheus.Histogram
 }
 
 func newQueryFrontendMetrics(reg prometheus.Registerer) *queryFrontendMetrics {
@@ -77,9 +78,30 @@ func newQueryFrontendMetrics(reg prometheus.Registerer) *queryFrontendMetrics {
 			},
 			[]string{"tenant", "kind"},
 		),
+		// estimationAccuracyRatio records the ratio of the pre-execution
+		// metadata size estimate (weight.Total()) to the actual object-storage
+		// bytes fetched per query.  A value of 1.0 means the estimate matched
+		// exactly; values below 1.0 mean the query fetched less than estimated
+		// (the common case, since the weight is an upper-bound derived from
+		// section offsets).  Format1 index-lookup blocks have unknown
+		// profile/symbol sizes pre-execution, so queries that hit those blocks
+		// will tend to produce ratios below 1.0.
+		// Both classic explicit buckets and native-histogram parameters are set
+		// so that scrapers that support native histograms get higher resolution
+		// automatically.
+		estimationAccuracyRatio: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace:                       "pyroscope",
+			Subsystem:                       "query_frontend",
+			Name:                            "estimation_accuracy_ratio",
+			Help:                            "Ratio of the pre-execution metadata size estimate to actual object-storage bytes fetched per query (estimate / actual). 1.0 = perfect estimate; <1.0 = over-estimated; >1.0 = under-estimated.",
+			Buckets:                         []float64{0.1, 0.25, 0.5, 0.75, 0.9, 1.0, 1.1, 1.25, 1.5, 2, 5, 10},
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
+		}),
 	}
 	if reg != nil {
-		reg.MustRegister(m.fetchedBytesTotal)
+		reg.MustRegister(m.fetchedBytesTotal, m.estimationAccuracyRatio)
 	}
 	return m
 }
@@ -241,9 +263,16 @@ func (q *QueryFrontend) doQuery(
 	objectBytes := resp.GetDiagnostics().GetExecutionNode().GetStats().GetBytesFetched()
 	q.metrics.fetchedBytesTotal.WithLabelValues(tenantLabel, "object_storage").Add(float64(objectBytes))
 	q.metrics.fetchedBytesTotal.WithLabelValues(tenantLabel, "metastore").Add(float64(metastoreBytes))
+	// Record estimation accuracy: ratio of pre-execution weight to actual bytes
+	// fetched. Only observed when the backend fetched bytes to avoid division
+	// by zero (e.g. empty result sets).
+	if objectBytes > 0 {
+		q.metrics.estimationAccuracyRatio.Observe(float64(weight.Total()) / float64(objectBytes))
+	}
 	if qs := spanlogger.QueryStatsFromContext(ctx); qs != nil {
 		qs.ObjectStorageBytes += objectBytes
 		qs.MetastoreBytes += metastoreBytes
+		qs.EstimatedBytes += weight.Total()
 	}
 
 	if resp.Diagnostics == nil {

--- a/pkg/util/spanlogger/query_log.go
+++ b/pkg/util/spanlogger/query_log.go
@@ -2,6 +2,7 @@ package spanlogger
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -64,7 +65,13 @@ func (l LogSpanParametersWrapper) logQuery(
 		finishFields = append(finishFields,
 			"fetched_object_bytes", humanize.Bytes(stats.ObjectStorageBytes),
 			"fetched_metastore_bytes", humanize.Bytes(stats.MetastoreBytes),
+			"estimated_object_bytes", humanize.Bytes(stats.EstimatedBytes),
 		)
+		if stats.ObjectStorageBytes > 0 {
+			finishFields = append(finishFields,
+				"estimation_ratio", fmt.Sprintf("%.2f", float64(stats.EstimatedBytes)/float64(stats.ObjectStorageBytes)),
+			)
+		}
 	}
 	level.Info(logger).Log(finishFields...)
 	return err

--- a/pkg/util/spanlogger/query_stats.go
+++ b/pkg/util/spanlogger/query_stats.go
@@ -8,6 +8,9 @@ import "context"
 type QueryStats struct {
 	ObjectStorageBytes uint64
 	MetastoreBytes     uint64
+	// EstimatedBytes is the pre-execution metadata size estimate (weight.Total())
+	// derived from block dataset section offsets before the backend is invoked.
+	EstimatedBytes uint64
 }
 
 type queryStatsKey struct{}


### PR DESCRIPTION
Follows up on the review comment in #5180.

Adds a `pyroscope_query_frontend_estimation_accuracy_ratio` histogram that records, per query, the ratio of the pre-execution metadata size estimate (`weight.Total()`) to actual object-storage bytes fetched (`BytesFetched`):

- **< 1.0** — fetched less than estimated (common; weight is an upper bound from section offsets)
- **1.0** — estimate matched exactly
- **> 1.0** — fetched more than estimated (e.g. Format1 index-lookup blocks whose profile/symbol sizes are unknown pre-execution)

Configured with both classic explicit buckets centred around 1.0 `{0.1, 0.25, 0.5, 0.75, 0.9, 1.0, 1.1, 1.25, 1.5, 2, 5, 10}` and native histogram parameters (`factor=1.1`, `maxBuckets=100`) so scrapers that support native histograms get higher resolution automatically.

The ratio is also surfaced on the existing **"query finished"** log line as two new fields:
- `estimated_object_bytes` — humanized pre-execution estimate
- `estimation_ratio` — 2 d.p. ratio (omitted when no bytes were fetched)