### PR TITLE
fix: reject non-positive ingest sample rates

### DIFF
--- a/pkg/ingester/pyroscope/ingest_handler.go
+++ b/pkg/ingester/pyroscope/ingest_handler.go
@@ -135,7 +135,10 @@ func (h ingestHandler) parseInputMetadataFromRequest(_ context.Context, r *http.
 
 	if sr := q.Get("sampleRate"); sr != "" {
 		sampleRate, err := strconv.Atoi(sr)
-		if err != nil {
+		if err != nil || sampleRate <= 0 {
+			if err == nil {
+				err = fmt.Errorf("sample rate must be positive")
+			}
 			_ = h.log.Log(
 				"err", err,
 				"msg", fmt.Sprintf("invalid sample rate: %q", sr),

--- a/pkg/ingester/pyroscope/ingest_handler_test.go
+++ b/pkg/ingester/pyroscope/ingest_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"mime/multipart"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"slices"
@@ -24,6 +25,7 @@ import (
 	v1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	"github.com/grafana/pyroscope/v2/pkg/distributor/model"
 	phlaremodel "github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/og/agent/types"
 	pprof2 "github.com/grafana/pyroscope/v2/pkg/og/convert/pprof"
 	"github.com/grafana/pyroscope/v2/pkg/og/convert/pprof/bench"
 	"github.com/grafana/pyroscope/v2/pkg/pprof"
@@ -210,6 +212,44 @@ func BenchmarkIngestJFR(b *testing.B) {
 			}
 		})
 	}
+}
+
+func TestParseInputMetadataFromRequest_InvalidSampleRateDefaults(t *testing.T) {
+	t.Parallel()
+
+	h := ingestHandler{log: log.NewNopLogger()}
+
+	tests := []struct {
+		name       string
+		sampleRate string
+	}{
+		{name: "negative", sampleRate: "-1"},
+		{name: "zero", sampleRate: "0"},
+		{name: "non numeric", sampleRate: "abc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodPost, "/ingest?name=test-app&sampleRate="+tt.sampleRate, nil)
+
+			input, err := h.parseInputMetadataFromRequest(context.Background(), req)
+			require.NoError(t, err)
+			require.EqualValues(t, types.DefaultSampleRate, input.Metadata.SampleRate)
+		})
+	}
+}
+
+func TestParseInputMetadataFromRequest_ValidSampleRatePreserved(t *testing.T) {
+	t.Parallel()
+
+	h := ingestHandler{log: log.NewNopLogger()}
+	req := httptest.NewRequest(http.MethodPost, "/ingest?name=test-app&sampleRate=97", nil)
+
+	input, err := h.parseInputMetadataFromRequest(context.Background(), req)
+	require.NoError(t, err)
+	require.EqualValues(t, 97, input.Metadata.SampleRate)
 }
 
 func TestIngestPPROFFixtures(t *testing.T) {


### PR DESCRIPTION
tiny footgun, but real.

`/ingest` accepts `sampleRate` from the query string. Before this patch, `sampleRate=-1` was parsed as an `int` and then cast to `uint32`, so it wrapped to `4294967295`. For CPU and wall profiles that can drive the computed period down to `0`, which is pretty cursed.

fix:
- treat `sampleRate <= 0` as invalid
- fall back to the documented default `100`
- add tests for `-1`, `0`, `abc`, and a valid positive value

repro:
1. hit `/ingest?...&sampleRate=-1`
2. before this patch, the handler stored `4294967295` as the sample rate
3. after this patch, it falls back to `100`

verified with `go test ./pkg/ingester/pyroscope -count=1`
