### PR TITLE
chore: Update dashboards to their internal version

### DIFF
--- a/operations/monitoring/dashboards-classic-histogram/operational.json
+++ b/operations/monitoring/dashboards-classic-histogram/operational.json
@@ -173,7 +173,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -271,7 +270,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -369,7 +367,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -434,7 +431,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -503,7 +499,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -632,7 +627,6 @@
           }
         ]
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -802,7 +796,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -898,7 +891,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -995,7 +987,6 @@
         "showRowNums": false,
         "sortBy": []
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -1165,7 +1156,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -1261,7 +1251,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -1382,7 +1371,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -1425,7 +1413,6 @@
         "sortOrder": "Descending",
         "wrapLogMessage": true
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -1603,7 +1590,6 @@
           }
         ]
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -2887,7 +2873,6 @@
             "showHeader": true,
             "showRowNums": false
           },
-          "pluginVersion": "9.5.0-53857pre",
           "targets": [
             {
               "datasource": {
@@ -7154,7 +7139,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -7258,7 +7242,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {

--- a/operations/monitoring/dashboards-classic-histogram/v2-metastore.json
+++ b/operations/monitoring/dashboards-classic-histogram/v2-metastore.json
@@ -195,7 +195,6 @@
           "sort": "asc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -323,7 +322,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -449,7 +447,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -575,7 +572,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -714,7 +710,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -816,7 +811,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -972,7 +966,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1095,7 +1088,6 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1226,7 +1218,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1352,7 +1343,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1462,7 +1452,6 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1593,7 +1582,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1732,7 +1720,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1842,7 +1829,6 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1973,7 +1959,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2099,7 +2084,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2209,7 +2193,6 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2340,7 +2323,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2479,7 +2461,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2589,7 +2570,6 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2720,7 +2700,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2859,7 +2838,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -3006,7 +2984,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -3135,7 +3112,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -3236,7 +3212,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -3340,7 +3315,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -3459,7 +3433,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -3579,7 +3552,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -3713,7 +3685,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.0.0-85518.patch7-85777",
           "targets": [
             {
               "datasource": {
@@ -3836,7 +3807,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.0.0-85518.patch7-85777",
           "targets": [
             {
               "datasource": {
@@ -3959,7 +3929,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.0.0-85518.patch7-85777",
           "targets": [
             {
               "datasource": {
@@ -4083,7 +4052,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.0.0-85518.patch7-85777",
           "targets": [
             {
               "datasource": {

--- a/operations/monitoring/dashboards-classic-histogram/v2-read-path.json
+++ b/operations/monitoring/dashboards-classic-histogram/v2-read-path.json
@@ -272,7 +272,6 @@
               }
             ]
           },
-          "pluginVersion": "12.1.0-90017",
           "targets": [
             {
               "datasource": {
@@ -484,7 +483,6 @@
               }
             ]
           },
-          "pluginVersion": "12.1.0-90017",
           "targets": [
             {
               "datasource": {
@@ -650,7 +648,6 @@
           "sort": "asc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -778,7 +775,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -917,7 +913,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1056,7 +1051,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1188,7 +1182,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1320,7 +1313,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1444,7 +1436,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1571,7 +1562,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1717,7 +1707,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1843,7 +1832,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1948,7 +1936,6 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2074,7 +2061,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2235,7 +2221,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2417,7 +2402,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2576,7 +2560,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2701,7 +2684,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2805,7 +2787,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2951,7 +2932,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.0.0-85113",
           "targets": [
             {
               "datasource": {
@@ -3074,7 +3054,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.0.0-85113",
           "targets": [
             {
               "datasource": {
@@ -3197,7 +3176,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.0.0-85113",
           "targets": [
             {
               "datasource": {
@@ -3321,7 +3299,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.0.0-85113",
           "targets": [
             {
               "datasource": {
@@ -3381,7 +3358,6 @@
             "sortOrder": "Descending",
             "wrapLogMessage": false
           },
-          "pluginVersion": "12.0.0-85113",
           "targets": [
             {
               "datasource": {

--- a/operations/monitoring/dashboards-classic-histogram/v2-write-path.json
+++ b/operations/monitoring/dashboards-classic-histogram/v2-write-path.json
@@ -121,6 +121,11 @@
               "type": "auto"
             },
             "filterable": true,
+            "footer": {
+              "reducers": [
+                "countAll"
+              ]
+            },
             "inspect": false
           },
           "mappings": [],
@@ -257,15 +262,7 @@
       "id": 68,
       "options": {
         "cellHeight": "sm",
-        "footer": {
-          "countRows": true,
-          "enablePagination": false,
-          "fields": "",
-          "reducer": [
-            "count"
-          ],
-          "show": true
-        },
+        "enablePagination": false,
         "showHeader": true,
         "sortBy": [
           {
@@ -274,7 +271,6 @@
           }
         ]
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -360,6 +356,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -411,7 +408,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -464,6 +460,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -516,7 +513,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -578,13 +574,13 @@
           "fields": "",
           "values": false
         },
+        "sort": "desc",
         "tooltip": {
           "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -650,13 +646,13 @@
           "fields": "",
           "values": false
         },
+        "sort": "desc",
         "tooltip": {
           "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -682,7 +678,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 25
       },
       "id": 90,
       "panels": [
@@ -774,7 +770,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 20
+            "y": 34
           },
           "id": 94,
           "options": {
@@ -792,7 +788,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -847,7 +842,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 20
+            "y": 34
           },
           "id": 93,
           "options": {
@@ -900,7 +895,6 @@
               "unit": "s"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -987,7 +981,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 20
+            "y": 34
           },
           "id": 42,
           "options": {
@@ -1005,7 +999,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -1093,7 +1086,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 28
+            "y": 42
           },
           "id": 72,
           "options": {
@@ -1109,7 +1102,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -1167,7 +1159,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 28
+            "y": 42
           },
           "id": 56,
           "options": {
@@ -1220,7 +1212,6 @@
               "unit": "s"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -1307,7 +1298,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 28
+            "y": 42
           },
           "id": 95,
           "options": {
@@ -1327,7 +1318,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -1468,7 +1458,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 36
+            "y": 50
           },
           "id": 97,
           "options": {
@@ -1489,7 +1479,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -1627,7 +1616,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 36
+            "y": 50
           },
           "id": 62,
           "options": {
@@ -1648,7 +1637,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -1759,7 +1747,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 36
+            "y": 50
           },
           "id": 98,
           "options": {
@@ -1779,7 +1767,6 @@
               "sort": "asc"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -1808,7 +1795,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 26
       },
       "id": 47,
       "panels": [],
@@ -1850,6 +1837,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1907,7 +1895,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 21
+        "y": 27
       },
       "id": 79,
       "options": {
@@ -1923,7 +1911,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -2007,7 +1994,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 21
+        "y": 27
       },
       "id": 76,
       "options": {
@@ -2060,7 +2047,6 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -2115,6 +2101,7 @@
               "type": "log"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -2147,7 +2134,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 21
+        "y": 27
       },
       "id": 52,
       "options": {
@@ -2163,7 +2150,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -2217,6 +2203,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -2274,7 +2261,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 29
+        "y": 35
       },
       "id": 57,
       "options": {
@@ -2290,7 +2277,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -2374,7 +2360,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 29
+        "y": 35
       },
       "id": 80,
       "options": {
@@ -2427,7 +2413,6 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -2482,6 +2467,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -2530,7 +2516,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 29
+        "y": 35
       },
       "id": 59,
       "options": {
@@ -2546,7 +2532,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -2671,7 +2656,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 37
+        "y": 43
       },
       "id": 77,
       "options": {
@@ -2687,7 +2672,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -2771,7 +2755,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 37
+        "y": 43
       },
       "id": 78,
       "options": {
@@ -2824,7 +2808,6 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -2934,7 +2917,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 37
+        "y": 43
       },
       "id": 73,
       "options": {
@@ -2950,7 +2933,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -3063,7 +3045,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 45
+        "y": 51
       },
       "id": 21,
       "options": {
@@ -3081,7 +3063,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -3207,7 +3188,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 45
+        "y": 51
       },
       "id": 63,
       "options": {
@@ -3228,7 +3209,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -3361,7 +3341,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 45
+        "y": 51
       },
       "id": 27,
       "options": {
@@ -3381,7 +3361,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -3417,7 +3396,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 53
+        "y": 59
       },
       "id": 51,
       "panels": [
@@ -3492,7 +3471,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 92
+            "y": 106
           },
           "id": 65,
           "options": {
@@ -3511,7 +3490,6 @@
               "sort": "asc"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -3627,7 +3605,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 97
+            "y": 111
           },
           "id": 49,
           "options": {
@@ -3643,7 +3621,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -3786,7 +3763,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 97
+            "y": 111
           },
           "id": 50,
           "options": {
@@ -3802,7 +3779,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -3832,7 +3808,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 54
+        "y": 60
       },
       "id": 22,
       "panels": [
@@ -3901,7 +3877,7 @@
             "h": 9,
             "w": 17,
             "x": 0,
-            "y": 55
+            "y": 69
           },
           "id": 44,
           "options": {
@@ -3922,7 +3898,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -4006,7 +3981,7 @@
             "h": 9,
             "w": 7,
             "x": 17,
-            "y": 55
+            "y": 69
           },
           "id": 107,
           "options": {
@@ -4026,7 +4001,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -4069,7 +4043,7 @@
             "h": 11,
             "w": 24,
             "x": 0,
-            "y": 64
+            "y": 78
           },
           "id": 23,
           "options": {
@@ -4112,7 +4086,6 @@
               "unit": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -4199,7 +4172,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 75
+            "y": 89
           },
           "id": 64,
           "options": {
@@ -4219,7 +4192,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -4305,7 +4277,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 75
+            "y": 89
           },
           "id": 26,
           "options": {
@@ -4325,7 +4297,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -4411,7 +4382,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 84
+            "y": 98
           },
           "id": 24,
           "options": {
@@ -4431,7 +4402,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -4515,7 +4485,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 84
+            "y": 98
           },
           "id": 34,
           "options": {
@@ -4535,7 +4505,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -4632,7 +4601,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 93
+            "y": 107
           },
           "id": 35,
           "options": {
@@ -4652,7 +4621,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -4736,7 +4704,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 93
+            "y": 107
           },
           "id": 36,
           "options": {
@@ -4756,7 +4724,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -4784,7 +4751,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 55
+        "y": 61
       },
       "id": 86,
       "panels": [
@@ -4816,7 +4783,7 @@
             "h": 13,
             "w": 12,
             "x": 0,
-            "y": 154
+            "y": 168
           },
           "id": 87,
           "options": {
@@ -4828,7 +4795,6 @@
             "textField": "instance_type",
             "tiling": "treemapSquarify"
           },
-          "pluginVersion": "2.1.1",
           "targets": [
             {
               "datasource": {
@@ -4915,7 +4881,7 @@
             "h": 13,
             "w": 12,
             "x": 12,
-            "y": 154
+            "y": 168
           },
           "id": 84,
           "options": {
@@ -4934,7 +4900,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -4959,7 +4924,7 @@
     }
   ],
   "preload": false,
-  "schemaVersion": 41,
+  "schemaVersion": 42,
   "tags": [
     "pyroscope",
     "pyroscope-v2"
@@ -4995,8 +4960,8 @@
       {
         "allowCustomValue": false,
         "current": {
-          "text": "prod-eu-west-2",
-          "value": "prod-eu-west-2"
+          "text": "pyroscope-dev",
+          "value": "pyroscope-dev"
         },
         "datasource": {
           "type": "prometheus",

--- a/operations/monitoring/dashboards/operational.json
+++ b/operations/monitoring/dashboards/operational.json
@@ -173,7 +173,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -271,7 +270,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -369,7 +367,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -434,7 +431,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -503,7 +499,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -632,7 +627,6 @@
           }
         ]
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -802,7 +796,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -898,7 +891,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -995,7 +987,6 @@
         "showRowNums": false,
         "sortBy": []
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -1165,7 +1156,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -1261,7 +1251,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -1382,7 +1371,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -1425,7 +1413,6 @@
         "sortOrder": "Descending",
         "wrapLogMessage": true
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -1603,7 +1590,6 @@
           }
         ]
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -2887,7 +2873,6 @@
             "showHeader": true,
             "showRowNums": false
           },
-          "pluginVersion": "9.5.0-53857pre",
           "targets": [
             {
               "datasource": {
@@ -7154,7 +7139,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {
@@ -7258,7 +7242,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-88106",
       "targets": [
         {
           "datasource": {

--- a/operations/monitoring/dashboards/v2-metastore.json
+++ b/operations/monitoring/dashboards/v2-metastore.json
@@ -195,7 +195,6 @@
           "sort": "asc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -323,7 +322,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -449,7 +447,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -575,7 +572,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -714,7 +710,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -816,7 +811,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -972,7 +966,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1095,7 +1088,6 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1226,7 +1218,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1352,7 +1343,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1462,7 +1452,6 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1593,7 +1582,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1732,7 +1720,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1842,7 +1829,6 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1973,7 +1959,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2099,7 +2084,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2209,7 +2193,6 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2340,7 +2323,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2479,7 +2461,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2589,7 +2570,6 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2720,7 +2700,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2859,7 +2838,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -3006,7 +2984,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -3135,7 +3112,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -3236,7 +3212,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -3340,7 +3315,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -3459,7 +3433,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -3579,7 +3552,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -3713,7 +3685,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.0.0-85518.patch7-85777",
           "targets": [
             {
               "datasource": {
@@ -3836,7 +3807,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.0.0-85518.patch7-85777",
           "targets": [
             {
               "datasource": {
@@ -3959,7 +3929,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.0.0-85518.patch7-85777",
           "targets": [
             {
               "datasource": {
@@ -4083,7 +4052,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.0.0-85518.patch7-85777",
           "targets": [
             {
               "datasource": {

--- a/operations/monitoring/dashboards/v2-read-path.json
+++ b/operations/monitoring/dashboards/v2-read-path.json
@@ -272,7 +272,6 @@
               }
             ]
           },
-          "pluginVersion": "12.1.0-90017",
           "targets": [
             {
               "datasource": {
@@ -484,7 +483,6 @@
               }
             ]
           },
-          "pluginVersion": "12.1.0-90017",
           "targets": [
             {
               "datasource": {
@@ -650,7 +648,6 @@
           "sort": "asc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -778,7 +775,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -917,7 +913,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1056,7 +1051,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1188,7 +1182,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1320,7 +1313,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1444,7 +1436,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1571,7 +1562,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1717,7 +1707,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1843,7 +1832,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -1948,7 +1936,6 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2074,7 +2061,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2235,7 +2221,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2417,7 +2402,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2576,7 +2560,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2701,7 +2684,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2805,7 +2787,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90017",
       "targets": [
         {
           "datasource": {
@@ -2951,7 +2932,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.0.0-85113",
           "targets": [
             {
               "datasource": {
@@ -3074,7 +3054,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.0.0-85113",
           "targets": [
             {
               "datasource": {
@@ -3197,7 +3176,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.0.0-85113",
           "targets": [
             {
               "datasource": {
@@ -3321,7 +3299,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.0.0-85113",
           "targets": [
             {
               "datasource": {
@@ -3381,7 +3358,6 @@
             "sortOrder": "Descending",
             "wrapLogMessage": false
           },
-          "pluginVersion": "12.0.0-85113",
           "targets": [
             {
               "datasource": {

--- a/operations/monitoring/dashboards/v2-write-path.json
+++ b/operations/monitoring/dashboards/v2-write-path.json
@@ -121,6 +121,11 @@
               "type": "auto"
             },
             "filterable": true,
+            "footer": {
+              "reducers": [
+                "countAll"
+              ]
+            },
             "inspect": false
           },
           "mappings": [],
@@ -257,15 +262,7 @@
       "id": 68,
       "options": {
         "cellHeight": "sm",
-        "footer": {
-          "countRows": true,
-          "enablePagination": false,
-          "fields": "",
-          "reducer": [
-            "count"
-          ],
-          "show": true
-        },
+        "enablePagination": false,
         "showHeader": true,
         "sortBy": [
           {
@@ -274,7 +271,6 @@
           }
         ]
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -360,6 +356,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -411,7 +408,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -464,6 +460,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -516,7 +513,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -578,13 +574,13 @@
           "fields": "",
           "values": false
         },
+        "sort": "desc",
         "tooltip": {
           "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -650,13 +646,13 @@
           "fields": "",
           "values": false
         },
+        "sort": "desc",
         "tooltip": {
           "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -682,7 +678,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 25
       },
       "id": 90,
       "panels": [
@@ -774,7 +770,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 20
+            "y": 34
           },
           "id": 94,
           "options": {
@@ -792,7 +788,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -847,7 +842,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 20
+            "y": 34
           },
           "id": 93,
           "options": {
@@ -900,7 +895,6 @@
               "unit": "s"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -987,7 +981,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 20
+            "y": 34
           },
           "id": 42,
           "options": {
@@ -1005,7 +999,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -1093,7 +1086,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 28
+            "y": 42
           },
           "id": 72,
           "options": {
@@ -1109,7 +1102,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -1167,7 +1159,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 28
+            "y": 42
           },
           "id": 56,
           "options": {
@@ -1220,7 +1212,6 @@
               "unit": "s"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -1307,7 +1298,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 28
+            "y": 42
           },
           "id": 95,
           "options": {
@@ -1327,7 +1318,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -1468,7 +1458,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 36
+            "y": 50
           },
           "id": 97,
           "options": {
@@ -1489,7 +1479,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -1627,7 +1616,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 36
+            "y": 50
           },
           "id": 62,
           "options": {
@@ -1648,7 +1637,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -1759,7 +1747,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 36
+            "y": 50
           },
           "id": 98,
           "options": {
@@ -1779,7 +1767,6 @@
               "sort": "asc"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -1808,7 +1795,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 26
       },
       "id": 47,
       "panels": [],
@@ -1850,6 +1837,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1907,7 +1895,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 21
+        "y": 27
       },
       "id": 79,
       "options": {
@@ -1923,7 +1911,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -2007,7 +1994,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 21
+        "y": 27
       },
       "id": 76,
       "options": {
@@ -2060,7 +2047,6 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -2115,6 +2101,7 @@
               "type": "log"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -2147,7 +2134,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 21
+        "y": 27
       },
       "id": 52,
       "options": {
@@ -2163,7 +2150,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -2217,6 +2203,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -2274,7 +2261,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 29
+        "y": 35
       },
       "id": 57,
       "options": {
@@ -2290,7 +2277,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -2374,7 +2360,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 29
+        "y": 35
       },
       "id": 80,
       "options": {
@@ -2427,7 +2413,6 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -2482,6 +2467,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -2530,7 +2516,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 29
+        "y": 35
       },
       "id": 59,
       "options": {
@@ -2546,7 +2532,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -2671,7 +2656,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 37
+        "y": 43
       },
       "id": 77,
       "options": {
@@ -2687,7 +2672,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -2771,7 +2755,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 37
+        "y": 43
       },
       "id": 78,
       "options": {
@@ -2824,7 +2808,6 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -2934,7 +2917,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 37
+        "y": 43
       },
       "id": 73,
       "options": {
@@ -2950,7 +2933,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -3063,7 +3045,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 45
+        "y": 51
       },
       "id": 21,
       "options": {
@@ -3081,7 +3063,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -3207,7 +3188,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 45
+        "y": 51
       },
       "id": 63,
       "options": {
@@ -3228,7 +3209,6 @@
           "sort": "desc"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -3361,7 +3341,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 45
+        "y": 51
       },
       "id": 27,
       "options": {
@@ -3381,7 +3361,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0-90139",
       "targets": [
         {
           "datasource": {
@@ -3417,7 +3396,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 53
+        "y": 59
       },
       "id": 51,
       "panels": [
@@ -3492,7 +3471,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 92
+            "y": 106
           },
           "id": 65,
           "options": {
@@ -3511,7 +3490,6 @@
               "sort": "asc"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -3627,7 +3605,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 97
+            "y": 111
           },
           "id": 49,
           "options": {
@@ -3643,7 +3621,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -3786,7 +3763,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 97
+            "y": 111
           },
           "id": 50,
           "options": {
@@ -3802,7 +3779,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -3832,7 +3808,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 54
+        "y": 60
       },
       "id": 22,
       "panels": [
@@ -3901,7 +3877,7 @@
             "h": 9,
             "w": 17,
             "x": 0,
-            "y": 55
+            "y": 69
           },
           "id": 44,
           "options": {
@@ -3922,7 +3898,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -4006,7 +3981,7 @@
             "h": 9,
             "w": 7,
             "x": 17,
-            "y": 55
+            "y": 69
           },
           "id": 107,
           "options": {
@@ -4026,7 +4001,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -4069,7 +4043,7 @@
             "h": 11,
             "w": 24,
             "x": 0,
-            "y": 64
+            "y": 78
           },
           "id": 23,
           "options": {
@@ -4112,7 +4086,6 @@
               "unit": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -4199,7 +4172,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 75
+            "y": 89
           },
           "id": 64,
           "options": {
@@ -4219,7 +4192,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -4305,7 +4277,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 75
+            "y": 89
           },
           "id": 26,
           "options": {
@@ -4325,7 +4297,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -4411,7 +4382,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 84
+            "y": 98
           },
           "id": 24,
           "options": {
@@ -4431,7 +4402,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -4515,7 +4485,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 84
+            "y": 98
           },
           "id": 34,
           "options": {
@@ -4535,7 +4505,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -4632,7 +4601,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 93
+            "y": 107
           },
           "id": 35,
           "options": {
@@ -4652,7 +4621,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -4736,7 +4704,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 93
+            "y": 107
           },
           "id": 36,
           "options": {
@@ -4756,7 +4724,6 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -4784,7 +4751,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 55
+        "y": 61
       },
       "id": 86,
       "panels": [
@@ -4816,7 +4783,7 @@
             "h": 13,
             "w": 12,
             "x": 0,
-            "y": 154
+            "y": 168
           },
           "id": 87,
           "options": {
@@ -4828,7 +4795,6 @@
             "textField": "instance_type",
             "tiling": "treemapSquarify"
           },
-          "pluginVersion": "2.1.1",
           "targets": [
             {
               "datasource": {
@@ -4915,7 +4881,7 @@
             "h": 13,
             "w": 12,
             "x": 12,
-            "y": 154
+            "y": 168
           },
           "id": 84,
           "options": {
@@ -4934,7 +4900,6 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.1.0-90058",
           "targets": [
             {
               "datasource": {
@@ -4959,7 +4924,7 @@
     }
   ],
   "preload": false,
-  "schemaVersion": 41,
+  "schemaVersion": 42,
   "tags": [
     "pyroscope",
     "pyroscope-v2"
@@ -4995,8 +4960,8 @@
       {
         "allowCustomValue": false,
         "current": {
-          "text": "prod-eu-west-2",
-          "value": "prod-eu-west-2"
+          "text": "pyroscope-dev",
+          "value": "pyroscope-dev"
         },
         "datasource": {
           "type": "prometheus",

--- a/operations/monitoring/helm/pyroscope-monitoring/README.md
+++ b/operations/monitoring/helm/pyroscope-monitoring/README.md
@@ -39,13 +39,14 @@ The committed JSON files under `operations/monitoring/dashboards/` (native) and 
 | dashboards.cloudBackendGateway | bool | `false` |  |
 | dashboards.cloudBackendGatewaySelector | string | `"container=~\"cortex-gw(-internal)?\""` |  |
 | dashboards.cluster | string | `"pyroscope-dev"` |  |
+| dashboards.ingestNamespaceSelector | string | `"namespace=~\"$namespace\""` |  |
 | dashboards.ingestSelector | string | `"container=~\"pyroscope|distributor|query-frontend\""` |  |
 | dashboards.kubeStateMetricsSelector | string | `"job=~\"(.*/)?kube-state-metrics\""` |  |
 | dashboards.namespace | string | `"default"` |  |
 | dashboards.namespaceRegex | string | `".*"` |  |
+| dashboards.namespaceRegexPerDashboard | object | `{}` |  |
 | dashboards.nativeHistograms | bool | `true` |  |
-| dashboards.tenantQuery | string | `"sum by (tenant, slug, org_name, environment) (\n  histogram_sum(rate(pyroscope_distributor_received_decompressed_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval]))\n)\n"` |  |
-| dashboards.tenantQueryClassic | string | `"sum by (tenant, slug, org_name, environment) (\n  rate(pyroscope_distributor_received_decompressed_bytes_sum{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])\n)\n"` |  |
+| dashboards.tenantQuery | string | `"sum by (tenant, slug, org_name, environment) (\n  {{- if .Values.dashboards.nativeHistograms }}\n  histogram_sum(rate(pyroscope_distributor_received_decompressed_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval]))\n  {{- else }}\n  rate(pyroscope_distributor_received_decompressed_bytes_sum{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])\n  {{- end }}\n)\n"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"grafana/otel-lgtm"` |  |

--- a/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboard_operational.yaml
+++ b/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboard_operational.yaml
@@ -133,7 +133,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-88106
     targets:
       - datasource:
           type: prometheus
@@ -214,7 +213,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-88106
     targets:
       - datasource:
           type: prometheus
@@ -295,7 +293,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 12.1.0-88106
     targets:
       - datasource:
           type: prometheus
@@ -344,7 +341,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-88106
     targets:
       - datasource:
           type: prometheus
@@ -399,7 +395,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-88106
     targets:
       - datasource:
           type: prometheus
@@ -482,20 +477,14 @@ panels:
       sortBy:
         - desc: true
           displayName: Value
-    pluginVersion: 12.1.0-88106
     targets:
       - datasource:
           type: prometheus
           uid: ${datasource}
         editorMode: code
         exemplar: false
-        {{- if .Values.dashboards.nativeHistograms }}
         expr: |
-          {{ .Values.dashboards.tenantQuery | nindent 10 }}
-        {{- else }}
-        expr: |
-          {{ .Values.dashboards.tenantQueryClassic | nindent 10 }}
-        {{- end }}
+          {{ tpl .Values.dashboards.tenantQuery . | nindent 10 }}
         format: table
         instant: true
         legendFormat: __auto
@@ -605,7 +594,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: none
-    pluginVersion: 12.1.0-88106
     targets:
       - datasource:
           uid: $datasource
@@ -624,7 +612,7 @@ panels:
           sum by (status) (
           label_replace(
             label_replace(
-                  rate(pyroscope_request_duration_seconds_count{cluster=~"$cluster", {{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}, namespace=~"$namespace", route=~".*ingest.*|.*pusher.*"}[$__rate_interval]),
+                  rate(pyroscope_request_duration_seconds_count{cluster=~"$cluster", {{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}{{ include "pyroscope-monitoring.dashboards-ingest-namespace-selector" . }}, route=~".*ingest.*|.*pusher.*"}[$__rate_interval]),
             "status", "${1}xx", "status_code", "([0-9]).."),
           "status", "${1}", "status_code", "([a-z]+)")
           )
@@ -694,7 +682,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-88106
     targets:
       - datasource:
           type: prometheus
@@ -703,7 +690,7 @@ panels:
         {{- if .Values.dashboards.nativeHistograms }}
         expr: >-
           histogram_quantile(0.99, sum by (route) (
-          rate(pyroscope_request_duration_seconds{{ "{" }}{{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}, namespace=~"$namespace",
+          rate(pyroscope_request_duration_seconds{{ "{" }}{{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}{{ include "pyroscope-monitoring.dashboards-ingest-namespace-selector" . }},
           cluster=~"$cluster",route=~".*ingest.*|.*pusher.*"}[$__rate_interval])))
         {{- else }}
         expr: >-
@@ -721,7 +708,7 @@ panels:
         {{- if .Values.dashboards.nativeHistograms }}
         expr: >-
           histogram_quantile(0.75, sum by (route) (
-          rate(pyroscope_request_duration_seconds{{ "{" }}{{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}, namespace=~"$namespace",
+          rate(pyroscope_request_duration_seconds{{ "{" }}{{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}{{ include "pyroscope-monitoring.dashboards-ingest-namespace-selector" . }},
           cluster=~"$cluster",route=~".*ingest.*|.*pusher.*"}[$__rate_interval])))
         {{- else }}
         expr: >-
@@ -740,7 +727,7 @@ panels:
         {{- if .Values.dashboards.nativeHistograms }}
         expr: >-
           histogram_quantile(0.5, sum by (route) (
-          rate(pyroscope_request_duration_seconds{{ "{" }}{{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}, namespace=~"$namespace",
+          rate(pyroscope_request_duration_seconds{{ "{" }}{{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}{{ include "pyroscope-monitoring.dashboards-ingest-namespace-selector" . }},
           cluster=~"$cluster",route=~".*ingest.*|.*pusher.*"}[$__rate_interval])))
         {{- else }}
         expr: >-
@@ -793,7 +780,6 @@ panels:
       showHeader: true
       showRowNums: false
       sortBy: []
-    pluginVersion: 12.1.0-88106
     targets:
       - datasource:
           type: prometheus
@@ -911,7 +897,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: none
-    pluginVersion: 12.1.0-88106
     targets:
       - datasource:
           uid: $datasource
@@ -930,7 +915,7 @@ panels:
           sum by (status) (
           label_replace(
             label_replace(
-                  rate(pyroscope_request_duration_seconds_count{cluster=~"$cluster", {{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}, namespace=~"$namespace", route=~".*pyroscope_render.*|.*pyroscope_label.*|.*querierservice.*"}[$__rate_interval]),
+                  rate(pyroscope_request_duration_seconds_count{cluster=~"$cluster", {{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}{{ include "pyroscope-monitoring.dashboards-ingest-namespace-selector" . }}, route=~".*pyroscope_render.*|.*pyroscope_label.*|.*querierservice.*"}[$__rate_interval]),
             "status", "${1}xx", "status_code", "([0-9]).."),
           "status", "${1}", "status_code", "([a-z]+)")
           )
@@ -1000,7 +985,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-88106
     targets:
       - datasource:
           type: prometheus
@@ -1009,7 +993,7 @@ panels:
         {{- if .Values.dashboards.nativeHistograms }}
         expr: >-
           histogram_quantile(0.99, sum by (route) (
-          rate(pyroscope_request_duration_seconds{{ "{" }}{{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}, namespace=~"$namespace",
+          rate(pyroscope_request_duration_seconds{{ "{" }}{{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}{{ include "pyroscope-monitoring.dashboards-ingest-namespace-selector" . }},
           cluster=~"$cluster",route=~".*pyroscope_render.*|.*pyroscope_label.*|.*querierservice.*"}[$__rate_interval])))
         {{- else }}
         expr: >-
@@ -1027,7 +1011,7 @@ panels:
         {{- if .Values.dashboards.nativeHistograms }}
         expr: >-
           histogram_quantile(0.75, sum by (route) (
-          rate(pyroscope_request_duration_seconds{{ "{" }}{{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}, namespace=~"$namespace",
+          rate(pyroscope_request_duration_seconds{{ "{" }}{{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}{{ include "pyroscope-monitoring.dashboards-ingest-namespace-selector" . }},
           cluster=~"$cluster",route=~".*pyroscope_render.*|.*pyroscope_label.*|.*querierservice.*"}[$__rate_interval])))
         {{- else }}
         expr: >-
@@ -1046,7 +1030,7 @@ panels:
         {{- if .Values.dashboards.nativeHistograms }}
         expr: >-
           histogram_quantile(0.5, sum by (route) (
-          rate(pyroscope_request_duration_seconds{{ "{" }}{{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}, namespace=~"$namespace",
+          rate(pyroscope_request_duration_seconds{{ "{" }}{{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}{{ include "pyroscope-monitoring.dashboards-ingest-namespace-selector" . }},
           cluster=~"$cluster",route=~".*pyroscope_render.*|.*pyroscope_label.*|.*querierservice.*"}[$__rate_interval])))
         {{- else }}
         expr: >-
@@ -1120,7 +1104,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-88106
     targets:
       - datasource:
           type: loki
@@ -1158,7 +1141,6 @@ panels:
       showTime: false
       sortOrder: Descending
       wrapLogMessage: true
-    pluginVersion: 12.1.0-88106
     targets:
       - datasource:
           type: loki
@@ -1270,7 +1252,6 @@ panels:
       sortBy:
         - desc: false
           displayName: status
-    pluginVersion: 12.1.0-88106
     targets:
       - datasource:
           type: loki
@@ -2293,7 +2274,6 @@ panels:
             show: false
           showHeader: true
           showRowNums: false
-        pluginVersion: 9.5.0-53857pre
         targets:
           - datasource:
               type: prometheus
@@ -5629,7 +5609,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-88106
     targets:
       - datasource:
           type: prometheus
@@ -5719,7 +5698,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-88106
     targets:
       - datasource:
           type: prometheus
@@ -5817,7 +5795,7 @@ templating:
         query: label_values(pyroscope_build_info,namespace)
         refId: PrometheusVariableQueryEditor-VariableQuery
       refresh: 1
-      regex: {{.Values.dashboards.namespaceRegex | quote}}
+      regex: {{ include "pyroscope-monitoring.dashboards-namespace-regex" (list . $dashboard) | quote }}
       sort: 1
       type: query
 time:

--- a/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboard_v2-metastore.yaml
+++ b/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboard_v2-metastore.yaml
@@ -149,7 +149,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: asc
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -244,7 +243,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -345,7 +343,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -446,7 +443,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -573,7 +569,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -651,7 +646,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -781,7 +775,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -918,7 +911,6 @@ panels:
         axisPlacement: left
         reverse: false
         unit: s
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -1014,7 +1006,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -1120,7 +1111,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -1233,7 +1223,6 @@ panels:
         axisPlacement: left
         reverse: false
         unit: s
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -1329,7 +1318,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -1445,7 +1433,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -1558,7 +1545,6 @@ panels:
         axisPlacement: left
         reverse: false
         unit: s
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -1654,7 +1640,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -1760,7 +1745,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -1873,7 +1857,6 @@ panels:
         axisPlacement: left
         reverse: false
         unit: s
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -1969,7 +1952,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -2085,7 +2067,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -2198,7 +2179,6 @@ panels:
         axisPlacement: left
         reverse: false
         unit: s
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -2294,7 +2274,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -2410,7 +2389,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -2529,7 +2507,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -2639,7 +2616,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -2720,7 +2696,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -2801,7 +2776,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -2906,7 +2880,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -3001,7 +2974,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -3115,7 +3087,6 @@ panels:
             hideZeros: false
             mode: multi
             sort: desc
-        pluginVersion: 12.0.0-85518.patch7-85777
         targets:
           - datasource:
               type: prometheus
@@ -3204,7 +3175,6 @@ panels:
             hideZeros: false
             mode: multi
             sort: desc
-        pluginVersion: 12.0.0-85518.patch7-85777
         targets:
           - datasource:
               type: prometheus
@@ -3295,7 +3265,6 @@ panels:
             hideZeros: false
             mode: multi
             sort: desc
-        pluginVersion: 12.0.0-85518.patch7-85777
         targets:
           - datasource:
               type: prometheus
@@ -3387,7 +3356,6 @@ panels:
             hideZeros: false
             mode: multi
             sort: desc
-        pluginVersion: 12.0.0-85518.patch7-85777
         targets:
           - datasource:
               type: prometheus
@@ -3467,7 +3435,7 @@ templating:
         query: label_values(pyroscope_build_info,namespace)
         refId: PrometheusVariableQueryEditor-VariableQuery
       refresh: 1
-      regex: {{.Values.dashboards.namespaceRegex | quote}}
+      regex: {{ include "pyroscope-monitoring.dashboards-namespace-regex" (list . $dashboard) | quote }}
       type: query
 time:
   from: now-6h

--- a/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboard_v2-read-path.yaml
+++ b/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboard_v2-read-path.yaml
@@ -178,7 +178,6 @@ panels:
           sortBy:
             - desc: true
               displayName: Time
-        pluginVersion: 12.1.0-90017
         targets:
           - datasource:
               type: loki
@@ -348,7 +347,6 @@ panels:
           sortBy:
             - desc: true
               displayName: Start time
-        pluginVersion: 12.1.0-90017
         targets:
           - datasource:
               type: tempo
@@ -468,7 +466,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: asc
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -566,7 +563,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -700,7 +696,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -831,7 +826,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -924,7 +918,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -1030,7 +1023,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -1138,7 +1130,6 @@ panels:
         hideZeros: true
         mode: multi
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           uid: $datasource
@@ -1153,7 +1144,7 @@ panels:
         expr: >-
           sum by (status_code)
           (rate(pyroscope_request_duration_seconds_count{cluster=~"$cluster",
-          {{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}, namespace=~"$namespace",
+          {{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}{{ include "pyroscope-monitoring.dashboards-ingest-namespace-selector" . }},
           route=~".*pyroscope_render.*|.*pyroscope_label.*|.*querierservice.*"}[5m]))
         {{- end }}
         legendFormat: '{{"{{status_code}}"}} '
@@ -1239,7 +1230,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -1248,12 +1238,12 @@ panels:
         {{- if .Values.dashboards.nativeHistograms }}
         expr: >-
           histogram_quantile(0.99, sum by (route) (
-          rate(pyroscope_request_duration_seconds{{ "{" }}{{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}, namespace=~"$namespace",
+          rate(pyroscope_request_duration_seconds{{ "{" }}{{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}{{ include "pyroscope-monitoring.dashboards-ingest-namespace-selector" . }},
           cluster=~"$cluster",route=~".*pyroscope_render.*|.*pyroscope_label.*|.*querierservice.*"}[$__rate_interval])))
         {{- else }}
         expr: >-
           histogram_quantile(0.99, sum by (le, route) (
-          rate(pyroscope_request_duration_seconds_bucket{{ "{" }}{{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}, namespace=~"$namespace",
+          rate(pyroscope_request_duration_seconds_bucket{{ "{" }}{{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}{{ include "pyroscope-monitoring.dashboards-ingest-namespace-selector" . }},
           cluster=~"$cluster",route=~".*pyroscope_render.*|.*pyroscope_label.*|.*querierservice.*"}[$__rate_interval])))
         {{- end }}
         hide: false
@@ -1360,7 +1350,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -1463,7 +1452,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -1572,7 +1560,6 @@ panels:
         axisPlacement: left
         reverse: false
         unit: s
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -1667,7 +1654,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -1797,7 +1783,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -1935,7 +1920,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -2054,7 +2038,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -2155,7 +2138,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: none
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -2236,7 +2218,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 12.1.0-90017
     targets:
       - datasource:
           type: prometheus
@@ -2359,7 +2340,6 @@ panels:
             hideZeros: false
             mode: multi
             sort: desc
-        pluginVersion: 12.0.0-85113
         targets:
           - datasource:
               type: prometheus
@@ -2448,7 +2428,6 @@ panels:
             hideZeros: false
             mode: multi
             sort: desc
-        pluginVersion: 12.0.0-85113
         targets:
           - datasource:
               type: prometheus
@@ -2539,7 +2518,6 @@ panels:
             hideZeros: false
             mode: multi
             sort: desc
-        pluginVersion: 12.0.0-85113
         targets:
           - datasource:
               type: prometheus
@@ -2631,7 +2609,6 @@ panels:
             hideZeros: false
             mode: multi
             sort: desc
-        pluginVersion: 12.0.0-85113
         targets:
           - datasource:
               type: prometheus
@@ -2679,7 +2656,6 @@ panels:
           showTime: false
           sortOrder: Descending
           wrapLogMessage: false
-        pluginVersion: 12.0.0-85113
         targets:
           - datasource:
               type: loki
@@ -2774,7 +2750,7 @@ templating:
         query: label_values(pyroscope_build_info,namespace)
         refId: PrometheusVariableQueryEditor-VariableQuery
       refresh: 1
-      regex: {{.Values.dashboards.namespaceRegex | quote}}
+      regex: {{ include "pyroscope-monitoring.dashboards-namespace-regex" (list . $dashboard) | quote }}
       type: query
 time:
   from: now-6h

--- a/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboard_v2-write-path.yaml
+++ b/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboard_v2-write-path.yaml
@@ -95,6 +95,9 @@ panels:
           cellOptions:
             type: auto
           filterable: true
+          footer:
+            reducers:
+              - countAll
           inspect: false
         mappings: []
         thresholds:
@@ -168,31 +171,19 @@ panels:
     id: 68
     options:
       cellHeight: sm
-      footer:
-        countRows: true
-        enablePagination: false
-        fields: ''
-        reducer:
-          - count
-        show: true
+      enablePagination: false
       showHeader: true
       sortBy:
         - desc: true
           displayName: Value
-    pluginVersion: 12.1.0-90139
     targets:
       - datasource:
           type: prometheus
           uid: ${datasource}
         editorMode: code
         exemplar: false
-        {{- if .Values.dashboards.nativeHistograms }}
         expr: |
-          {{ .Values.dashboards.tenantQuery | nindent 10 }}
-        {{- else }}
-        expr: |
-          {{ .Values.dashboards.tenantQueryClassic | nindent 10 }}
-        {{- end }}
+          {{ tpl .Values.dashboards.tenantQuery . | nindent 10 }}
         format: table
         instant: true
         legendFormat: __auto
@@ -254,6 +245,7 @@ panels:
           scaleDistribution:
             type: linear
           showPoints: auto
+          showValues: false
           spanNulls: false
           stacking:
             group: A
@@ -289,7 +281,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90139
     targets:
       - datasource:
           type: prometheus
@@ -340,6 +331,7 @@ panels:
           scaleDistribution:
             type: linear
           showPoints: auto
+          showValues: false
           spanNulls: false
           stacking:
             group: A
@@ -376,7 +368,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90139
     targets:
       - datasource:
           type: prometheus
@@ -429,11 +420,11 @@ panels:
           - lastNotNull
         fields: ''
         values: false
+      sort: desc
       tooltip:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90139
     targets:
       - datasource:
           type: prometheus
@@ -486,11 +477,11 @@ panels:
           - lastNotNull
         fields: ''
         values: false
+      sort: desc
       tooltip:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90139
     targets:
       - datasource:
           type: prometheus
@@ -564,6 +555,7 @@ panels:
             log: 10
             type: log
           showPoints: never
+          showValues: false
           spanNulls: false
           stacking:
             group: A
@@ -625,7 +617,7 @@ panels:
             - id: custom.hideFrom
               value:
                 legend: false
-                tooltip: false
+                tooltip: true
                 viz: true
     gridPos:
       h: 8
@@ -644,7 +636,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: none
-    pluginVersion: 12.1.0-90139
     targets:
       - datasource:
           type: prometheus
@@ -692,7 +683,7 @@ panels:
         expr: >-
           histogram_quantile(0.999, sum by (le, status_code)
           (rate(pyroscope_request_duration_seconds_bucket{
-              {{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}, namespace=~"$namespace",
+              {{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}{{ include "pyroscope-monitoring.dashboards-ingest-namespace-selector" . }},
               route=~".*pusher.*|.*ingest.*",
               status_code="200",
           }[$__rate_interval])))
@@ -717,7 +708,7 @@ panels:
         expr: >-
           histogram_quantile(0.99, sum by (le, status_code)
           (rate(pyroscope_request_duration_seconds_bucket{
-              {{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}, namespace=~"$namespace",
+              {{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}{{ include "pyroscope-monitoring.dashboards-ingest-namespace-selector" . }},
               route=~".*pusher.*|.*ingest.*",
               status_code="200",
           }[$__rate_interval])))
@@ -742,7 +733,7 @@ panels:
         expr: >-
           histogram_quantile(0.95, sum by (le, status_code)
           (rate(pyroscope_request_duration_seconds_bucket{
-              {{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}, namespace=~"$namespace",
+              {{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}{{ include "pyroscope-monitoring.dashboards-ingest-namespace-selector" . }},
               route=~".*pusher.*|.*ingest.*",
               status_code="200",
           }[$__rate_interval])))
@@ -767,7 +758,7 @@ panels:
         expr: >-
           histogram_quantile(0.50, sum by (le, status_code)
           (rate(pyroscope_request_duration_seconds_bucket{
-              {{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}, namespace=~"$namespace",
+              {{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}{{ include "pyroscope-monitoring.dashboards-ingest-namespace-selector" . }},
               route=~".*pusher.*|.*ingest.*",
               status_code="200",
           }[$__rate_interval])))
@@ -783,18 +774,18 @@ panels:
         {{- if .Values.dashboards.nativeHistograms }}
         expr: |-
           histogram_avg(sum (rate(pyroscope_request_duration_seconds{
-              {{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}, namespace=~"$namespace",
+              {{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}{{ include "pyroscope-monitoring.dashboards-ingest-namespace-selector" . }},
               route=~".*pusher.*|.*ingest.*",
               status_code="200",
           }[$__rate_interval])))
         {{- else }}
         expr: |-
           sum(rate(pyroscope_request_duration_seconds_sum{
-              {{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}, namespace=~"$namespace",
+              {{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}{{ include "pyroscope-monitoring.dashboards-ingest-namespace-selector" . }},
               route=~".*pusher.*|.*ingest.*",
               status_code="200",
           }[$__rate_interval])) / sum(rate(pyroscope_request_duration_seconds_count{
-              {{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}, namespace=~"$namespace",
+              {{ include "pyroscope-monitoring.dashboards-ingest-selector" . }}{{ include "pyroscope-monitoring.dashboards-ingest-namespace-selector" . }},
               route=~".*pusher.*|.*ingest.*",
               status_code="200",
           }[$__rate_interval]))
@@ -862,7 +853,6 @@ panels:
         axisPlacement: left
         reverse: false
         unit: s
-    pluginVersion: 12.1.0-90139
     targets:
       - datasource:
           type: prometheus
@@ -911,6 +901,7 @@ panels:
             log: 2
             type: log
           showPoints: auto
+          showValues: false
           spanNulls: false
           stacking:
             group: A
@@ -943,7 +934,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90139
     targets:
       - datasource:
           type: prometheus
@@ -975,710 +965,167 @@ panels:
     title: Rate
     transparent: true
     type: timeseries
-  - collapsed: true
+  - datasource:
+      type: prometheus
+      uid: ${datasource}
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ''
+          axisPlacement: auto
+          barAlignment: 0
+          barWidthFactor: 0.6
+          drawStyle: line
+          fillOpacity: 0
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: auto
+          showValues: false
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: 'off'
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value: 0
+            - color: red
+              value: 80
+      overrides: []
     gridPos:
-      h: 1
-      w: 24
+      h: 7
+      w: 8
       x: 0
       'y': 18
-    id: 100
-    panels:
+    id: 99
+    options:
+      legend:
+        calcs: []
+        displayMode: table
+        placement: right
+        showLegend: false
+      tooltip:
+        hideZeros: false
+        mode: single
+        sort: none
+    targets:
       - datasource:
           type: prometheus
           uid: ${datasource}
-        description: >-
-          During load balancing, Envoy will generally only consider available
-          (healthy or degraded) hosts in an upstream cluster. However, if the
-          percentage of available hosts in the cluster becomes too low, Envoy
-          will disregard health status and balance either amongst all hosts or
-          no hosts. This is known as the panic threshold. The default panic
-          threshold is 50%. 
-        fieldConfig:
-          defaults:
-            color:
-              mode: palette-classic
-            custom:
-              axisBorderShow: false
-              axisCenteredZero: false
-              axisColorMode: text
-              axisLabel: ''
-              axisPlacement: auto
-              barAlignment: 0
-              barWidthFactor: 0.6
-              drawStyle: line
-              fillOpacity: 0
-              gradientMode: none
-              hideFrom:
-                legend: false
-                tooltip: false
-                viz: false
-              insertNulls: false
-              lineInterpolation: linear
-              lineWidth: 1
-              pointSize: 5
-              scaleDistribution:
-                type: linear
-              showPoints: auto
-              spanNulls: false
-              stacking:
-                group: A
-                mode: none
-              thresholdsStyle:
-                mode: 'off'
-            mappings: []
-            thresholds:
-              mode: absolute
-              steps:
-                - color: green
-                  value: 0
-                - color: red
-                  value: 80
-          overrides: []
-        gridPos:
-          h: 7
-          w: 8
-          x: 0
-          'y': 19
-        id: 102
-        options:
-          legend:
-            calcs: []
-            displayMode: table
-            placement: right
-            showLegend: false
-          tooltip:
-            hideZeros: false
-            mode: single
-            sort: none
-        pluginVersion: 12.1.0-90058
-        targets:
-          - datasource:
-              type: prometheus
-              uid: ${datasource}
-            editorMode: code
-            expr: >-
-              sum by (pod)
-              (rate(envoy_cluster_lb_healthy_panic{namespace="$namespace",container="envoy"}[$__rate_interval]))
-            hide: false
-            legendFormat: __auto
-            range: true
-            refId: A
-        title: Envoy Panics
-        transparent: true
-        type: timeseries
+        editorMode: code
+        expr: >-
+          sum by (direction,pod)
+          (conntrack_pod_connections{namespace="$namespace",pod=~"cortex-gw-.*"})
+        hide: false
+        legendFormat: '{{"{{pod}} {{direction}}"}}'
+        range: true
+        refId: A
+    title: Connections per pod
+    transparent: true
+    type: timeseries
+  - datasource:
+      type: prometheus
+      uid: ${datasource}
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ''
+          axisPlacement: auto
+          barAlignment: 0
+          barWidthFactor: 0.6
+          drawStyle: line
+          fillOpacity: 0
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: auto
+          showValues: false
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: 'off'
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value: 0
+            - color: red
+              value: 80
+        unit: binBps
+      overrides: []
+    gridPos:
+      h: 7
+      w: 8
+      x: 8
+      'y': 18
+    id: 108
+    options:
+      legend:
+        calcs: []
+        displayMode: table
+        placement: right
+        showLegend: false
+      tooltip:
+        hideZeros: false
+        mode: single
+        sort: none
+    targets:
       - datasource:
           type: prometheus
           uid: ${datasource}
-        fieldConfig:
-          defaults:
-            color:
-              mode: palette-classic
-            custom:
-              axisBorderShow: false
-              axisCenteredZero: false
-              axisColorMode: text
-              axisLabel: ''
-              axisPlacement: auto
-              barAlignment: 0
-              barWidthFactor: 0.6
-              drawStyle: line
-              fillOpacity: 0
-              gradientMode: none
-              hideFrom:
-                legend: false
-                tooltip: false
-                viz: false
-              insertNulls: false
-              lineInterpolation: linear
-              lineWidth: 1
-              pointSize: 5
-              scaleDistribution:
-                type: linear
-              showPoints: auto
-              spanNulls: false
-              stacking:
-                group: A
-                mode: none
-              thresholdsStyle:
-                mode: 'off'
-            mappings: []
-            thresholds:
-              mode: absolute
-              steps:
-                - color: green
-                  value: 0
-                - color: red
-                  value: 80
-          overrides: []
-        gridPos:
-          h: 7
-          w: 8
-          x: 8
-          'y': 19
-        id: 99
-        options:
-          legend:
-            calcs: []
-            displayMode: table
-            placement: right
-            showLegend: false
-          tooltip:
-            hideZeros: false
-            mode: single
-            sort: none
-        pluginVersion: 12.1.0-90058
-        targets:
-          - datasource:
-              type: prometheus
-              uid: ${datasource}
-            editorMode: code
-            expr: >-
-              sum by (direction,pod)
-              (conntrack_pod_connections{namespace="$namespace",pod=~"cortex-gw-.*"})
-            hide: false
-            legendFormat: '{{"{{pod}} {{direction}}"}}'
-            range: true
-            refId: A
-        title: Connections per pod
-        transparent: true
-        type: timeseries
-      - datasource:
-          type: prometheus
-          uid: ${datasource}
-        description: >-
-          See
-          https://www.envoyproxy.io/docs/envoy/latest/configuration/upstream/cluster_manager/cluster_stats
-        fieldConfig:
-          defaults:
-            color:
-              mode: palette-classic
-            custom:
-              axisBorderShow: false
-              axisCenteredZero: false
-              axisColorMode: text
-              axisLabel: ''
-              axisPlacement: auto
-              barAlignment: 0
-              barWidthFactor: 0.6
-              drawStyle: line
-              fillOpacity: 0
-              gradientMode: none
-              hideFrom:
-                legend: false
-                tooltip: false
-                viz: false
-              insertNulls: false
-              lineInterpolation: linear
-              lineWidth: 1
-              pointSize: 5
-              scaleDistribution:
-                type: linear
-              showPoints: auto
-              spanNulls: false
-              stacking:
-                group: A
-                mode: none
-              thresholdsStyle:
-                mode: 'off'
-            mappings: []
-            thresholds:
-              mode: absolute
-              steps:
-                - color: green
-                  value: 0
-                - color: red
-                  value: 80
-          overrides: []
-        gridPos:
-          h: 7
-          w: 8
-          x: 16
-          'y': 19
-        id: 105
-        options:
-          legend:
-            calcs: []
-            displayMode: list
-            placement: bottom
-            showLegend: true
-          tooltip:
-            hideZeros: false
-            mode: single
-            sort: none
-        pluginVersion: 12.1.0-90058
-        targets:
-          - datasource:
-              type: prometheus
-              uid: ${datasource}
-            editorMode: code
-            expr: >-
-              sum by ()
-              (rate(envoy_cluster_upstream_rq_pending_overflow{namespace="$namespace",container="envoy"}[$__rate_interval]))
-            hide: false
-            instant: false
-            legendFormat: pending overflow
-            range: true
-            refId: B
-          - datasource:
-              type: prometheus
-              uid: ${datasource}
-            editorMode: code
-            expr: >-
-              sum by ()
-              (rate(envoy_cluster_upstream_rq_pending_failure_eject{namespace="$namespace",container="envoy"}[$__rate_interval]))
-            hide: false
-            instant: false
-            legendFormat: pending failure eject
-            range: true
-            refId: C
-          - datasource:
-              type: prometheus
-              uid: ${datasource}
-            editorMode: code
-            expr: >-
-              sum by ()
-              (rate(envoy_cluster_upstream_rq_timeout{namespace="$namespace",container="envoy"}[$__rate_interval]))
-            hide: false
-            instant: false
-            legendFormat: timeout
-            range: true
-            refId: A
-          - datasource:
-              type: prometheus
-              uid: ${datasource}
-            editorMode: code
-            expr: >-
-              sum by ()
-              (rate(envoy_cluster_upstream_rq_cancelled{namespace="$namespace",container="envoy"}[$__rate_interval]))
-            hide: false
-            instant: false
-            legendFormat: cancelled
-            range: true
-            refId: D
-          - datasource:
-              type: prometheus
-              uid: ${datasource}
-            editorMode: code
-            expr: >-
-              sum by ()
-              (rate(envoy_cluster_upstream_rq_max_duration_reached{namespace="$namespace",container="envoy"}[$__rate_interval]))
-            hide: false
-            instant: false
-            legendFormat: max_duration_reached
-            range: true
-            refId: E
-        title: Envoy RQ Errors
-        transparent: true
-        type: timeseries
-      - datasource:
-          type: prometheus
-          uid: ${datasource}
-        description: >-
-          See
-          https://www.envoyproxy.io/docs/envoy/latest/configuration/upstream/cluster_manager/cluster_stats
-        fieldConfig:
-          defaults:
-            color:
-              mode: palette-classic
-            custom:
-              axisBorderShow: false
-              axisCenteredZero: false
-              axisColorMode: text
-              axisLabel: ''
-              axisPlacement: auto
-              barAlignment: 0
-              barWidthFactor: 0.6
-              drawStyle: line
-              fillOpacity: 0
-              gradientMode: none
-              hideFrom:
-                legend: false
-                tooltip: false
-                viz: false
-              insertNulls: false
-              lineInterpolation: linear
-              lineWidth: 1
-              pointSize: 5
-              scaleDistribution:
-                type: linear
-              showPoints: auto
-              spanNulls: false
-              stacking:
-                group: A
-                mode: none
-              thresholdsStyle:
-                mode: 'off'
-            mappings: []
-            thresholds:
-              mode: absolute
-              steps:
-                - color: green
-                  value: 0
-                - color: red
-                  value: 80
-          overrides: []
-        gridPos:
-          h: 7
-          w: 8
-          x: 0
-          'y': 26
-        id: 106
-        options:
-          legend:
-            calcs: []
-            displayMode: list
-            placement: bottom
-            showLegend: false
-          tooltip:
-            hideZeros: false
-            mode: single
-            sort: none
-        pluginVersion: 12.1.0-90058
-        targets:
-          - datasource:
-              type: prometheus
-              uid: ${datasource}
-            editorMode: code
-            expr: >-
-              sum by (pod)
-              (envoy_cluster_membership_healthy{namespace="$namespace",container="envoy",envoy_cluster_name="phlare_write_h2c"})
-            hide: true
-            instant: false
-            legendFormat: healthy {{"{{pod}}"}}
-            range: true
-            refId: A
-          - datasource:
-              type: prometheus
-              uid: ${datasource}
-            editorMode: code
-            expr: >-
-              sum by (pod)
-              (envoy_cluster_membership_total{namespace="$namespace",container="envoy",envoy_cluster_name="phlare_write_h2c"})
-            hide: false
-            instant: false
-            legendFormat: total {{"{{pod}}"}}
-            range: true
-            refId: B
-        title: Envoy Membership
-        transparent: true
-        type: timeseries
-      - datasource:
-          type: prometheus
-          uid: ${datasource}
-        fieldConfig:
-          defaults:
-            color:
-              mode: palette-classic
-            custom:
-              axisBorderShow: false
-              axisCenteredZero: false
-              axisColorMode: text
-              axisLabel: ''
-              axisPlacement: auto
-              barAlignment: 0
-              barWidthFactor: 0.6
-              drawStyle: line
-              fillOpacity: 0
-              gradientMode: none
-              hideFrom:
-                legend: false
-                tooltip: false
-                viz: false
-              insertNulls: false
-              lineInterpolation: linear
-              lineWidth: 1
-              pointSize: 5
-              scaleDistribution:
-                type: linear
-              showPoints: auto
-              spanNulls: false
-              stacking:
-                group: A
-                mode: none
-              thresholdsStyle:
-                mode: 'off'
-            mappings: []
-            thresholds:
-              mode: absolute
-              steps:
-                - color: green
-                  value: 0
-                - color: red
-                  value: 80
-          overrides: []
-        gridPos:
-          h: 7
-          w: 5
-          x: 8
-          'y': 26
-        id: 103
-        options:
-          legend:
-            calcs: []
-            displayMode: list
-            placement: bottom
-            showLegend: true
-          tooltip:
-            hideZeros: false
-            mode: single
-            sort: none
-        pluginVersion: 12.1.0-90058
-        targets:
-          - datasource:
-              type: prometheus
-              uid: ${datasource}
-            editorMode: code
-            expr: >-
-              sum by ()
-              (rate(envoy_cluster_upstream_cx_connect_fail{namespace="$namespace",container="envoy"}[$__rate_interval]))
-            hide: false
-            instant: false
-            legendFormat: '{{"{{pod}}"}} fail'
-            range: true
-            refId: B
-          - datasource:
-              type: prometheus
-              uid: ${datasource}
-            editorMode: code
-            expr: >-
-              sum by ()
-              (rate(envoy_cluster_upstream_cx_connect_timeout{namespace="$namespace",container="envoy"}[$__rate_interval]))
-            hide: false
-            instant: false
-            legendFormat: '{{"{{pod}}"}} timeout'
-            range: true
-            refId: C
-          - datasource:
-              type: prometheus
-              uid: ${datasource}
-            editorMode: code
-            expr: >-
-              sum by ()
-              (rate(envoy_cluster_upstream_cx_connect_attempts_exceeded{namespace="$namespace",container="envoy"}[$__rate_interval]))
-            hide: false
-            instant: false
-            legendFormat: attempts exceeded
-            range: true
-            refId: A
-        title: Envoy CX Connect
-        transparent: true
-        type: timeseries
-      - datasource:
-          type: prometheus
-          uid: ${datasource}
-        description: |-
-          How and when upstream connections are destroyed.
-
-          Only connections with 1+ in-flight requests are accounted for. 
-        fieldConfig:
-          defaults:
-            color:
-              mode: palette-classic
-            custom:
-              axisBorderShow: false
-              axisCenteredZero: false
-              axisColorMode: text
-              axisLabel: ''
-              axisPlacement: auto
-              barAlignment: 0
-              barWidthFactor: 0.6
-              drawStyle: line
-              fillOpacity: 0
-              gradientMode: none
-              hideFrom:
-                legend: false
-                tooltip: false
-                viz: false
-              insertNulls: false
-              lineInterpolation: linear
-              lineWidth: 1
-              pointSize: 5
-              scaleDistribution:
-                type: linear
-              showPoints: auto
-              spanNulls: false
-              stacking:
-                group: A
-                mode: none
-              thresholdsStyle:
-                mode: 'off'
-            mappings: []
-            thresholds:
-              mode: absolute
-              steps:
-                - color: green
-                  value: 0
-                - color: red
-                  value: 80
-          overrides: []
-        gridPos:
-          h: 7
-          w: 5
-          x: 13
-          'y': 26
-        id: 101
-        options:
-          legend:
-            calcs: []
-            displayMode: list
-            placement: bottom
-            showLegend: true
-          tooltip:
-            hideZeros: false
-            mode: single
-            sort: none
-        pluginVersion: 12.1.0-90058
-        targets:
-          - datasource:
-              type: prometheus
-              uid: ${datasource}
-            editorMode: code
-            expr: >-
-              sum by ()
-              (rate(envoy_cluster_upstream_cx_destroy_local_with_active_rq{namespace="$namespace",container="envoy"}[$__rate_interval]))
-            hide: false
-            instant: false
-            legendFormat: local destroy
-            range: true
-            refId: B
-          - datasource:
-              type: prometheus
-              uid: ${datasource}
-            editorMode: code
-            expr: >-
-              sum by ()
-              (rate(envoy_cluster_upstream_cx_destroy_remote_with_active_rq{namespace="$namespace",container="envoy"}[$__rate_interval]))
-            hide: false
-            instant: false
-            legendFormat: remote destroy
-            range: true
-            refId: C
-        title: Envoy CX Destroy
-        transparent: true
-        type: timeseries
-      - datasource:
-          type: prometheus
-          uid: ${datasource}
-        description: Connection errors
-        fieldConfig:
-          defaults:
-            color:
-              mode: palette-classic
-            custom:
-              axisBorderShow: false
-              axisCenteredZero: false
-              axisColorMode: text
-              axisLabel: ''
-              axisPlacement: auto
-              barAlignment: 0
-              barWidthFactor: 0.6
-              drawStyle: line
-              fillOpacity: 0
-              gradientMode: none
-              hideFrom:
-                legend: false
-                tooltip: false
-                viz: false
-              insertNulls: false
-              lineInterpolation: linear
-              lineWidth: 1
-              pointSize: 5
-              scaleDistribution:
-                type: linear
-              showPoints: auto
-              spanNulls: false
-              stacking:
-                group: A
-                mode: none
-              thresholdsStyle:
-                mode: 'off'
-            mappings: []
-            thresholds:
-              mode: absolute
-              steps:
-                - color: green
-                  value: 0
-                - color: red
-                  value: 80
-          overrides: []
-        gridPos:
-          h: 7
-          w: 6
-          x: 18
-          'y': 26
-        id: 104
-        options:
-          legend:
-            calcs: []
-            displayMode: list
-            placement: bottom
-            showLegend: true
-          tooltip:
-            hideZeros: false
-            mode: single
-            sort: none
-        pluginVersion: 12.1.0-90058
-        targets:
-          - datasource:
-              type: prometheus
-              uid: ${datasource}
-            editorMode: code
-            expr: >-
-              sum by ()
-              (rate(envoy_cluster_upstream_cx_protocol_error{namespace="$namespace",container="envoy"}[$__rate_interval]))
-            hide: false
-            instant: false
-            legendFormat: protocol error
-            range: true
-            refId: B
-          - datasource:
-              type: prometheus
-              uid: ${datasource}
-            editorMode: code
-            expr: >-
-              sum by ()
-              (rate(envoy_cluster_upstream_cx_idle_timeout{namespace="$namespace",container="envoy"}[$__rate_interval]))
-            hide: false
-            instant: false
-            legendFormat: idle timeout
-            range: true
-            refId: A
-          - datasource:
-              type: prometheus
-              uid: ${datasource}
-            editorMode: code
-            expr: >-
-              sum by ()
-              (rate(envoy_cluster_upstream_cx_overflow{namespace="$namespace",container="envoy"}[$__rate_interval]))
-            hide: false
-            instant: false
-            legendFormat: cb overflow
-            range: true
-            refId: C
-          - datasource:
-              type: prometheus
-              uid: ${datasource}
-            editorMode: code
-            expr: >-
-              sum by ()
-              (rate(envoy_cluster_upstream_cx_pool_overflow{namespace="$namespace",container="envoy"}[$__rate_interval]))
-            hide: false
-            instant: false
-            legendFormat: pool overflow
-            range: true
-            refId: E
-        title: Envoy CX Errors
-        transparent: true
-        type: timeseries
-    title: Cortex Gateway Networking
-    type: row
+        editorMode: code
+        expr: >-
+          sum by(pod)
+          (rate(container_network_receive_bytes_total{namespace="$namespace",
+          cluster="$cluster", pod=~"cortex-gw.*"}[$__rate_interval]))
+        hide: false
+        legendFormat: '{{"{{pod}} {{direction}}"}}'
+        range: true
+        refId: A
+    title: MBs container received per pod
+    transparent: true
+    type: timeseries
 {{- end }}
   - collapsed: true
     gridPos:
       h: 1
       w: 24
       x: 0
-      'y': 19
+      'y': 25
     id: 90
     panels:
       - datasource:
@@ -1749,7 +1196,7 @@ panels:
           h: 8
           w: 8
           x: 0
-          'y': 20
+          'y': 34
         id: 94
         options:
           legend:
@@ -1762,7 +1209,6 @@ panels:
             hideZeros: false
             mode: multi
             sort: desc
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -1838,7 +1284,7 @@ panels:
           h: 8
           w: 8
           x: 8
-          'y': 20
+          'y': 34
         id: 93
         options:
           calculate: false
@@ -1877,7 +1323,6 @@ panels:
             axisPlacement: left
             reverse: false
             unit: s
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -1948,7 +1393,7 @@ panels:
           h: 8
           w: 8
           x: 16
-          'y': 20
+          'y': 34
         id: 42
         options:
           legend:
@@ -1962,7 +1407,6 @@ panels:
             hideZeros: false
             mode: multi
             sort: none
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -2056,7 +1500,7 @@ panels:
           h: 8
           w: 8
           x: 0
-          'y': 28
+          'y': 42
         id: 72
         options:
           legend:
@@ -2068,7 +1512,6 @@ panels:
             hideZeros: false
             mode: single
             sort: none
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -2143,7 +1586,7 @@ panels:
           h: 8
           w: 8
           x: 8
-          'y': 28
+          'y': 42
         id: 56
         options:
           calculate: false
@@ -2182,7 +1625,6 @@ panels:
             axisPlacement: left
             reverse: false
             unit: s
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -2252,7 +1694,7 @@ panels:
           h: 8
           w: 8
           x: 16
-          'y': 28
+          'y': 42
         id: 95
         options:
           legend:
@@ -2267,7 +1709,6 @@ panels:
             hideZeros: false
             mode: multi
             sort: none
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -2389,7 +1830,7 @@ panels:
           h: 8
           w: 8
           x: 0
-          'y': 36
+          'y': 50
         id: 97
         options:
           legend:
@@ -2405,7 +1846,6 @@ panels:
             hideZeros: false
             mode: multi
             sort: desc
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -2505,7 +1945,7 @@ panels:
           h: 8
           w: 8
           x: 8
-          'y': 36
+          'y': 50
         id: 62
         options:
           legend:
@@ -2521,7 +1961,6 @@ panels:
             hideZeros: false
             mode: multi
             sort: desc
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -2619,7 +2058,7 @@ panels:
           h: 8
           w: 8
           x: 16
-          'y': 36
+          'y': 50
         id: 98
         options:
           legend:
@@ -2634,7 +2073,6 @@ panels:
             hideZeros: false
             mode: single
             sort: asc
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -2673,7 +2111,7 @@ panels:
       h: 1
       w: 24
       x: 0
-      'y': 20
+      'y': 26
     id: 47
     panels: []
     title: Segment Writer
@@ -2708,6 +2146,7 @@ panels:
           scaleDistribution:
             type: linear
           showPoints: auto
+          showValues: false
           spanNulls: false
           stacking:
             group: A
@@ -2741,7 +2180,7 @@ panels:
       h: 8
       w: 8
       x: 0
-      'y': 21
+      'y': 27
     id: 79
     options:
       legend:
@@ -2753,7 +2192,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 12.1.0-90139
     targets:
       - datasource:
           type: prometheus
@@ -2882,7 +2320,7 @@ panels:
       h: 8
       w: 8
       x: 8
-      'y': 21
+      'y': 27
     id: 76
     options:
       calculate: false
@@ -2921,7 +2359,6 @@ panels:
         axisPlacement: left
         reverse: false
         unit: s
-    pluginVersion: 12.1.0-90139
     targets:
       - datasource:
           type: prometheus
@@ -2973,6 +2410,7 @@ panels:
             log: 2
             type: log
           showPoints: auto
+          showValues: false
           spanNulls: false
           stacking:
             group: A
@@ -2994,7 +2432,7 @@ panels:
       h: 8
       w: 8
       x: 16
-      'y': 21
+      'y': 27
     id: 52
     options:
       legend:
@@ -3006,7 +2444,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90139
     targets:
       - datasource:
           type: prometheus
@@ -3066,6 +2503,7 @@ panels:
           scaleDistribution:
             type: linear
           showPoints: auto
+          showValues: false
           spanNulls: false
           stacking:
             group: A
@@ -3099,7 +2537,7 @@ panels:
       h: 8
       w: 8
       x: 0
-      'y': 29
+      'y': 35
     id: 57
     options:
       legend:
@@ -3111,7 +2549,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 12.1.0-90139
     targets:
       - datasource:
           type: prometheus
@@ -3208,7 +2645,7 @@ panels:
       h: 8
       w: 8
       x: 8
-      'y': 29
+      'y': 35
     id: 80
     options:
       calculate: false
@@ -3247,7 +2684,6 @@ panels:
         axisPlacement: left
         reverse: false
         unit: s
-    pluginVersion: 12.1.0-90139
     targets:
       - datasource:
           type: prometheus
@@ -3293,6 +2729,7 @@ panels:
           scaleDistribution:
             type: linear
           showPoints: auto
+          showValues: false
           spanNulls: false
           stacking:
             group: A
@@ -3321,7 +2758,7 @@ panels:
       h: 8
       w: 8
       x: 16
-      'y': 29
+      'y': 35
     id: 59
     options:
       legend:
@@ -3333,7 +2770,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90139
     targets:
       - datasource:
           type: prometheus
@@ -3439,7 +2875,7 @@ panels:
       h: 8
       w: 8
       x: 0
-      'y': 37
+      'y': 43
     id: 77
     options:
       legend:
@@ -3451,7 +2887,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 12.1.0-90139
     targets:
       - datasource:
           type: prometheus
@@ -3550,7 +2985,7 @@ panels:
       h: 8
       w: 8
       x: 8
-      'y': 37
+      'y': 43
     id: 78
     options:
       calculate: false
@@ -3589,7 +3024,6 @@ panels:
         axisPlacement: left
         reverse: false
         unit: s
-    pluginVersion: 12.1.0-90139
     targets:
       - datasource:
           type: prometheus
@@ -3667,7 +3101,7 @@ panels:
       h: 8
       w: 8
       x: 16
-      'y': 37
+      'y': 43
     id: 73
     options:
       legend:
@@ -3679,7 +3113,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90139
     targets:
       - datasource:
           type: prometheus
@@ -3776,7 +3209,7 @@ panels:
       h: 8
       w: 8
       x: 0
-      'y': 45
+      'y': 51
     id: 21
     options:
       legend:
@@ -3789,7 +3222,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 12.1.0-90139
     targets:
       - datasource:
           type: prometheus
@@ -3893,7 +3325,7 @@ panels:
       h: 8
       w: 8
       x: 8
-      'y': 45
+      'y': 51
     id: 63
     options:
       legend:
@@ -3909,7 +3341,6 @@ panels:
         hideZeros: false
         mode: multi
         sort: desc
-    pluginVersion: 12.1.0-90139
     targets:
       - datasource:
           type: prometheus
@@ -4015,7 +3446,7 @@ panels:
       h: 8
       w: 8
       x: 16
-      'y': 45
+      'y': 51
     id: 27
     options:
       legend:
@@ -4030,7 +3461,6 @@ panels:
         hideZeros: false
         mode: single
         sort: none
-    pluginVersion: 12.1.0-90139
     targets:
       - datasource:
           type: prometheus
@@ -4060,7 +3490,7 @@ panels:
       h: 1
       w: 24
       x: 0
-      'y': 53
+      'y': 59
     id: 51
     panels:
       - datasource:
@@ -4112,7 +3542,7 @@ panels:
           h: 5
           w: 24
           x: 0
-          'y': 92
+          'y': 106
         id: 65
         options:
           alignValue: center
@@ -4127,7 +3557,6 @@ panels:
             hideZeros: false
             mode: multi
             sort: asc
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -4212,7 +3641,7 @@ panels:
           h: 8
           w: 12
           x: 0
-          'y': 97
+          'y': 111
         id: 49
         options:
           legend:
@@ -4224,7 +3653,6 @@ panels:
             hideZeros: false
             mode: single
             sort: none
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -4371,7 +3799,7 @@ panels:
           h: 8
           w: 12
           x: 12
-          'y': 97
+          'y': 111
         id: 50
         options:
           legend:
@@ -4383,7 +3811,6 @@ panels:
             hideZeros: false
             mode: single
             sort: none
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -4421,7 +3848,7 @@ panels:
       h: 1
       w: 24
       x: 0
-      'y': 54
+      'y': 60
     id: 22
     panels:
       - datasource:
@@ -4473,7 +3900,7 @@ panels:
           h: 9
           w: 17
           x: 0
-          'y': 55
+          'y': 69
         id: 44
         options:
           legend:
@@ -4489,7 +3916,6 @@ panels:
             hideZeros: false
             mode: single
             sort: none
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -4555,7 +3981,7 @@ panels:
           h: 9
           w: 7
           x: 17
-          'y': 55
+          'y': 69
         id: 107
         options:
           legend:
@@ -4570,7 +3996,6 @@ panels:
             hideZeros: false
             mode: single
             sort: none
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -4604,7 +4029,7 @@ panels:
           h: 11
           w: 24
           x: 0
-          'y': 64
+          'y': 78
         id: 23
         options:
           calculate: false
@@ -4637,7 +4062,6 @@ panels:
             axisPlacement: right
             reverse: true
             unit: none
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -4711,7 +4135,7 @@ panels:
           h: 9
           w: 12
           x: 0
-          'y': 75
+          'y': 89
         id: 64
         options:
           legend:
@@ -4726,7 +4150,6 @@ panels:
             hideZeros: false
             mode: single
             sort: none
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -4799,7 +4222,7 @@ panels:
           h: 9
           w: 12
           x: 12
-          'y': 75
+          'y': 89
         id: 26
         options:
           legend:
@@ -4814,7 +4237,6 @@ panels:
             hideZeros: false
             mode: single
             sort: none
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -4887,7 +4309,7 @@ panels:
           h: 9
           w: 12
           x: 0
-          'y': 84
+          'y': 98
         id: 24
         options:
           legend:
@@ -4902,7 +4324,6 @@ panels:
             hideZeros: false
             mode: single
             sort: none
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -4973,7 +4394,7 @@ panels:
           h: 9
           w: 12
           x: 12
-          'y': 84
+          'y': 98
         id: 34
         options:
           legend:
@@ -4988,7 +4409,6 @@ panels:
             hideZeros: false
             mode: single
             sort: none
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -5069,7 +4489,7 @@ panels:
           h: 9
           w: 12
           x: 0
-          'y': 93
+          'y': 107
         id: 35
         options:
           legend:
@@ -5084,7 +4504,6 @@ panels:
             hideZeros: false
             mode: multi
             sort: desc
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -5155,7 +4574,7 @@ panels:
           h: 9
           w: 12
           x: 12
-          'y': 93
+          'y': 107
         id: 36
         options:
           legend:
@@ -5170,7 +4589,6 @@ panels:
             hideZeros: false
             mode: multi
             sort: desc
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -5198,7 +4616,7 @@ panels:
       h: 1
       w: 24
       x: 0
-      'y': 55
+      'y': 61
     id: 86
     panels:
       - datasource:
@@ -5220,7 +4638,7 @@ panels:
           h: 13
           w: 12
           x: 0
-          'y': 154
+          'y': 168
         id: 87
         options:
           groupByField: container
@@ -5229,7 +4647,6 @@ panels:
             - instance_type
           textField: instance_type
           tiling: treemapSquarify
-        pluginVersion: 2.1.1
         targets:
           - datasource:
               type: prometheus
@@ -5304,7 +4721,7 @@ panels:
           h: 13
           w: 12
           x: 12
-          'y': 154
+          'y': 168
         id: 84
         options:
           legend:
@@ -5318,7 +4735,6 @@ panels:
             hideZeros: false
             mode: single
             sort: none
-        pluginVersion: 12.1.0-90058
         targets:
           - datasource:
               type: prometheus
@@ -5344,7 +4760,7 @@ panels:
     title: Resource Allocation
     type: row
 preload: false
-schemaVersion: 41
+schemaVersion: 42
 tags:
   - pyroscope
   - pyroscope-v2
@@ -5372,8 +4788,8 @@ templating:
       type: datasource
     - allowCustomValue: false
       current:
-        text: prod-eu-west-2
-        value: prod-eu-west-2
+        text: {{.Values.dashboards.cluster | quote}}
+        value: {{.Values.dashboards.cluster | quote}}
       datasource:
         type: prometheus
         uid: ${datasource}
@@ -5405,7 +4821,7 @@ templating:
         query: label_values(pyroscope_build_info,namespace)
         refId: PrometheusVariableQueryEditor-VariableQuery
       refresh: 1
-      regex: {{.Values.dashboards.namespaceRegex | quote}}
+      regex: {{ include "pyroscope-monitoring.dashboards-namespace-regex" (list . $dashboard) | quote }}
       type: query
     - baseFilters: []
       datasource:

--- a/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboards.tpl
+++ b/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboards.tpl
@@ -46,3 +46,19 @@ Ingest selector: This is the selector to be added to get the most outside metric
 {{- define "pyroscope-monitoring.dashboards-ingest-selector" -}}
 {{- if .Values.dashboards.cloudBackendGateway }}{{ .Values.dashboards.cloudBackendGatewaySelector }}{{ else }}{{ .Values.dashboards.ingestSelector }}{{ end -}}
 {{- end }}
+
+{{/*
+Optional namespace matcher appended to the ingest selector.
+*/}}
+{{- define "pyroscope-monitoring.dashboards-ingest-namespace-selector" -}}
+{{- with .Values.dashboards.ingestNamespaceSelector }}, {{ . }}{{- end -}}
+{{- end }}
+
+{{/*
+Namespace regex, optionally overridden per dashboard.
+*/}}
+{{- define "pyroscope-monitoring.dashboards-namespace-regex" -}}
+{{- $root := index . 0 -}}
+{{- $dashboard := index . 1 -}}
+{{- default $root.Values.dashboards.namespaceRegex (dig $dashboard nil $root.Values.dashboards.namespaceRegexPerDashboard) -}}
+{{- end }}

--- a/operations/monitoring/helm/pyroscope-monitoring/values.yaml
+++ b/operations/monitoring/helm/pyroscope-monitoring/values.yaml
@@ -147,14 +147,20 @@ dashboards:
   # When false, dashboards use classic _bucket/_sum/_count suffix queries instead.
   nativeHistograms: true
 
+  # Matcher appended to ingest queries. Set to "" to omit it.
+  ingestNamespaceSelector: namespace=~"$namespace"
+
+  # Optional namespace regex overrides keyed by dashboard name.
+  namespaceRegexPerDashboard: {}
+
+  # Tenant query rendered with Helm tpl.
   tenantQuery: |
     sum by (tenant, slug, org_name, environment) (
+      {{- if .Values.dashboards.nativeHistograms }}
       histogram_sum(rate(pyroscope_distributor_received_decompressed_bytes{cluster=~"$cluster",namespace=~"$namespace"}[$__rate_interval]))
-    )
-
-  tenantQueryClassic: |
-    sum by (tenant, slug, org_name, environment) (
+      {{- else }}
       rate(pyroscope_distributor_received_decompressed_bytes_sum{cluster=~"$cluster",namespace=~"$namespace"}[$__rate_interval])
+      {{- end }}
     )
 
   # -- @ignored


### PR DESCRIPTION
## Summary

- Removes unused envoy-related panels from all monitoring dashboards
- Removes fields that typically cause drift between internal and published dashboard versions
- Adds a shared `_dashboards.tpl` helper to reduce duplication in Helm templates

## Test plan

- [ ] Verify dashboards render correctly in Grafana after applying the Helm chart changes
- [ ] Confirm no envoy panels appear in the updated dashboards