### PR TITLE
helm: add service_name relabel rule to alloy scrape config

### DIFF
--- a/operations/pyroscope/helm/pyroscope/Chart.yaml
+++ b/operations/pyroscope/helm/pyroscope/Chart.yaml
@@ -3,7 +3,7 @@ name: pyroscope
 description: horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 home: https://grafana.com/oss/pyroscope/
 type: application
-version: 2.1.1
+version: 2.1.2
 appVersion: 2.1.1
 dependencies:
   - name: grafana-agent

--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -1,6 +1,6 @@
 # pyroscope
 
-![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
+![Version: 2.1.2](https://img.shields.io/badge/Version-2.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
 
 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -27,7 +27,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -48,7 +48,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -69,7 +69,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -90,7 +90,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -111,7 +111,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -132,7 +132,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -176,7 +176,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -523,7 +523,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -585,6 +585,21 @@ data:
     		action        = "replace"
     		source_labels = ["__meta_kubernetes_pod_container_name"]
     		target_label  = "container"
+    	}
+
+    	// Set service_name by choosing the first non-empty value from the following ordered list:
+    	// - pod.annotation[profiles.grafana.com/service_name]
+    	// - pod.annotation[resource.opentelemetry.io/service.name]
+    	rule {
+    		action        = "replace"
+    		source_labels = [
+    			"__meta_kubernetes_pod_annotation_profiles_grafana_com_service_name",
+    			"__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+    		]
+    		separator    = ";"
+    		regex        = "^(?:;*)?([^;]+).*$"
+    		replacement  = "$1"
+    		target_label = "service_name"
     	}
 
     	rule {
@@ -1381,7 +1396,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1398,7 +1413,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1556,7 +1571,7 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1581,7 +1596,7 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1728,7 +1743,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1755,7 +1770,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1784,7 +1799,7 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1814,7 +1829,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1843,7 +1858,7 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1873,7 +1888,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1902,7 +1917,7 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1932,7 +1947,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1961,7 +1976,7 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1991,7 +2006,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2020,7 +2035,7 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2050,7 +2065,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2079,7 +2094,7 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2109,7 +2124,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2138,7 +2153,7 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2168,7 +2183,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2183,7 +2198,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2278,7 +2293,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2293,7 +2308,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2388,7 +2403,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2403,7 +2418,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2498,7 +2513,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2513,7 +2528,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2608,7 +2623,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2636,7 +2651,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2667,7 +2682,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2695,7 +2710,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2906,7 +2921,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2924,7 +2939,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3024,7 +3039,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3042,7 +3057,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3138,7 +3153,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3156,7 +3171,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -27,7 +27,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -48,7 +48,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -69,7 +69,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -90,7 +90,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -111,7 +111,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -132,7 +132,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -153,7 +153,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -174,7 +174,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -218,7 +218,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -565,7 +565,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -627,6 +627,21 @@ data:
     		action        = "replace"
     		source_labels = ["__meta_kubernetes_pod_container_name"]
     		target_label  = "container"
+    	}
+
+    	// Set service_name by choosing the first non-empty value from the following ordered list:
+    	// - pod.annotation[profiles.grafana.com/service_name]
+    	// - pod.annotation[resource.opentelemetry.io/service.name]
+    	rule {
+    		action        = "replace"
+    		source_labels = [
+    			"__meta_kubernetes_pod_annotation_profiles_grafana_com_service_name",
+    			"__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+    		]
+    		separator    = ";"
+    		regex        = "^(?:;*)?([^;]+).*$"
+    		replacement  = "$1"
+    		target_label = "service_name"
     	}
 
     	rule {
@@ -1423,7 +1438,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1440,7 +1455,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1598,7 +1613,7 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1623,7 +1638,7 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1770,7 +1785,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1797,7 +1812,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1826,7 +1841,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1856,7 +1871,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1885,7 +1900,7 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1915,7 +1930,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1944,7 +1959,7 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1974,7 +1989,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2003,7 +2018,7 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2033,7 +2048,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2062,7 +2077,7 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2092,7 +2107,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2121,7 +2136,7 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2151,7 +2166,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2180,7 +2195,7 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2210,7 +2225,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2239,7 +2254,7 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2269,7 +2284,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2298,7 +2313,7 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2328,7 +2343,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2344,7 +2359,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2439,7 +2454,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2455,7 +2470,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2550,7 +2565,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2566,7 +2581,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2661,7 +2676,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2677,7 +2692,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2772,7 +2787,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2788,7 +2803,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2883,7 +2898,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2899,7 +2914,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3177,7 +3192,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3195,7 +3210,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3295,7 +3310,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3313,7 +3328,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3409,7 +3424,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3427,7 +3442,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -27,7 +27,7 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -48,7 +48,7 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -69,7 +69,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -90,7 +90,7 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -111,7 +111,7 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -132,7 +132,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -153,7 +153,7 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -174,7 +174,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -218,7 +218,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -565,7 +565,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -627,6 +627,21 @@ data:
     		action        = "replace"
     		source_labels = ["__meta_kubernetes_pod_container_name"]
     		target_label  = "container"
+    	}
+
+    	// Set service_name by choosing the first non-empty value from the following ordered list:
+    	// - pod.annotation[profiles.grafana.com/service_name]
+    	// - pod.annotation[resource.opentelemetry.io/service.name]
+    	rule {
+    		action        = "replace"
+    		source_labels = [
+    			"__meta_kubernetes_pod_annotation_profiles_grafana_com_service_name",
+    			"__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+    		]
+    		separator    = ";"
+    		regex        = "^(?:;*)?([^;]+).*$"
+    		replacement  = "$1"
+    		target_label = "service_name"
     	}
 
     	rule {
@@ -1423,7 +1438,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1440,7 +1455,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1598,7 +1613,7 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1623,7 +1638,7 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1770,7 +1785,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1797,7 +1812,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1826,7 +1841,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1856,7 +1871,7 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1885,7 +1900,7 @@ metadata:
   name: pyroscope-dev-admin-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1915,7 +1930,7 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1944,7 +1959,7 @@ metadata:
   name: pyroscope-dev-compaction-worker-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1974,7 +1989,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2003,7 +2018,7 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2033,7 +2048,7 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2066,7 +2081,7 @@ metadata:
   name: pyroscope-dev-metastore-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2101,7 +2116,7 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2130,7 +2145,7 @@ metadata:
   name: pyroscope-dev-query-backend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2160,7 +2175,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2189,7 +2204,7 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2219,7 +2234,7 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2248,7 +2263,7 @@ metadata:
   name: pyroscope-dev-segment-writer-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2278,7 +2293,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2307,7 +2322,7 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2337,7 +2352,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2353,7 +2368,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2447,7 +2462,7 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2463,7 +2478,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2557,7 +2572,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2573,7 +2588,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2667,7 +2682,7 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2683,7 +2698,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2777,7 +2792,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2793,7 +2808,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2887,7 +2902,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2903,7 +2918,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3180,7 +3195,7 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3198,7 +3213,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3293,7 +3308,7 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3311,7 +3326,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3422,7 +3437,7 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3440,7 +3455,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -27,7 +27,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -48,7 +48,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -69,7 +69,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -90,7 +90,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -111,7 +111,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -132,7 +132,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -153,7 +153,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -174,7 +174,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -218,7 +218,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -565,7 +565,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -627,6 +627,21 @@ data:
     		action        = "replace"
     		source_labels = ["__meta_kubernetes_pod_container_name"]
     		target_label  = "container"
+    	}
+
+    	// Set service_name by choosing the first non-empty value from the following ordered list:
+    	// - pod.annotation[profiles.grafana.com/service_name]
+    	// - pod.annotation[resource.opentelemetry.io/service.name]
+    	rule {
+    		action        = "replace"
+    		source_labels = [
+    			"__meta_kubernetes_pod_annotation_profiles_grafana_com_service_name",
+    			"__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+    		]
+    		separator    = ";"
+    		regex        = "^(?:;*)?([^;]+).*$"
+    		replacement  = "$1"
+    		target_label = "service_name"
     	}
 
     	rule {
@@ -1423,7 +1438,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1440,7 +1455,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1725,7 +1740,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1752,7 +1767,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1777,7 +1792,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1803,7 +1818,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1828,7 +1843,7 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1854,7 +1869,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1879,7 +1894,7 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1905,7 +1920,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1930,7 +1945,7 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1956,7 +1971,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1981,7 +1996,7 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2007,7 +2022,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2032,7 +2047,7 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2058,7 +2073,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2083,7 +2098,7 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2109,7 +2124,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2134,7 +2149,7 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2160,7 +2175,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2185,7 +2200,7 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2211,7 +2226,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2227,7 +2242,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2315,7 +2330,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2331,7 +2346,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2419,7 +2434,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2435,7 +2450,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2524,7 +2539,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2540,7 +2555,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2628,7 +2643,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2644,7 +2659,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2732,7 +2747,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2748,7 +2763,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3019,7 +3034,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3037,7 +3052,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3130,7 +3145,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3148,7 +3163,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3237,7 +3252,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3255,7 +3270,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: edf124a7e575c1c06c058614ae0247005699c7579745d656b11c4cf7dcbc5a14
+        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -43,7 +43,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -56,7 +56,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -118,6 +118,21 @@ data:
     		action        = "replace"
     		source_labels = ["__meta_kubernetes_pod_container_name"]
     		target_label  = "container"
+    	}
+
+    	// Set service_name by choosing the first non-empty value from the following ordered list:
+    	// - pod.annotation[profiles.grafana.com/service_name]
+    	// - pod.annotation[resource.opentelemetry.io/service.name]
+    	rule {
+    		action        = "replace"
+    		source_labels = [
+    			"__meta_kubernetes_pod_annotation_profiles_grafana_com_service_name",
+    			"__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+    		]
+    		separator    = ";"
+    		regex        = "^(?:;*)?([^;]+).*$"
+    		replacement  = "$1"
+    		target_label = "service_name"
     	}
 
     	rule {
@@ -914,7 +929,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -931,7 +946,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1082,7 +1097,7 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1107,7 +1122,7 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1186,7 +1201,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1213,7 +1228,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1246,7 +1261,7 @@ metadata:
   name: pyroscope-dev-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1371,7 +1386,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1389,7 +1404,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 05d4038b2fc42e4fa9b5a05294adde9c09fe02f8d96096e89261cf481732d5f8
+        checksum/config: 7e08f7bdb4b975597fff0044d0b49682d96bf1d45146fcfad98342d3bf791f20
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -43,7 +43,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -56,7 +56,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -118,6 +118,21 @@ data:
     		action        = "replace"
     		source_labels = ["__meta_kubernetes_pod_container_name"]
     		target_label  = "container"
+    	}
+
+    	// Set service_name by choosing the first non-empty value from the following ordered list:
+    	// - pod.annotation[profiles.grafana.com/service_name]
+    	// - pod.annotation[resource.opentelemetry.io/service.name]
+    	rule {
+    		action        = "replace"
+    		source_labels = [
+    			"__meta_kubernetes_pod_annotation_profiles_grafana_com_service_name",
+    			"__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+    		]
+    		separator    = ";"
+    		regex        = "^(?:;*)?([^;]+).*$"
+    		replacement  = "$1"
+    		target_label = "service_name"
     	}
 
     	rule {
@@ -914,7 +929,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -931,7 +946,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1141,7 +1156,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1168,7 +1183,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1193,7 +1208,7 @@ metadata:
   name: pyroscope-dev-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1309,7 +1324,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.1
+    helm.sh/chart: pyroscope-2.1.2
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1327,7 +1342,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 05d4038b2fc42e4fa9b5a05294adde9c09fe02f8d96096e89261cf481732d5f8
+        checksum/config: 7e08f7bdb4b975597fff0044d0b49682d96bf1d45146fcfad98342d3bf791f20
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/templates/configmap-alloy.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/configmap-alloy.yaml
@@ -65,6 +65,21 @@ data:
     		target_label  = "container"
     	}
 
+    	// Set service_name by choosing the first non-empty value from the following ordered list:
+    	// - pod.annotation[profiles.grafana.com/service_name]
+    	// - pod.annotation[resource.opentelemetry.io/service.name]
+    	rule {
+    		action        = "replace"
+    		source_labels = [
+    			"__meta_kubernetes_pod_annotation_profiles_grafana_com_service_name",
+    			"__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+    		]
+    		separator    = ";"
+    		regex        = "^(?:;*)?([^;]+).*$"
+    		replacement  = "$1"
+    		target_label = "service_name"
+    	}
+
     	rule {
     		action        = "replace"
     		source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_service_repository"]


### PR DESCRIPTION
## What

Adds a relabel rule to the Helm chart's default Alloy scrape config that maps the `profiles.grafana.com/service_name` pod annotation to the `service_name` label:

```alloy
rule {
    action        = "replace"
    source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_service_name"]
    target_label  = "service_name"
}
```

It sits alongside the existing `service_repository` / `service_git_ref` / `service_root_path` rules in `templates/configmap-alloy.yaml`.

## Why

The chart already lets users set `service_repository`, `service_git_ref` and `service_root_path` via `profiles.grafana.com/*` annotations, but **not `service_name`** — the single most important label, used by the App Selector to identify an application (#2051).

Without it, Alloy falls back to inferring `service_name` from target metadata (namespace + `app.kubernetes.io/*`). When that inference is generic — e.g. a Helm component literally named `default` — pods surface under a useless/colliding `service_name` (`<namespace>/default`) with **no annotation-based way to override it**, unlike every other `service_*` label. This rule closes that gap so an operator can simply set `profiles.grafana.com/service_name: my-app`.

## Behaviour / compatibility

- **No-op unless a pod sets the annotation.** An explicit `service_name` label takes precedence over Alloy's inference, so existing deployments are completely unaffected until they opt in.
- Consistent with the existing `service_*` annotation rules — same block, same placement.

## Changes

- `templates/configmap-alloy.yaml` — the new rule.
- `rendered/*.yaml` — regenerated (the rule is in the static config block, so it appears identically in all six fixtures).
- `Chart.yaml` / `README.md` — chart `version` 2.0.3 → 2.0.4 (appVersion unchanged).

Closes #2051