### PR TITLE
docs: add v2.1 release notes

### DIFF
--- a/docs/sources/release-notes/v2-1.md
+++ b/docs/sources/release-notes/v2-1.md
@@ -1,0 +1,64 @@
+---
+title: Version 2.1 release notes
+menuTitle: V2.1
+description: Release notes for Grafana Pyroscope 2.1
+weight: 670
+---
+
+## Version 2.1.0 release notes
+
+The Pyroscope team is excited to present Grafana Pyroscope 2.1.0.
+
+This release adds new operational metrics, expands debug information management APIs, improves Helm chart defaults for the v2 storage architecture, and includes stability and security fixes across the read path, store-gateway, metastore, UI, and dependencies.
+
+Notable changes are listed below. For the full diff, check out the [2.1.0 changelog](https://github.com/grafana/pyroscope/compare/v2.0.3...v2.1.0).
+
+### Enhancements
+
+* **distributor**: Add readiness checks ([#5142](https://github.com/grafana/pyroscope/pull/5142))
+* **debuginfo**: Add list and delete APIs, including `profilecli` support ([#5217](https://github.com/grafana/pyroscope/pull/5217))
+* **segment-writer**: Build dataset indexes in segments ([#5112](https://github.com/grafana/pyroscope/pull/5112))
+* **metastore**: Add cache hit and miss metrics ([#5156](https://github.com/grafana/pyroscope/pull/5156))
+* **distributor**: Add ingest parse duration histogram metrics for `/ingest` ([#5107](https://github.com/grafana/pyroscope/pull/5107))
+* **query-backend**: Add per-tenant, per-query bytes-fetched metrics ([#5180](https://github.com/grafana/pyroscope/pull/5180))
+* **query-frontend**: Add estimation accuracy histogram metrics and log ratio output ([#5252](https://github.com/grafana/pyroscope/pull/5252))
+* Add per-tenant limits for the number of recording rules ([#5247](https://github.com/grafana/pyroscope/pull/5247))
+* Helm: Default to the v2 storage architecture ([#5160](https://github.com/grafana/pyroscope/pull/5160))
+* Helm: Add `extraObjects` for deploying extra Kubernetes manifests ([#5097](https://github.com/grafana/pyroscope/pull/5097))
+* Monitoring: Migrate dashboards to native histograms ([#5048](https://github.com/grafana/pyroscope/pull/5048))
+
+### Fixes
+
+* Fix an out-of-bounds panic in `clearAddresses` ([#5250](https://github.com/grafana/pyroscope/pull/5250))
+* Fix nil matcher handling for recording rule upserts ([#5134](https://github.com/grafana/pyroscope/pull/5134))
+* **store-gateway**: Validate tenant IDs ([#5194](https://github.com/grafana/pyroscope/pull/5194))
+* Fix archive extraction issues, including zip-slip/tar-slip cleanup and file closure handling ([#5195](https://github.com/grafana/pyroscope/pull/5195), [#5206](https://github.com/grafana/pyroscope/pull/5206))
+* Fix label value cloning to avoid buffer reuse-after-free issues ([#5116](https://github.com/grafana/pyroscope/pull/5116))
+* **query-backend**: Restore the original start time for `RangeSeries` bucketing ([#5161](https://github.com/grafana/pyroscope/pull/5161))
+* **read path**: Reject sub-millisecond `step` parameters ([#5137](https://github.com/grafana/pyroscope/pull/5137))
+* Fix a panic on unknown `QueryNode` types ([#5196](https://github.com/grafana/pyroscope/pull/5196))
+* **store-gateway**: Restore the ring info route from `/tenants` to `/ring` ([#5130](https://github.com/grafana/pyroscope/pull/5130))
+* **speedscope**: Return an error instead of panicking for unknown unit values ([#5143](https://github.com/grafana/pyroscope/pull/5143))
+* **metastore**: Version shard cache reads ([#5189](https://github.com/grafana/pyroscope/pull/5189))
+* **compaction-worker**: Correct `time_to_compaction_seconds` histogram buckets ([#5164](https://github.com/grafana/pyroscope/pull/5164))
+* Helm: Add `apiVersion` and `kind` to `volumeClaimTemplates` ([#5203](https://github.com/grafana/pyroscope/pull/5203))
+
+### Security fixes
+
+* **ui**: Update Vite to v8.0.16 ([#5260](https://github.com/grafana/pyroscope/pull/5260))
+* **ui**: Bump `tar`, `js-yaml`, and `@babel/core` ([#5263](https://github.com/grafana/pyroscope/pull/5263))
+* **ui**: Bump `uuid` from 11.1.0 to 11.1.1 ([#5123](https://github.com/grafana/pyroscope/pull/5123))
+* **ui**: Patch CVE-2026-45149 and CVE-2026-46625 in Yarn dependencies ([#5181](https://github.com/grafana/pyroscope/pull/5181))
+* Update `golang.org/x/net` to v0.53.0 ([#5131](https://github.com/grafana/pyroscope/pull/5131))
+* Update `golang.org/x/crypto` to v0.52.0 ([#5197](https://github.com/grafana/pyroscope/pull/5197))
+* Update `golang.org/x/image` to v0.41.0 ([#5216](https://github.com/grafana/pyroscope/pull/5216))
+* Update `github.com/prometheus/prometheus` to v0.311.3 ([#5113](https://github.com/grafana/pyroscope/pull/5113))
+* Update the Go toolchain directive to v1.25.11 ([#5228](https://github.com/grafana/pyroscope/pull/5228))
+
+### Documentation
+
+* Add generated YAML examples and documentation for v2 configuration blocks ([#5151](https://github.com/grafana/pyroscope/pull/5151))
+* Remove the public preview note from `pyroscope.receive_http` documentation ([#5176](https://github.com/grafana/pyroscope/pull/5176))
+* Update supported .NET versions to 8, 9, and 10 ([#5096](https://github.com/grafana/pyroscope/pull/5096))
+* Refresh README content and agent guides for the v2 layout, Go version, and tracing updates ([#5246](https://github.com/grafana/pyroscope/pull/5246), [#5183](https://github.com/grafana/pyroscope/pull/5183))
+* Fix a broken Grafana Cloud Profiles link in SDK guides ([#5132](https://github.com/grafana/pyroscope/pull/5132))


### PR DESCRIPTION
Adds public Grafana Pyroscope v2.1.0 release notes based on the curated GitHub release changelog.

This should be backported to release/v2.1 so the release branch docs include the new page.