### PR TITLE
docs: add v2.0.4 release notes

### DIFF
--- a/docs/sources/release-notes/v2-0.md
+++ b/docs/sources/release-notes/v2-0.md
@@ -5,6 +5,11 @@ description: Release notes for Grafana Pyroscope 2.0
 weight: 680
 ---
 
+## Version 2.0.4 release notes
+
+### Security fixes
+* Refresh the `/ui` dependency tree to clear known frontend vulnerabilities. The flame graph is now vendored, removing `@grafana/flamegraph` and its vulnerable transitive dependencies `protobufjs` (CVE-2026-44293, CVE-2026-44291, CVE-2026-48712) and `dompurify` (CVE-2026-49978, GHSA-vxr8-fq34-vvx9, GHSA-gvmj-g25r-r7wr, GHSA-x4vx-rjvf-j5p4); and `vite` (CVE-2026-53571), `@babel/core` (CVE-2026-49356), `tar` (CVE-2026-53655), and `js-yaml` (CVE-2026-53550) are updated to patched versions (security) ([#5264](https://github.com/grafana/pyroscope/pull/5264))
+
 ## Version 2.0.3 release notes
 
 ### Fixes


### PR DESCRIPTION
Adds the release notes for the **v2.0.4** patch release.

v2.0.4 refreshes the `/ui` dependency tree to clear the frontend vulnerabilities reported on v2.0.3 — it vendors the flame graph (removing `@grafana/flamegraph` and its `protobufjs`/`dompurify` transitive deps entirely) and updates `vite`, `@babel/core`, `tar`, and `js-yaml` to patched versions ([#5264](https://github.com/grafana/pyroscope/pull/5264)).

Labeled `type/docs` + `backport release/v2.0` so the notes are backported to `release/v2.0` ahead of tagging `v2.0.4`, per `docs/internal/RELEASE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)