### PR TITLE
fix(ui): do not parse label selector - send as is to server.

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -9,11 +9,7 @@ import { Panel } from '@components/Panel';
 import { TenantDialog } from '@components/TenantDialog';
 import { usePyroscopeQuery, type ProfileType } from '@hooks/usePyroscopeQuery';
 import { useTenant } from '@hooks/useTenant';
-import {
-  profileTypeLabel,
-  profileTypeRateLabel,
-  sortProfileTypes,
-} from '@api/client';
+import { profileTypeRateLabel, sortProfileTypes } from '@api/client';
 
 function useTheme() {
   const [theme, setTheme] = useState<'dark' | 'light'>('dark');
@@ -26,23 +22,17 @@ function useTheme() {
   return { theme, setTheme: setAndApply };
 }
 
-function buildQuery(service: string, pt: ProfileType): string {
-  return `{service_name="${service}", profile_type="${pt}"}`;
+function buildQuery(service: string): string {
+  return `{service_name="${service}"}`;
 }
-
-function parseQuery(
-  q: string,
-): { service: string; profileType: string } | null {
+function parseQueryServiceName(q: string): string | null {
   const service = q.match(/service_name\s*=\s*"([^"]+)"/)?.[1];
-  const profileType = q.match(/profile_type\s*=\s*"([^"]+)"/)?.[1];
-  if (!service || !profileType) return null;
-  return { service, profileType };
+  if (!service) return null;
+  return service;
 }
-
 export default function App() {
   const { theme, setTheme } = useTheme();
   const tenant = useTenant();
-  const [service, setService] = useState('');
   const [profileType, setProfileType] = useState<ProfileType>('');
   const [timeRange, setTimeRange] = useState('now-1h');
   const [absoluteRange, setAbsoluteRange] = useState<
@@ -52,13 +42,12 @@ export default function App() {
       }
     | undefined
   >(undefined);
-  const [queryUserInput, setQueryUserInput] = useState<string | null>(null);
-  const queryInput =
-    queryUserInput ??
-    (service || profileType ? buildQuery(service, profileType) : '');
+  const [queryUserInput, setQueryUserInput] = useState<string>('');
+  const [labelSelector, setLabelSelector] = useState<string>('');
+  const service = parseQueryServiceName(labelSelector);
 
   const query = usePyroscopeQuery({
-    service,
+    labelSelector,
     profileType,
     timeRange,
     absoluteRange,
@@ -66,27 +55,24 @@ export default function App() {
   });
 
   useEffect(() => {
-    if (query.servicesLoading || service) return;
+    if (query.servicesLoading || labelSelector) return;
     const first = query.services[0];
     if (!first) return;
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setService(first.name);
+    setQueryUserInput(buildQuery(first.name));
+    setLabelSelector(buildQuery(first.name));
     setProfileType(
       sortProfileTypes(first.profileTypes).find(
         (pt): pt is string => typeof pt === 'string',
       ) ?? '',
     );
-  }, [query.services, query.servicesLoading, service]);
+  }, [query.services, query.servicesLoading, labelSelector]);
 
   const handleAppSelect = (s: string, pt: ProfileType) => {
-    setService(s);
+    setQueryUserInput(buildQuery(s));
+    setLabelSelector(buildQuery(s));
     setProfileType(pt);
-    setQueryUserInput(null);
   };
-
-  const queryDirty =
-    !!service && queryInput !== buildQuery(service, profileType);
-  const handleReset = () => setQueryUserInput(null);
 
   if (tenant.status === 'loading') return null;
 
@@ -107,11 +93,10 @@ export default function App() {
       <NavBar
         services={query.services}
         servicesLoading={query.servicesLoading}
-        service={service}
+        service={service ?? ''}
         profileType={profileType}
         timeRange={timeRange}
         theme={theme}
-        queryDirty={queryDirty}
         onAppSelect={handleAppSelect}
         absoluteRange={absoluteRange}
         onTimeChange={(v) => {
@@ -119,19 +104,15 @@ export default function App() {
           setTimeRange(v);
         }}
         onThemeChange={setTheme}
-        onReset={handleReset}
         isMultiTenant={isMultiTenant}
         tenantID={tenant.tenantID}
         onChangeTenant={() => tenant.setWantsToChange(true)}
       />
       <QueryBar
-        query={queryInput}
+        query={queryUserInput}
         onQueryChange={setQueryUserInput}
         onRun={(q) => {
-          const parsed = parseQuery(q);
-          if (parsed) {
-            query.execute(parsed.service, parsed.profileType, timeRange);
-          }
+          setLabelSelector(q);
         }}
       />
 
@@ -154,10 +135,7 @@ export default function App() {
           />
         </Panel>
 
-        <Panel
-          title="Flamegraph"
-          meta={`${service} · ${profileTypeLabel(profileType)} · ${timeRange}`}
-        >
+        <Panel title="Flamegraph">
           <FlameGraph data={query.flamegraph} profileTypeId={profileType} />
         </Panel>
       </div>

--- a/ui/src/components/NavBar.tsx
+++ b/ui/src/components/NavBar.tsx
@@ -45,11 +45,9 @@ export function NavBar({
   timeRange,
   absoluteRange,
   theme,
-  queryDirty,
   onAppSelect,
   onTimeChange,
   onThemeChange,
-  onReset,
   isMultiTenant,
   tenantID,
   onChangeTenant,
@@ -61,11 +59,9 @@ export function NavBar({
   timeRange: string;
   absoluteRange: { start: number; end: number } | undefined;
   theme: 'dark' | 'light';
-  queryDirty: boolean;
   onAppSelect: (s: string, pt: ProfileType) => void;
   onTimeChange: (v: string) => void;
   onThemeChange: (t: 'dark' | 'light') => void;
-  onReset: () => void;
   isMultiTenant?: boolean;
   tenantID?: string;
   onChangeTenant?: () => void;
@@ -116,11 +112,6 @@ export function NavBar({
           if (v !== ABS_VALUE) onTimeChange(v);
         }}
       />
-      {queryDirty && (
-        <button className="navbar-reset" onClick={onReset}>
-          Reset query
-        </button>
-      )}
 
       <div className="navbar-spacer" />
 

--- a/ui/src/components/Panel.tsx
+++ b/ui/src/components/Panel.tsx
@@ -2,18 +2,15 @@ import './Panel.css';
 
 export function Panel({
   title,
-  meta,
   children,
 }: {
   title: string;
-  meta?: React.ReactNode;
   children: React.ReactNode;
 }) {
   return (
     <div className="panel">
       <div className="panel-header">
         <span className="panel-title">{title}</span>
-        {meta && <span className="panel-meta">{meta}</span>}
       </div>
       <div className="panel-body">{children}</div>
     </div>

--- a/ui/src/components/QueryBar.tsx
+++ b/ui/src/components/QueryBar.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { Icon } from '@components/core/Icon';
 import './QueryBar.css';
 
@@ -11,11 +10,7 @@ export function QueryBar({
   onQueryChange: (q: string) => void;
   onRun: (query: string) => void;
 }) {
-  const [lastRun, setLastRun] = useState<string | null>(null);
-  const dirty = lastRun === null || lastRun !== query;
-
   const handleRun = () => {
-    setLastRun(query);
     onRun(query);
   };
 
@@ -29,7 +24,7 @@ export function QueryBar({
       />
 
       <button className="querybar-run" onClick={handleRun}>
-        <Icon name={dirty ? 'play' : 'refresh'} size={10} />
+        <Icon name={'play'} size={10} />
         Run
       </button>
     </div>

--- a/ui/src/hooks/usePyroscopeQuery.ts
+++ b/ui/src/hooks/usePyroscopeQuery.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   fetchServices,
   fetchFlamegraph,
@@ -12,7 +12,7 @@ export type { Service, FlamegraphData } from '@api/client';
 export type ProfileType = string;
 
 export interface QueryParams {
-  service: string;
+  labelSelector: string;
   profileType: ProfileType;
   timeRange: string;
   absoluteRange?: { start: number; end: number };
@@ -26,8 +26,6 @@ export interface QueryResult {
   timeline: Point[];
   loading: boolean;
   error: string | null;
-  run: () => void;
-  execute: (service: string, profileType: string, timeRange: string) => void;
 }
 
 function parseTimeRange(range: string): { start: number; end: number } {
@@ -54,9 +52,11 @@ export function usePyroscopeQuery(params: QueryParams): QueryResult {
   const [servicesLoading, setServicesLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const { service, profileType, timeRange, absoluteRange, tenantID } = params;
+  const { labelSelector, profileType, timeRange, absoluteRange, tenantID } =
+    params;
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setServicesLoading(true);
     const { start, end } = absoluteRange ?? parseTimeRange(timeRange);
     fetchServices(start, end)
@@ -70,43 +70,13 @@ export function usePyroscopeQuery(params: QueryParams): QueryResult {
       .finally(() => setServicesLoading(false));
   }, [timeRange, absoluteRange, tenantID]);
 
-  const execute = useCallback(
-    (svc: string, pt: string, tr: string) => {
-      if (!svc || !pt) return;
-      const { start, end } = absoluteRange ?? parseTimeRange(tr);
-      const labelSelector = `{service_name="${svc}"}`;
-      const rangeSeconds = (end - start) / 1000;
-      const step = Math.max(15, Math.ceil(rangeSeconds / 100));
-      setLoading(true);
-      Promise.all([
-        fetchFlamegraph({ profileTypeID: pt, labelSelector, start, end }),
-        fetchTimeline({ profileTypeID: pt, labelSelector, start, end, step }),
-      ])
-        .then(([fg, tl]) => {
-          setFlamegraph(fg);
-          setTimeline(tl);
-          setError(null);
-        })
-        .catch((e: unknown) =>
-          setError(e instanceof Error ? e.message : String(e)),
-        )
-        .finally(() => setLoading(false));
-    },
-    // tenantID is not read inside the callback but is included to invalidate
-    // execute (and run) when the tenant changes, ensuring the run callback is
-    // re-created.
-    //
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [absoluteRange, tenantID],
-  );
-
   useEffect(() => {
-    if (!service || !profileType) return;
+    if (!labelSelector || !profileType) return;
     const { start, end } = absoluteRange ?? parseTimeRange(timeRange);
-    const labelSelector = `{service_name="${service}"}`;
     const rangeSeconds = (end - start) / 1000;
     const step = Math.max(15, Math.ceil(rangeSeconds / 100));
 
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoading(true);
     Promise.all([
       fetchFlamegraph({
@@ -132,11 +102,7 @@ export function usePyroscopeQuery(params: QueryParams): QueryResult {
         setError(e instanceof Error ? e.message : String(e)),
       )
       .finally(() => setLoading(false));
-  }, [service, profileType, timeRange, absoluteRange, tenantID]);
-
-  const run = useCallback(() => {
-    execute(service, profileType, timeRange);
-  }, [service, profileType, timeRange, execute]);
+  }, [labelSelector, profileType, timeRange, absoluteRange, tenantID]);
 
   return {
     services,
@@ -145,7 +111,5 @@ export function usePyroscopeQuery(params: QueryParams): QueryResult {
     timeline,
     loading,
     error,
-    run,
-    execute,
   };
 }


### PR DESCRIPTION
Before this change the UI does not allow to send arbitrary labels - the app parsed `service_name` and `profile_type` label from the query and only sent them.

In this change, I remove the `profile_type` from the label selector - it is stored separately and we do not append and parse back the query.
Furthermore we do not parse labelSelector at all - we send it as is to the server, letting the server validate the query. We still parse the label selector for service name detection, but it is no longer required and that means we can query even without `service_name`.
As a result we don't need the callbacks from the `userPyroscopeQuery` anymore and they are removed too.
