### PR TITLE
fix(helm): respect metastore raft extraArgs overrides

### DIFF
--- a/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
@@ -105,7 +105,7 @@ spec:
           {{-  if (not (hasKey $extraArgs "metastore.raft.snapshots-dir"))  }}
             - "-metastore.raft.snapshots-dir=./data-metastore/raft"
           {{- end }}
-          {{-  if (not (hasKey $extraArgs "metastore.raft.server-id"))  }}
+          {{-  if (not (hasKey $extraArgs "metastore.raft.bind-address"))  }}
             - "-metastore.raft.bind-address=:{{ .Values.pyroscope.metastore.port }}"
           {{- end }}
           {{-  if (not (hasKey $extraArgs "metastore.raft.server-id"))  }}
@@ -114,7 +114,7 @@ spec:
           {{-  if (not (hasKey $extraArgs "metastore.raft.advertise-address"))  }}
             - "-metastore.raft.advertise-address=$(POD_NAME).$(PYROSCOPE_METASTORE_SERVICE)"
           {{- end }}
-          {{-  if (not (hasKey $extraArgs "metastore.raft.server-id"))  }}
+          {{-  if (not (hasKey $extraArgs "metastore.raft.bootstrap-peers"))  }}
             - "-metastore.raft.bootstrap-peers=dnssrvnoa+_raft._tcp.$(PYROSCOPE_METASTORE_SERVICE)"
           {{- end }}
           {{- end }}


### PR DESCRIPTION
Helm checks `metastore.raft.server-id` before adding defaults for `metastore.raft.bind-address` and `metastore.raft.bootstrap-peers`.

So if a user sets either override in `pyroscope.extraArgs`, the chart still renders the default too. The later default wins, pretty sneaky, so the override gets clobbered.

This patch checks the matching keys instead.

Repro:

```sh
tmp=$(mktemp)
printf 'architecture:\n  storage:\n    v1: false\n    v2: true\npyroscope:\n  extraArgs:\n    metastore.raft.bind-address: ":1234"\n' > "$tmp"
helm template -n default --kube-version 1.23.0 pyroscope-dev ./operations/pyroscope/helm/pyroscope -f "$tmp" | rg 'metastore\.raft\.bind-address='
rm -f "$tmp"
```

Before:

```text
-metastore.raft.bind-address=:1234
-metastore.raft.bind-address=:9099
```

After:

```text
-metastore.raft.bind-address=:1234
```

Same thing happens for `metastore.raft.bootstrap-peers`.
