### PR TITLE
fix: sample rate error logs 

### DIFF
--- a/pkg/ingester/pyroscope/ingest_handler.go
+++ b/pkg/ingester/pyroscope/ingest_handler.go
@@ -135,7 +135,7 @@ func (h ingestHandler) parseInputMetadataFromRequest(_ context.Context, r *http.
 
 	if sr := q.Get("sampleRate"); sr != "" {
 		sampleRate, err := strconv.Atoi(sr)
-		if err != nil || sampleRate <= 0 {
+		if err != nil || sampleRate < 0 {
 			if err == nil {
 				err = fmt.Errorf("sample rate must be positive")
 			}

--- a/pkg/ingester/pyroscope/ingest_handler_test.go
+++ b/pkg/ingester/pyroscope/ingest_handler_test.go
@@ -25,7 +25,6 @@ import (
 	v1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	"github.com/grafana/pyroscope/v2/pkg/distributor/model"
 	phlaremodel "github.com/grafana/pyroscope/v2/pkg/model"
-	"github.com/grafana/pyroscope/v2/pkg/og/agent/types"
 	pprof2 "github.com/grafana/pyroscope/v2/pkg/og/convert/pprof"
 	"github.com/grafana/pyroscope/v2/pkg/og/convert/pprof/bench"
 	"github.com/grafana/pyroscope/v2/pkg/pprof"
@@ -222,10 +221,11 @@ func TestParseInputMetadataFromRequest_InvalidSampleRateDefaults(t *testing.T) {
 	tests := []struct {
 		name       string
 		sampleRate string
+		expect     uint32
 	}{
-		{name: "negative", sampleRate: "-1"},
-		{name: "zero", sampleRate: "0"},
-		{name: "non numeric", sampleRate: "abc"},
+		{name: "negative", sampleRate: "-1", expect: 100},
+		{name: "zero", sampleRate: "0", expect: 0},
+		{name: "non numeric", sampleRate: "abc", expect: 100},
 	}
 
 	for _, tt := range tests {
@@ -236,7 +236,7 @@ func TestParseInputMetadataFromRequest_InvalidSampleRateDefaults(t *testing.T) {
 
 			input, err := h.parseInputMetadataFromRequest(context.Background(), req)
 			require.NoError(t, err)
-			require.EqualValues(t, types.DefaultSampleRate, input.Metadata.SampleRate)
+			require.Equal(t, tt.expect, input.Metadata.SampleRate)
 		})
 	}
 }


### PR DESCRIPTION

```
I see a lot of errors ts=2026-06-19T10:46:30.348505Z caller=ingest_handler.go:142 level=error err="sample rate must be
  positive" msg="invalid sample rate: \"0\""
```
I see quite a lot of errors on my pyroscope containers. They seem to mostly come from `pyrroscope-go` non CPU profiles. Historically sample rate of zero was sent from multiple sdks.

In this change we do not reset sample rate to 100 and do not log the errors if sample rate is 0.