### PR TITLE
fix: enable metastore retention cleanup by default

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -580,7 +580,7 @@ Usage of ./pyroscope:
   -metastore.index.cleanup-grace-period duration
     	After a partition is eligible for deletion, it will be kept for this period before actually being evaluated. The period should cover the time difference between the block creation time and the data timestamps. Blocks are only deleted if all data in the block has passed the retention period, and the grace period delays the moment when the partition is evaluated for deletion. (default 6h0m0s)
   -metastore.index.cleanup-interval duration
-    	Interval for index cleanup check. 0 to disable.
+    	Interval for index cleanup check. 0 to disable. (default 15m0s)
   -metastore.index.cleanup-max-partitions int
     	Maximum number of partitions to cleanup at once. A partition is qualified by partition key, tenant, and shard. (default 32)
   -metastore.index.dlq-recovery-check-interval duration

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -1309,7 +1309,7 @@ index:
 
   # (advanced) Interval for index cleanup check. 0 to disable.
   # CLI flag: -metastore.index.cleanup-interval
-  [cleanup_interval: <duration> | default = 0s]
+  [cleanup_interval: <duration> | default = 15m]
 
   # (advanced) Dead Letter Queue check interval. 0 to disable.
   # CLI flag: -metastore.index.dlq-recovery-check-interval

--- a/pkg/metastore/index/cleaner/cleaner.go
+++ b/pkg/metastore/index/cleaner/cleaner.go
@@ -24,8 +24,10 @@ type Config struct {
 	CleanupInterval      time.Duration `yaml:"cleanup_interval" category:"advanced"`
 }
 
+const DefaultCleanupInterval = 15 * time.Minute
+
 func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
-	f.DurationVar(&c.CleanupInterval, prefix+"cleanup-interval", 0, "Interval for index cleanup check. 0 to disable.")
+	f.DurationVar(&c.CleanupInterval, prefix+"cleanup-interval", DefaultCleanupInterval, "Interval for index cleanup check. 0 to disable.")
 	f.DurationVar(&c.CleanupGracePeriod, prefix+"cleanup-grace-period", time.Hour*6, "After a partition is eligible for deletion, it will be kept for this period before actually being evaluated. The period should cover the time difference between the block creation time and the data timestamps. Blocks are only deleted if all data in the block has passed the retention period, and the grace period delays the moment when the partition is evaluated for deletion.")
 	f.IntVar(&c.CleanupMaxPartitions, prefix+"cleanup-max-partitions", 32, "Maximum number of partitions to cleanup at once. A partition is qualified by partition key, tenant, and shard.")
 }

--- a/pkg/metastore/index/cleaner/cleaner_test.go
+++ b/pkg/metastore/index/cleaner/cleaner_test.go
@@ -1,0 +1,27 @@
+package cleaner
+
+import (
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_RegisterFlagsWithPrefix_DefaultCleanupInterval(t *testing.T) {
+	var cfg Config
+	fs := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+	cfg.RegisterFlagsWithPrefix("metastore.index.", fs)
+
+	require.NoError(t, fs.Parse(nil))
+	require.Equal(t, 15*time.Minute, cfg.CleanupInterval)
+}
+
+func TestConfig_RegisterFlagsWithPrefix_ZeroCleanupIntervalDisablesCleanup(t *testing.T) {
+	var cfg Config
+	fs := flag.NewFlagSet(t.Name(), flag.ContinueOnError)
+	cfg.RegisterFlagsWithPrefix("metastore.index.", fs)
+
+	require.NoError(t, fs.Parse([]string{"-metastore.index.cleanup-interval=0"}))
+	require.Zero(t, cfg.CleanupInterval)
+}


### PR DESCRIPTION
## What

Enable metastore index cleanup by default by setting `metastore.index.cleanup-interval` to `15m` while preserving `0` as the explicit disable value.

Also regenerates reference configuration/help output and adds coverage for the default and explicit-zero behavior.

Fixes #5278
Related to #5279

## Testing

- `go test ./pkg/metastore/index/cleaner/...`
- `make generate`
- `make reference-help`
