### PR TITLE
chore: enable renovate on release branches

### DIFF
--- a/docs/internal/RELEASE.md
+++ b/docs/internal/RELEASE.md
@@ -12,9 +12,10 @@
    > ✅ Correct: `release/v1.3`
    >
    > ⚠️  Incorrect: `release/v1.3.0`  
-3. Create the tag for the release (e.g., `vX.Y.Z`)
-4. Push the release branch and tag to the remote. Note that the tag will kick off a release workflow via [goreleaser](https://github.com/grafana/pyroscope/actions/workflows/release.yml).
-5. Create a GitHub label for backports:
+3. Update `renovate.json` so `baseBranchPatterns` includes the new release branch and only the latest two release branches.
+4. Create the tag for the release (e.g., `vX.Y.Z`)
+5. Push the release branch and tag to the remote. Note that the tag will kick off a release workflow via [goreleaser](https://github.com/grafana/pyroscope/actions/workflows/release.yml).
+6. Create a GitHub label for backports:
 
    ```gh label create "backport release/vX.Y" -d "This label will backport a merged PR to the release/vX.Y branch" -c "#0052cc"```
 

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:best-practices"],
   "timezone": "UTC",
   "schedule": ["before 4am on monday"],
+  "baseBranchPatterns": ["$default", "release/v2.1", "release/v2.0"],
   "prConcurrentLimit": 239,
   "prCreation": "not-pending",
   "internalChecksFilter": "strict",


### PR DESCRIPTION
## Summary
- enable Renovate for the default branch plus release/v2.1 and release/v2.0
- document rotating Renovate's release branch list during releases

## Testing
- jq -e . renovate.json
- nix shell nixpkgs#renovate -c renovate-config-validator --strict --no-global renovate.json