### PR TITLE
docs: add v2.0.5 release notes

### DIFF
--- a/docs/sources/release-notes/v2-0.md
+++ b/docs/sources/release-notes/v2-0.md
@@ -5,6 +5,11 @@ description: Release notes for Grafana Pyroscope 2.0
 weight: 680
 ---
 
+## Version 2.0.5 release notes
+
+### Security fixes
+* Update `golang.org/x/image` to v0.43.0 and refresh related `golang.org/x` dependencies for CVE fixes (security) ([#5281](https://github.com/grafana/pyroscope/pull/5281))
+
 ## Version 2.0.4 release notes
 
 ### Security fixes


### PR DESCRIPTION
Add the Grafana Pyroscope v2.0.5 patch release notes for the golang.org/x/image CVE fix.