### PR TITLE
[release/v2.0] docs: add v2.0.5 release notes

### DIFF
--- a/docs/sources/release-notes/v2-0.md
+++ b/docs/sources/release-notes/v2-0.md
@@ -5,6 +5,11 @@ description: Release notes for Grafana Pyroscope 2.0
 weight: 680
 ---
 
+## Version 2.0.5 release notes
+
+### Security fixes
+* Update `golang.org/x/image` to v0.43.0 and refresh related `golang.org/x` dependencies for CVE fixes (security) ([#5281](https://github.com/grafana/pyroscope/pull/5281))
+
 ## Version 2.0.4 release notes
 
 ### Security fixes


### PR DESCRIPTION
Backport of #5283 to release/v2.0.\n\nOriginal commit: 2933348ade4934244e7de1816f277d9d0e28fa89