### PR TITLE
dx: upgrade devcontainer to Go 1.25 and add DinD support

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:3.1.0": {
+      "version": "3.1.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:62e04ec83d944da4fd2830f68a677d1f5466c0654aea1e4baa30232d16029ac1",
+      "integrity": "sha256:62e04ec83d944da4fd2830f68a677d1f5466c0654aea1e4baa30232d16029ac1"
+    },
+    "ghcr.io/devcontainers/features/node:2.1.0": {
+      "version": "2.1.0",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857",
+      "integrity": "sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,12 @@
 {
   "name": "Go",
-  "image": "mcr.microsoft.com/devcontainers/go:1-1-bookworm",
+  "image": "mcr.microsoft.com/devcontainers/go:1.25-bookworm",
   "features": {
-    "ghcr.io/devcontainers/features/node:1": {}
+    "ghcr.io/devcontainers/features/node:2.1.0": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:3.1.0": {
+      "version": "latest",
+      "moby": true
+    }
   },
   "customizations": {
     "vscode": {


### PR DESCRIPTION
## Summary

Quite a small update for better devcontainer experience. Updated the devcontainer image to match with project Go version. Running `go version` command with previous `mcr.microsoft.com/devcontainers/go:1-1-bookworm` outputs version `1.24.5`. Additionally enabled `ghcr.io/devcontainers/features/docker-in-docker:3.1.0` feature to be able to support `make build` run. Now `make all` finishes successfully. Let me know if there is anything else to check.

## Changes
- .devcontainer/devcontainer.json image is changed to `mcr.microsoft.com/devcontainers/go:1.25-bookworm`
- .devcontainer/devcontainer.json feature `ghcr.io/devcontainers/features/docker-in-docker:3.1.0` is added
- .devcontainer/devcontainer-lock.json added to ensure version consistency