### PR TITLE
querybackend: scan profile entries columnar

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	connectrpc.com/connect v1.19.2
 	connectrpc.com/grpchealth v1.4.0
 	github.com/PuerkitoBio/goquery v1.12.0
+	github.com/RoaringBitmap/roaring/v2 v2.18.2
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/colega/zeropool v0.0.0-20230505084239-6fb4a4f75381
@@ -89,6 +90,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.8 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/basgys/goxml2json v1.1.1-0.20231018121955-e66ee54ceaad // indirect
+	github.com/bits-and-blooms/bitset v1.24.2 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
@@ -108,6 +110,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/crc32 v1.3.0 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
+	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/opentracing-contrib/go-grpc v0.1.2 // indirect
 	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b // indirect
 	github.com/parquet-go/bitpack v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA
 github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO8RIBo=
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
 github.com/QcloudApi/qcloud_sign_golang v0.0.0-20141224014652-e4130a326409/go.mod h1:1pk82RBxDY/JZnPQrtqHlUFfCctgdorsd9M06fMynOM=
+github.com/RoaringBitmap/roaring/v2 v2.18.2 h1:oPq3Cgx//iDuJQVp6xSInAKW34J9CEwE5GmLI2z+Eic=
+github.com/RoaringBitmap/roaring/v2 v2.18.2/go.mod h1:eq4wdNXxtJIS/oikeCzdX1rBzek7ANzbth041hrU8Q4=
 github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjHpqDjYY=
 github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -139,6 +141,8 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bitly/go-simplejson v0.5.1 h1:xgwPbetQScXt1gh9BmoJ6j9JMr3TElvuIyjR8pgdoow=
 github.com/bitly/go-simplejson v0.5.1/go.mod h1:YOPVLzCfwK14b4Sff3oP1AmGhI9T9Vsg84etUnlyp+Q=
+github.com/bits-and-blooms/bitset v1.24.2 h1:M7/NzVbsytmtfHbumG+K2bremQPMJuqv1JD3vOaFxp0=
+github.com/bits-and-blooms/bitset v1.24.2/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/bluele/gcache v0.0.2 h1:WcbfdXICg7G/DGBh1PFfcirkWOQV+v077yF1pSy3DGw=
 github.com/bluele/gcache v0.0.2/go.mod h1:m15KV+ECjptwSPxKhOhQoAFQVtUFjTVkc3H8o0t/fp0=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
@@ -589,6 +593,8 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwd
 github.com/mozillazg/go-httpheader v0.2.1/go.mod h1:jJ8xECTlalr6ValeXYdOF8fFUISeBAdw6E61aqQma60=
 github.com/mozillazg/go-httpheader v0.3.1 h1:IRP+HFrMX2SlwY9riuio7raffXUpzAosHtZu25BSJok=
 github.com/mozillazg/go-httpheader v0.3.1/go.mod h1:PuT8h0pw6efvp8ZeUec1Rs7dwjK08bt6gKSReGMqtdA=
+github.com/mschoch/smat v0.2.0 h1:8imxQsjDm8yFEAVBe7azKmKSgzSkZXDuKkSq9374khM=
+github.com/mschoch/smat v0.2.0/go.mod h1:kc9mz7DoBKqDyiRL7VZN8KvXQMWeTaVnttLRXOlotKw=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/go.work.sum
+++ b/go.work.sum
@@ -361,6 +361,8 @@ github.com/lyft/protoc-gen-star/v2 v2.0.4 h1:JDlNKttNIRd68AAIychs0AqEpO8/I/WYi01
 github.com/lyft/protoc-gen-star/v2 v2.0.4/go.mod h1:amey7yeodaJhXSbf/TlLvWiqQfLOSpEk//mLlc+axEk=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mdempsky/unconvert v0.0.0-20250216222326-4a038b3d31f5 h1:KXBP3ozzczYKdX6aHLYRxr0RVkc4Zt2wZk2hZP5yTqc=
+github.com/mdempsky/unconvert v0.0.0-20250216222326-4a038b3d31f5/go.mod h1:mVCHGHs8r8jnrZ2ammcv8ySbhG2+rEPXegFmdNA51GI=
 github.com/minio/sha256-simd v1.0.0 h1:v1ta+49hkWZyvaKwrQB8elexRqm6Y0aMLjCNsrYxo6g=
 github.com/minio/sha256-simd v1.0.0/go.mod h1:OuYzVNI5vcoYIAmbIvHPl3N3jUzVedXbKy5RFepssQM=
 github.com/mitchellh/cli v1.1.5 h1:OxRIeJXpAMztws/XHlN2vu6imG5Dpq+j61AzAX5fLng=

--- a/pkg/querybackend/query_profile_entry.go
+++ b/pkg/querybackend/query_profile_entry.go
@@ -1,9 +1,10 @@
 package querybackend
 
 import (
-	"slices"
-	"strings"
+	"fmt"
+	"io"
 
+	"github.com/RoaringBitmap/roaring/v2"
 	"github.com/google/uuid"
 	"github.com/parquet-go/parquet-go"
 	"github.com/prometheus/common/model"
@@ -20,6 +21,8 @@ import (
 // As we expect rows to be very small, we want to fetch a bigger
 // batch of rows at once to amortize the latency of reading.
 const bigBatchSize = 2 << 10
+
+const profileEntryColumnReadSize = 1024
 
 type ProfileEntry struct {
 	RowNum      int64
@@ -105,51 +108,6 @@ func iteratorOptsFromOptions(options []profileIteratorOption) iteratorOpts {
 	return opts
 }
 
-type queryColumn struct {
-	name      string
-	predicate parquetquery.Predicate
-	priority  int
-}
-
-type queryColumns []queryColumn
-
-func (c queryColumns) names() []string {
-	result := make([]string, len(c))
-	for idx := range result {
-		result[idx] = c[idx].name
-	}
-	return result
-}
-
-func (c queryColumns) join(q *queryContext) parquetquery.Iterator {
-	var result parquetquery.Iterator
-
-	// sort columns by priority, without modifying queryColumn slice
-	order := make([]int, len(c))
-	for idx := range order {
-		order[idx] = idx
-	}
-	slices.SortFunc(order, func(a, b int) int {
-		if r := c[a].priority - c[b].priority; r != 0 {
-			return r
-		}
-		return strings.Compare(c[a].name, c[b].name)
-	})
-
-	for _, idx := range order {
-		it := q.ds.Profiles().Column(q.ctx, c[idx].name, c[idx].predicate)
-		if result == nil {
-			result = it
-			continue
-		}
-		result = parquetquery.NewBinaryJoinIterator(0,
-			result,
-			it,
-		)
-	}
-	return result
-}
-
 func profileEntryIterator(q *queryContext, options ...profileIteratorOption) (iter.Iterator[ProfileEntry], error) {
 	opts := iteratorOptsFromOptions(options)
 
@@ -157,72 +115,430 @@ func profileEntryIterator(q *queryContext, options ...profileIteratorOption) (it
 	if err != nil {
 		return nil, err
 	}
-
-	columns := queryColumns{
-		{schemav1.SeriesIndexColumnName, parquetquery.NewMapPredicate(series), 10},
-		{schemav1.TimeNanosColumnName, parquetquery.NewIntBetweenPredicate(q.req.startTime, q.req.endTime), 15},
+	if len(series) == 0 {
+		return iter.NewSliceIterator[ProfileEntry](nil), nil
 	}
-	processor := []func([][]parquet.Value, *ProfileEntry){}
 
-	// fetch partition if requested
-	if opts.fetchPartition {
-		offset := len(columns)
-		columns = append(
-			columns,
-			queryColumn{schemav1.StacktracePartitionColumnName, nil, 20},
-		)
-		processor = append(processor, func(buf [][]parquet.Value, e *ProfileEntry) {
-			e.Partition = buf[offset][0].Uint64()
+	// Profile metadata lives in a small set of top-level parquet columns. Scan the
+	// predicate columns into bitmaps first, then project only accepted rows. This
+	// keeps the query path columnar and avoids the generic row-oriented join stack.
+	scanner := profileEntryColumnScanner{
+		q:           q,
+		int32Values: make([]int32, profileEntryColumnReadSize),
+		int64Values: make([]int64, profileEntryColumnReadSize),
+	}
+	acceptedRows, err := selectProfileEntryRows(&scanner, series, opts)
+	if err != nil {
+		return nil, err
+	}
+	if acceptedRows.IsEmpty() {
+		return iter.NewSliceIterator[ProfileEntry](nil), nil
+	}
+
+	entries, err := materializeProfileEntries(&scanner, acceptedRows, series, opts)
+	if err != nil {
+		return nil, err
+	}
+	return iter.NewSliceIterator(entries), nil
+}
+
+func selectProfileEntryRows(scanner *profileEntryColumnScanner, series map[uint32]series, opts iteratorOpts) (*roaring.Bitmap, error) {
+	timePredicate := parquetquery.NewIntBetweenPredicate(scanner.q.req.startTime, scanner.q.req.endTime)
+	timeRows, err := scanner.matchingInt64Rows(schemav1.TimeNanosColumnName, timePredicate, func(value int64) bool {
+		return scanner.q.req.startTime <= value && value <= scanner.q.req.endTime
+	})
+	if err != nil {
+		return nil, err
+	}
+	if timeRows.IsEmpty() {
+		return timeRows, nil
+	}
+
+	seriesPredicate := parquetquery.NewMapPredicate(series)
+	acceptedRows, err := scanner.matchingInt32Rows(schemav1.SeriesIndexColumnName, seriesPredicate, func(value int32) bool {
+		_, ok := series[uint32(value)]
+		return ok
+	})
+	if err != nil {
+		return nil, err
+	}
+	acceptedRows.And(timeRows)
+
+	if len(opts.profileIDSelector) > 0 && !acceptedRows.IsEmpty() {
+		idPredicate := parquetquery.NewStringInPredicate(opts.profileIDSelector)
+		profileIDs := profileIDSelectorSet(opts.profileIDSelector)
+		profileIDRows, err := scanner.matchingFixedLenByteArrayRows(schemav1.IDColumnName, idPredicate, func(value []byte) bool {
+			if len(value) != 16 {
+				return false
+			}
+			var id [16]byte
+			copy(id[:], value)
+			_, ok := profileIDs[id]
+			return ok
 		})
-	}
-	// fetch profile id if requested or part of the predicate
-	if opts.fetchProfileIDs || len(opts.profileIDSelector) > 0 {
-		var (
-			predicate parquetquery.Predicate
-			priority  = 20
-		)
-		if len(opts.profileIDSelector) > 0 {
-			predicate = parquetquery.NewStringInPredicate(opts.profileIDSelector)
-			priority = 5
+		if err != nil {
+			return nil, err
 		}
-		offset := len(columns)
-		columns = append(
-			columns,
-			queryColumn{schemav1.IDColumnName, predicate, priority},
-		)
-		var u uuid.UUID
-		processor = append(processor, func(buf [][]parquet.Value, e *ProfileEntry) {
-			b := buf[offset][0].Bytes()
-			if len(b) != 16 {
-				return
-			}
-			copy(u[:], b)
-			e.ID = u.String()
-		})
+		acceptedRows.And(profileIDRows)
 	}
 
-	buf := make([][]parquet.Value, len(columns))
-	columnNames := columns.names()
+	return acceptedRows, nil
+}
 
-	entries := iter.NewAsyncBatchIterator[*parquetquery.IteratorResult, ProfileEntry](
-		columns.join(q), bigBatchSize,
-		func(r *parquetquery.IteratorResult) ProfileEntry {
-			buf = r.Columns(buf, columnNames...)
-			x := series[buf[0][0].Uint32()]
-			e := ProfileEntry{
-				RowNum:      r.RowNumber[0],
-				Timestamp:   model.TimeFromUnixNano(buf[1][0].Int64()),
-				Fingerprint: x.fingerprint,
-				Labels:      x.labels,
+func materializeProfileEntries(scanner *profileEntryColumnScanner, acceptedRows *roaring.Bitmap, series map[uint32]series, opts iteratorOpts) ([]ProfileEntry, error) {
+	entries := make([]ProfileEntry, 0, acceptedRows.GetCardinality())
+	// Build entries from SeriesIndex first. Subsequent scans over top-level
+	// scalar columns visit rows in the same order, so their accepted-row ordinal
+	// maps directly to the entry slice index.
+	if err := scanner.scanInt32(schemav1.SeriesIndexColumnName, parquetquery.NewMapPredicate(series), func(row uint32, value int32) error {
+		if !acceptedRows.Contains(row) {
+			return nil
+		}
+		x := series[uint32(value)]
+		entries = append(entries, ProfileEntry{
+			RowNum:      int64(row),
+			Fingerprint: x.fingerprint,
+			Labels:      x.labels,
+		})
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	if err := scanAcceptedRowsInt64Column(scanner, acceptedRows, schemav1.TimeNanosColumnName, func(i int, value int64) error {
+		entries[i].Timestamp = model.TimeFromUnixNano(value)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	if opts.fetchPartition {
+		if err := scanAcceptedRowsInt64Column(scanner, acceptedRows, schemav1.StacktracePartitionColumnName, func(i int, value int64) error {
+			entries[i].Partition = uint64(value)
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	if opts.fetchProfileIDs {
+		var u uuid.UUID
+		if err := scanAcceptedRowsFixedLenByteArrayColumn(scanner, acceptedRows, schemav1.IDColumnName, func(i int, value []byte) error {
+			if len(value) != 16 {
+				return nil
 			}
-			for _, proc := range processor {
-				proc(buf, &e)
-			}
-			return e
-		},
-		func([]ProfileEntry) {},
-	)
+			copy(u[:], value)
+			entries[i].ID = u.String()
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+
 	return entries, nil
+}
+
+func scanAcceptedRowsInt64Column(scanner *profileEntryColumnScanner, acceptedRows *roaring.Bitmap, columnName string, fn func(entryIndex int, value int64) error) error {
+	entryIndex := 0
+	return scanner.scanInt64(columnName, nil, func(row uint32, value int64) error {
+		if !acceptedRows.Contains(row) {
+			return nil
+		}
+		if err := fn(entryIndex, value); err != nil {
+			return err
+		}
+		entryIndex++
+		return nil
+	})
+}
+
+func scanAcceptedRowsFixedLenByteArrayColumn(scanner *profileEntryColumnScanner, acceptedRows *roaring.Bitmap, columnName string, fn func(entryIndex int, value []byte) error) error {
+	entryIndex := 0
+	return scanner.scanFixedLenByteArray(columnName, nil, func(row uint32, value []byte) error {
+		if !acceptedRows.Contains(row) {
+			return nil
+		}
+		if err := fn(entryIndex, value); err != nil {
+			return err
+		}
+		entryIndex++
+		return nil
+	})
+}
+
+type profileEntryColumnScanner struct {
+	q           *queryContext
+	values      []parquet.Value
+	int32Values []int32
+	int64Values []int64
+	byteValues  []byte
+}
+
+func (s *profileEntryColumnScanner) matchingInt32Rows(columnName string, predicate parquetquery.Predicate, keep func(int32) bool) (*roaring.Bitmap, error) {
+	rows := roaring.New()
+	if err := s.scanInt32(columnName, predicate, func(row uint32, value int32) error {
+		if keep(value) {
+			rows.Add(row)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (s *profileEntryColumnScanner) matchingInt64Rows(columnName string, predicate parquetquery.Predicate, keep func(int64) bool) (*roaring.Bitmap, error) {
+	rows := roaring.New()
+	if err := s.scanInt64(columnName, predicate, func(row uint32, value int64) error {
+		if keep(value) {
+			rows.Add(row)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (s *profileEntryColumnScanner) matchingFixedLenByteArrayRows(columnName string, predicate parquetquery.Predicate, keep func([]byte) bool) (*roaring.Bitmap, error) {
+	rows := roaring.New()
+	if err := s.scanFixedLenByteArray(columnName, predicate, func(row uint32, value []byte) error {
+		if keep(value) {
+			rows.Add(row)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (s *profileEntryColumnScanner) scanInt32(columnName string, predicate parquetquery.Predicate, fn func(row uint32, value int32) error) error {
+	return s.scanTypedColumn(columnName, predicate, func(page parquet.Page, firstRow int64) error {
+		reader := page.Values()
+		if typed, ok := reader.(parquet.Int32Reader); ok {
+			return s.readInt32Page(typed, page.NumRows(), firstRow, fn)
+		}
+		return s.readValuePage(reader, page.NumRows(), firstRow, func(row uint32, value parquet.Value) error {
+			return fn(row, int32(value.Uint32()))
+		})
+	})
+}
+
+func (s *profileEntryColumnScanner) scanInt64(columnName string, predicate parquetquery.Predicate, fn func(row uint32, value int64) error) error {
+	return s.scanTypedColumn(columnName, predicate, func(page parquet.Page, firstRow int64) error {
+		reader := page.Values()
+		if typed, ok := reader.(parquet.Int64Reader); ok {
+			return s.readInt64Page(typed, page.NumRows(), firstRow, fn)
+		}
+		return s.readValuePage(reader, page.NumRows(), firstRow, func(row uint32, value parquet.Value) error {
+			return fn(row, value.Int64())
+		})
+	})
+}
+
+func (s *profileEntryColumnScanner) scanFixedLenByteArray(columnName string, predicate parquetquery.Predicate, fn func(row uint32, value []byte) error) error {
+	return s.scanTypedColumn(columnName, predicate, func(page parquet.Page, firstRow int64) error {
+		reader := page.Values()
+		if typed, ok := reader.(parquet.FixedLenByteArrayReader); ok {
+			return s.readFixedLenByteArrayPage(typed, page.Type().Length(), page.NumRows(), firstRow, fn)
+		}
+		return s.readValuePage(reader, page.NumRows(), firstRow, func(row uint32, value parquet.Value) error {
+			return fn(row, value.Bytes())
+		})
+	})
+}
+
+// scanTypedColumn reads required top-level scalar columns page-by-page. The
+// per-type scanners use parquet's native slice readers when available and only
+// fall back to parquet.Value materialization for pages that do not expose them.
+func (s *profileEntryColumnScanner) scanTypedColumn(columnName string, predicate parquetquery.Predicate, readPage func(page parquet.Page, firstRow int64) error) error {
+	columnIndex, _ := parquetquery.GetColumnIndexByPath(s.q.ds.Profiles().Root(), columnName)
+	if columnIndex < 0 {
+		return fmt.Errorf("column %s not found in profile parquet table", columnName)
+	}
+
+	var rowBase int64
+	for _, rowGroup := range s.q.ds.Profiles().RowGroups() {
+		if err := s.q.ctx.Err(); err != nil {
+			return err
+		}
+		columnChunk := rowGroup.ColumnChunks()[columnIndex]
+		if predicate != nil {
+			columnChunkIndex, err := columnChunk.ColumnIndex()
+			if err != nil {
+				return err
+			}
+			if !predicate.KeepColumnChunk(columnChunkIndex) {
+				rowBase += rowGroup.NumRows()
+				continue
+			}
+		}
+
+		pages := columnChunk.Pages()
+		var rowInGroup int64
+		for {
+			page, err := pages.ReadPage()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				_ = pages.Close()
+				return err
+			}
+			if page == nil {
+				break
+			}
+
+			pageRows := page.NumRows()
+			if predicate != nil && !predicate.KeepPage(page) {
+				rowInGroup += pageRows
+				parquet.Release(page)
+				continue
+			}
+
+			if err := readPage(page, rowBase+rowInGroup); err != nil {
+				parquet.Release(page)
+				_ = pages.Close()
+				return err
+			}
+			rowInGroup += pageRows
+			parquet.Release(page)
+		}
+		if err := pages.Close(); err != nil {
+			return err
+		}
+		rowBase += rowGroup.NumRows()
+	}
+	return nil
+}
+
+func (s *profileEntryColumnScanner) readInt32Page(reader parquet.Int32Reader, pageRows, firstRow int64, fn func(row uint32, value int32) error) error {
+	var rowInPage int64
+	for rowInPage < pageRows {
+		n, err := reader.ReadInt32s(s.int32Values)
+		for i := 0; i < n; i++ {
+			row, rowErr := profileEntryRowNumber(firstRow + rowInPage)
+			if rowErr != nil {
+				return rowErr
+			}
+			if err := fn(row, s.int32Values[i]); err != nil {
+				return err
+			}
+			rowInPage++
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *profileEntryColumnScanner) readInt64Page(reader parquet.Int64Reader, pageRows, firstRow int64, fn func(row uint32, value int64) error) error {
+	var rowInPage int64
+	for rowInPage < pageRows {
+		n, err := reader.ReadInt64s(s.int64Values)
+		for i := 0; i < n; i++ {
+			row, rowErr := profileEntryRowNumber(firstRow + rowInPage)
+			if rowErr != nil {
+				return rowErr
+			}
+			if err := fn(row, s.int64Values[i]); err != nil {
+				return err
+			}
+			rowInPage++
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *profileEntryColumnScanner) readFixedLenByteArrayPage(reader parquet.FixedLenByteArrayReader, valueWidth int, pageRows, firstRow int64, fn func(row uint32, value []byte) error) error {
+	if valueWidth <= 0 {
+		return fmt.Errorf("fixed-length byte array width must be positive")
+	}
+	if cap(s.byteValues) < profileEntryColumnReadSize*valueWidth {
+		s.byteValues = make([]byte, profileEntryColumnReadSize*valueWidth)
+	}
+	buffer := s.byteValues[:profileEntryColumnReadSize*valueWidth]
+
+	var rowInPage int64
+	for rowInPage < pageRows {
+		n, err := reader.ReadFixedLenByteArrays(buffer)
+		for i := 0; i < n; i++ {
+			row, rowErr := profileEntryRowNumber(firstRow + rowInPage)
+			if rowErr != nil {
+				return rowErr
+			}
+			start := i * valueWidth
+			if err := fn(row, buffer[start:start+valueWidth]); err != nil {
+				return err
+			}
+			rowInPage++
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *profileEntryColumnScanner) readValuePage(reader parquet.ValueReader, pageRows, firstRow int64, fn func(row uint32, value parquet.Value) error) error {
+	if s.values == nil {
+		s.values = make([]parquet.Value, profileEntryColumnReadSize)
+	}
+	var rowInPage int64
+	for rowInPage < pageRows {
+		n, err := reader.ReadValues(s.values)
+		for i := 0; i < n; i++ {
+			row, rowErr := profileEntryRowNumber(firstRow + rowInPage)
+			if rowErr != nil {
+				return rowErr
+			}
+			if err := fn(row, s.values[i]); err != nil {
+				return err
+			}
+			rowInPage++
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func profileIDSelectorSet(selectors []string) map[[16]byte]struct{} {
+	ids := make(map[[16]byte]struct{}, len(selectors))
+	for _, selector := range selectors {
+		if len(selector) != 16 {
+			continue
+		}
+		var id [16]byte
+		copy(id[:], selector)
+		ids[id] = struct{}{}
+	}
+	return ids
+}
+
+func profileEntryRowNumber(row int64) (uint32, error) {
+	if row < 0 || row > int64(^uint32(0)) {
+		return 0, fmt.Errorf("profile row number %d out of uint32 range", row)
+	}
+	return uint32(row), nil
 }
 
 type series struct {

--- a/pkg/querybackend/query_profile_entry_bench_test.go
+++ b/pkg/querybackend/query_profile_entry_bench_test.go
@@ -1,0 +1,141 @@
+package querybackend
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	"github.com/grafana/pyroscope/v2/pkg/block"
+	"github.com/grafana/pyroscope/v2/pkg/objstore/testutil"
+)
+
+const (
+	defaultProfileEntryIteratorBenchBlockPath = "/var/folders/n_/n694y4s176x9v42kyj3rr_tr0000gn/T/opencode/01KVST78893AT2XMBK68S1YBKA-block.bin"
+	profileEntryIteratorBenchObjectPath       = "blocks/11/7874/01KVST78893AT2XMBK68S1YBKA/block.bin"
+)
+
+func BenchmarkProfileEntryIterator_RealBlock(b *testing.B) {
+	ctx := context.Background()
+	q, expectedRows := setupProfileEntryIteratorBenchmark(b, ctx)
+
+	benchmarks := []struct {
+		name    string
+		options []profileIteratorOption
+	}{
+		{name: "Default"},
+		{name: "GroupedServiceName", options: []profileIteratorOption{withFetchPartition(false), withGroupByLabels("service_name")}},
+		{name: "AllLabelsProfileIDs", options: []profileIteratorOption{withFetchPartition(false), withAllLabels(), withFetchProfileIDs(true)}},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				it, err := profileEntryIterator(q, bm.options...)
+				require.NoError(b, err)
+
+				rows := 0
+				for it.Next() {
+					rows++
+				}
+				require.NoError(b, it.Err())
+				require.NoError(b, it.Close())
+				if rows != expectedRows {
+					b.Fatalf("unexpected row count: got %d, want %d", rows, expectedRows)
+				}
+			}
+		})
+	}
+}
+
+func setupProfileEntryIteratorBenchmark(b *testing.B, ctx context.Context) (*queryContext, int) {
+	b.Helper()
+
+	blockPath := os.Getenv("PYROSCOPE_VALIDATE_BLOCK_PATH")
+	if blockPath == "" {
+		blockPath = defaultProfileEntryIteratorBenchBlockPath
+	}
+	if _, err := os.Stat(blockPath); err != nil {
+		b.Skipf("set PYROSCOPE_VALIDATE_BLOCK_PATH to a downloaded block.bin: %v", err)
+	}
+
+	root := b.TempDir()
+	require.NoError(b, linkOrCopyBenchmarkFile(blockPath, filepath.Join(root, filepath.FromSlash(profileEntryIteratorBenchObjectPath))))
+	bucket, _ := testutil.NewFilesystemBucket(b, ctx, root)
+
+	obj, err := block.NewObjectFromPath(ctx, bucket, profileEntryIteratorBenchObjectPath, block.WithObjectMaxSizeLoadInMemory(0))
+	require.NoError(b, err)
+	md, err := obj.ReadMetadata(ctx)
+	require.NoError(b, err)
+	obj.SetMetadata(md)
+
+	dsMeta := firstProfileEntryIteratorDataset(md)
+	if dsMeta == nil {
+		b.Skip("block has no format0 datasets")
+	}
+	ds := block.NewDataset(dsMeta, obj)
+	require.NoError(b, ds.Open(ctx, block.SectionTSDB, block.SectionProfiles))
+	b.Cleanup(func() { require.NoError(b, ds.Close()) })
+
+	q := &queryContext{
+		blockContext: &blockContext{
+			ctx: ctx,
+			req: &request{
+				startTime: model.Time(md.MinTime).UnixNano(),
+				endTime:   model.Time(md.MaxTime).UnixNano(),
+			},
+		},
+		ctx: ctx,
+		ds:  ds,
+	}
+
+	it, err := profileEntryIterator(q)
+	require.NoError(b, err)
+	rows := 0
+	for it.Next() {
+		rows++
+	}
+	require.NoError(b, it.Err())
+	require.NoError(b, it.Close())
+	require.NotZero(b, rows)
+
+	return q, rows
+}
+
+func firstProfileEntryIteratorDataset(md *metastorev1.BlockMeta) *metastorev1.Dataset {
+	for _, ds := range md.Datasets {
+		if block.DatasetFormat(ds.Format) == block.DatasetFormat0 {
+			return ds
+		}
+	}
+	return nil
+}
+
+func linkOrCopyBenchmarkFile(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	if err := os.Link(src, dst); err == nil || errors.Is(err, os.ErrExist) {
+		return nil
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+	_, err = io.Copy(out, in)
+	return err
+}


### PR DESCRIPTION
Something I came up with working on performance for #5290. I think this has wider benefit.

This replaces the profile entry iterator's row-oriented parquet joins with columnar predicate scans that build accepted-row bitmaps and materialize entries from scalar columns using native parquet typed readers when available. It also adds a real-block benchmark covering the default, grouped-label, and all-labels-with-profile-IDs iterator modes.

Not quite ready for merge, TODOs:
- [ ] Remove make benchmark against bucket/file more generic
- [ ] Asses in the real world against bucket

