### PR TITLE
fix(vcs): match prefix only at path segment boundaries

### DIFF
--- a/pkg/frontend/vcs/config/config.go
+++ b/pkg/frontend/vcs/config/config.go
@@ -193,21 +193,33 @@ func (c *PyroscopeConfig) FindMapping(file FileSpec) *MappingConfig {
 	return bestMatch
 }
 
+func matchPrefix(value, prefix string) int {
+	if !strings.HasPrefix(value, prefix) {
+		return -1
+	}
+
+	if len(value) == len(prefix) || strings.HasSuffix(prefix, "/") {
+		return len(prefix)
+	}
+
+	if value[len(prefix)] == '/' {
+		return len(prefix)
+	}
+
+	return -1
+}
+
 // Returns -1 if no match, otherwise the number of characters that matched
 func (m *MappingConfig) Match(file FileSpec) int {
 	result := -1
 	for _, fun := range m.FunctionName {
-		if strings.HasPrefix(file.FunctionName, fun.Prefix) {
-			if len(fun.Prefix) > result {
-				result = len(fun.Prefix)
-			}
+		if matched := matchPrefix(file.FunctionName, fun.Prefix); matched > result {
+			result = matched
 		}
 	}
 	for _, path := range m.Path {
-		if strings.HasPrefix(file.Path, path.Prefix) {
-			if len(path.Prefix) > result {
-				result = len(path.Prefix)
-			}
+		if matched := matchPrefix(file.Path, path.Prefix); matched > result {
+			result = matched
 		}
 	}
 	return result

--- a/pkg/frontend/vcs/config/config_test.go
+++ b/pkg/frontend/vcs/config/config_test.go
@@ -314,6 +314,11 @@ func TestFindMapping(t *testing.T) {
 			fileSpec:    FileSpec{Path: "organization/test/File.java"},
 			shouldBeNil: true,
 		},
+		{
+			name:        "path prefix should not match partial path segment",
+			fileSpec:    FileSpec{Path: "javax/swing/JFrame.java"},
+			shouldBeNil: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -334,4 +339,32 @@ func TestFindMapping(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMappingConfig_Match(t *testing.T) {
+	t.Run("function name prefix matches full path segment only", func(t *testing.T) {
+		mapping := MappingConfig{
+			FunctionName: []Match{{Prefix: "java"}},
+		}
+
+		assert.Equal(t, 4, mapping.Match(FileSpec{FunctionName: "java/lang/Math.floorMod"}))
+		assert.Equal(t, -1, mapping.Match(FileSpec{FunctionName: "javax/swing/JFrame.<init>"}))
+	})
+
+	t.Run("path prefix matches full path segment only", func(t *testing.T) {
+		mapping := MappingConfig{
+			Path: []Match{{Prefix: "/usr/src/app"}},
+		}
+
+		assert.Equal(t, len("/usr/src/app"), mapping.Match(FileSpec{Path: "/usr/src/app/index.js"}))
+		assert.Equal(t, -1, mapping.Match(FileSpec{Path: "/usr/src/application/index.js"}))
+	})
+
+	t.Run("trailing slash prefix keeps matching descendants", func(t *testing.T) {
+		mapping := MappingConfig{
+			Path: []Match{{Prefix: "vendor/"}},
+		}
+
+		assert.Equal(t, len("vendor/"), mapping.Match(FileSpec{Path: "vendor/github.com/pkg/errors/errors.go"}))
+	})
 }


### PR DESCRIPTION
The `Match` method in `MappingConfig` used plain `strings.HasPrefix`, so a prefix like `java` would match `javax/swing/JFrame.java` - wrong VCS source gets picked for those files.

The fix adds `matchPrefix` that only accepts a match when the prefix ends at a `/` boundary (or is an exact match, or itself ends with `/`).

Reproduce:

```yaml
mappings:
  - path:
      - prefix: "java"
    source:
      github:
        repository: ...
```

Any file whose path starts with `javax` or `javafx` will be incorrectly matched by that rule. After this fix it won't be.

Related: issue #4878 (Kotlin `.kt` extension support - same VCS config area).