### PR TITLE
refactor(distributor): remove deprecated receivedDecompressedBytes metric

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -604,7 +604,8 @@ func (d *Distributor) pushSeries(ctx context.Context, req *distributormodel.Prof
 		"sample_count", len(p.Sample),
 		"parse_duration", parseDuration,
 	)
-	d.metrics.observeProfileSize(tenantID, StageSampled, int64(decompressedSize)) //todo use req.TotalBytesUncompressed to include labels siz
+	// TODO: use req.TotalBytesUncompressed to include labels in the size measurement.
+	d.metrics.observeProfileSize(tenantID, StageSampled, int64(decompressedSize))
 	d.metrics.receivedSamples.WithLabelValues(profName, tenantID).Observe(float64(len(p.Sample)))
 	d.profileSizeStats.Record(float64(decompressedSize), profLanguage)
 	groups.CountReceivedBytes(profName, int64(decompressedSize))

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -604,8 +604,7 @@ func (d *Distributor) pushSeries(ctx context.Context, req *distributormodel.Prof
 		"sample_count", len(p.Sample),
 		"parse_duration", parseDuration,
 	)
-	d.metrics.observeProfileSize(tenantID, StageSampled, int64(decompressedSize))                              //todo use req.TotalBytesUncompressed to include labels siz
-	d.metrics.receivedDecompressedBytes.WithLabelValues(profName, tenantID).Observe(float64(decompressedSize)) // deprecated TODO remove
+	d.metrics.observeProfileSize(tenantID, StageSampled, int64(decompressedSize)) //todo use req.TotalBytesUncompressed to include labels siz
 	d.metrics.receivedSamples.WithLabelValues(profName, tenantID).Observe(float64(len(p.Sample)))
 	d.profileSizeStats.Record(float64(decompressedSize), profLanguage)
 	groups.CountReceivedBytes(profName, int64(decompressedSize))

--- a/pkg/distributor/metrics.go
+++ b/pkg/distributor/metrics.go
@@ -33,7 +33,6 @@ var allStages = fmt.Sprintf("%s, %s, %s",
 
 type metrics struct {
 	receivedCompressedBytes        *prometheus.HistogramVec
-	receivedDecompressedBytes      *prometheus.HistogramVec // deprecated TODO remove
 	receivedSamples                *prometheus.HistogramVec
 	receivedSamplesBytes           *prometheus.HistogramVec
 	receivedSymbolsBytes           *prometheus.HistogramVec
@@ -54,20 +53,6 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 				Namespace:                       "pyroscope",
 				Name:                            "distributor_received_compressed_bytes",
 				Help:                            "The number of compressed bytes per profile received by the distributor.",
-				Buckets:                         prometheus.ExponentialBucketsRange(minBytes, maxBytes, bucketsCount),
-				NativeHistogramBucketFactor:     1.1,
-				NativeHistogramMaxBucketNumber:  50,
-				NativeHistogramMinResetDuration: time.Hour,
-			},
-			[]string{"type", "tenant"},
-		),
-		receivedDecompressedBytes: prometheus.NewHistogramVec(
-			prometheus.HistogramOpts{
-				Namespace: "pyroscope",
-				Name:      "distributor_received_decompressed_bytes",
-				Help: "The number of decompressed bytes per profiles received by the distributor after " +
-					"limits/sampling checks. distributor_received_decompressed_bytes is deprecated, use " +
-					"distributor_received_decompressed_bytes_total instead.",
 				Buckets:                         prometheus.ExponentialBucketsRange(minBytes, maxBytes, bucketsCount),
 				NativeHistogramBucketFactor:     1.1,
 				NativeHistogramMaxBucketNumber:  50,
@@ -143,7 +128,6 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 	if reg != nil {
 		reg.MustRegister(
 			m.receivedCompressedBytes,
-			m.receivedDecompressedBytes,
 			m.receivedSamples,
 			m.receivedSamplesBytes,
 			m.receivedSymbolsBytes,

--- a/pkg/validation/usage_groups.go
+++ b/pkg/validation/usage_groups.go
@@ -29,8 +29,8 @@ const (
 )
 
 var (
-	// This is a duplicate of distributor_received_decompressed_bytes, but with
-	// usage_group as a label.
+	// This tracks the same data as distributor_received_decompressed_bytes_total, but with
+	// usage_group as an additional label.
 	usageGroupReceivedDecompressedBytes = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "pyroscope",


### PR DESCRIPTION
### What

Remove the deprecated `pyroscope_distributor_received_decompressed_bytes`
histogram metric from the distributor, which has been marked `TODO remove`
and self-documented as deprecated in its own help text.

### Why

This metric was superseded by `pyroscope_distributor_received_decompressed_bytes_total`,
which provides finer-grained observability with `stage` labels (`received`, `sampled`,
`normalized`) instead of only tracking a single processing stage with `type` labels.

The replacement `observeProfileSize()` helper was already being called at all three
processing stages — the deprecated metric was simply a duplicate observation that
added no value.

### Changes

- **Distributor:** Remove `receivedDecompressedBytes` field, histogram creation,
  registration, and the observe call at the sampled stage
- **Validation:** Update stale comment in `usage_groups.go` that referenced the
  removed metric name
- **Distributor:** Preserve existing TODO about using `req.TotalBytesUncompressed`
  at the sampled stage as a proper doc comment

### Dashboard Migration (follow-up)

Dashboard queries in `operations/` still reference `pyroscope_distributor_received_decompressed_bytes`.
These need migration to `_total` with appropriate `stage` selectors — the label structure
changed from `{type, tenant}` to `{tenant, stage}`.

### Testing

- All 160 distributor tests pass
- All validation tests pass