### PR TITLE
feat(profilecli): add --trace-id to filter query profile samples by trace

### DIFF
--- a/cmd/profilecli/main.go
+++ b/cmd/profilecli/main.go
@@ -78,6 +78,7 @@ func main() {
 	queryProfileAsync := queryProfileCmd.Flag("async", "Force async query execution, polling until results are ready.").Default("false").Bool()
 	queryProfileParams := addQueryProfileParams(queryProfileCmd)
 	queryProfileCmd.Flag("profile-id", "Profile ID (UUID) to query a specific profile. Repeatable for multiple IDs. Use 'query exemplars profile' to find IDs.").StringsVar(&queryProfileParams.ProfileIDs)
+	queryProfileCmd.Flag("trace-id", "Trace ID (32 hex characters) to filter samples by. Repeatable for multiple traces.").StringsVar(&queryProfileParams.TraceIDs)
 	queryGoPGOCmd := queryCmd.Command("go-pgo", "Request profile for Go PGO.")
 	queryGoPGOOutput := queryGoPGOCmd.Flag("output", "How to output the result, examples: console, raw, pprof=./my.pprof").Default("pprof=./default.pgo").String()
 	queryGoPGOForce := queryGoPGOCmd.Flag("force", "Overwrite the output file if it already exists.").Short('f').Default("false").Bool()

--- a/cmd/profilecli/query.go
+++ b/cmd/profilecli/query.go
@@ -101,6 +101,7 @@ type queryProfileParams struct {
 	StacktraceSelector []string
 	SpanSelector       []string
 	ProfileIDs         []string
+	TraceIDs           []string
 	MaxNodes           int64
 }
 
@@ -128,10 +129,25 @@ func validateQueryProfileParams(params *queryProfileParams) error {
 		return errors.New("--profile-id and --span-selector cannot be used together. --profile-id selects a specific profile by UUID (from exemplar queries). --span-selector filters by trace span ID.")
 	}
 
+	// --trace-id is a sample-level filter; it can't combine with span or profile selectors.
+	if len(params.TraceIDs) > 0 && len(params.SpanSelector) > 0 {
+		return errors.New("--trace-id and --span-selector cannot be used together")
+	}
+	if len(params.TraceIDs) > 0 && len(params.ProfileIDs) > 0 {
+		return errors.New("--trace-id and --profile-id cannot be used together. --profile-id selects a whole profile by UUID; --trace-id filters samples by trace id.")
+	}
+
 	// Validate each --profile-id is a valid UUID if provided.
 	for _, id := range params.ProfileIDs {
 		if _, err := uuid.Parse(id); err != nil {
 			return errors.New("--profile-id must be a valid UUID (e.g. 550e8400-e29b-41d4-a716-446655440000). Did you mean --span-selector for span IDs?")
+		}
+	}
+
+	// Validate each --trace-id is a 32-character hex trace id.
+	for _, id := range params.TraceIDs {
+		if _, err := model.DecodeTraceID(id); err != nil {
+			return fmt.Errorf("--trace-id must be a 32-character hex string (128-bit trace id): %w", err)
 		}
 	}
 
@@ -245,6 +261,10 @@ func queryProfilePprof(ctx context.Context, params *queryProfileParams, from tim
 		req.ProfileIdSelector = params.ProfileIDs
 	}
 
+	if len(params.TraceIDs) > 0 {
+		req.TraceIdSelector = params.TraceIDs
+	}
+
 	qc := params.phlareClient.queryClient()
 
 	resp, err := qc.SelectMergeProfile(ctx, connect.NewRequest(req))
@@ -279,6 +299,10 @@ func queryProfileTree(ctx context.Context, params *queryProfileParams, from time
 	// ProfileIdSelector uses profile_id (UUID), NOT span_id. See PR #4872.
 	if len(params.ProfileIDs) > 0 {
 		req.ProfileIdSelector = params.ProfileIDs
+	}
+
+	if len(params.TraceIDs) > 0 {
+		req.TraceIdSelector = params.TraceIDs
 	}
 
 	qc := params.phlareClient.queryClient()

--- a/cmd/profilecli/query_test.go
+++ b/cmd/profilecli/query_test.go
@@ -98,4 +98,49 @@ func TestQueryProfileParams_MutualExclusion(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--span-selector and --stacktrace-selector cannot be used together")
+
+	// --trace-id and --span-selector cannot be used together.
+	err = validateQueryProfileParams(&queryProfileParams{
+		TraceIDs:     []string{"0123456789abcdef0123456789abcdef"},
+		SpanSelector: []string{"deadbeef12345678"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--trace-id and --span-selector cannot be used together")
+
+	// --trace-id and --profile-id cannot be used together.
+	err = validateQueryProfileParams(&queryProfileParams{
+		TraceIDs:   []string{"0123456789abcdef0123456789abcdef"},
+		ProfileIDs: []string{"550e8400-e29b-41d4-a716-446655440000"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--trace-id and --profile-id cannot be used together")
+}
+
+func TestQueryProfileParams_TraceIDValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		traceIDs []string
+		wantErr  bool
+	}{
+		{name: "valid 32-char hex", traceIDs: []string{"0123456789abcdef0123456789abcdef"}, wantErr: false},
+		{name: "multiple valid", traceIDs: []string{"0123456789abcdef0123456789abcdef", "ffffffffffffffffffffffffffffffff"}, wantErr: false},
+		{name: "too short (span id)", traceIDs: []string{"deadbeef12345678"}, wantErr: true},
+		{name: "invalid hex", traceIDs: []string{"0123456789abcdef0123456789abcdeg"}, wantErr: true},
+		{name: "empty slice is valid", traceIDs: nil, wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateQueryProfileParams(&queryProfileParams{TraceIDs: tt.traceIDs})
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "--trace-id must be a 32-character hex string")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Adds a `--trace-id` flag to `profilecli query profile` that filters samples by trace id via the `trace_id_selector` query path from #5284. Repeatable, mutually exclusive with `--span-selector` and `--profile-id`, and validated as a 32-hex (128-bit) id.

Verified against dev (fire-dev-001): a metastore trace id from Tempo returns the matching profile, confirming trace_id is stored in parquet and filtered end-to-end.
