### PR TITLE
fix(otlp): coalesce per-profile pushes to fix ingest timeout (#5299)

### DIFF
--- a/pkg/ingester/otlp/ingest_handler.go
+++ b/pkg/ingester/otlp/ingest_handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -26,6 +27,7 @@ import (
 	pprofileotlp "go.opentelemetry.io/proto/otlp/collector/profiles/v1development"
 	v1 "go.opentelemetry.io/proto/otlp/common/v1"
 
+	googlev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	distributormodel "github.com/grafana/pyroscope/v2/pkg/distributor/model"
 	"github.com/grafana/pyroscope/v2/pkg/model"
@@ -243,20 +245,78 @@ func (h *ingestHandler) export(ctx context.Context, er *pprofileotlp.ExportProfi
 		return &pprofileotlp.ExportProfilesServiceResponse{}, status.Errorf(codes.InvalidArgument, "missing resource profiles")
 	}
 
+	req := &distributormodel.PushRequest{RawProfileType: distributormodel.RawProfileTypeOTEL}
+
+	// Accumulate all converted pprof profiles across the whole
+	// ResourceProfiles -> ScopeProfiles -> Profiles walk into a single
+	// PushRequest, merging profiles that share the same (sorted) label set so
+	// that PushBatch is called at most once per export.
+	//
+	// Each accumulator emits one ProfileSeries. Profiles are merged via
+	// pprof.ProfileMerge when compatible. A profile that cannot be merged
+	// (genuinely incompatible sample/period type, or a degenerate header that
+	// the merge rejects on its own) is emitted as its own standalone series via
+	// the raw field rather than dropped or failing the request.
+	type seriesAccumulator struct {
+		labels []*typesv1.LabelPair
+		merge  *pprof.ProfileMerge
+		raw    *googlev1.Profile // set only for standalone (unmergeable) profiles
+	}
+
+	// Coarse upper bound on the number of distinct series, used only as a sizing
+	// hint for the containers below.
+	estimatedSeries := 0
+	for _, rp := range rps {
+		for _, sp := range rp.ScopeProfiles {
+			estimatedSeries += len(sp.Profiles)
+		}
+	}
+	order := make([]*seriesAccumulator, 0, estimatedSeries)
+	byKey := make(map[uint64]*seriesAccumulator, estimatedSeries)
+
+	// addProfile merges prof into the mergeable accumulator for the given
+	// label-set key, creating one if absent. A profile that is genuinely
+	// incompatible (or degenerate on its own) is appended to order as a
+	// standalone raw accumulator and is NOT registered in byKey, so a later
+	// compatible profile for the same label set still finds or creates the real
+	// merge accumulator.
+	addProfile := func(key uint64, labels []*typesv1.LabelPair, prof *googlev1.Profile) {
+		if acc, ok := byKey[key]; ok {
+			if err := acc.merge.Merge(prof, true); err != nil {
+				level.Warn(h.log).Log("msg", "otlp: incompatible profile for label set, emitting unmerged", "err", err)
+				order = append(order, &seriesAccumulator{labels: labels, raw: prof})
+			}
+			return
+		}
+		// First profile for this label set.
+		m := new(pprof.ProfileMerge)
+		if err := m.Merge(prof, true); err != nil {
+			// Degenerate profile that fails even on its own merge. Emit it raw,
+			// and do not register it in byKey so it is never reused as a target.
+			level.Warn(h.log).Log("msg", "otlp: profile not mergeable, emitting unmerged", "err", err)
+			order = append(order, &seriesAccumulator{labels: labels, raw: prof})
+			return
+		}
+		acc := &seriesAccumulator{labels: labels, merge: m}
+		byKey[key] = acc
+		order = append(order, acc)
+	}
+
 	for _, rp := range rps {
 		serviceName := getServiceNameFromAttributes(rp.Resource.GetAttributes())
 		for _, sp := range rp.ScopeProfiles {
 			for _, p := range sp.Profiles {
+				// Account for the size of every message walked, regardless of
+				// whether it produces any series. Measure before conversion, which
+				// mutates the message in place.
+				size := proto.Size(p)
+				req.ReceivedCompressedProfileSize += size
+				req.ReceivedDecompressedProfileSize += size
+
 				pprofProfiles, err := ConvertOtelToGoogle(p, dc)
 				if err != nil {
 					grpcError := status.Errorf(codes.InvalidArgument, "failed to convert otel profile: %s", err.Error())
 					return &pprofileotlp.ExportProfilesServiceResponse{}, grpcError
-				}
-
-				req := &distributormodel.PushRequest{
-					ReceivedCompressedProfileSize:   proto.Size(p),
-					ReceivedDecompressedProfileSize: proto.Size(p),
-					RawProfileType:                  distributormodel.RawProfileTypeOTEL,
 				}
 
 				for samplesServiceName, pprofProfile := range pprofProfiles {
@@ -274,26 +334,36 @@ func (h *ingestHandler) export(ctx context.Context, er *pprofileotlp.ExportProfi
 						Value: svc,
 					})
 
-					s := &distributormodel.ProfileSeries{
-						Labels:     labels,
-						RawProfile: nil,
-						Profile:    pprof.RawFromProto(pprofProfile.profile),
-						ID:         uuid.New().String(),
-					}
-					req.Series = append(req.Series, s)
-				}
-				if len(req.Series) == 0 {
-					continue
-				}
-				err = h.svc.PushBatch(ctx, req)
-				if err != nil {
-					h.log.Log("msg", "failed to push profile", "err", err)
-					// Note: Validation metrics are already tracked by the distributor for errors
-					// returned from PushBatch, so we don't track them here to avoid double-counting.
-					return &pprofileotlp.ExportProfilesServiceResponse{}, fmt.Errorf("failed to make a GRPC request: %w", err)
+					sort.Sort(model.Labels(labels))
+					key := model.Labels(labels).Hash()
+					addProfile(key, labels, pprofProfile.profile)
 				}
 			}
 		}
+	}
+
+	for _, acc := range order {
+		profile := acc.raw
+		if profile == nil {
+			profile = acc.merge.Profile()
+		}
+		req.Series = append(req.Series, &distributormodel.ProfileSeries{
+			Labels:     acc.labels,
+			RawProfile: nil,
+			Profile:    pprof.RawFromProto(profile),
+			ID:         uuid.New().String(),
+		})
+	}
+
+	if len(req.Series) == 0 {
+		return &pprofileotlp.ExportProfilesServiceResponse{}, nil
+	}
+
+	if err := h.svc.PushBatch(ctx, req); err != nil {
+		h.log.Log("msg", "failed to push profile", "err", err)
+		// Note: Validation metrics are already tracked by the distributor for errors
+		// returned from PushBatch, so we don't track them here to avoid double-counting.
+		return &pprofileotlp.ExportProfilesServiceResponse{}, fmt.Errorf("failed to make a GRPC request: %w", err)
 	}
 
 	return &pprofileotlp.ExportProfilesServiceResponse{}, nil

--- a/pkg/ingester/otlp/ingest_handler_test.go
+++ b/pkg/ingester/otlp/ingest_handler_test.go
@@ -3,6 +3,7 @@ package otlp
 import (
 	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"net/http"
 	"net/http/httptest"
@@ -1121,4 +1122,448 @@ func TestHTTPRequestWithGzipCompressionAndJSON(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "gzip-json-tenant", capturedTenantID)
+}
+
+// recordingPushService captures every PushRequest passed to PushBatch and can be
+// configured to return an error.
+func recordPushBatch(t *testing.T) (*mockotlp.MockPushService, *[]*model.PushRequest) {
+	t.Helper()
+	svc := mockotlp.NewMockPushService(t)
+	var profiles []*model.PushRequest
+	svc.On("PushBatch", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		c := (args.Get(1)).(*model.PushRequest)
+		for _, series := range c.Series {
+			sort.Sort(phlaremodel.Labels(series.Labels))
+		}
+		profiles = append(profiles, c)
+	}).Return(nil)
+	return svc, &profiles
+}
+
+// newCPUProfile builds a minimal profile that references the shared builder's
+// dictionary. value is the single sample value; the SampleType/PeriodType are
+// keyed by the provided unit strings so callers can force compatible/incompatible
+// merges.
+func newCPUProfile(b *otlpbuilder, sampleUnit, periodUnit string, value, timeUnixNano, durationNanos uint64) *v1experimental.Profile {
+	stackIdx := int32(len(b.dictionary.StackTable))
+	locIdx := int32(len(b.dictionary.LocationTable))
+	mapIdx := int32(len(b.dictionary.MappingTable))
+	funcIdx := int32(len(b.dictionary.FunctionTable))
+
+	b.dictionary.FunctionTable = append(b.dictionary.FunctionTable, &v1experimental.Function{
+		NameStrindex:       b.addstr("shared_func"),
+		SystemNameStrindex: b.addstr("shared_func"),
+		FilenameStrindex:   b.addstr("shared.go"),
+	})
+	b.dictionary.MappingTable = append(b.dictionary.MappingTable, &v1experimental.Mapping{
+		MemoryStart:      0x1000,
+		MemoryLimit:      0x2000,
+		FilenameStrindex: b.addstr("shared.so"),
+	})
+	b.dictionary.LocationTable = append(b.dictionary.LocationTable, &v1experimental.Location{
+		MappingIndex: mapIdx,
+		Address:      0x1100,
+		Lines: []*v1experimental.Line{{
+			FunctionIndex: funcIdx,
+			Line:          10,
+		}},
+	})
+	b.dictionary.StackTable = append(b.dictionary.StackTable, &v1experimental.Stack{
+		LocationIndices: []int32{locIdx},
+	})
+
+	return &v1experimental.Profile{
+		SampleType: &v1experimental.ValueType{
+			TypeStrindex: b.addstr("samples"),
+			UnitStrindex: b.addstr(sampleUnit),
+		},
+		PeriodType: &v1experimental.ValueType{
+			TypeStrindex: b.addstr("cpu"),
+			UnitStrindex: b.addstr(periodUnit),
+		},
+		Period:       10000000,
+		TimeUnixNano: timeUnixNano,
+		DurationNano: durationNanos,
+		Samples: []*v1experimental.Sample{{
+			StackIndex: stackIdx,
+			Values:     []int64{int64(value)},
+		}},
+	}
+}
+
+// reproducing test: two identical Profile messages in a single
+// ScopeProfiles must produce a single PushBatch call with a single merged series.
+func TestExport_BatchesAcrossProfileMessages(t *testing.T) {
+	svc, profiles := recordPushBatch(t)
+
+	b := new(otlpbuilder)
+	p0 := newCPUProfile(b, "count", "nanoseconds", 5, 100, 10)
+	p1 := newCPUProfile(b, "count", "nanoseconds", 7, 200, 20)
+
+	req := &v1experimental2.ExportProfilesServiceRequest{
+		ResourceProfiles: []*v1experimental.ResourceProfiles{{
+			ScopeProfiles: []*v1experimental.ScopeProfiles{{
+				Profiles: []*v1experimental.Profile{p0, p1},
+			}},
+		}},
+		Dictionary: &b.dictionary,
+	}
+
+	logger := test.NewTestingLogger(t)
+	h := NewOTLPIngestHandler(testConfig(), svc, logger, defaultLimits())
+	_, err := h.Export(user.InjectOrgID(context.Background(), tenant.DefaultTenantID), req)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(*profiles), "PushBatch must be called exactly once")
+	require.Equal(t, 1, len((*profiles)[0].Series), "identical series must merge into one")
+	assert.Equal(t, model.RawProfileTypeOTEL, (*profiles)[0].RawProfileType)
+}
+
+// merging the same series sums sample values and combines headers
+// (smallest TimeNanos, summed DurationNanos).
+func TestExport_MergesSameSeriesValues(t *testing.T) {
+	svc, profiles := recordPushBatch(t)
+
+	b := new(otlpbuilder)
+	p0 := newCPUProfile(b, "count", "nanoseconds", 5, 100, 10)
+	p1 := newCPUProfile(b, "count", "nanoseconds", 7, 50, 20)
+
+	req := &v1experimental2.ExportProfilesServiceRequest{
+		ResourceProfiles: []*v1experimental.ResourceProfiles{{
+			ScopeProfiles: []*v1experimental.ScopeProfiles{{
+				Profiles: []*v1experimental.Profile{p0, p1},
+			}},
+		}},
+		Dictionary: &b.dictionary,
+	}
+
+	logger := test.NewTestingLogger(t)
+	h := NewOTLPIngestHandler(testConfig(), svc, logger, defaultLimits())
+	_, err := h.Export(user.InjectOrgID(context.Background(), tenant.DefaultTenantID), req)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(*profiles))
+	require.Equal(t, 1, len((*profiles)[0].Series))
+
+	gp := (*profiles)[0].Series[0].Profile.Profile
+	require.Equal(t, 1, len(gp.Sample), "the shared stack must collapse to one sample")
+	var total int64
+	for _, v := range gp.Sample[0].Value {
+		total += v
+	}
+	// The "samples:count:cpu:nanoseconds" conversion scales each value by the
+	// period (10ms here); the merge then sums them: (5+7)*10000000.
+	assert.Equal(t, int64(12*10000000), total, "merged sample value must be the sum of inputs")
+	assert.Equal(t, int64(50), gp.TimeNanos, "TimeNanos must be the smallest")
+	assert.Equal(t, int64(30), gp.DurationNanos, "DurationNanos must be summed")
+}
+
+// Received{Compressed,Decompressed}ProfileSize must be the sum of
+// proto.Size over every Profile message.
+func TestExport_SumsReceivedSizesAcrossMessages(t *testing.T) {
+	svc := mockotlp.NewMockPushService(t)
+	var capturedReq *model.PushRequest
+	svc.On("PushBatch", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		capturedReq = args.Get(1).(*model.PushRequest)
+	}).Return(nil)
+
+	b := new(otlpbuilder)
+	p0 := newCPUProfile(b, "count", "nanoseconds", 5, 100, 10)
+	p1 := newCPUProfile(b, "count", "nanoseconds", 7, 200, 20)
+
+	req := &v1experimental2.ExportProfilesServiceRequest{
+		ResourceProfiles: []*v1experimental.ResourceProfiles{{
+			ScopeProfiles: []*v1experimental.ScopeProfiles{{
+				Profiles: []*v1experimental.Profile{p0, p1},
+			}},
+		}},
+		Dictionary: &b.dictionary,
+	}
+
+	expectedSize := proto.Size(p0) + proto.Size(p1)
+
+	logger := test.NewTestingLogger(t)
+	h := NewOTLPIngestHandler(testConfig(), svc, logger, defaultLimits())
+	_, err := h.Export(user.InjectOrgID(context.Background(), tenant.DefaultTenantID), req)
+	require.NoError(t, err)
+	require.NotNil(t, capturedReq)
+	assert.Equal(t, expectedSize, capturedReq.ReceivedDecompressedProfileSize)
+	assert.Equal(t, expectedSize, capturedReq.ReceivedCompressedProfileSize)
+}
+
+// distinct services across messages stay separate but collapse into a
+// single PushBatch call.
+func TestExport_DistinctServicesAcrossMessages(t *testing.T) {
+	svc, profiles := recordPushBatch(t)
+
+	b := new(otlpbuilder)
+	p0 := newCPUProfile(b, "count", "nanoseconds", 5, 100, 10)
+	p1 := newCPUProfile(b, "count", "nanoseconds", 7, 200, 20)
+
+	// Give each profile a per-sample service.name attribute so they key to
+	// distinct services in conversion.
+	attrA := int32(len(b.dictionary.AttributeTable))
+	b.dictionary.AttributeTable = append(b.dictionary.AttributeTable, &v1experimental.KeyValueAndUnit{
+		KeyStrindex: b.addstr("service.name"),
+		Value:       &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "service-a"}},
+	})
+	attrB := int32(len(b.dictionary.AttributeTable))
+	b.dictionary.AttributeTable = append(b.dictionary.AttributeTable, &v1experimental.KeyValueAndUnit{
+		KeyStrindex: b.addstr("service.name"),
+		Value:       &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "service-b"}},
+	})
+	p0.Samples[0].AttributeIndices = []int32{attrA}
+	p1.Samples[0].AttributeIndices = []int32{attrB}
+
+	req := &v1experimental2.ExportProfilesServiceRequest{
+		ResourceProfiles: []*v1experimental.ResourceProfiles{{
+			ScopeProfiles: []*v1experimental.ScopeProfiles{
+				{Profiles: []*v1experimental.Profile{p0}},
+				{Profiles: []*v1experimental.Profile{p1}},
+			},
+		}},
+		Dictionary: &b.dictionary,
+	}
+
+	logger := test.NewTestingLogger(t)
+	h := NewOTLPIngestHandler(testConfig(), svc, logger, defaultLimits())
+	_, err := h.Export(user.InjectOrgID(context.Background(), tenant.DefaultTenantID), req)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(*profiles), "PushBatch must be called exactly once")
+	require.Equal(t, 2, len((*profiles)[0].Series), "distinct services must not merge")
+
+	services := map[string]bool{}
+	for _, s := range (*profiles)[0].Series {
+		for _, l := range s.Labels {
+			if l.Name == phlaremodel.LabelNameServiceName {
+				services[l.Value] = true
+			}
+		}
+	}
+	assert.Equal(t, map[string]bool{"service-a": true, "service-b": true}, services)
+}
+
+// identical label sets across distinct ScopeProfiles merge into one series.
+func TestExport_MergesAcrossScopeProfiles(t *testing.T) {
+	svc, profiles := recordPushBatch(t)
+
+	b := new(otlpbuilder)
+	p0 := newCPUProfile(b, "count", "nanoseconds", 5, 100, 10)
+	p1 := newCPUProfile(b, "count", "nanoseconds", 7, 200, 20)
+
+	req := &v1experimental2.ExportProfilesServiceRequest{
+		ResourceProfiles: []*v1experimental.ResourceProfiles{{
+			ScopeProfiles: []*v1experimental.ScopeProfiles{
+				{Profiles: []*v1experimental.Profile{p0}},
+				{Profiles: []*v1experimental.Profile{p1}},
+			},
+		}},
+		Dictionary: &b.dictionary,
+	}
+
+	logger := test.NewTestingLogger(t)
+	h := NewOTLPIngestHandler(testConfig(), svc, logger, defaultLimits())
+	_, err := h.Export(user.InjectOrgID(context.Background(), tenant.DefaultTenantID), req)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(*profiles))
+	require.Equal(t, 1, len((*profiles)[0].Series))
+}
+
+// two messages with the same label set but incompatible headers
+// (differing period unit) must each be emitted as their own series, with no
+// error and a single PushBatch call.
+func TestExport_IncompatibleSampleTypesFallBack(t *testing.T) {
+	svc, profiles := recordPushBatch(t)
+
+	b := new(otlpbuilder)
+	// Same sample type / profile-name label, but different period unit ->
+	// combineHeaders' compatible() check fails on the second merge.
+	p0 := newCPUProfile(b, "count", "nanoseconds", 5, 100, 10)
+	p1 := newCPUProfile(b, "count", "milliseconds", 7, 200, 20)
+
+	req := &v1experimental2.ExportProfilesServiceRequest{
+		ResourceProfiles: []*v1experimental.ResourceProfiles{{
+			ScopeProfiles: []*v1experimental.ScopeProfiles{{
+				Profiles: []*v1experimental.Profile{p0, p1},
+			}},
+		}},
+		Dictionary: &b.dictionary,
+	}
+
+	logger := test.NewTestingLogger(t)
+	h := NewOTLPIngestHandler(testConfig(), svc, logger, defaultLimits())
+	_, err := h.Export(user.InjectOrgID(context.Background(), tenant.DefaultTenantID), req)
+	require.NoError(t, err, "incompatible profiles must not fail the request")
+
+	require.Equal(t, 1, len(*profiles), "PushBatch must be called exactly once")
+	require.Equal(t, 2, len((*profiles)[0].Series), "incompatible profiles must be emitted separately")
+}
+
+// a known validation error from PushBatch maps to HTTP 400; an unknown
+// error maps to HTTP 500. With a single PushBatch the error may be a multierror;
+// isKnownValidationError inspects only the top-level error, so these tests pin
+// the single-error cases. Mixed validation+internal errors are classified by the
+// top-level wrapper (documented, not asserted).
+func TestExport_ValidationErrorMapsTo400(t *testing.T) {
+	svc := mockotlp.NewMockPushService(t)
+	svc.On("PushBatch", mock.Anything, mock.Anything).
+		Return(validation.NewErrorf(validation.BodySizeLimit, "too big"))
+
+	logger := test.NewTestingLogger(t)
+	h := NewOTLPIngestHandler(testConfig(), svc, logger, defaultLimits())
+
+	w := doValidOTLPHTTPRequest(t, h)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestExport_InternalErrorMapsTo500(t *testing.T) {
+	svc := mockotlp.NewMockPushService(t)
+	svc.On("PushBatch", mock.Anything, mock.Anything).
+		Return(errors.New("boom"))
+
+	logger := test.NewTestingLogger(t)
+	h := NewOTLPIngestHandler(testConfig(), svc, logger, defaultLimits())
+
+	w := doValidOTLPHTTPRequest(t, h)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// doValidOTLPHTTPRequest drives a valid protobuf OTLP request through the HTTP
+// handler and returns the recorder.
+func doValidOTLPHTTPRequest(t *testing.T, h Handler) *httptest.ResponseRecorder {
+	t.Helper()
+	req := createValidOTLPRequest()
+	body, err := proto.Marshal(req)
+	require.NoError(t, err)
+
+	httpReq := httptest.NewRequest("POST", "/otlp/v1/profiles", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/x-protobuf")
+	httpReq.Header.Set(user.OrgIDHeaderName, "test-tenant")
+
+	w := httptest.NewRecorder()
+	httputil.AuthenticateUser(true).Wrap(h).ServeHTTP(w, httpReq)
+	return w
+}
+
+// newNilPeriodTypeProfile builds a minimal profile WITHOUT a PeriodType,
+// matching the shape produced by createValidOTLPRequest() and the common
+// OTLP/eBPF case. All such profiles share one stack/location so they merge into
+// a single series.
+func newNilPeriodTypeProfile(b *otlpbuilder, value, timeUnixNano uint64) *v1experimental.Profile {
+	stackIdx := int32(len(b.dictionary.StackTable))
+	locIdx := int32(len(b.dictionary.LocationTable))
+	mapIdx := int32(len(b.dictionary.MappingTable))
+	funcIdx := int32(len(b.dictionary.FunctionTable))
+
+	b.dictionary.FunctionTable = append(b.dictionary.FunctionTable, &v1experimental.Function{
+		NameStrindex:       b.addstr("nilpt_func"),
+		SystemNameStrindex: b.addstr("nilpt_func"),
+		FilenameStrindex:   b.addstr("nilpt.go"),
+	})
+	b.dictionary.MappingTable = append(b.dictionary.MappingTable, &v1experimental.Mapping{
+		MemoryStart:      0x1000,
+		MemoryLimit:      0x2000,
+		FilenameStrindex: b.addstr("nilpt.so"),
+	})
+	b.dictionary.LocationTable = append(b.dictionary.LocationTable, &v1experimental.Location{
+		MappingIndex: mapIdx,
+		Address:      0x1100,
+		Lines: []*v1experimental.Line{{
+			FunctionIndex: funcIdx,
+			Line:          10,
+		}},
+	})
+	b.dictionary.StackTable = append(b.dictionary.StackTable, &v1experimental.Stack{
+		LocationIndices: []int32{locIdx},
+	})
+
+	return &v1experimental.Profile{
+		SampleType: &v1experimental.ValueType{
+			TypeStrindex: b.addstr("samples"),
+			UnitStrindex: b.addstr("count"),
+		},
+		// No PeriodType — the common OTLP/eBPF shape.
+		TimeUnixNano: timeUnixNano,
+		Samples: []*v1experimental.Sample{{
+			StackIndex: stackIdx,
+			Values:     []int64{int64(value)},
+		}},
+	}
+}
+
+// TestExport_ThreeIncompatibleSameLabelSet_NoHang guards CRITICAL #1: three
+// Profile messages sharing one label set but pairwise-incompatible headers must
+// not hang the export call (the old constant-XOR fallback-key search looped
+// forever on the 3rd message). The call must complete and emit one PushBatch
+// with three separate series. This calls Export synchronously; if an unbounded
+// loop is reintroduced, the go test package timeout will hang the test binary
+// and fail here.
+func TestExport_ThreeIncompatibleSameLabelSet_NoHang(t *testing.T) {
+	svc, profiles := recordPushBatch(t)
+
+	b := new(otlpbuilder)
+	// Same profile-name label (the sample unit avoids the special
+	// "samples:count:cpu:nanoseconds" case, so all three land on the custom
+	// "cpu" profile name and thus share one label set), but three distinct
+	// period units, so each fails to merge into the previous accumulator.
+	p0 := newCPUProfile(b, "milliseconds", "nanoseconds", 5, 100, 10)
+	p1 := newCPUProfile(b, "milliseconds", "milliseconds", 7, 200, 20)
+	p2 := newCPUProfile(b, "milliseconds", "microseconds", 9, 300, 30)
+
+	req := &v1experimental2.ExportProfilesServiceRequest{
+		ResourceProfiles: []*v1experimental.ResourceProfiles{{
+			ScopeProfiles: []*v1experimental.ScopeProfiles{{
+				Profiles: []*v1experimental.Profile{p0, p1, p2},
+			}},
+		}},
+		Dictionary: &b.dictionary,
+	}
+
+	logger := test.NewTestingLogger(t)
+	h := NewOTLPIngestHandler(testConfig(), svc, logger, defaultLimits())
+	_, err := h.Export(user.InjectOrgID(context.Background(), tenant.DefaultTenantID), req)
+	require.NoError(t, err, "incompatible profiles must not fail the request")
+
+	require.Equal(t, 1, len(*profiles), "PushBatch must be called exactly once")
+	require.Equal(t, 3, len((*profiles)[0].Series), "three incompatible profiles must be emitted separately")
+}
+
+// TestExport_NilPeriodType_MergesToOneSeries guards CRITICAL #2 / HIGH #3: two
+// Profile messages sharing a label set with a nil PeriodType (the common
+// OTLP/eBPF shape, matching createValidOTLPRequest) must merge into a single
+// series with summed values, in one PushBatch call. Before the equalValueType
+// fix this produced two series.
+func TestExport_NilPeriodType_MergesToOneSeries(t *testing.T) {
+	svc, profiles := recordPushBatch(t)
+
+	b := new(otlpbuilder)
+	p0 := newNilPeriodTypeProfile(b, 5, 100)
+	p1 := newNilPeriodTypeProfile(b, 7, 200)
+
+	req := &v1experimental2.ExportProfilesServiceRequest{
+		ResourceProfiles: []*v1experimental.ResourceProfiles{{
+			ScopeProfiles: []*v1experimental.ScopeProfiles{{
+				Profiles: []*v1experimental.Profile{p0, p1},
+			}},
+		}},
+		Dictionary: &b.dictionary,
+	}
+
+	logger := test.NewTestingLogger(t)
+	h := NewOTLPIngestHandler(testConfig(), svc, logger, defaultLimits())
+	_, err := h.Export(user.InjectOrgID(context.Background(), tenant.DefaultTenantID), req)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(*profiles), "PushBatch must be called exactly once")
+	require.Equal(t, 1, len((*profiles)[0].Series), "nil-PeriodType profiles with the same label set must merge into one series")
+
+	gp := (*profiles)[0].Series[0].Profile.Profile
+	require.Equal(t, 1, len(gp.Sample), "the shared stack must collapse to one sample")
+	var total int64
+	for _, v := range gp.Sample[0].Value {
+		total += v
+	}
+	assert.Equal(t, int64(12), total, "merged sample value must be the sum of inputs (5+7)")
 }

--- a/pkg/pprof/merge.go
+++ b/pkg/pprof/merge.go
@@ -220,6 +220,10 @@ func compatible(a, b *profilev1.Profile) error {
 // equalValueType returns true if the two value types are semantically
 // equal. It ignores the internal fields used during encode/decode.
 func equalValueType(st1, st2 *profilev1.ValueType) bool {
+	if st1 == nil && st2 == nil {
+		// Two absent value types agree — there is nothing to disagree about.
+		return true
+	}
 	if st1 == nil || st2 == nil {
 		return false
 	}

--- a/pkg/pprof/merge_test.go
+++ b/pkg/pprof/merge_test.go
@@ -627,3 +627,68 @@ func Benchmark_Merge_self(b *testing.B) {
 		}
 	})
 }
+
+// nilPeriodTypeProfile builds a minimal profile with a nil PeriodType and a
+// single sample carrying the given value on a single-location stack. This
+// mirrors the common OTLP/eBPF shape where the source profile omits PeriodType.
+func nilPeriodTypeProfile(value int64) *profilev1.Profile {
+	return &profilev1.Profile{
+		SampleType: []*profilev1.ValueType{
+			{Type: 2, Unit: 1}, // samples / count
+		},
+		PeriodType: nil,
+		Sample: []*profilev1.Sample{
+			{
+				LocationId: []uint64{1},
+				Value:      []int64{value},
+			},
+		},
+		Location: []*profilev1.Location{
+			{
+				Id:        1,
+				MappingId: 1,
+				Line:      []*profilev1.Line{{FunctionId: 1, Line: 1}},
+			},
+		},
+		Mapping: []*profilev1.Mapping{
+			{Id: 1, HasFunctions: true},
+		},
+		Function: []*profilev1.Function{
+			{Id: 1, Name: 3},
+		},
+		StringTable: []string{"", "count", "samples", "fn"},
+	}
+}
+
+func Test_Merge_NilPeriodType_Compatible(t *testing.T) {
+	var m ProfileMerge
+	require.NoError(t, m.Merge(nilPeriodTypeProfile(5), true))
+	require.NoError(t, m.Merge(nilPeriodTypeProfile(7), true))
+
+	out := m.Profile()
+	require.Nil(t, out.PeriodType, "nil PeriodType must be preserved")
+	require.Len(t, out.Sample, 1)
+	require.Equal(t, []int64{12}, out.Sample[0].Value, "values must be summed")
+}
+
+func Test_Merge_NilVsNonNilPeriodType_Incompatible(t *testing.T) {
+	var m ProfileMerge
+	require.NoError(t, m.Merge(nilPeriodTypeProfile(5), true))
+
+	withPeriod := nilPeriodTypeProfile(7)
+	withPeriod.PeriodType = &profilev1.ValueType{Type: 2, Unit: 1}
+
+	err := m.Merge(withPeriod, true)
+	require.Error(t, err, "present-vs-absent period type must stay incompatible")
+	require.Contains(t, err.Error(), "incompatible period types")
+}
+
+func Test_Merge_NilPeriodType_Single(t *testing.T) {
+	var m ProfileMerge
+	require.NoError(t, m.Merge(nilPeriodTypeProfile(3), true))
+
+	out := m.Profile()
+	require.Nil(t, out.PeriodType)
+	require.Len(t, out.Sample, 1)
+	require.Equal(t, []int64{3}, out.Sample[0].Value)
+}

--- a/pkg/usagestats/stats.go
+++ b/pkg/usagestats/stats.go
@@ -418,9 +418,8 @@ func (s *MultiStatistics) Value() map[string]interface{} {
 }
 
 func (s *MultiStatistics) Record(v float64, key string) {
-	keyStats := s.getOrCreateStatistics(key)
-	keyStats.Record(v)
-	s.values["__total__"].Record(v)
+	s.getOrCreateStatistics(key).Record(v)
+	s.getOrCreateStatistics("__total__").Record(v)
 }
 
 func (s *MultiStatistics) getOrCreateStatistics(key string) *Statistics {
@@ -588,9 +587,8 @@ func (c *MultiCounter) reset() {
 }
 
 func (c *MultiCounter) Inc(i int64, keyValue string) {
-	v := c.getOrCreateCounter(keyValue)
-	v.Inc(i)
-	c.values["__total__"].Inc(i)
+	c.getOrCreateCounter(keyValue).Inc(i)
+	c.getOrCreateCounter("__total__").Inc(i)
 }
 
 func (c *MultiCounter) getOrCreateCounter(keyValue string) *Counter {

--- a/pkg/usagestats/stats_test.go
+++ b/pkg/usagestats/stats_test.go
@@ -2,6 +2,7 @@ package usagestats
 
 import (
 	"encoding/json"
+	"fmt"
 	"runtime"
 	"sync"
 	"testing"
@@ -220,4 +221,23 @@ func TestPanics(t *testing.T) {
 		NewFloat(editionKey)
 		Edition("new edition")
 	})
+}
+
+func TestMultiCounter_ConcurrentInc(t *testing.T) {
+	// Concurrent Inc with distinct keys overlaps map inserts with the
+	// "__total__" access; run with -race to guard the counter's thread-safety.
+	mc := NewMultiCounter("test_multi_counter_concurrent", "key_name")
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(g int) {
+			defer wg.Done()
+			mc.Inc(1, fmt.Sprintf("key_%d", g))
+		}(g)
+	}
+	wg.Wait()
+
+	require.Equal(t, int64(goroutines), mc.Value()["total"])
 }


### PR DESCRIPTION
Fixes #5299

## Problem
The OTLP profiling ingest endpoint (`/v1development/profiles`, used by eBPF) times out
under load. `ingestHandler.export()` called `PushBatch` **once per OTLP `Profile` message,
sequentially**, awaiting each before the next. Each `PushBatch` ultimately does a
segment-writer push that only acks after the segment flushes (~0.3s p50), so request
latency scaled with the number of messages an eBPF exporter packs into one request.

**Observed on a production deployment (current, unfixed):**
- OTLP p99 latency **~24.6s**, regularly exceeding the 15s gateway timeout.
- ~10% of OTLP requests erroring (`504` gateway timeouts + `500`).
- A slow request fans out to **~80–100 sequential segment-writer pushes** (24.6s ÷ ~0.3s
  per push; consistent with the reported ~104× fan-out).

## Fix
Restructure `export()` to accumulate the converted pprof profiles across the **entire**
`ResourceProfiles → ScopeProfiles → Profiles` walk into a **single** `PushRequest`,
**merging profiles that share a label set** via `pprof.ProfileMerge`, and call `PushBatch`
**once**. This turns N sequential per-message pushes into one concurrent fan-out (fixes the
latency regardless of mergeability) and collapses repeated series into one push (fewer
segment-writer pushes when messages repeat a service).

Two commits:
1. **`fix(pprof)`** — `equalValueType` treated two `nil` `PeriodType`/`SampleType` values as
   *incompatible*, so `ProfileMerge` refused to merge profiles that both omit a
   `PeriodType` (the common OTLP/eBPF shape) — it would even fail the *first* self-merge.
   `PeriodType` is optional/informational per the pprof spec, so two absent value types
   agree. Now `nil == nil → compatible`; present-vs-absent stays incompatible. This also
   fixes latent merge failures on the read/aggregation paths that share `ProfileMerge`.
2. **`fix(otlp)`** — the `export()` restructure above. Profiles that genuinely cannot be
   merged (incompatible sample/period types) are emitted as their own series — never
   dropped, never failing the request — using an `order` slice + `byKey` map so termination
   is O(N) regardless of how many incompatible profiles collide on a label set.

## Evidence (internal dev cluster canary, controlled single-service load)
Identical load both runs (`-messages 10 -rps 5 -concurrency 8`, one distributor pod):

| Metric | main (unfixed) | fix | change |
|---|---|---|---|
| OTLP ingest p99 (server) | 7.5 s | 0.81 s | ~9× faster |
| Sustained throughput @ conc 8 | ~1.7 req/s | ~4.3 req/s | ~2.5× |
| Segment-writer pushes / request | ~10 (= message count) | ~1–2 (merged) | ~10× fewer |
| Requests completed in 3 min | 299 | 722 | ~2.4× more |
| Server-side errors | 0 | 0 | — |

At 1300 messages/request, unfixed `main` cannot service the request at all (times out);
the fix returns in <1s.

## Testing
- New unit tests: batching-into-one-PushBatch, cross-message merge correctness (summed
  values, combined headers), nil-PeriodType merge, distinct-service separation,
  incompatible-type fallback (no drop / no 500), 3-incompatible no-hang regression,
  HTTP 400/500 status mapping, summed size accounting.
- `pkg/pprof/merge_test.go`: nil==nil compatible, nil-vs-non-nil still incompatible.
- `go test ./pkg/pprof/... ./pkg/ingester/otlp/... ./pkg/distributor/...` pass, incl.
  `-race`. Blast-radius checked: querier/phlaredb also green.
- No `make generate` needed (no proto/config/flag changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
