### PR TITLE
fix(debuginfo): decline empty build IDs during upload initiation

### DIFF
--- a/pkg/debuginfo/store.go
+++ b/pkg/debuginfo/store.go
@@ -80,6 +80,7 @@ const (
 	ReasonUploadInProgress       = "A previous upload is still in-progress and not stale yet (only stale uploads can be retried)."
 	ReasonDebuginfoAlreadyExists = "Debuginfo already exists and is not marked as invalid, therefore no new upload is needed."
 	ReasonDisabled               = "DebugInfo upload disabled"
+	ReasonEmptyBuildID           = "Empty GNU build ID, therefore no upload is needed."
 )
 
 func (s *Store) checkShouldInitiateUpload(
@@ -216,6 +217,13 @@ func (s *Store) ShouldInitiateUpload(
 		return connect.NewResponse(&debuginfov1alpha1.ShouldInitiateUploadResponse{
 			ShouldInitiateUpload: false,
 			Reason:               ReasonDisabled,
+		}), nil
+	}
+
+	if req.Msg != nil && req.Msg.File != nil && req.Msg.File.GnuBuildId == "" {
+		return connect.NewResponse(&debuginfov1alpha1.ShouldInitiateUploadResponse{
+			ShouldInitiateUpload: false,
+			Reason:               ReasonEmptyBuildID,
 		}), nil
 	}
 

--- a/pkg/debuginfo/store_test.go
+++ b/pkg/debuginfo/store_test.go
@@ -629,6 +629,25 @@ func TestUploadE2E(t *testing.T) {
 		assert.Equal(t, ReasonDebuginfoAlreadyExists, resp.Msg.Reason)
 	})
 
+	t.Run("empty build id returns should not initiate", func(t *testing.T) {
+		t.Parallel()
+		store, bucket := newTestStore(t, Config{Enabled: true, UploadStalePeriod: time.Minute})
+		ts := startTestServer(t, store)
+
+		ctx := tenant.InjectTenantID(context.Background(), "test-tenant")
+		resp, err := ts.client.ShouldInitiateUpload(ctx, connect.NewRequest(&debuginfov1alpha1.ShouldInitiateUploadRequest{
+			File: &debuginfov1alpha1.FileMetadata{
+				GnuBuildId: "",
+				Name:       "my-binary",
+				Type:       debuginfov1alpha1.FileMetadata_TYPE_EXECUTABLE_FULL,
+			},
+		}))
+		require.NoError(t, err)
+		assert.False(t, resp.Msg.ShouldInitiateUpload)
+		assert.Equal(t, ReasonEmptyBuildID, resp.Msg.Reason)
+		assert.Empty(t, bucket.Objects())
+	})
+
 	t.Run("disabled service returns should not initiate", func(t *testing.T) {
 		t.Parallel()
 		store, _ := newTestStore(t, Config{Enabled: false, UploadStalePeriod: time.Minute})


### PR DESCRIPTION
This makes debug info upload initiation return false when the client sends an empty GNU build ID. It keeps invalid non-empty build IDs as errors and adds a regression test for the empty value.