### PR TITLE
fix(usagestats): guard MultiCounter/MultiStatistics total against data race

### DIFF
--- a/pkg/usagestats/stats.go
+++ b/pkg/usagestats/stats.go
@@ -418,9 +418,8 @@ func (s *MultiStatistics) Value() map[string]interface{} {
 }
 
 func (s *MultiStatistics) Record(v float64, key string) {
-	keyStats := s.getOrCreateStatistics(key)
-	keyStats.Record(v)
-	s.values["__total__"].Record(v)
+	s.getOrCreateStatistics(key).Record(v)
+	s.getOrCreateStatistics("__total__").Record(v)
 }
 
 func (s *MultiStatistics) getOrCreateStatistics(key string) *Statistics {
@@ -588,9 +587,8 @@ func (c *MultiCounter) reset() {
 }
 
 func (c *MultiCounter) Inc(i int64, keyValue string) {
-	v := c.getOrCreateCounter(keyValue)
-	v.Inc(i)
-	c.values["__total__"].Inc(i)
+	c.getOrCreateCounter(keyValue).Inc(i)
+	c.getOrCreateCounter("__total__").Inc(i)
 }
 
 func (c *MultiCounter) getOrCreateCounter(keyValue string) *Counter {

--- a/pkg/usagestats/stats_test.go
+++ b/pkg/usagestats/stats_test.go
@@ -2,6 +2,7 @@ package usagestats
 
 import (
 	"encoding/json"
+	"fmt"
 	"runtime"
 	"sync"
 	"testing"
@@ -220,4 +221,23 @@ func TestPanics(t *testing.T) {
 		NewFloat(editionKey)
 		Edition("new edition")
 	})
+}
+
+func TestMultiCounter_ConcurrentInc(t *testing.T) {
+	// Concurrent Inc with distinct keys overlaps map inserts with the
+	// "__total__" access; run with -race to guard the counter's thread-safety.
+	mc := NewMultiCounter("test_multi_counter_concurrent", "key_name")
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(g int) {
+			defer wg.Done()
+			mc.Inc(1, fmt.Sprintf("key_%d", g))
+		}(g)
+	}
+	wg.Wait()
+
+	require.Equal(t, int64(goroutines), mc.Value()["total"])
 }


### PR DESCRIPTION
## What

`MultiCounter.Inc` and `MultiStatistics.Record` read `c.values["__total__"]` without holding the lock, while `getOrCreateCounter` / `getOrCreateStatistics` can concurrently insert new keys into the same map under the lock. That is a concurrent map read and map write: the race detector flags it, and the runtime can `fatal: concurrent map read and map write` in production.

The fix routes the `__total__` access through the existing lock-safe `getOrCreate` accessors, and adds `TestMultiCounter_ConcurrentInc`.

## Why now / why standalone

This was surfaced by `-race` integration CI while working on the OTLP ingest fix for #5299: batching profile ingestion makes the distributor's per-series fan-out actually concurrent, which makes this race hot. Both candidate fixes for #5299 (#5301 and a forthcoming alternate PR) currently carry this exact commit; splitting it out lets it merge independently, and both will drop their copy on rebase.

Refs #5299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)