### PR TITLE
feat(distributor): add push_batch_series histogram

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -412,6 +412,8 @@ func (d *Distributor) PushBatch(ctx context.Context, req *distributormodel.PushR
 		return noNewProfilesReceivedError()
 	}
 
+	d.metrics.pushBatchSeries.WithLabelValues(tenantID).Observe(float64(len(req.Series)))
+
 	d.bytesReceivedTotalStats.Inc(int64(req.ReceivedCompressedProfileSize))
 	d.bytesReceivedStats.Record(float64(req.ReceivedCompressedProfileSize))
 	if req.RawProfileType != distributormodel.RawProfileTypePPROF {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"regexp"
 	"runtime/pprof"
 	"strconv"
 	"strings"
@@ -27,6 +28,7 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/stretchr/testify/assert"
@@ -2096,6 +2098,61 @@ func TestPush_Aggregation(t *testing.T) {
 	// RF * samples_per_profile * clients * requests
 	assert.Equal(t, int64(3*2*clients*requests), sum)
 	assert.Equal(t, len(sessions), maxSessions)
+}
+
+func TestPushBatch_SeriesHistogram(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	ing := newFakeIngester(t, false)
+	overrides := validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+		tenantLimits["user-1"] = validation.MockDefaultLimits()
+	})
+	d, err := New(
+		Config{DistributorRing: ringConfig},
+		testhelper.NewMockRing([]ring.InstanceDesc{{Addr: "foo"}}, 3),
+		&poolFactory{func(addr string) (client.PoolClient, error) { return ing, nil }},
+		overrides,
+		reg,
+		log.NewLogfmtLogger(os.Stdout),
+		nil,
+	)
+	require.NoError(t, err)
+
+	ctx := tenant.InjectTenantID(context.Background(), "user-1")
+
+	// makeRequest builds a push request carrying the given number of series.
+	makeRequest := func(series int) *distributormodel.PushRequest {
+		req := &distributormodel.PushRequest{RawProfileType: distributormodel.RawProfileTypePPROF}
+		for i := 0; i < series; i++ {
+			req.Series = append(req.Series, &distributormodel.ProfileSeries{
+				Labels: []*typesv1.LabelPair{
+					{Name: "cluster", Value: "us-central1"},
+					{Name: phlaremodel.LabelNameServiceName, Value: "svc"},
+					{Name: "__name__", Value: "cpu"},
+					{Name: "series", Value: strconv.Itoa(i)},
+				},
+				Profile: &pprof2.Profile{Profile: testProfile(0)},
+			})
+		}
+		return req
+	}
+
+	// Two non-empty calls: the histogram observes N per call, so sum = 3 + 1
+	// and count = 2 (one observation per PushBatch call).
+	require.NoError(t, d.PushBatch(ctx, makeRequest(3)))
+	require.NoError(t, d.PushBatch(ctx, makeRequest(1)))
+
+	// An empty request returns before the observation, so it is not counted.
+	require.Error(t, d.PushBatch(ctx, makeRequest(0)))
+
+	bs, err := testutil.CollectAndFormat(reg, expfmt.TypeTextPlain, "pyroscope_distributor_push_batch_series")
+	require.NoError(t, err)
+
+	got := regexp.MustCompile(`pyroscope_distributor_push_batch_series_(sum|count).*`).
+		FindAllString(string(bs), -1)
+	assert.Equal(t, []string{
+		`pyroscope_distributor_push_batch_series_sum{tenant="user-1"} 4`,
+		`pyroscope_distributor_push_batch_series_count{tenant="user-1"} 2`,
+	}, got)
 }
 
 func testProfile(t int64) *profilev1.Profile {

--- a/pkg/distributor/metrics.go
+++ b/pkg/distributor/metrics.go
@@ -40,6 +40,7 @@ type metrics struct {
 	replicationFactor              prometheus.Gauge
 	receivedDecompressedBytesTotal *prometheus.HistogramVec
 	parseDuration                  *prometheus.HistogramVec
+	pushBatchSeries                *prometheus.HistogramVec
 }
 
 func newMetrics(reg prometheus.Registerer) *metrics {
@@ -139,6 +140,18 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			},
 			[]string{"type", "tenant"},
 		),
+		pushBatchSeries: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace:                       "pyroscope",
+				Name:                            "distributor_push_batch_series",
+				Help:                            "Number of series per batched push request (PushBatch call).",
+				Buckets:                         prometheus.ExponentialBuckets(1, 2, 13),
+				NativeHistogramBucketFactor:     1.1,
+				NativeHistogramMaxBucketNumber:  50,
+				NativeHistogramMinResetDuration: time.Hour,
+			},
+			[]string{"tenant"},
+		),
 	}
 	if reg != nil {
 		reg.MustRegister(
@@ -150,6 +163,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 			m.replicationFactor,
 			m.receivedDecompressedBytesTotal,
 			m.parseDuration,
+			m.pushBatchSeries,
 		)
 	}
 	return m


### PR DESCRIPTION
## What

Adds `pyroscope_distributor_push_batch_series`, a per-tenant histogram
(labeled `tenant`) that records the number of series in each `PushBatch`
request. It is observed in `Distributor.PushBatch` at request arrival —
right after tenant extraction and the empty-series early return — so it
captures the request's series count before any per-series processing.

Buckets are exponential powers of two covering 1..4096
(`prometheus.ExponentialBuckets(1, 2, 13)`), and it carries the same
native-histogram options as the neighboring distributor histograms.

## Why

While sizing the per-tenant push concurrency limit for the #5299 fix, N (the
number of series per `PushBatch` request) proved unmeasurable in production:

- No per-request series histogram existed, so N could only be inferred
  indirectly.
- Duration-derived estimates are **censored** by gateway timeouts: large-N
  requests get cancelled, so their durations never appear in the latency
  histograms. Any estimate of N built from durations is therefore biased
  toward the small requests that complete.

Observing N at request arrival is immune to that censoring and makes sizing
and validating the per-tenant push concurrency limit a one-line query. This
is useful across production cells without any per-cell configuration.

Complements the #5299 fix PRs (#5306 + #5304),
which batches OTLP exports into a single PushBatch — this histogram is what
makes the per-tenant concurrency limit from #5306 observable and tunable from live data.
Works standalone on main.

Refs #5299

🤖 Generated with [Claude Code](https://claude.com/claude-code)


