### PR TITLE
fix(distributor): bound PushBatch series fan-out with a per-tenant limit

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -257,6 +257,8 @@ Usage of ./pyroscope:
     	List of ingestion relabel configurations. The relabeling rules work the same way, as those of [Prometheus](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config). All rules are applied in the order they are specified. Note: In most situations, it is more effective to use relabeling directly in Grafana Alloy.
   -distributor.ingestion-tenant-shard-size int
     	The tenant's shard size used by shuffle-sharding. Must be set both on ingesters and distributors. 0 disables shuffle sharding.
+  -distributor.push.max-concurrency int
+    	Maximum number of series within a single batched push that are processed concurrently. 0 = unbounded (legacy behavior); 1 = serialize pushes (kill switch). (default 256)
   -distributor.push.timeout duration
     	Timeout when pushing data to ingester. (default 5s)
   -distributor.replication-factor int

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -67,6 +67,8 @@ Usage of ./pyroscope:
     	Per-tenant ingestion rate limit in sample size per second. Units in MB. (default 4)
   -distributor.ingestion-tenant-shard-size int
     	The tenant's shard size used by shuffle-sharding. Must be set both on ingesters and distributors. 0 disables shuffle sharding.
+  -distributor.push.max-concurrency int
+    	Maximum number of series within a single batched push that are processed concurrently. 0 = unbounded (legacy behavior); 1 = serialize pushes (kill switch). (default 256)
   -distributor.push.timeout duration
     	Timeout when pushing data to ingester. (default 5s)
   -distributor.replication-factor int

--- a/cmd/pyroscope/pyroscope.yaml
+++ b/cmd/pyroscope/pyroscope.yaml
@@ -325,6 +325,11 @@ limits:
   # disabled, labels with dots are accepted as-is using UTF-8 validation.
   # disable_label_sanitization: true
 
+  # Maximum number of series within a single batched push that are processed
+  # concurrently. 0 = unbounded (legacy behavior); 1 = serialize pushes (kill
+  # switch).
+  # push_max_concurrency: 256
+
   # Maximum size of a profile in bytes. This is based off the uncompressed size.
   # 0 to disable.
   # max_profile_size_bytes: 4194304

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -3122,6 +3122,12 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -validation.disable-label-sanitization
 [disable_label_sanitization: <boolean> | default = true]
 
+# Maximum number of series within a single batched push that are processed
+# concurrently. 0 = unbounded (legacy behavior); 1 = serialize pushes (kill
+# switch).
+# CLI flag: -distributor.push.max-concurrency
+[push_max_concurrency: <int> | default = 256]
+
 # Maximum size of a profile in bytes. This is based off the uncompressed size. 0
 # to disable.
 # CLI flag: -validation.max-profile-size-bytes

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -137,6 +137,7 @@ type Limits interface {
 	IngestionBodyLimitBytes(tenantID string) int64
 	DistributorSampling(tenantID string) *sampling.Config
 	IngestionTenantShardSize(tenantID string) int
+	PushMaxConcurrency(tenantID string) int
 	MaxLabelNameLength(tenantID string) int
 	MaxLabelValueLength(tenantID string) int
 	MaxLabelNamesPerSeries(tenantID string) int
@@ -435,11 +436,18 @@ func (d *Distributor) PushBatch(ctx context.Context, req *distributormodel.PushR
 
 	res := multierror.New()
 	errorsMutex := new(sync.Mutex)
-	wg := new(sync.WaitGroup)
+	// Bound the per-series fan-out. We use errgroup purely as a limited
+	// WaitGroup: the closures always return nil (errors are funneled into the
+	// multierror below), so a plain Group never cancels siblings and every
+	// series is attempted. The per-tenant limit <= 0 leaves it unbounded (legacy
+	// behavior); SetLimit(0) would block every Go call, so we skip SetLimit
+	// entirely rather than pass a non-positive limit.
+	g := new(errgroup.Group)
+	if limit := d.limits.PushMaxConcurrency(tenantID); limit > 0 {
+		g.SetLimit(limit)
+	}
 	for index, s := range req.Series {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		g.Go(func() error {
 			itErr := util.RecoverPanic(func() error {
 				return d.pushSeries(ctx, s, req.RawProfileType, tenantID, req.ParseDuration)
 			})()
@@ -450,9 +458,10 @@ func (d *Distributor) PushBatch(ctx context.Context, req *distributormodel.PushR
 			errorsMutex.Lock()
 			res.Add(itErr)
 			errorsMutex.Unlock()
-		}()
+			return nil
+		})
 	}
-	wg.Wait()
+	_ = g.Wait()
 	return res.Err()
 }
 

--- a/pkg/distributor/distributor_pushbatch_test.go
+++ b/pkg/distributor/distributor_pushbatch_test.go
@@ -1,0 +1,223 @@
+package distributor
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/ring"
+	"github.com/grafana/dskit/ring/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	segmentwriterv1 "github.com/grafana/pyroscope/api/gen/proto/go/segmentwriter/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	distributormodel "github.com/grafana/pyroscope/v2/pkg/distributor/model"
+	"github.com/grafana/pyroscope/v2/pkg/distributor/writepath"
+	phlaremodel "github.com/grafana/pyroscope/v2/pkg/model"
+	pprof2 "github.com/grafana/pyroscope/v2/pkg/pprof"
+	"github.com/grafana/pyroscope/v2/pkg/tenant"
+	"github.com/grafana/pyroscope/v2/pkg/testhelper"
+	"github.com/grafana/pyroscope/v2/pkg/validation"
+)
+
+// probeSegmentWriter is a SegmentWriterClient that observes the concurrency of
+// PushBatch's per-series fan-out. Tests route every series through the segment
+// writer (see newProbeDistributor), whose fast path calls Push synchronously
+// inside the errgroup-bounded goroutine — so the number of concurrent Push
+// calls equals the number of concurrently executing pushSeries.
+//
+// Push sleeps briefly while holding a slot so overlapping calls are observed;
+// maxInFlight records the peak fan-out using atomics only (no channels, no
+// timing windows).
+type probeSegmentWriter struct {
+	inFlight    atomic.Int64
+	maxInFlight atomic.Int64
+	pushed      atomic.Int64
+
+	// failServices / panicServices select, by service_name, the calls that
+	// return an error or panic respectively. They are populated before PushBatch
+	// runs and only read afterwards, so concurrent reads are race-free.
+	failServices  map[string]bool
+	panicServices map[string]bool
+}
+
+func (p *probeSegmentWriter) CheckReady(context.Context) error { return nil }
+
+func (p *probeSegmentWriter) Push(_ context.Context, req *segmentwriterv1.PushRequest) (*segmentwriterv1.PushResponse, error) {
+	svc := phlaremodel.Labels(req.Labels).Get(phlaremodel.LabelNameServiceName)
+
+	n := p.inFlight.Add(1)
+	for {
+		m := p.maxInFlight.Load()
+		if n <= m || p.maxInFlight.CompareAndSwap(m, n) {
+			break
+		}
+	}
+	// Hold the slot briefly so concurrent calls overlap and maxInFlight reflects
+	// the real peak fan-out.
+	time.Sleep(2 * time.Millisecond)
+	p.inFlight.Add(-1)
+
+	if p.panicServices[svc] {
+		panic(fmt.Sprintf("probe panic for %s", svc))
+	}
+	if p.failServices[svc] {
+		return nil, fmt.Errorf("probe failure for %s", svc)
+	}
+	p.pushed.Add(1)
+	return &segmentwriterv1.PushResponse{}, nil
+}
+
+// newProbeDistributor builds a distributor whose write path routes every series
+// to the segment-writer probe (synchronous fast path), with the fan-out bounded
+// to maxConcurrency.
+func newProbeDistributor(t *testing.T, sw SegmentWriterClient, maxConcurrency int) *Distributor {
+	t.Helper()
+	overrides := validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {
+		l := validation.MockDefaultLimits()
+		l.WritePathOverrides.WritePath = writepath.SegmentWriterPath
+		l.PushMaxConcurrency = maxConcurrency
+		tenantLimits["user-1"] = l
+	})
+	d, err := New(
+		Config{DistributorRing: ringConfig},
+		testhelper.NewMockRing([]ring.InstanceDesc{{Addr: "foo"}}, 3),
+		&poolFactory{f: func(addr string) (client.PoolClient, error) { return newFakeIngester(t, false), nil }},
+		overrides, nil, log.NewNopLogger(), sw,
+	)
+	require.NoError(t, err)
+	return d
+}
+
+// probeProfileSeries builds n distinct-label series, each carrying a minimal
+// valid profile that splits into exactly one segment-writer request (so PushBatch
+// takes the synchronous fast path). Series i is tagged service_name=svc-i.
+func probeProfileSeries(n int) []*distributormodel.ProfileSeries {
+	series := make([]*distributormodel.ProfileSeries, n)
+	for i := range series {
+		series[i] = &distributormodel.ProfileSeries{
+			Labels: []*typesv1.LabelPair{
+				{Name: ProfileName, Value: "process_cpu"},
+				{Name: phlaremodel.LabelNameServiceName, Value: fmt.Sprintf("svc-%d", i)},
+			},
+			Profile: newProbeProfile(),
+		}
+	}
+	return series
+}
+
+// newProbeProfile returns a minimal, valid profile: one sample type, one sample
+// with a non-zero value (survives normalization) and no sample labels (so the
+// segment-writer split yields exactly one series/request).
+func newProbeProfile() *pprof2.Profile {
+	return pprof2.RawFromProto(&profilev1.Profile{
+		SampleType:  []*profilev1.ValueType{{Type: 1, Unit: 2}},
+		Sample:      []*profilev1.Sample{{LocationId: []uint64{1}, Value: []int64{1}}},
+		Mapping:     []*profilev1.Mapping{{Id: 1, HasFunctions: true}},
+		Location:    []*profilev1.Location{{Id: 1, MappingId: 1, Line: []*profilev1.Line{{FunctionId: 1}}}},
+		Function:    []*profilev1.Function{{Id: 1, Name: 3, SystemName: 3, Filename: 4}},
+		StringTable: []string{"", "cpu", "nanoseconds", "main", "main.go"},
+	})
+}
+
+// runPushBatchProbe pushes n distinct series through a probe distributor bounded
+// to maxConcurrency and returns the probe for assertions.
+func runPushBatchProbe(t *testing.T, maxConcurrency, n int) *probeSegmentWriter {
+	t.Helper()
+	probe := &probeSegmentWriter{}
+	d := newProbeDistributor(t, probe, maxConcurrency)
+	ctx := tenant.InjectTenantID(context.Background(), "user-1")
+	err := d.PushBatch(ctx, &distributormodel.PushRequest{
+		RawProfileType: distributormodel.RawProfileTypePPROF,
+		Series:         probeProfileSeries(n),
+	})
+	require.NoError(t, err)
+	return probe
+}
+
+// TestPushBatch_ConcurrencyCeiling: the fan-out never exceeds the configured
+// bound, and every series is attempted.
+func TestPushBatch_ConcurrencyCeiling(t *testing.T) {
+	t.Parallel()
+	const limit, n = 8, 50
+	probe := runPushBatchProbe(t, limit, n)
+	assert.LessOrEqual(t, probe.maxInFlight.Load(), int64(limit), "fan-out must never exceed the bound")
+	assert.Equal(t, int64(n), probe.pushed.Load(), "all series attempted")
+}
+
+// TestPushBatch_LimitOneSerializes: a bound of 1 serializes the fan-out (kill
+// switch) — at most one series is ever in flight.
+func TestPushBatch_LimitOneSerializes(t *testing.T) {
+	t.Parallel()
+	const n = 10
+	probe := runPushBatchProbe(t, 1, n)
+	assert.LessOrEqual(t, probe.maxInFlight.Load(), int64(1), "limit=1 must serialize pushes")
+	assert.Equal(t, int64(n), probe.pushed.Load(), "all series attempted")
+}
+
+// TestPushBatch_LimitZeroUnbounded: a bound of 0 is legacy/unbounded. The point
+// is that a non-positive bound skips SetLimit rather than calling SetLimit(0),
+// which would deadlock — so all N series must complete.
+func TestPushBatch_LimitZeroUnbounded(t *testing.T) {
+	t.Parallel()
+	const n = 16
+	probe := runPushBatchProbe(t, 0, n)
+	assert.Equal(t, int64(n), probe.pushed.Load(), "all series must complete (no SetLimit(0) deadlock)")
+}
+
+// TestPushBatch_AggregatesAllErrors: every failing series is attempted and its
+// error is aggregated into the multierror, each wrapped with its index;
+// non-failing series still succeed.
+func TestPushBatch_AggregatesAllErrors(t *testing.T) {
+	t.Parallel()
+	const n = 10
+	failIdx := []int{2, 5, 8}
+	probe := &probeSegmentWriter{failServices: map[string]bool{}}
+	for _, i := range failIdx {
+		probe.failServices[fmt.Sprintf("svc-%d", i)] = true
+	}
+	d := newProbeDistributor(t, probe, 4)
+	ctx := tenant.InjectTenantID(context.Background(), "user-1")
+
+	err := d.PushBatch(ctx, &distributormodel.PushRequest{
+		RawProfileType: distributormodel.RawProfileTypePPROF,
+		Series:         probeProfileSeries(n),
+	})
+	require.Error(t, err)
+	msg := err.Error()
+	for _, i := range failIdx {
+		assert.Contains(t, msg, fmt.Sprintf("push series with index %d and", i), "aggregated error must include failing series %d", i)
+		assert.Contains(t, msg, fmt.Sprintf("probe failure for svc-%d", i))
+	}
+	// Non-failing series must not surface as errors.
+	assert.NotContains(t, msg, "push series with index 0 and")
+	assert.NotContains(t, msg, "push series with index 9 and")
+	// Every non-failing series was still pushed.
+	assert.Equal(t, int64(n-len(failIdx)), probe.pushed.Load())
+}
+
+// TestPushBatch_PanicInOneSeriesDoesNotKillOthers: a panic in one series is
+// recovered (util.RecoverPanic / router recovery) and surfaces as an aggregated
+// error; the other series still complete.
+func TestPushBatch_PanicInOneSeriesDoesNotKillOthers(t *testing.T) {
+	t.Parallel()
+	const n = 5
+	probe := &probeSegmentWriter{panicServices: map[string]bool{"svc-1": true}}
+	d := newProbeDistributor(t, probe, 4)
+	ctx := tenant.InjectTenantID(context.Background(), "user-1")
+
+	err := d.PushBatch(ctx, &distributormodel.PushRequest{
+		RawProfileType: distributormodel.RawProfileTypePPROF,
+		Series:         probeProfileSeries(n),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "push series with index 1 and")
+	assert.Contains(t, err.Error(), "probe panic for svc-1")
+	// The panicking series is recovered; the other four still complete.
+	assert.Equal(t, int64(n-1), probe.pushed.Load())
+}

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -45,6 +45,7 @@ type Limits struct {
 	MaxSessionsPerSeries     int                  `yaml:"max_sessions_per_series" json:"max_sessions_per_series"`
 	EnforceLabelsOrder       bool                 `yaml:"enforce_labels_order" json:"enforce_labels_order"`
 	DisableLabelSanitization bool                 `yaml:"disable_label_sanitization" json:"disable_label_sanitization"`
+	PushMaxConcurrency       int                  `yaml:"push_max_concurrency" json:"push_max_concurrency"`
 
 	MaxProfileSizeBytes              int `yaml:"max_profile_size_bytes" json:"max_profile_size_bytes"`
 	MaxProfileStacktraceSamples      int `yaml:"max_profile_stacktrace_samples" json:"max_profile_stacktrace_samples"`
@@ -154,6 +155,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.Float64Var(&l.IngestionBurstSizeMB, "distributor.ingestion-burst-size-mb", 2, "Per-tenant allowed ingestion burst size (in sample size). Units in MB. The burst size refers to the per-distributor local rate limiter, and should be set at least to the maximum profile size expected in a single push request.")
 	f.Float64Var(&l.IngestionBodyLimitMB, "distributor.ingestion-body-limit-mb", 256, "Per-tenant ingestion body size limit in MB, before decompressing. 0 to disable.")
 	f.IntVar(&l.IngestionTenantShardSize, "distributor.ingestion-tenant-shard-size", 0, "The tenant's shard size used by shuffle-sharding. Must be set both on ingesters and distributors. 0 disables shuffle sharding.")
+	f.IntVar(&l.PushMaxConcurrency, "distributor.push.max-concurrency", 256, "Maximum number of series within a single batched push that are processed concurrently. 0 = unbounded (legacy behavior); 1 = serialize pushes (kill switch).")
 
 	f.IntVar(&l.MaxLabelNameLength, "validation.max-length-label-name", 1024, "Maximum length accepted for label names.")
 	f.IntVar(&l.MaxLabelValueLength, "validation.max-length-label-value", 2048, "Maximum length accepted for label value. This setting also applies to the metric name.")
@@ -423,6 +425,13 @@ func (o *Overrides) MaxQueryLength(tenantID string) time.Duration {
 // frontend will process in parallel.
 func (o *Overrides) MaxQueryParallelism(tenantID string) int {
 	return o.getOverridesForTenant(tenantID).MaxQueryParallelism
+}
+
+// PushMaxConcurrency returns the maximum number of series within a single
+// batched push that the distributor processes concurrently. 0 means unbounded
+// (legacy behavior); 1 serializes pushes (kill switch).
+func (o *Overrides) PushMaxConcurrency(tenantID string) int {
+	return o.getOverridesForTenant(tenantID).PushMaxConcurrency
 }
 
 // MaxQueryLookback returns the max lookback period of queries.

--- a/pkg/validation/testutil.go
+++ b/pkg/validation/testutil.go
@@ -41,10 +41,13 @@ type MockLimits struct {
 	MaxAsyncQueryConcurrencyValue int
 
 	IngestionBodyLimitBytesValue int64
+
+	PushMaxConcurrencyValue int
 }
 
 func (m MockLimits) QuerySplitDuration(string) time.Duration        { return m.QuerySplitDurationValue }
 func (m MockLimits) MaxQueryParallelism(string) int                 { return m.MaxQueryParallelismValue }
+func (m MockLimits) PushMaxConcurrency(string) int                  { return m.PushMaxConcurrencyValue }
 func (m MockLimits) MaxQueryLength(tenantID string) time.Duration   { return m.MaxQueryLengthValue }
 func (m MockLimits) MaxQueryLookback(tenantID string) time.Duration { return m.MaxQueryLookbackValue }
 func (m MockLimits) QueryAnalysisEnabled(tenantID string) bool      { return m.QueryAnalysisEnabledValue }


### PR DESCRIPTION
Depends on #5303.

## What

`PushBatch`'s per-series fan-out (previously one unbounded goroutine per series) is now bounded by a new per-tenant limit **`push_max_concurrency`** (`-distributor.push.max-concurrency`, default **256**; `0` = unbounded legacy behavior; `1` = serialize — an operational kill switch, changeable at runtime via tenant overrides).

Semantics are unchanged: every series is attempted, per-series errors are aggregated, and per-series panic recovery is preserved (errgroup is used purely as a bounded WaitGroup).

## Why

Today every caller hands `PushBatch` only a handful of series, so the unbounded fan-out is harmless. #5304 changes that: it batches whole OTLP export requests into a single call — ~1300 series at the #5299 tail, i.e. ~1300 goroutines and marshaled profile buffers landing on one distributor at once, ~9× the highest concurrent-push level observed anywhere in production today (~140/pod). gRPC `max_concurrent_streams` (100/conn/target) queues the wire RPCs, but only after the goroutine and buffer are already allocated, so memory is otherwise unbounded in N.

Refs #5299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
