### PR TITLE
fix(metastore): reconcile abandoned raft log writes

### DIFF
--- a/pkg/metastore/raftnode/logstore.go
+++ b/pkg/metastore/raftnode/logstore.go
@@ -2,6 +2,8 @@ package raftnode
 
 import (
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/raft"
@@ -16,11 +18,80 @@ import (
 // the raft leader. Without this, a blocked StoreLogs call freezes the
 // leader's main goroutine while heartbeats continue on separate goroutines,
 // preventing followers from ever triggering an election.
+//
+// A timed-out write is *abandoned*, not cancelled: the goroutine performing
+// it keeps running and will eventually land its entries on disk regardless
+// of what the caller (raft) does next. This desyncs raft's view of the log
+// (which believes the append failed) from what's actually persisted, and
+// creates two problems that timeoutLogStore must handle itself, because the
+// underlying store (raft-wal) will not:
+//
+//   - The retry raft sends for the same index arrives after the abandoned
+//     write already landed it. Monotonic stores like raft-wal reject the
+//     re-append outright ("non-monotonic log entries"), which without
+//     reconciliation here becomes a permanent livelock: every retry fails
+//     the same way until the leader independently snapshots and forces an
+//     InstallSnapshot.
+//   - The retry can race the still-running abandoned write inside the
+//     underlying store. raft-wal (like most LogStore implementations)
+//     requires a single writer; concurrent Append calls are undefined
+//     behavior.
+//
+// writeMu serializes all writes to the underlying store and is held for the
+// reconciliation logic below: before appending, an overlapping prefix of the
+// batch is compared against what's already on disk (by index and term) and
+// either dropped (idempotent retry) or truncated (term conflict, e.g. from a
+// stepped-down leader) so only the genuinely new tail is appended.
+//
+// DeleteRange must be serialized under writeMu too, for two reasons:
+//
+//   - In production this store is wrapped in a raft.LogCache (see node.go),
+//     whose StoreLogs populates its ring-buffer cache only *after* the
+//     underlying write succeeds, while its DeleteRange clears the cache
+//     first and then deletes from the store, with no lock spanning both
+//     steps. An abandoned write that is still inside LogCache.StoreLogs
+//     when a DeleteRange runs on a different goroutine (e.g. compactLogs,
+//     which raft runs on its own snapshot goroutine, concurrently with the
+//     main loop) can populate the cache with entries *after* the delete
+//     runs, serving reads that no longer match what's on disk. Holding
+//     writeMu around the whole StoreLogs/DeleteRange call — including
+//     LogCache's cache bookkeeping — closes that window.
+//   - It orders DeleteRange against reconcileOverlap's own reads, so a
+//     truncation can't happen mid-reconciliation.
+//
+// Serializing alone is not sufficient for a suffix/full truncation (raft's
+// conflict-clearing DeleteRange, or removeOldLogs after InstallSnapshot):
+// if an abandoned write's goroutine has not yet reached writeMu.Lock() by
+// the time such a DeleteRange runs and completes (a real possibility, since
+// nothing guarantees a just-spawned goroutine is scheduled promptly), the
+// write proceeds afterwards against an empty or shortened log. Its indexes
+// then look like new, past-the-end entries rather than an overlap, and
+// reconcileOverlap has nothing on disk to compare them against — the stale
+// batch gets appended as if it were current. epoch guards against this: a
+// suffix/full DeleteRange bumps it, and every write captures the epoch
+// *before* being dispatched to its goroutine, so a write whose captured
+// epoch is stale by the time it reaches writeMu is rejected outright,
+// however late it runs. Prefix compaction does not bump epoch: it targets
+// indexes strictly below the last one and can run genuinely concurrently
+// with legitimate in-flight writes to newer indexes, which must not be
+// rejected.
 type timeoutLogStore struct {
 	store        raft.LogStore
 	timeout      time.Duration
 	writeLatency prometheus.Histogram
 	timeouts     prometheus.Counter
+
+	// writeMu is acquired *inside* the goroutine that performs the write,
+	// not before spawning it. This way the timeout in withTimeout can still
+	// fire and return promptly to raft even while a previous abandoned
+	// write is still holding the lock; the next write simply waits for it
+	// to finish (and can itself time out while waiting).
+	writeMu sync.Mutex
+
+	// epoch is bumped by every suffix/full DeleteRange (see comment above).
+	// Writes capture it before dispatch and are rejected if it has moved by
+	// the time they reach writeMu.
+	epoch atomic.Uint64
 }
 
 func newTimeoutLogStore(store raft.LogStore, timeout time.Duration, writeLatency prometheus.Histogram, timeouts prometheus.Counter) raft.LogStore {
@@ -40,7 +111,30 @@ func (s *timeoutLogStore) LastIndex() (uint64, error)  { return s.store.LastInde
 func (s *timeoutLogStore) GetLog(index uint64, log *raft.Log) error {
 	return s.store.GetLog(index, log)
 }
+
+// DeleteRange is serialized with writes under writeMu and bumps epoch for
+// suffix/full truncations (max reaching the current last index) to reject
+// stale abandoned writes that were dispatched before the truncation. See
+// the timeoutLogStore doc comment for the full rationale. It is not itself
+// subject to the write timeout: an abandoned truncation landing late would
+// be worse than raft's main loop blocking on a slow one.
 func (s *timeoutLogStore) DeleteRange(min, max uint64) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	lastIdx, err := s.store.LastIndex()
+	if err != nil {
+		return fmt.Errorf("failed to read last index: %w", err)
+	}
+	if max >= lastIdx {
+		// Suffix or full truncation: raft's conflict-clearing DeleteRange
+		// (raft.go) and removeOldLogs after InstallSnapshot both clear up
+		// to (at least) the current last index. Prefix compaction
+		// (compactLogs) always targets a strictly older range and must not
+		// invalidate writes to newer indexes that may legitimately be in
+		// flight concurrently.
+		s.epoch.Add(1)
+	}
 	return s.store.DeleteRange(min, max)
 }
 
@@ -57,15 +151,106 @@ func (s *timeoutLogStore) IsMonotonic() bool {
 }
 
 func (s *timeoutLogStore) StoreLog(log *raft.Log) error {
-	return s.withTimeout(func() error {
-		return s.store.StoreLog(log)
-	})
+	return s.StoreLogs([]*raft.Log{log})
 }
 
 func (s *timeoutLogStore) StoreLogs(logs []*raft.Log) error {
+	// Captured before dispatch, on the caller's goroutine, so it reflects
+	// the epoch at the moment raft issued the write rather than whenever
+	// the write's goroutine eventually gets scheduled. See the
+	// timeoutLogStore doc comment.
+	epoch := s.epoch.Load()
 	return s.withTimeout(func() error {
-		return s.store.StoreLogs(logs)
+		return s.storeLogsAtEpoch(logs, epoch)
 	})
+}
+
+// storeLogsAtEpoch performs the actual write, rejecting it outright if
+// epoch has moved past the value captured by StoreLogs before dispatch
+// (see the timeoutLogStore doc comment). It is split out from StoreLogs so
+// the abandoned-write-after-truncation scenario can be driven directly and
+// deterministically in tests, since it does not otherwise depend on
+// goroutine scheduling.
+func (s *timeoutLogStore) storeLogsAtEpoch(logs []*raft.Log, epoch uint64) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	if current := s.epoch.Load(); current != epoch {
+		return fmt.Errorf("log store write abandoned: log was truncated (epoch %d != %d) since this write was issued", current, epoch)
+	}
+	return s.reconcileAndStore(logs)
+}
+
+// reconcileAndStore appends logs to the underlying store, first reconciling
+// any overlap with entries already persisted by a previously abandoned
+// write (see reconcileOverlap). It must be called with writeMu held.
+func (s *timeoutLogStore) reconcileAndStore(logs []*raft.Log) error {
+	if len(logs) == 0 {
+		return nil
+	}
+
+	lastIdx, err := s.store.LastIndex()
+	if err != nil {
+		return fmt.Errorf("failed to read last index: %w", err)
+	}
+
+	i, err := s.reconcileOverlap(logs, lastIdx)
+	if err != nil {
+		return err
+	}
+
+	remaining := logs[i:]
+	if len(remaining) == 0 {
+		// The whole batch was an idempotent retry of what's already on
+		// disk; nothing left to do.
+		return nil
+	}
+	return s.store.StoreLogs(remaining)
+}
+
+// reconcileOverlap compares the leading entries of logs against what's
+// already persisted at their indexes (up to lastIdx) and returns the index
+// into logs from which appending should resume. It must be called with
+// writeMu held, since it reads and truncates the underlying store directly.
+//
+//   - entries with an index beyond lastIdx are new; the loop stops there
+//     and that index is returned as-is.
+//   - entries whose on-disk counterpart has the same term are dropped
+//     (idempotent retry); the loop continues to the next entry.
+//   - an entry whose on-disk counterpart has a lower term wins: the stale
+//     tail on disk is truncated via DeleteRange and that entry's index is
+//     returned, so it (and the rest of the batch) is appended as the new
+//     tail.
+//   - an entry whose on-disk counterpart has a higher term is itself stale
+//     (e.g. a since-superseded abandoned write only now getting its turn)
+//     and is rejected: per raft's log matching property, an entry can only
+//     replace one at the same index by carrying a strictly higher term, so
+//     it must not clobber the newer entry already on disk.
+func (s *timeoutLogStore) reconcileOverlap(logs []*raft.Log, lastIdx uint64) (int, error) {
+	i := 0
+	for ; i < len(logs) && logs[i].Index <= lastIdx; i++ {
+		var existing raft.Log
+		if err := s.store.GetLog(logs[i].Index, &existing); err != nil {
+			// This includes the case where the index has already been
+			// compacted away below FirstIndex (e.g. a snapshot install
+			// raced this reconciliation): there's nothing to compare
+			// against, so surface the error and let raft retry rather than
+			// guessing at intent.
+			return 0, fmt.Errorf("failed to read existing log at index %d: %w", logs[i].Index, err)
+		}
+		switch {
+		case existing.Term == logs[i].Term:
+			continue
+		case logs[i].Term < existing.Term:
+			return 0, fmt.Errorf("log store index %d: on-disk term %d is newer than incoming term %d, refusing to overwrite",
+				logs[i].Index, existing.Term, logs[i].Term)
+		default:
+			if err := s.store.DeleteRange(logs[i].Index, lastIdx); err != nil {
+				return 0, fmt.Errorf("failed to truncate conflicting tail from index %d: %w", logs[i].Index, err)
+			}
+			return i, nil
+		}
+	}
+	return i, nil
 }
 
 func (s *timeoutLogStore) withTimeout(fn func() error) error {

--- a/pkg/metastore/raftnode/logstore.go
+++ b/pkg/metastore/raftnode/logstore.go
@@ -16,23 +16,40 @@ import (
 // the raft leader. Without this, a blocked StoreLogs call freezes the
 // leader's main goroutine while heartbeats continue on separate goroutines,
 // preventing followers from ever triggering an election.
+//
+// A timed-out write is abandoned, not cancelled, and may still land after
+// raft has observed an error. writeToken ensures there is at most one such
+// write: callers that time out waiting for the token never dispatch their
+// write. Retries reconcile entries already persisted by an abandoned write
+// before appending their new tail.
 type timeoutLogStore struct {
 	store        raft.LogStore
 	timeout      time.Duration
 	writeLatency prometheus.Histogram
 	timeouts     prometheus.Counter
+
+	writeToken       chan struct{}
+	acknowledgedLast uint64
 }
 
-func newTimeoutLogStore(store raft.LogStore, timeout time.Duration, writeLatency prometheus.Histogram, timeouts prometheus.Counter) raft.LogStore {
+func newTimeoutLogStore(store raft.LogStore, timeout time.Duration, writeLatency prometheus.Histogram, timeouts prometheus.Counter) (raft.LogStore, error) {
 	if timeout <= 0 {
-		return store
+		return store, nil
 	}
-	return &timeoutLogStore{
-		store:        store,
-		timeout:      timeout,
-		writeLatency: writeLatency,
-		timeouts:     timeouts,
+	last, err := store.LastIndex()
+	if err != nil {
+		return nil, fmt.Errorf("read initial log store index: %w", err)
 	}
+	s := &timeoutLogStore{
+		store:            store,
+		timeout:          timeout,
+		writeLatency:     writeLatency,
+		timeouts:         timeouts,
+		writeToken:       make(chan struct{}, 1),
+		acknowledgedLast: last,
+	}
+	s.writeToken <- struct{}{}
+	return s, nil
 }
 
 func (s *timeoutLogStore) FirstIndex() (uint64, error) { return s.store.FirstIndex() }
@@ -40,7 +57,33 @@ func (s *timeoutLogStore) LastIndex() (uint64, error)  { return s.store.LastInde
 func (s *timeoutLogStore) GetLog(index uint64, log *raft.Log) error {
 	return s.store.GetLog(index, log)
 }
+
+// DeleteRange is not timed out: unlike an append, a delayed truncation cannot
+// safely be allowed to land after raft has moved on.
 func (s *timeoutLogStore) DeleteRange(min, max uint64) error {
+	start := time.Now()
+	timer := time.NewTimer(s.timeout)
+	defer timer.Stop()
+	if !s.acquireWriteToken(timer) {
+		return fmt.Errorf("timed out waiting for in-flight log store write after %s", s.timeout)
+	}
+	if time.Since(start) >= s.timeout {
+		s.writeToken <- struct{}{}
+		return fmt.Errorf("timed out waiting for in-flight log store write after %s", s.timeout)
+	}
+	defer func() { s.writeToken <- struct{}{} }()
+
+	lastIdx, err := s.store.LastIndex()
+	if err != nil {
+		return fmt.Errorf("failed to read last index: %w", err)
+	}
+	if max >= s.acknowledgedLast {
+		// Raft calculates suffix deletions from its last acknowledged index.
+		// Include any physical tail left by a timed-out write.
+		if lastIdx > max {
+			max = lastIdx
+		}
+	}
 	return s.store.DeleteRange(min, max)
 }
 
@@ -57,38 +100,153 @@ func (s *timeoutLogStore) IsMonotonic() bool {
 }
 
 func (s *timeoutLogStore) StoreLog(log *raft.Log) error {
-	return s.withTimeout(func() error {
-		return s.store.StoreLog(log)
-	})
+	return s.StoreLogs([]*raft.Log{log})
 }
 
 func (s *timeoutLogStore) StoreLogs(logs []*raft.Log) error {
 	return s.withTimeout(func() error {
-		return s.store.StoreLogs(logs)
+		return s.reconcileAndStore(logs)
+	}, func() {
+		if len(logs) > 0 {
+			s.acknowledgedLast = logs[len(logs)-1].Index
+		}
 	})
 }
 
-func (s *timeoutLogStore) withTimeout(fn func() error) error {
+// reconcileAndStore appends logs to the underlying store, first reconciling
+// any overlap with entries already persisted by a previously abandoned
+// write (see reconcileOverlap). It must be called while holding writeToken.
+func (s *timeoutLogStore) reconcileAndStore(logs []*raft.Log) error {
+	if len(logs) == 0 {
+		return nil
+	}
+
+	lastIdx, err := s.store.LastIndex()
+	if err != nil {
+		return fmt.Errorf("failed to read last index: %w", err)
+	}
+
+	i, err := s.reconcileOverlap(logs, lastIdx)
+	if err != nil {
+		return err
+	}
+
+	remaining := logs[i:]
+	if len(remaining) == 0 {
+		// The whole batch was an idempotent retry of what's already on
+		// disk; nothing left to do.
+		return nil
+	}
+	return s.store.StoreLogs(remaining)
+}
+
+// reconcileOverlap compares the leading entries of logs against what's
+// already persisted at their indexes (up to lastIdx) and returns the index
+// into logs from which appending should resume. It must be called while
+// holding writeToken, since it reads and truncates the store directly.
+//
+//   - entries with an index beyond lastIdx are new; the loop stops there
+//     and that index is returned as-is.
+//   - entries whose on-disk counterpart has the same term are dropped
+//     (idempotent retry); the loop continues to the next entry.
+//   - entries with a different term conflict; the on-disk suffix is truncated
+//     and the incoming entry and its tail are appended in its place.
+func (s *timeoutLogStore) reconcileOverlap(logs []*raft.Log, lastIdx uint64) (int, error) {
+	i := 0
+	for ; i < len(logs) && logs[i].Index <= lastIdx; i++ {
+		var existing raft.Log
+		if err := s.store.GetLog(logs[i].Index, &existing); err != nil {
+			// This includes the case where the index has already been
+			// compacted away below FirstIndex (e.g. a snapshot install
+			// raced this reconciliation): there's nothing to compare
+			// against, so surface the error and let raft retry rather than
+			// guessing at intent.
+			return 0, fmt.Errorf("failed to read existing log at index %d: %w", logs[i].Index, err)
+		}
+		if existing.Term == logs[i].Term {
+			continue
+		}
+		if err := s.store.DeleteRange(logs[i].Index, lastIdx); err != nil {
+			return 0, fmt.Errorf("failed to truncate conflicting tail from index %d: %w", logs[i].Index, err)
+		}
+		return i, nil
+	}
+	return i, nil
+}
+
+func (s *timeoutLogStore) withTimeout(fn func() error, onSuccess func()) error {
 	start := time.Now()
-	done := make(chan error, 1)
+	timer := time.NewTimer(s.timeout)
+	defer timer.Stop()
+
+	if !s.acquireWriteToken(timer) {
+		s.observeTimeout(start)
+		return fmt.Errorf("log store write timed out after %s", s.timeout)
+	}
+	if time.Since(start) >= s.timeout {
+		s.writeToken <- struct{}{}
+		s.observeTimeout(start)
+		return fmt.Errorf("log store write timed out after %s", s.timeout)
+	}
+
+	done := make(chan error)
+	abandoned := make(chan struct{})
 	go func() {
-		done <- fn()
+		err := fn()
+		select {
+		case done <- err:
+		case <-abandoned:
+			s.writeToken <- struct{}{}
+		}
 	}()
 	select {
 	case err := <-done:
+		if err == nil {
+			onSuccess()
+		}
+		s.writeToken <- struct{}{}
 		s.writeLatency.Observe(time.Since(start).Seconds())
 		return err
-	case <-time.After(s.timeout):
+	case <-timer.C:
 		// Check if the operation completed concurrently with the timeout.
 		// Go's select picks randomly when multiple cases are ready.
 		select {
 		case err := <-done:
+			if err == nil {
+				onSuccess()
+			}
+			s.writeToken <- struct{}{}
 			s.writeLatency.Observe(time.Since(start).Seconds())
 			return err
 		default:
 		}
-		s.writeLatency.Observe(time.Since(start).Seconds())
-		s.timeouts.Inc()
+		close(abandoned)
+		s.observeTimeout(start)
 		return fmt.Errorf("log store write timed out after %s", s.timeout)
 	}
+}
+
+// acquireWriteToken returns false if the deadline expires before the caller
+// owns the token. The second check handles the race where the token and timer
+// become ready at the same time: no operation is dispatched after its budget
+// has already elapsed.
+func (s *timeoutLogStore) acquireWriteToken(timer *time.Timer) bool {
+	select {
+	case <-s.writeToken:
+	case <-timer.C:
+		return false
+	}
+
+	select {
+	case <-timer.C:
+		s.writeToken <- struct{}{}
+		return false
+	default:
+		return true
+	}
+}
+
+func (s *timeoutLogStore) observeTimeout(start time.Time) {
+	s.writeLatency.Observe(time.Since(start).Seconds())
+	s.timeouts.Inc()
 }

--- a/pkg/metastore/raftnode/logstore_test.go
+++ b/pkg/metastore/raftnode/logstore_test.go
@@ -1,0 +1,596 @@
+package raftnode
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/raft"
+	raftwal "github.com/hashicorp/raft-wal"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// gatedLogStore wraps a raft.LogStore and lets tests hold StoreLogs/StoreLog
+// calls open on a channel, so a write can be started, "abandoned" by a
+// timeout wrapper, and completed later out of band. This simulates a slow
+// disk: the write is real and eventually lands, but the caller (raft, via
+// timeoutLogStore) may have already given up waiting for it.
+type gatedLogStore struct {
+	store raft.LogStore
+
+	mu   sync.Mutex
+	gate chan struct{}
+
+	// holdDuration, if set, is slept once a call has passed the gate but
+	// before it reaches the real underlying store, simulating a slow disk
+	// write that stays "in flight" for a known, deterministic window. This
+	// lets tests reliably observe (or fail to observe) overlapping calls
+	// without depending on goroutine-scheduling luck.
+	holdDuration time.Duration
+
+	waiting     int32 // number of callers currently parked at the gate
+	writes      int32 // number of StoreLogs/StoreLog calls currently inside the underlying store
+	maxInFlight int32
+
+	intervals []interval // [start,end) of every completed StoreLogs call into the underlying store
+}
+
+type interval struct {
+	start, end time.Time
+}
+
+// overlaps reports whether any two recorded intervals overlap in time,
+// which would indicate two writes were concurrently inside the underlying
+// store — a single-writer violation.
+func (g *gatedLogStore) overlaps() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for i := range g.intervals {
+		for j := range g.intervals {
+			if i == j {
+				continue
+			}
+			a, b := g.intervals[i], g.intervals[j]
+			if a.start.Before(b.end) && b.start.Before(a.end) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func newGatedLogStore(store raft.LogStore) *gatedLogStore {
+	return &gatedLogStore{store: store}
+}
+
+// arm makes the next write block until release is called (or the returned
+// channel is closed).
+func (g *gatedLogStore) arm() chan struct{} {
+	ch := make(chan struct{})
+	g.mu.Lock()
+	g.gate = ch
+	g.mu.Unlock()
+	return ch
+}
+
+// release unblocks a write previously armed with arm.
+func (g *gatedLogStore) release(ch chan struct{}) {
+	close(ch)
+	g.mu.Lock()
+	if g.gate == ch {
+		g.gate = nil
+	}
+	g.mu.Unlock()
+}
+
+func (g *gatedLogStore) waitAtGate() {
+	g.mu.Lock()
+	ch := g.gate
+	g.mu.Unlock()
+	if ch != nil {
+		g.mu.Lock()
+		g.waiting++
+		g.mu.Unlock()
+		<-ch
+		g.mu.Lock()
+		g.waiting--
+		g.mu.Unlock()
+	}
+}
+
+func (g *gatedLogStore) waitersAtGate() int32 {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.waiting
+}
+
+func (g *gatedLogStore) FirstIndex() (uint64, error) { return g.store.FirstIndex() }
+func (g *gatedLogStore) LastIndex() (uint64, error)  { return g.store.LastIndex() }
+func (g *gatedLogStore) GetLog(index uint64, log *raft.Log) error {
+	return g.store.GetLog(index, log)
+}
+func (g *gatedLogStore) DeleteRange(min, max uint64) error { return g.store.DeleteRange(min, max) }
+
+func (g *gatedLogStore) IsMonotonic() bool {
+	if m, ok := g.store.(raft.MonotonicLogStore); ok {
+		return m.IsMonotonic()
+	}
+	return false
+}
+
+func (g *gatedLogStore) StoreLog(log *raft.Log) error {
+	return g.StoreLogs([]*raft.Log{log})
+}
+
+func (g *gatedLogStore) StoreLogs(logs []*raft.Log) error {
+	g.waitAtGate()
+	g.trackInFlight(1)
+	defer g.trackInFlight(-1)
+	start := time.Now()
+	if g.holdDuration > 0 {
+		// Simulate the on-disk write taking a known amount of time, so
+		// concurrent calls that pass the gate together have a deterministic
+		// window in which to overlap inside the underlying store.
+		time.Sleep(g.holdDuration)
+	}
+	err := g.store.StoreLogs(logs)
+	g.mu.Lock()
+	g.intervals = append(g.intervals, interval{start: start, end: time.Now()})
+	g.mu.Unlock()
+	return err
+}
+
+func (g *gatedLogStore) trackInFlight(delta int32) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.writes += delta
+	if g.writes > g.maxInFlight {
+		g.maxInFlight = g.writes
+	}
+}
+
+func (g *gatedLogStore) maxConcurrentWrites() int32 {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.maxInFlight
+}
+
+func testMetrics() (prometheus.Histogram, prometheus.Counter) {
+	return prometheus.NewHistogram(prometheus.HistogramOpts{Name: "test_write_latency"}),
+		prometheus.NewCounter(prometheus.CounterOpts{Name: "test_timeouts"})
+}
+
+// entry builds a minimal raft.Log for use in these tests.
+func entry(index, term uint64) *raft.Log {
+	return &raft.Log{Index: index, Term: term, Type: raft.LogCommand, Data: []byte("x")}
+}
+
+// TestTimeoutLogStore_TimeoutThenRetryLivelock reproduces the follower
+// livelock this fix addresses:
+//
+//  1. A StoreLogs call for index N is slow; timeoutLogStore gives up on it
+//     and returns an error to raft, but the underlying raft-wal write is
+//     *not* cancelled and eventually lands entry N on disk anyway.
+//  2. Raft, believing the append failed, retries StoreLogs for the same
+//     index N.
+//  3. Against a real raft-wal store (which enforces strict monotonicity and
+//     refuses to re-append an index it already has), the retry fails with
+//     "non-monotonic log entries", forever — the node is stuck reporting
+//     "too far behind" until the leader falls back to InstallSnapshot.
+//
+// A correct wrapper must reconcile the desync itself: the retry for an
+// already-persisted, identical index should be treated as a success (or
+// merged/truncated on conflict), so that StoreLogs(N) returns nil and
+// replication can continue with N+1.
+//
+// This pins down the bug: it fails against a naive wrapper that just
+// re-appends, and passes against timeoutLogStore's reconciliation logic.
+func TestTimeoutLogStore_TimeoutThenRetryLivelock(t *testing.T) {
+	dir := t.TempDir()
+	wal, err := raftwal.Open(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = wal.Close() })
+
+	gated := newGatedLogStore(wal)
+	writeLatency, timeouts := testMetrics()
+	ls := newTimeoutLogStore(gated, 50*time.Millisecond, writeLatency, timeouts)
+
+	const N = uint64(1)
+
+	// Step 1: the write for index N is slow. Arm the gate so the underlying
+	// raft-wal write blocks; timeoutLogStore should give up after 50ms and
+	// return an error to the caller (simulating raft observing the append
+	// as failed), even though the real write is still in flight.
+	gate := gated.arm()
+
+	timeoutErr := make(chan error, 1)
+	go func() {
+		timeoutErr <- ls.StoreLogs([]*raft.Log{entry(N, 1)})
+	}()
+
+	select {
+	case err := <-timeoutErr:
+		require.Error(t, err, "expected the slow write to time out")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the abandoned write to report a timeout")
+	}
+
+	// Step 2: release the blocked write and let it land on disk. This is
+	// the "phantom persist": raft believes the append failed, but the WAL
+	// now actually has index N.
+	gated.release(gate)
+	require.Eventually(t, func() bool {
+		last, err := wal.LastIndex()
+		return err == nil && last == N
+	}, 5*time.Second, 10*time.Millisecond, "the abandoned write never landed on disk")
+
+	// Step 3: raft retries AppendEntries for the same index N. A correct
+	// implementation reconciles this with what's already on disk instead
+	// of blindly re-appending and hitting raft-wal's monotonicity check.
+	retryErr := ls.StoreLogs([]*raft.Log{entry(N, 1)})
+	require.NoError(t, retryErr, "retry of an already-persisted identical entry must not fail")
+
+	last, err := wal.LastIndex()
+	require.NoError(t, err)
+	require.Equal(t, N, last)
+
+	// Step 4: replication must be able to continue with the next index.
+	require.NoError(t, ls.StoreLogs([]*raft.Log{entry(N+1, 1)}))
+	last, err = wal.LastIndex()
+	require.NoError(t, err)
+	require.Equal(t, N+1, last)
+}
+
+// TestTimeoutLogStore_TermConflictTruncates reproduces the stepped-down
+// leader variant: the retry for an overlapping index carries a *different*
+// (higher) term than what is already on disk. A correct wrapper must
+// truncate the conflicting tail and append the new entry, rather than
+// treating it as an idempotent duplicate or failing outright.
+func TestTimeoutLogStore_TermConflictTruncates(t *testing.T) {
+	dir := t.TempDir()
+	wal, err := raftwal.Open(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = wal.Close() })
+
+	gated := newGatedLogStore(wal)
+	writeLatency, timeouts := testMetrics()
+	// The retry path here does more work than a plain append (it reads the
+	// existing entry and truncates before re-appending), so give it a more
+	// generous timeout than the bare-minimum livelock test; the point of
+	// this test is the reconciliation logic, not the timeout value itself.
+	ls := newTimeoutLogStore(gated, 500*time.Millisecond, writeLatency, timeouts)
+
+	const N = uint64(1)
+
+	gate := gated.arm()
+	timeoutErr := make(chan error, 1)
+	go func() {
+		timeoutErr <- ls.StoreLogs([]*raft.Log{entry(N, 1)})
+	}()
+	select {
+	case err := <-timeoutErr:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the abandoned write to report a timeout")
+	}
+
+	gated.release(gate)
+	require.Eventually(t, func() bool {
+		last, err := wal.LastIndex()
+		return err == nil && last == N
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// A new leader (higher term) now retries with a different entry at the
+	// same index N.
+	require.NoError(t, ls.StoreLogs([]*raft.Log{entry(N, 2)}))
+
+	var got raft.Log
+	require.NoError(t, wal.GetLog(N, &got))
+	require.Equal(t, uint64(2), got.Term, "entry at N must reflect the new leader's term")
+}
+
+// TestTimeoutLogStore_PartialOverlapAppendsOnlyNewTail exercises a batch
+// where only a *prefix* of the entries is already persisted (from a
+// previously abandoned write) and the rest is genuinely new. Only the
+// already-persisted prefix must be dropped; the new tail must still be
+// appended in the same call.
+func TestTimeoutLogStore_PartialOverlapAppendsOnlyNewTail(t *testing.T) {
+	dir := t.TempDir()
+	wal, err := raftwal.Open(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = wal.Close() })
+
+	gated := newGatedLogStore(wal)
+	writeLatency, timeouts := testMetrics()
+	ls := newTimeoutLogStore(gated, 50*time.Millisecond, writeLatency, timeouts)
+
+	// Abandoned write lands indexes 1 and 2 on disk, but the caller (raft)
+	// observed a timeout and believes the append failed.
+	gate := gated.arm()
+	timeoutErr := make(chan error, 1)
+	go func() {
+		timeoutErr <- ls.StoreLogs([]*raft.Log{entry(1, 1), entry(2, 1)})
+	}()
+	select {
+	case err := <-timeoutErr:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the abandoned write to report a timeout")
+	}
+	gated.release(gate)
+	require.Eventually(t, func() bool {
+		last, err := wal.LastIndex()
+		return err == nil && last == 2
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Raft retries with the full batch it originally intended to send:
+	// indexes 1-2 (already on disk, same term) followed by the genuinely
+	// new indexes 3-4.
+	require.NoError(t, ls.StoreLogs([]*raft.Log{
+		entry(1, 1), entry(2, 1), entry(3, 1), entry(4, 1),
+	}))
+
+	last, err := wal.LastIndex()
+	require.NoError(t, err)
+	require.Equal(t, uint64(4), last, "the new tail must be appended alongside the already-persisted prefix")
+
+	for idx := uint64(1); idx <= 4; idx++ {
+		var got raft.Log
+		require.NoError(t, wal.GetLog(idx, &got))
+		require.Equal(t, uint64(1), got.Term)
+	}
+}
+
+// TestTimeoutLogStore_StaleTermRejected verifies that reconcileAndStore
+// refuses to overwrite an on-disk entry with an incoming entry that carries
+// a *lower* term at the same index. This can happen when an abandoned
+// write (from a leader that has since been superseded) is still queued
+// behind writeMu and only gets its turn after a newer leader's entry has
+// already been persisted at that index. Per raft's log matching property,
+// only a strictly higher term may replace an entry; a lower term must never
+// clobber what's already there.
+func TestTimeoutLogStore_StaleTermRejected(t *testing.T) {
+	dir := t.TempDir()
+	wal, err := raftwal.Open(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = wal.Close() })
+
+	gated := newGatedLogStore(wal)
+	writeLatency, timeouts := testMetrics()
+	ls := newTimeoutLogStore(gated, 50*time.Millisecond, writeLatency, timeouts)
+
+	const N = uint64(1)
+
+	// A newer leader's entry is already persisted at index N with term 2.
+	require.NoError(t, ls.StoreLogs([]*raft.Log{entry(N, 2)}))
+
+	// A stale write for the same index, carrying an older term, arrives
+	// afterwards (e.g. a delayed abandoned write from the deposed leader).
+	err = ls.StoreLogs([]*raft.Log{entry(N, 1)})
+	require.Error(t, err, "a stale, lower-term entry must not be accepted")
+
+	var got raft.Log
+	require.NoError(t, wal.GetLog(N, &got))
+	require.Equal(t, uint64(2), got.Term, "the newer on-disk entry must not be clobbered by the stale retry")
+}
+
+// TestTimeoutLogStore_SerializesAbandonedWrite verifies that once a write
+// has been abandoned by the timeout, a subsequent StoreLogs call does not
+// race with it inside the underlying store. raft-wal requires a single
+// writer; two concurrent Append calls are undefined behavior and a path to
+// WAL corruption.
+//
+// The abandoned write is held at the gate (still "in flight" as far as the
+// underlying store is concerned) while a second write is issued. The second
+// write must not enter the underlying store until the first one, once
+// released, has fully completed — i.e. a correct wrapper serializes on the
+// underlying store rather than letting the retry run concurrently with the
+// stray goroutine from the timed-out call.
+func TestTimeoutLogStore_SerializesAbandonedWrite(t *testing.T) {
+	dir := t.TempDir()
+	wal, err := raftwal.Open(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = wal.Close() })
+
+	gated := newGatedLogStore(wal)
+	// Once released, hold the underlying store for a known duration so a
+	// second write that (incorrectly) entered concurrently has a wide
+	// window in which to be observed overlapping.
+	gated.holdDuration = 200 * time.Millisecond
+	writeLatency, timeouts := testMetrics()
+	ls := newTimeoutLogStore(gated, 50*time.Millisecond, writeLatency, timeouts)
+
+	gate := gated.arm()
+
+	// The abandoned write: timeoutLogStore gives up after 50ms, but its
+	// spawned goroutine is still blocked at the gate, about to enter the
+	// (simulated) underlying store.
+	timeoutErr := make(chan error, 1)
+	go func() {
+		timeoutErr <- ls.StoreLogs([]*raft.Log{entry(1, 1)})
+	}()
+	select {
+	case err := <-timeoutErr:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the abandoned write to report a timeout")
+	}
+
+	// The retry, issued while the first write is still blocked. A correct
+	// wrapper serializes internally, so this call must not even reach the
+	// underlying store's gate until the first write completes; an unfixed
+	// wrapper lets it straight through, so it also parks at the (still
+	// armed) gate alongside the first call.
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- ls.StoreLogs([]*raft.Log{entry(2, 1)})
+	}()
+
+	// Give the retry a chance to (incorrectly) reach the gate before we
+	// release the first write.
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, int32(1), gated.waitersAtGate(),
+		"the retry must not reach the underlying store's gate while the abandoned write is still blocked there")
+
+	gated.release(gate)
+
+	select {
+	case <-secondDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second write never completed")
+	}
+
+	require.LessOrEqual(t, gated.maxConcurrentWrites(), int32(1),
+		"at most one write must be in flight in the underlying store at a time")
+	require.False(t, gated.overlaps(),
+		"no two writes may have been concurrently inside the underlying store")
+}
+
+// TestTimeoutLogStore_DeleteRangeWaitsForInFlightWrite verifies that
+// DeleteRange is serialized with StoreLogs under writeMu: it must not enter
+// the underlying store while an abandoned write is still holding the lock.
+//
+// This matters beyond the underlying store's own single-writer contract:
+// in production this store is wrapped in a raft.LogCache (see node.go),
+// whose StoreLogs populates its cache only after the underlying write
+// succeeds and whose DeleteRange clears the cache before deleting from the
+// store, with no lock spanning both steps. If DeleteRange could run while
+// an abandoned write is still inside the (LogCache-wrapped) store, the
+// write could populate the cache with entries after the delete has already
+// cleared it, serving reads that no longer match what's on disk.
+func TestTimeoutLogStore_DeleteRangeWaitsForInFlightWrite(t *testing.T) {
+	dir := t.TempDir()
+	wal, err := raftwal.Open(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = wal.Close() })
+
+	gated := newGatedLogStore(wal)
+	writeLatency, timeouts := testMetrics()
+	// A generous timeout: the first write to a fresh WAL creates segment
+	// files and can occasionally exceed a bare-minimum timeout under load
+	// (e.g. -race), independent of the reconciliation logic under test.
+	ls := newTimeoutLogStore(gated, 500*time.Millisecond, writeLatency, timeouts)
+
+	require.NoError(t, ls.StoreLogs([]*raft.Log{entry(1, 1), entry(2, 1)}))
+
+	// Abandon a write for index 3: timeoutLogStore gives up after the
+	// timeout, but its goroutine is still blocked at the gate, holding
+	// writeMu, about to enter the underlying store.
+	gate := gated.arm()
+	timeoutErr := make(chan error, 1)
+	go func() {
+		timeoutErr <- ls.StoreLogs([]*raft.Log{entry(3, 1)})
+	}()
+	select {
+	case err := <-timeoutErr:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the abandoned write to report a timeout")
+	}
+
+	// DeleteRange must not proceed while the abandoned write still holds
+	// writeMu.
+	deleteDone := make(chan error, 1)
+	go func() {
+		deleteDone <- ls.DeleteRange(1, 2)
+	}()
+
+	select {
+	case <-deleteDone:
+		t.Fatal("DeleteRange must not complete while an abandoned write still holds writeMu")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	gated.release(gate)
+
+	select {
+	case err := <-deleteDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("DeleteRange never completed after the abandoned write was released")
+	}
+}
+
+// TestTimeoutLogStore_EpochRejectsWriteDispatchedBeforeTruncation covers
+// the residual hazard that serializing on writeMu alone does not close: an
+// abandoned write's goroutine that has not yet reached writeMu.Lock() by
+// the time a suffix/full DeleteRange (raft's conflict-clearing truncation,
+// or removeOldLogs after InstallSnapshot) runs and completes. Nothing
+// guarantees a just-spawned goroutine is scheduled promptly, so without a
+// guard the write can proceed afterwards against an empty or shortened
+// log: its indexes look like new, past-the-end entries rather than an
+// overlap, and reconcileOverlap has nothing on disk to compare them
+// against — the stale batch would be appended as if current, resurrecting
+// data a newer leader already discarded.
+//
+// This drives storeLogsAtEpoch directly with an epoch captured before the
+// truncation, simulating exactly that scheduling delay without depending
+// on goroutine-scheduling luck.
+func TestTimeoutLogStore_EpochRejectsWriteDispatchedBeforeTruncation(t *testing.T) {
+	dir := t.TempDir()
+	wal, err := raftwal.Open(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = wal.Close() })
+
+	writeLatency, timeouts := testMetrics()
+	// See TestTimeoutLogStore_DeleteRangeWaitsForInFlightWrite for why this
+	// is more generous than the bare-minimum timeout used elsewhere.
+	ls := newTimeoutLogStore(wal, 500*time.Millisecond, writeLatency, timeouts)
+	impl := ls.(*timeoutLogStore)
+
+	require.NoError(t, ls.StoreLogs([]*raft.Log{entry(1, 1)}))
+	staleEpoch := impl.epoch.Load()
+
+	// A new leader's InstallSnapshot wipes the log — a suffix/full
+	// truncation that must invalidate any write dispatched before it.
+	require.NoError(t, ls.DeleteRange(1, 1))
+	require.NotEqual(t, staleEpoch, impl.epoch.Load(), "a suffix/full DeleteRange must bump epoch")
+
+	// The abandoned write for the old index, dispatched (and its epoch
+	// captured) before the truncation, only now reaches writeMu.
+	err = impl.storeLogsAtEpoch([]*raft.Log{entry(1, 1)}, staleEpoch)
+	require.Error(t, err, "a write captured at a stale epoch must be rejected")
+
+	last, err := wal.LastIndex()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), last, "the stale write must not have been appended into the truncated log")
+
+	// Replication can continue normally afterwards.
+	require.NoError(t, ls.StoreLogs([]*raft.Log{entry(1, 2)}))
+}
+
+// TestTimeoutLogStore_PrefixDeleteRangeDoesNotBumpEpoch verifies that a
+// prefix compaction (raft's compactLogs, which runs on its own snapshot
+// goroutine concurrently with the main loop) does not invalidate
+// legitimately in-flight writes to newer indexes. Only suffix/full
+// truncations, which discard the tail a write might target, need to bump
+// epoch.
+func TestTimeoutLogStore_PrefixDeleteRangeDoesNotBumpEpoch(t *testing.T) {
+	dir := t.TempDir()
+	wal, err := raftwal.Open(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = wal.Close() })
+
+	writeLatency, timeouts := testMetrics()
+	// See TestTimeoutLogStore_DeleteRangeWaitsForInFlightWrite for why this
+	// is more generous than the bare-minimum timeout used elsewhere.
+	ls := newTimeoutLogStore(wal, 500*time.Millisecond, writeLatency, timeouts)
+	impl := ls.(*timeoutLogStore)
+
+	require.NoError(t, ls.StoreLogs([]*raft.Log{entry(1, 1), entry(2, 1), entry(3, 1)}))
+	epoch := impl.epoch.Load()
+
+	// Prefix compaction: truncate index 1 only, well short of the last
+	// index (3).
+	require.NoError(t, ls.DeleteRange(1, 1))
+	require.Equal(t, epoch, impl.epoch.Load(), "prefix compaction must not bump epoch")
+
+	// A write dispatched before the compaction (captured the old epoch)
+	// must still succeed.
+	require.NoError(t, impl.storeLogsAtEpoch([]*raft.Log{entry(4, 1)}, epoch))
+
+	last, err := wal.LastIndex()
+	require.NoError(t, err)
+	require.Equal(t, uint64(4), last)
+}

--- a/pkg/metastore/raftnode/logstore_test.go
+++ b/pkg/metastore/raftnode/logstore_test.go
@@ -1,0 +1,337 @@
+package raftnode
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/raft"
+	raftwal "github.com/hashicorp/raft-wal"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type writeGate struct {
+	release chan struct{}
+	entered chan struct{}
+
+	releaseOnce sync.Once
+	enteredOnce sync.Once
+}
+
+func (g *writeGate) unblock() {
+	g.releaseOnce.Do(func() { close(g.release) })
+}
+
+// gatedLogStore records calls and can block writes until its current gate is
+// released. It models a disk write that continues after the caller times out.
+type gatedLogStore struct {
+	store raft.LogStore
+
+	mu      sync.Mutex
+	gate    *writeGate
+	writes  [][]raft.Log
+	deletes [][2]uint64
+}
+
+func newGatedLogStore(store raft.LogStore) *gatedLogStore {
+	return &gatedLogStore{store: store}
+}
+
+func (g *gatedLogStore) arm() *writeGate {
+	gate := &writeGate{release: make(chan struct{}), entered: make(chan struct{})}
+	g.mu.Lock()
+	g.gate = gate
+	g.mu.Unlock()
+	return gate
+}
+
+func (g *gatedLogStore) StoreLog(log *raft.Log) error {
+	return g.StoreLogs([]*raft.Log{log})
+}
+
+func (g *gatedLogStore) StoreLogs(logs []*raft.Log) error {
+	copyLogs := make([]raft.Log, len(logs))
+	for i := range logs {
+		copyLogs[i] = *logs[i]
+	}
+
+	g.mu.Lock()
+	g.writes = append(g.writes, copyLogs)
+	gate := g.gate
+	g.mu.Unlock()
+	if gate != nil {
+		gate.enteredOnce.Do(func() { close(gate.entered) })
+		<-gate.release
+	}
+	return g.store.StoreLogs(logs)
+}
+
+func (g *gatedLogStore) DeleteRange(min, max uint64) error {
+	g.mu.Lock()
+	g.deletes = append(g.deletes, [2]uint64{min, max})
+	g.mu.Unlock()
+	return g.store.DeleteRange(min, max)
+}
+
+func (g *gatedLogStore) FirstIndex() (uint64, error) { return g.store.FirstIndex() }
+func (g *gatedLogStore) LastIndex() (uint64, error)  { return g.store.LastIndex() }
+func (g *gatedLogStore) GetLog(index uint64, log *raft.Log) error {
+	return g.store.GetLog(index, log)
+}
+
+func (g *gatedLogStore) IsMonotonic() bool {
+	if m, ok := g.store.(raft.MonotonicLogStore); ok {
+		return m.IsMonotonic()
+	}
+	return false
+}
+
+func (g *gatedLogStore) writeCount() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return len(g.writes)
+}
+
+func (g *gatedLogStore) deleteCount() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return len(g.deletes)
+}
+
+type lastIndexErrorStore struct {
+	raft.LogStore
+	err error
+}
+
+func (s lastIndexErrorStore) LastIndex() (uint64, error) { return 0, s.err }
+
+func testMetrics() (prometheus.Histogram, prometheus.Counter) {
+	return prometheus.NewHistogram(prometheus.HistogramOpts{Name: "test_write_latency"}),
+		prometheus.NewCounter(prometheus.CounterOpts{Name: "test_timeouts"})
+}
+
+func newTestLogStore(t *testing.T, store raft.LogStore, timeout time.Duration) (*timeoutLogStore, prometheus.Counter) {
+	t.Helper()
+	writeLatency, timeouts := testMetrics()
+	logStore, err := newTimeoutLogStore(store, timeout, writeLatency, timeouts)
+	require.NoError(t, err)
+	return logStore.(*timeoutLogStore), timeouts
+}
+
+func openWAL(t *testing.T) *raftwal.WAL {
+	t.Helper()
+	wal, err := raftwal.Open(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, wal.Close()) })
+	return wal
+}
+
+func entry(index, term uint64) *raft.Log {
+	return &raft.Log{Index: index, Term: term, Type: raft.LogCommand, Data: []byte("x")}
+}
+
+func entries(from, to, term uint64) []*raft.Log {
+	logs := make([]*raft.Log, 0, to-from+1)
+	for index := from; index <= to; index++ {
+		logs = append(logs, entry(index, term))
+	}
+	return logs
+}
+
+func waitForGate(t *testing.T, gate *writeGate) {
+	t.Helper()
+	select {
+	case <-gate.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for write to enter gate")
+	}
+}
+
+func waitForLastIndex(t *testing.T, store raft.LogStore, want uint64) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		last, err := store.LastIndex()
+		return err == nil && last == want
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func TestNewTimeoutLogStore_LastIndexError(t *testing.T) {
+	wantErr := errors.New("last index failed")
+	writeLatency, timeouts := testMetrics()
+	_, err := newTimeoutLogStore(lastIndexErrorStore{LogStore: newGatedLogStore(openWAL(t)), err: wantErr}, time.Second, writeLatency, timeouts)
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestTimeoutLogStore_AbandonedWriteRetry(t *testing.T) {
+	wal := openWAL(t)
+	gated := newGatedLogStore(wal)
+	logStore, timeouts := newTestLogStore(t, gated, 75*time.Millisecond)
+	gate := gated.arm()
+	t.Cleanup(gate.unblock)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- logStore.StoreLogs([]*raft.Log{entry(1, 1)}) }()
+	waitForGate(t, gate)
+	require.ErrorContains(t, <-errCh, "log store write timed out")
+	require.Equal(t, float64(1), testutil.ToFloat64(timeouts))
+
+	gate.unblock()
+	waitForLastIndex(t, wal, 1)
+	require.NoError(t, logStore.StoreLogs([]*raft.Log{entry(1, 1)}))
+	require.NoError(t, logStore.StoreLogs([]*raft.Log{entry(2, 1)}))
+	waitForLastIndex(t, wal, 2)
+	require.Equal(t, float64(1), testutil.ToFloat64(timeouts))
+}
+
+func TestTimeoutLogStore_ReconcileOverlap(t *testing.T) {
+	tests := []struct {
+		name        string
+		physical    []*raft.Log
+		incoming    []*raft.Log
+		wantTerms   map[uint64]uint64
+		missingFrom uint64
+	}{
+		{
+			name:      "partial identical overlap appends tail",
+			physical:  entries(3, 4, 1),
+			incoming:  append(entries(3, 4, 1), entries(5, 6, 1)...),
+			wantTerms: map[uint64]uint64{1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1},
+		},
+		{
+			name:        "conflict replaces physical suffix",
+			physical:    entries(3, 5, 1),
+			incoming:    entries(3, 4, 2),
+			wantTerms:   map[uint64]uint64{1: 1, 2: 1, 3: 2, 4: 2},
+			missingFrom: 5,
+		},
+		{
+			name:        "conflict after identical prefix replaces suffix",
+			physical:    entries(3, 5, 1),
+			incoming:    append(entries(3, 3, 1), entries(4, 5, 2)...),
+			wantTerms:   map[uint64]uint64{1: 1, 2: 1, 3: 1, 4: 2, 5: 2},
+			missingFrom: 6,
+		},
+		{
+			name:        "lower incoming term replaces unacknowledged suffix",
+			physical:    entries(3, 4, 2),
+			incoming:    entries(3, 4, 1),
+			wantTerms:   map[uint64]uint64{1: 1, 2: 1, 3: 1, 4: 1},
+			missingFrom: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wal := openWAL(t)
+			logStore, _ := newTestLogStore(t, wal, time.Second)
+			require.NoError(t, logStore.StoreLogs(entries(1, 2, 1)))
+			require.NoError(t, wal.StoreLogs(tt.physical))
+			require.NoError(t, logStore.StoreLogs(tt.incoming))
+
+			for index, term := range tt.wantTerms {
+				var got raft.Log
+				require.NoError(t, wal.GetLog(index, &got))
+				require.Equal(t, index, got.Index)
+				require.Equal(t, term, got.Term)
+			}
+			if tt.missingFrom > 0 {
+				var got raft.Log
+				require.ErrorIs(t, wal.GetLog(tt.missingFrom, &got), raft.ErrLogNotFound)
+			}
+		})
+	}
+}
+
+func TestTimeoutLogStore_WaitingWriteIsNotDispatched(t *testing.T) {
+	wal := openWAL(t)
+	gated := newGatedLogStore(wal)
+	logStore, timeouts := newTestLogStore(t, gated, 75*time.Millisecond)
+	gate := gated.arm()
+	t.Cleanup(gate.unblock)
+
+	firstErr := make(chan error, 1)
+	go func() { firstErr <- logStore.StoreLogs([]*raft.Log{entry(1, 1)}) }()
+	waitForGate(t, gate)
+	require.ErrorContains(t, <-firstErr, "log store write timed out")
+	require.ErrorContains(t, logStore.StoreLogs([]*raft.Log{entry(2, 1)}), "log store write timed out")
+	require.Equal(t, 1, gated.writeCount())
+	require.Equal(t, float64(2), testutil.ToFloat64(timeouts))
+
+	gate.unblock()
+	waitForLastIndex(t, wal, 1)
+	require.Equal(t, 1, gated.writeCount())
+	require.NoError(t, logStore.StoreLogs([]*raft.Log{entry(2, 1)}))
+	waitForLastIndex(t, wal, 2)
+}
+
+func TestTimeoutLogStore_DeleteRangeTimesOutWaitingForWrite(t *testing.T) {
+	wal := openWAL(t)
+	gated := newGatedLogStore(wal)
+	logStore, _ := newTestLogStore(t, gated, 75*time.Millisecond)
+	require.NoError(t, logStore.StoreLogs(entries(1, 2, 1)))
+	gate := gated.arm()
+	t.Cleanup(gate.unblock)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- logStore.StoreLogs([]*raft.Log{entry(3, 1)}) }()
+	waitForGate(t, gate)
+	require.ErrorContains(t, <-errCh, "log store write timed out")
+	require.ErrorContains(t, logStore.DeleteRange(1, 2), "timed out waiting for in-flight log store write")
+	require.Equal(t, 0, gated.deleteCount())
+
+	gate.unblock()
+	waitForLastIndex(t, wal, 3)
+	require.NoError(t, logStore.DeleteRange(1, 2))
+	require.Equal(t, 1, gated.deleteCount())
+	waitForLastIndex(t, wal, 0)
+}
+
+func TestTimeoutLogStore_DeleteRange(t *testing.T) {
+	tests := []struct {
+		name                string
+		acknowledgedLast    uint64
+		physicalLast        uint64
+		min, max            uint64
+		wantFirst, wantLast uint64
+	}{
+		{
+			name:             "logical suffix includes physical tail",
+			acknowledgedLast: 20,
+			physicalLast:     30,
+			min:              15,
+			max:              20,
+			wantFirst:        1,
+			wantLast:         14,
+		},
+		{
+			name:             "prefix compaction preserves tail",
+			acknowledgedLast: 30,
+			physicalLast:     30,
+			min:              1,
+			max:              10,
+			wantFirst:        11,
+			wantLast:         30,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wal := openWAL(t)
+			logStore, _ := newTestLogStore(t, wal, time.Second)
+			require.NoError(t, logStore.StoreLogs(entries(1, tt.acknowledgedLast, 1)))
+			if tt.physicalLast > tt.acknowledgedLast {
+				require.NoError(t, wal.StoreLogs(entries(tt.acknowledgedLast+1, tt.physicalLast, 1)))
+			}
+			require.NoError(t, logStore.DeleteRange(tt.min, tt.max))
+			first, err := wal.FirstIndex()
+			require.NoError(t, err)
+			require.Equal(t, tt.wantFirst, first)
+			last, err := wal.LastIndex()
+			require.NoError(t, err)
+			require.Equal(t, tt.wantLast, last)
+		})
+	}
+}

--- a/pkg/metastore/raftnode/node.go
+++ b/pkg/metastore/raftnode/node.go
@@ -266,7 +266,10 @@ func (n *Node) openStore() (err error) {
 		n.logStore = n.config.LogStoreMiddleware(n.logStore)
 	}
 
-	n.logStore = newTimeoutLogStore(n.logStore, n.config.LogStoreTimeout, n.metrics.logStoreWrite, n.metrics.logStoreTimeout)
+	n.logStore, err = newTimeoutLogStore(n.logStore, n.config.LogStoreTimeout, n.metrics.logStoreWrite, n.metrics.logStoreTimeout)
+	if err != nil {
+		return fmt.Errorf("initialize timeout log store: %w", err)
+	}
 	n.stableStore = n.wal
 	n.snapshotStore = n.snapshots
 	return nil

--- a/pkg/metastore/test/metastore_disk_stall_test.go
+++ b/pkg/metastore/test/metastore_disk_stall_test.go
@@ -1,0 +1,260 @@
+package test
+
+import (
+	"context"
+	"crypto/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grafana/dskit/flagext"
+	"github.com/hashicorp/raft"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	"github.com/grafana/pyroscope/v2/pkg/metastore"
+	"github.com/grafana/pyroscope/v2/pkg/metastore/raftnode/raftnodepb"
+	"github.com/grafana/pyroscope/v2/pkg/objstore/providers/memory"
+)
+
+// TestMetastoreDiskStall_FollowerRecoversAfterStalledWriteLands reproduces
+// the follower livelock fixed by timeoutLogStore's write reconciliation
+// (see pkg/metastore/raftnode/logstore.go): a slow disk write on a
+// follower is abandoned by the leader's replication retry logic once
+// timeoutLogStore's deadline elapses, but the goroutine performing the
+// write is not cancelled — it keeps running and eventually lands the
+// entry on disk anyway.
+//
+// This is a different fault model from
+// TestMetastoreDiskFailure_ClusterRecovery (#4892), whose faultInjector
+// blocks and then *fails* the call outright, so the delayed write never
+// lands. That test covers the leader-stuck-forever scenario #4892 fixed,
+// but its fault model can never exercise the bug fixed here: the real
+// raft-wal failure mode is block-then-*succeed* — the write is real, just
+// late. Once it lands, raft's retry for the same index hits an
+// already-persisted entry, which a monotonic store like raft-wal rejects
+// outright ("non-monotonic log entries"). Without reconciliation, that is
+// a permanent livelock: the follower is stuck reporting "too far behind"
+// forever, not just until the next heartbeat.
+//
+// Trailing-log and snapshot-threshold settings here are left at their
+// (generous) defaults, and few enough entries are written that no
+// InstallSnapshot ever triggers — recovery must come from ordinary log
+// replication reconciling with what the stalled write already persisted,
+// not from the leader happening to compact past the stuck index.
+func TestMetastoreDiskStall_FollowerRecoversAfterStalledWriteLands(t *testing.T) {
+	const clusterSize = 3
+
+	stalls := make([]*stallInjector, clusterSize)
+	for i := range stalls {
+		stalls[i] = &stallInjector{}
+	}
+
+	cfg := new(metastore.Config)
+	flagext.DefaultValues(cfg)
+	cfg.Raft.LogStoreTimeout = 500 * time.Millisecond
+
+	// Wire each node's log store through its stall injector.
+	// NewMetastoreSet creates nodes 0..n-1 in order, each calling
+	// LogStoreMiddleware during init.
+	var mu sync.Mutex
+	nodeIdx := 0
+	cfg.Raft.LogStoreMiddleware = func(store raft.LogStore) raft.LogStore {
+		mu.Lock()
+		i := nodeIdx
+		nodeIdx++
+		mu.Unlock()
+		stalls[i].store = store
+		return stalls[i]
+	}
+
+	ms := NewMetastoreSet(t, cfg, clusterSize, memory.NewInMemBucket())
+	defer func() {
+		for _, s := range stalls {
+			s.release()
+		}
+		ms.Close()
+	}()
+
+	leaderIdx := findLeader(t, ms)
+	followerIdx := (leaderIdx + 1) % clusterSize
+	t.Logf("leader is node %d, stalling follower node %d", leaderIdx, followerIdx)
+
+	// Stall the follower's log store: its next StoreLogs call blocks, then
+	// proceeds to the real underlying store once released.
+	stalls[followerIdx].stall()
+
+	// Write exactly one block through the leader while the follower is
+	// stalled. It commits via the healthy majority (leader + the other,
+	// non-stalled follower); timeoutLogStore on the stalled follower
+	// abandons its attempt to replicate it after LogStoreTimeout, but the
+	// goroutine performing the write is still running and will land it on
+	// disk once released.
+	//
+	// Deliberately only one: hashicorp/raft's pipeline-mode replication
+	// (which every follower graduates to once healthy, before we ever
+	// stall anything) sends AppendEntries without waiting for individual
+	// acks, handing each off to a decode goroutine over a small, bounded
+	// channel. If more than one write is issued here, a second pipelined
+	// send can block trying to hand off to that channel while the decode
+	// goroutine is itself blocked reading the (stalled) response to the
+	// first — and if the first response's failure then makes the decode
+	// goroutine exit, nothing is ever left to unblock that handoff. That
+	// is a real, pre-existing deadlock in raft's pipeline transport under
+	// a slow follower with multiple in-flight requests, independent of
+	// timeoutLogStore entirely; it's not what this test is about, so it
+	// only ever needs to drive a single request into that state.
+	blockID := ulid.MustNew(1, rand.Reader).String()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	_, err := ms.Instances[leaderIdx].AddBlock(ctx, &metastorev1.AddBlockRequest{
+		Block: &metastorev1.BlockMeta{Id: blockID},
+	})
+	cancel()
+	require.NoError(t, err, "write should commit via the healthy majority")
+	t.Logf("wrote block while follower %d was stalled", followerIdx)
+
+	leaderInfo := nodeInfo(t, ms, leaderIdx)
+	require.NotNil(t, leaderInfo)
+	leaderCommit := leaderInfo.GetCommitIndex()
+	t.Logf("leader commit index: %d", leaderCommit)
+
+	// Writing through the leader only needs a majority (leader + the
+	// other, non-stalled follower), so the write above can complete well
+	// within LogStoreTimeout without the stalled follower's attempt ever
+	// actually timing out — in which case it would just complete slowly
+	// but successfully once released, and there would be nothing
+	// abandoned to reconcile. Wait out multiple timeout windows here so
+	// the follower's StoreLogs call has genuinely been abandoned —
+	// reported as failed to raft, with its goroutine still running — and
+	// raft has fallen back from pipeline mode to retrying it individually,
+	// before releasing the stall.
+	time.Sleep(4 * cfg.Raft.LogStoreTimeout)
+
+	// Release the stall. The abandoned write's goroutine, still running
+	// underneath, now completes and lands the entry on disk, out of band
+	// from raft's view of it as failed. Without the reconciliation logic
+	// in timeoutLogStore, raft's retry for that same index would hit
+	// "non-monotonic log entries" and the follower would never catch up.
+	stalls[followerIdx].release()
+
+	// AppliedIndex (not just LastIndex) reaching the leader's commit index
+	// is the definitive proof of recovery: it means the follower's log
+	// store holds valid, correctly-ordered entries all the way through
+	// (raft never got permanently stuck retrying a "non-monotonic log
+	// entries" error), and its FSM successfully replayed every one of
+	// them. Without the fix, this would time out: the retry for the first
+	// abandoned index fails forever once the phantom write lands, and the
+	// follower's applied index never advances past it.
+	require.Eventually(t, func() bool {
+		info := nodeInfo(t, ms, followerIdx)
+		return info != nil && info.GetAppliedIndex() >= leaderCommit
+	}, 30*time.Second, 200*time.Millisecond,
+		"follower must catch up to the leader's commit index after the stalled writes land")
+
+	// GetBlockMetadata is served by the IndexService, which always reads
+	// through the leader by design (see Metastore.leaderRead); it cannot
+	// be used to directly inspect a follower's state. Reading the block
+	// back through the (still healthy, never-stalled) leader confirms the
+	// write path as a whole remained consistent throughout.
+	readCtx, readCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer readCancel()
+	resp, err := ms.Instances[leaderIdx].GetBlockMetadata(readCtx, &metastorev1.GetBlockMetadataRequest{
+		Blocks: &metastorev1.BlockList{Blocks: []string{blockID}},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.GetBlocks(), 1)
+
+	// The cluster overall must still be healthy: further writes commit
+	// normally through the leader, and the now-recovered (and now
+	// pipelining again) follower keeps up with them.
+	const moreBlocks = 10
+	for i := 0; i < moreBlocks; i++ {
+		writeCtx, writeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_, err = ms.Instances[leaderIdx].AddBlock(writeCtx, &metastorev1.AddBlockRequest{
+			Block: &metastorev1.BlockMeta{Id: ulid.MustNew(uint64(i+2), rand.Reader).String()},
+		})
+		writeCancel()
+		require.NoError(t, err)
+	}
+
+	leaderInfo = nodeInfo(t, ms, leaderIdx)
+	require.NotNil(t, leaderInfo)
+	require.Eventually(t, func() bool {
+		info := nodeInfo(t, ms, followerIdx)
+		return info != nil && info.GetAppliedIndex() >= leaderInfo.GetCommitIndex()
+	}, 30*time.Second, 200*time.Millisecond,
+		"recovered follower must keep up with further writes")
+}
+
+func nodeInfo(t *testing.T, ms MetastoreSet, idx int) *raftnodepb.NodeInfo {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	resp, err := ms.Instances[idx].NodeInfo(ctx, &raftnodepb.NodeInfoRequest{})
+	if err != nil {
+		return nil
+	}
+	return resp.GetNode()
+}
+
+// stallInjector wraps a raft.LogStore and can be switched to a "stalled"
+// mode where StoreLog/StoreLogs block until released, then proceed to the
+// real underlying store — i.e. the write is genuinely delayed, not
+// failed. This models a slow disk.
+//
+// This is deliberately different from faultInjector (used by
+// TestMetastoreDiskFailure_ClusterRecovery), which blocks and then fails
+// the call outright: that models a disk that never completes the write,
+// while stallInjector models one that eventually does, which is the
+// scenario timeoutLogStore's write reconciliation logic exists for.
+type stallInjector struct {
+	store   raft.LogStore
+	mu      sync.RWMutex
+	stalled chan struct{}
+}
+
+func (s *stallInjector) stall() {
+	s.mu.Lock()
+	s.stalled = make(chan struct{})
+	s.mu.Unlock()
+}
+
+func (s *stallInjector) release() {
+	s.mu.Lock()
+	if s.stalled != nil {
+		close(s.stalled)
+		s.stalled = nil
+	}
+	s.mu.Unlock()
+}
+
+func (s *stallInjector) awaitRelease() {
+	s.mu.RLock()
+	ch := s.stalled
+	s.mu.RUnlock()
+	if ch != nil {
+		<-ch
+	}
+}
+
+func (s *stallInjector) FirstIndex() (uint64, error)            { return s.store.FirstIndex() }
+func (s *stallInjector) LastIndex() (uint64, error)             { return s.store.LastIndex() }
+func (s *stallInjector) GetLog(idx uint64, log *raft.Log) error { return s.store.GetLog(idx, log) }
+func (s *stallInjector) DeleteRange(min, max uint64) error      { return s.store.DeleteRange(min, max) }
+
+func (s *stallInjector) IsMonotonic() bool {
+	if m, ok := s.store.(raft.MonotonicLogStore); ok {
+		return m.IsMonotonic()
+	}
+	return false
+}
+
+func (s *stallInjector) StoreLog(log *raft.Log) error {
+	return s.StoreLogs([]*raft.Log{log})
+}
+
+func (s *stallInjector) StoreLogs(logs []*raft.Log) error {
+	s.awaitRelease()
+	return s.store.StoreLogs(logs)
+}

--- a/pkg/metastore/test/metastore_disk_stall_test.go
+++ b/pkg/metastore/test/metastore_disk_stall_test.go
@@ -1,0 +1,233 @@
+package test
+
+import (
+	"context"
+	"crypto/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grafana/dskit/flagext"
+	"github.com/hashicorp/raft"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	"github.com/grafana/pyroscope/v2/pkg/metastore"
+	"github.com/grafana/pyroscope/v2/pkg/metastore/raftnode/raftnodepb"
+	"github.com/grafana/pyroscope/v2/pkg/objstore/providers/memory"
+)
+
+// TestMetastoreDiskStall_FollowerRecoversAfterStalledWriteLands reproduces
+// the follower livelock fixed by timeoutLogStore's write reconciliation
+// (see pkg/metastore/raftnode/logstore.go): a slow disk write on a
+// follower is abandoned by the leader's replication retry logic once
+// timeoutLogStore's deadline elapses, but the goroutine performing the
+// write is not cancelled — it keeps running and eventually lands the
+// entry on disk anyway.
+//
+// This is a different fault model from
+// TestMetastoreDiskFailure_ClusterRecovery (#4892), whose faultInjector
+// blocks and then *fails* the call outright, so the delayed write never
+// lands. That test covers the leader-stuck-forever scenario #4892 fixed,
+// but its fault model can never exercise the bug fixed here: the real
+// raft-wal failure mode is block-then-*succeed* — the write is real, just
+// late. Once it lands, raft's retry for the same index hits an
+// already-persisted entry, which a monotonic store like raft-wal rejects
+// outright ("non-monotonic log entries"). Without reconciliation, that is
+// a permanent livelock: the follower is stuck reporting "too far behind"
+// forever, not just until the next heartbeat.
+//
+// Trailing-log and snapshot-threshold settings here are left at their
+// (generous) defaults, and few enough entries are written that no
+// InstallSnapshot ever triggers — recovery must come from ordinary log
+// replication reconciling with what the stalled write already persisted,
+// not from the leader happening to compact past the stuck index.
+func TestMetastoreDiskStall_FollowerRecoversAfterStalledWriteLands(t *testing.T) {
+	const clusterSize = 3
+
+	stalls := make([]*stallInjector, clusterSize)
+	for i := range stalls {
+		stalls[i] = &stallInjector{}
+	}
+
+	cfg := new(metastore.Config)
+	flagext.DefaultValues(cfg)
+	cfg.Raft.LogStoreTimeout = 500 * time.Millisecond
+
+	// Wire each node's log store through its stall injector.
+	// NewMetastoreSet creates nodes 0..n-1 in order, each calling
+	// LogStoreMiddleware during init.
+	var mu sync.Mutex
+	nodeIdx := 0
+	cfg.Raft.LogStoreMiddleware = func(store raft.LogStore) raft.LogStore {
+		mu.Lock()
+		i := nodeIdx
+		nodeIdx++
+		mu.Unlock()
+		stalls[i].store = store
+		return stalls[i]
+	}
+
+	ms := NewMetastoreSet(t, cfg, clusterSize, memory.NewInMemBucket())
+	defer func() {
+		for _, s := range stalls {
+			s.release()
+		}
+		ms.Close()
+	}()
+
+	leaderIdx := findLeader(t, ms)
+	followerIdx := (leaderIdx + 1) % clusterSize
+	t.Logf("leader is node %d, stalling follower node %d", leaderIdx, followerIdx)
+
+	// Stall the follower's log store: its next StoreLogs call blocks, then
+	// proceeds to the real underlying store once released.
+	stall := stalls[followerIdx].stall()
+
+	// Write one block through the leader while the follower is
+	// stalled. It commits via the healthy majority (leader + the other,
+	// non-stalled follower); timeoutLogStore on the stalled follower
+	// abandons its attempt to replicate it after LogStoreTimeout, but the
+	// goroutine performing the write is still running and will land it on
+	// disk once released.
+	blockID := ulid.MustNew(1, rand.Reader).String()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	_, err := ms.Instances[leaderIdx].AddBlock(ctx, &metastorev1.AddBlockRequest{
+		Block: &metastorev1.BlockMeta{Id: blockID},
+	})
+	cancel()
+	require.NoError(t, err, "write should commit via the healthy majority")
+	t.Logf("wrote block while follower %d was stalled", followerIdx)
+
+	// The write must reach the stalled follower before the timeout window
+	// starts. Otherwise releasing the stall later could let an ordinary,
+	// non-abandoned write through and make this regression test pass without
+	// exercising reconciliation.
+	waitForStall(t, stall)
+	time.Sleep(cfg.Raft.LogStoreTimeout + 100*time.Millisecond)
+
+	// Release the stall. The abandoned write's goroutine, still running
+	// underneath, now completes and lands the entry on disk, out of band
+	// from raft's view of it as failed. Without the reconciliation logic
+	// in timeoutLogStore, raft's retry for that same index would hit
+	// "non-monotonic log entries" and the follower would never catch up.
+	stalls[followerIdx].release()
+
+	// A second append proves that recovery is ordinary log replication, not a
+	// coincidental catch-up to the first committed entry.
+	require.Equal(t, leaderIdx, findLeader(t, ms), "the original leader must remain in place")
+	block2ID := ulid.MustNew(2, rand.Reader).String()
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	_, err = ms.Instances[leaderIdx].AddBlock(ctx, &metastorev1.AddBlockRequest{
+		Block: &metastorev1.BlockMeta{Id: block2ID},
+	})
+	cancel()
+	require.NoError(t, err, "write after releasing the stalled follower should commit")
+
+	infoCtx, infoCancel := context.WithTimeout(context.Background(), time.Second)
+	leaderInfo, err := ms.Instances[leaderIdx].NodeInfo(infoCtx, &raftnodepb.NodeInfoRequest{})
+	infoCancel()
+	require.NoError(t, err)
+	targetIndex := leaderInfo.GetNode().GetCommitIndex()
+
+	// AppliedIndex reaching the captured post-recovery target proves the
+	// follower reconciled the late write and then replicated a new entry.
+	require.Eventually(t, func() bool {
+		followerCtx, followerCancel := context.WithTimeout(context.Background(), time.Second)
+		followerInfo, followerErr := ms.Instances[followerIdx].NodeInfo(followerCtx, &raftnodepb.NodeInfoRequest{})
+		followerCancel()
+		return followerErr == nil && followerInfo.GetNode().GetAppliedIndex() >= targetIndex
+	}, 30*time.Second, 100*time.Millisecond,
+		"follower must apply the post-recovery commit index")
+
+	readCtx, readCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	response, err := ms.Instances[leaderIdx].GetBlockMetadata(readCtx, &metastorev1.GetBlockMetadataRequest{
+		Blocks: &metastorev1.BlockList{Blocks: []string{blockID, block2ID}},
+	})
+	readCancel()
+	require.NoError(t, err)
+	require.Len(t, response.Blocks, 2)
+}
+
+// stallInjector wraps a raft.LogStore and can be switched to a "stalled"
+// mode where StoreLog/StoreLogs block until released, then proceed to the
+// real underlying store — i.e. the write is genuinely delayed, not
+// failed. This models a slow disk.
+//
+// This is deliberately different from faultInjector (used by
+// TestMetastoreDiskFailure_ClusterRecovery), which blocks and then fails
+// the call outright: that models a disk that never completes the write,
+// while stallInjector models one that eventually does, which is the
+// scenario timeoutLogStore's write reconciliation logic exists for.
+type stallInjector struct {
+	store raft.LogStore
+	mu    sync.Mutex
+	gate  *stall
+}
+
+type stall struct {
+	release chan struct{}
+	entered chan struct{}
+
+	releaseOnce sync.Once
+	enteredOnce sync.Once
+}
+
+func (s *stallInjector) stall() *stall {
+	stalled := &stall{release: make(chan struct{}), entered: make(chan struct{})}
+	s.mu.Lock()
+	s.gate = stalled
+	s.mu.Unlock()
+	return stalled
+}
+
+func (s *stallInjector) release() {
+	s.mu.Lock()
+	stalled := s.gate
+	s.gate = nil
+	s.mu.Unlock()
+	if stalled != nil {
+		stalled.releaseOnce.Do(func() { close(stalled.release) })
+	}
+}
+
+func (s *stallInjector) awaitRelease() {
+	s.mu.Lock()
+	stalled := s.gate
+	s.mu.Unlock()
+	if stalled != nil {
+		stalled.enteredOnce.Do(func() { close(stalled.entered) })
+		<-stalled.release
+	}
+}
+
+func waitForStall(t *testing.T, stalled *stall) {
+	t.Helper()
+	select {
+	case <-stalled.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for write to enter stalled log store")
+	}
+}
+
+func (s *stallInjector) FirstIndex() (uint64, error)            { return s.store.FirstIndex() }
+func (s *stallInjector) LastIndex() (uint64, error)             { return s.store.LastIndex() }
+func (s *stallInjector) GetLog(idx uint64, log *raft.Log) error { return s.store.GetLog(idx, log) }
+func (s *stallInjector) DeleteRange(min, max uint64) error      { return s.store.DeleteRange(min, max) }
+
+func (s *stallInjector) IsMonotonic() bool {
+	if m, ok := s.store.(raft.MonotonicLogStore); ok {
+		return m.IsMonotonic()
+	}
+	return false
+}
+
+func (s *stallInjector) StoreLog(log *raft.Log) error {
+	return s.StoreLogs([]*raft.Log{log})
+}
+
+func (s *stallInjector) StoreLogs(logs []*raft.Log) error {
+	s.awaitRelease()
+	return s.store.StoreLogs(logs)
+}


### PR DESCRIPTION
A log-store write may time out while continuing in the background. If it eventually succeeds, raft retries the same index and raft-wal rejects it as non-monotonic, leaving the follower permanently behind. This is a follow up to #4802

Serialize log mutations, reconcile late entries before retrying, and extend suffix truncation over stale physical tails. This allows followers to recover after temporary disk stalls.

Adds unit and cluster-level regression coverage for delayed writes.

### Limitations

A timed-out underlying operation cannot be cancelled through `raft.LogStore`. If it never returns, later mutations continue to time out waiting for the token; the safe recovery is to mark the node unhealthy and restart or replace it rather than issue concurrent WAL mutations.

### What changed since PR creation `950b6ab1551b3b811e78ceda43e91b595dba0283`

- Replaced the mutex plus truncation-epoch design with a capacity-one write token acquired before dispatch. Timed-out waiters now return without creating queued write goroutines, so only the one already-running operation can be abandoned.
- Removed lower-term rejection. Because no later mutation can pass the token while an abandoned write is active, any physical overlap beyond Raft's acknowledged tail can be reconciled by truncating the conflicting suffix and appending the requested entries.
- Reworked the unit tests around the token behavior, physical-tail reconciliation, timeout handling, and suffix versus prefix deletion. The cluster regression test remains focused on a delayed write that eventually succeeds.
