### PR TITLE
docs: Make clear what flags are v1 exclusive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,12 @@ GO_MOD_PATHS := api/ lidia/ examples/language-sdk-instrumentation/golang-push/ri
 # Add extra arguments to helm commands
 HELM_ARGS =
 
-HELM_FLAGS_V1 :=
-HELM_FLAGS_V1_MICROSERVICES := --set architecture.microservices.enabled=true --set minio.enabled=true
-HELM_FLAGS_V2 := --set architecture.storage.v1=false --set architecture.storage.v2=true
-HELM_FLAGS_V2_MICROSERVICES := $(HELM_FLAGS_V1_MICROSERVICES) $(HELM_FLAGS_V2)
+HELM_FLAGS_V1 := --set architecture.storage.v1=true --set architecture.storage.v2=false
+HELM_FLAGS_V1_MICROSERVICES := --set architecture.microservices.enabled=true --set minio.enabled=true $(HELM_FLAGS_V1)
+HELM_FLAGS_V1_DEPLOY := $(HELM_FLAGS_V1) --set pyroscope.extraArgs."pyroscopedb\.max-block-duration"=5m
+HELM_FLAGS_V1_MICROSERVICES_DEPLOY := $(HELM_FLAGS_V1_MICROSERVICES) --set pyroscope.extraArgs."pyroscopedb\.max-block-duration"=5m
+HELM_FLAGS_V2 :=
+HELM_FLAGS_V2_MICROSERVICES := --set architecture.microservices.enabled=true --set minio.enabled=true
 
 
 # Local deployment params
@@ -259,8 +261,7 @@ define deploy
 		--set-string pyroscope.podAnnotations."k8s\.grafana\.com/metrics\.scrapeInterval"=15s \
 		--set-string pyroscope.extraEnvVars.JAEGER_AGENT_HOST=pyroscope-monitoring-alloy-receiver \
 		--set pyroscope.extraEnvVars.JAEGER_SAMPLER_TYPE=const \
-		--set pyroscope.extraEnvVars.JAEGER_SAMPLER_PARAM=1 \
-		--set pyroscope.extraArgs."pyroscopedb\.max-block-duration"=5m
+		--set pyroscope.extraEnvVars.JAEGER_SAMPLER_PARAM=1
 endef
 
 # Function to handle multiarch image build. Depending on the
@@ -483,7 +484,7 @@ deploy: $(BIN)/kind $(BIN)/helm docker-image/pyroscope/build
 
 .PHONY: deploy-v1
 deploy-v1: $(BIN)/kind $(BIN)/helm docker-image/pyroscope/build
-	$(call deploy,pyroscope-dev,$(HELM_FLAGS_V1))
+	$(call deploy,pyroscope-dev,$(HELM_FLAGS_V1_DEPLOY))
 
 .PHONY: deploy-micro-services
 deploy-micro-services: $(BIN)/kind $(BIN)/helm docker-image/pyroscope/build
@@ -491,7 +492,7 @@ deploy-micro-services: $(BIN)/kind $(BIN)/helm docker-image/pyroscope/build
 
 .PHONY: deploy-micro-services-v1
 deploy-micro-services-v1: $(BIN)/kind $(BIN)/helm docker-image/pyroscope/build
-	$(call deploy,pyroscope-micro-services,$(HELM_FLAGS_V1_MICROSERVICES))
+	$(call deploy,pyroscope-micro-services,$(HELM_FLAGS_V1_MICROSERVICES_DEPLOY))
 
 .PHONY: deploy-monitoring
 deploy-monitoring: $(BIN)/kind $(BIN)/helm

--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -78,131 +78,131 @@ Usage of ./pyroscope:
   -compaction-worker.temp-dir string
     	Temporary directory for compaction jobs. (default "/tmp")
   -compactor.block-ranges value
-    	List of compaction time ranges. (default 1h0m0s,2h0m0s,8h0m0s)
+    	[v1 storage only] List of compaction time ranges. (default 1h0m0s,2h0m0s,8h0m0s)
   -compactor.block-sync-concurrency int
-    	Number of Go routines to use when downloading blocks for compaction and uploading resulting blocks. (default 8)
+    	[v1 storage only] Number of Go routines to use when downloading blocks for compaction and uploading resulting blocks. (default 8)
   -compactor.blocks-retention-period duration
-    	Delete blocks containing samples older than the specified retention period. 0 to disable.
+    	[v1 storage only] Delete blocks containing samples older than the specified retention period. 0 to disable.
   -compactor.cleanup-concurrency int
-    	Max number of tenants for which blocks cleanup and maintenance should run concurrently. (default 20)
+    	[v1 storage only] Max number of tenants for which blocks cleanup and maintenance should run concurrently. (default 20)
   -compactor.cleanup-interval duration
-    	How frequently compactor should run blocks cleanup and maintenance, as well as update the bucket index. (default 15m0s)
+    	[v1 storage only] How frequently compactor should run blocks cleanup and maintenance, as well as update the bucket index. (default 15m0s)
   -compactor.compaction-concurrency int
-    	Max number of concurrent compactions running. (default 1)
+    	[v1 storage only] Max number of concurrent compactions running. (default 1)
   -compactor.compaction-interval duration
-    	The frequency at which the compaction runs (default 30m0s)
+    	[v1 storage only] The frequency at which the compaction runs (default 30m0s)
   -compactor.compaction-jobs-order string
-    	The sorting to use when deciding which compaction jobs should run first for a given tenant. Supported values are: smallest-range-oldest-blocks-first, newest-blocks-first. (default "smallest-range-oldest-blocks-first")
+    	[v1 storage only] The sorting to use when deciding which compaction jobs should run first for a given tenant. Supported values are: smallest-range-oldest-blocks-first, newest-blocks-first. (default "smallest-range-oldest-blocks-first")
   -compactor.compaction-retries int
-    	How many times to retry a failed compaction within a single compaction run. (default 3)
+    	[v1 storage only] How many times to retry a failed compaction within a single compaction run. (default 3)
   -compactor.compaction-split-by string
-    	Experimental: The strategy to use when splitting blocks during compaction. Supported values are: fingerprint, stacktracePartition. (default "fingerprint")
+    	[v1 storage only] Experimental: The strategy to use when splitting blocks during compaction. Supported values are: fingerprint, stacktracePartition. (default "fingerprint")
   -compactor.compactor-downsampler-enabled
-    	If enabled, the compactor will downsample profiles in blocks at compaction level 3 and above. The original profiles are also kept. Note: This set the default for the teanant overrides, in order to be effective it also requires compactor.downsampler-enabled to be set to true. (default true)
+    	[v1 storage only] If enabled, the compactor will downsample profiles in blocks at compaction level 3 and above. The original profiles are also kept. Note: This set the default for the teanant overrides, in order to be effective it also requires compactor.downsampler-enabled to be set to true. (default true)
   -compactor.compactor-tenant-shard-size int
-    	Max number of compactors that can compact blocks for single tenant. 0 to disable the limit and use all compactors.
+    	[v1 storage only] Max number of compactors that can compact blocks for single tenant. 0 to disable the limit and use all compactors.
   -compactor.data-dir string
-    	Directory to temporarily store blocks during compaction. This directory is not required to be persisted between restarts. (default "./data-compactor")
+    	[v1 storage only] Directory to temporarily store blocks during compaction. This directory is not required to be persisted between restarts. (default "./data-compactor")
   -compactor.deletion-delay duration
-    	Time before a block marked for deletion is deleted from bucket. If not 0, blocks will be marked for deletion and compactor component will permanently delete blocks marked for deletion from the bucket. If 0, blocks will be deleted straight away. Note that deleting blocks immediately can cause query failures. (default 12h0m0s)
+    	[v1 storage only] Time before a block marked for deletion is deleted from bucket. If not 0, blocks will be marked for deletion and compactor component will permanently delete blocks marked for deletion from the bucket. If 0, blocks will be deleted straight away. Note that deleting blocks immediately can cause query failures. (default 12h0m0s)
   -compactor.disabled-tenants comma-separated-list-of-strings
-    	Comma separated list of tenants that cannot be compacted by this compactor. If specified, and compactor would normally pick given tenant for compaction (via -compactor.enabled-tenants or sharding), it will be ignored instead.
+    	[v1 storage only] Comma separated list of tenants that cannot be compacted by this compactor. If specified, and compactor would normally pick given tenant for compaction (via -compactor.enabled-tenants or sharding), it will be ignored instead.
   -compactor.downsampler-enabled
-    	If enabled, the compactor will downsample profiles in blocks at compaction level 3 and above. The original profiles are also kept.
+    	[v1 storage only] If enabled, the compactor will downsample profiles in blocks at compaction level 3 and above. The original profiles are also kept.
   -compactor.enabled-tenants comma-separated-list-of-strings
-    	Comma separated list of tenants that can be compacted. If specified, only these tenants will be compacted by compactor, otherwise all tenants can be compacted. Subject to sharding.
+    	[v1 storage only] Comma separated list of tenants that can be compacted. If specified, only these tenants will be compacted by compactor, otherwise all tenants can be compacted. Subject to sharding.
   -compactor.first-level-compaction-wait-period duration
-    	How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters. This configuration option allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. (default 25m0s)
+    	[v1 storage only] How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters. This configuration option allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. (default 25m0s)
   -compactor.max-compaction-time duration
-    	Max time for starting compactions for a single tenant. After this time no new compactions for the tenant are started before next compaction cycle. This can help in multi-tenant environments to avoid single tenant using all compaction time, but also in single-tenant environments to force new discovery of blocks more often. 0 = disabled. (default 1h0m0s)
+    	[v1 storage only] Max time for starting compactions for a single tenant. After this time no new compactions for the tenant are started before next compaction cycle. This can help in multi-tenant environments to avoid single tenant using all compaction time, but also in single-tenant environments to force new discovery of blocks more often. 0 = disabled. (default 1h0m0s)
   -compactor.max-opening-blocks-concurrency int
-    	Number of goroutines opening blocks before compaction. (default 16)
+    	[v1 storage only] Number of goroutines opening blocks before compaction. (default 16)
   -compactor.meta-sync-concurrency int
-    	Number of Go routines to use when syncing block meta files from the long term storage. (default 20)
+    	[v1 storage only] Number of Go routines to use when syncing block meta files from the long term storage. (default 20)
   -compactor.no-blocks-file-cleanup-enabled
-    	[experimental] If enabled, will delete the bucket-index, markers and debug files in the tenant bucket when there are no blocks left in the index.
+    	[experimental] [v1 storage only] If enabled, will delete the bucket-index, markers and debug files in the tenant bucket when there are no blocks left in the index.
   -compactor.partial-block-deletion-delay duration
-    	If a partial block (unfinished block without meta.json file) hasn't been modified for this time, it will be marked for deletion. The minimum accepted value is 4h0m0s: a lower value will be ignored and the feature disabled. 0 to disable. (default 1d)
+    	[v1 storage only] If a partial block (unfinished block without meta.json file) hasn't been modified for this time, it will be marked for deletion. The minimum accepted value is 4h0m0s: a lower value will be ignored and the feature disabled. 0 to disable. (default 1d)
   -compactor.ring.consul.acl-token string
-    	ACL Token used to interact with Consul.
+    	[v1 storage only] ACL Token used to interact with Consul.
   -compactor.ring.consul.cas-retry-delay duration
-    	Maximum duration to wait before retrying a Compare And Swap (CAS) operation. (default 1s)
+    	[v1 storage only] Maximum duration to wait before retrying a Compare And Swap (CAS) operation. (default 1s)
   -compactor.ring.consul.client-timeout duration
-    	HTTP timeout when talking to Consul (default 20s)
+    	[v1 storage only] HTTP timeout when talking to Consul (default 20s)
   -compactor.ring.consul.consistent-reads
-    	Enable consistent reads to Consul.
+    	[v1 storage only] Enable consistent reads to Consul.
   -compactor.ring.consul.hostname string
-    	Hostname and port of Consul. (default "localhost:8500")
+    	[v1 storage only] Hostname and port of Consul. (default "localhost:8500")
   -compactor.ring.consul.watch-burst-size int
-    	Burst size used in rate limit. Values less than 1 are treated as 1. (default 1)
+    	[v1 storage only] Burst size used in rate limit. Values less than 1 are treated as 1. (default 1)
   -compactor.ring.consul.watch-rate-limit float
-    	Rate limit when watching key or prefix in Consul, in requests per second. 0 disables the rate limit. (default 1)
+    	[v1 storage only] Rate limit when watching key or prefix in Consul, in requests per second. 0 disables the rate limit. (default 1)
   -compactor.ring.etcd.dial-timeout duration
-    	The dial timeout for the etcd connection. (default 10s)
+    	[v1 storage only] The dial timeout for the etcd connection. (default 10s)
   -compactor.ring.etcd.endpoints string
-    	The etcd endpoints to connect to.
+    	[v1 storage only] The etcd endpoints to connect to.
   -compactor.ring.etcd.max-retries int
-    	The maximum number of retries to do for failed ops. (default 10)
+    	[v1 storage only] The maximum number of retries to do for failed ops. (default 10)
   -compactor.ring.etcd.password string
-    	Etcd password.
+    	[v1 storage only] Etcd password.
   -compactor.ring.etcd.tls-ca-path string
-    	Path to the CA certificates to validate server certificate against. If not set, the host's root CA certificates are used.
+    	[v1 storage only] Path to the CA certificates to validate server certificate against. If not set, the host's root CA certificates are used.
   -compactor.ring.etcd.tls-cert-path string
-    	Path to the client certificate, which will be used for authenticating with the server. Also requires the key path to be configured.
+    	[v1 storage only] Path to the client certificate, which will be used for authenticating with the server. Also requires the key path to be configured.
   -compactor.ring.etcd.tls-cipher-suites string
-    	Override the default cipher suite list (separated by commas).
+    	[v1 storage only] Override the default cipher suite list (separated by commas).
   -compactor.ring.etcd.tls-enabled
-    	Enable TLS.
+    	[v1 storage only] Enable TLS.
   -compactor.ring.etcd.tls-insecure-skip-verify
-    	Skip validating server certificate.
+    	[v1 storage only] Skip validating server certificate.
   -compactor.ring.etcd.tls-key-path string
-    	Path to the key for the client certificate. Also requires the client certificate to be configured.
+    	[v1 storage only] Path to the key for the client certificate. Also requires the client certificate to be configured.
   -compactor.ring.etcd.tls-min-version string
-    	Override the default minimum TLS version. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
+    	[v1 storage only] Override the default minimum TLS version. Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
   -compactor.ring.etcd.tls-server-name string
-    	Override the expected name on the server certificate.
+    	[v1 storage only] Override the expected name on the server certificate.
   -compactor.ring.etcd.username string
-    	Etcd username.
+    	[v1 storage only] Etcd username.
   -compactor.ring.heartbeat-period duration
-    	Period at which to heartbeat to the ring. 0 = disabled. (default 15s)
+    	[v1 storage only] Period at which to heartbeat to the ring. 0 = disabled. (default 15s)
   -compactor.ring.heartbeat-timeout duration
-    	The heartbeat timeout after which compactors are considered unhealthy within the ring. 0 = never (timeout disabled). (default 1m0s)
+    	[v1 storage only] The heartbeat timeout after which compactors are considered unhealthy within the ring. 0 = never (timeout disabled). (default 1m0s)
   -compactor.ring.instance-addr string
-    	IP address to advertise in the ring. Default is auto-detected.
+    	[v1 storage only] IP address to advertise in the ring. Default is auto-detected.
   -compactor.ring.instance-enable-ipv6
-    	Enable using a IPv6 instance address. (default false)
+    	[v1 storage only] Enable using a IPv6 instance address. (default false)
   -compactor.ring.instance-id string
-    	Instance ID to register in the ring. (default "<hostname>")
+    	[v1 storage only] Instance ID to register in the ring. (default "<hostname>")
   -compactor.ring.instance-interface-names string
-    	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
+    	[v1 storage only] List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -compactor.ring.instance-port int
-    	Port to advertise in the ring (defaults to -server.http-listen-port).
+    	[v1 storage only] Port to advertise in the ring (defaults to -server.http-listen-port).
   -compactor.ring.multi.mirror-enabled
-    	Mirror writes to the secondary store.
+    	[v1 storage only] Mirror writes to the secondary store.
   -compactor.ring.multi.mirror-timeout duration
-    	Timeout for storing a value to the secondary store. (default 2s)
+    	[v1 storage only] Timeout for storing a value to the secondary store. (default 2s)
   -compactor.ring.multi.primary string
-    	Primary backend storage used by multi-client.
+    	[v1 storage only] Primary backend storage used by multi-client.
   -compactor.ring.multi.secondary string
-    	Secondary backend storage used by multi-client.
+    	[v1 storage only] Secondary backend storage used by multi-client.
   -compactor.ring.prefix string
-    	The prefix for the keys in the store. Should end with a /. (default "collectors/")
+    	[v1 storage only] The prefix for the keys in the store. Should end with a /. (default "collectors/")
   -compactor.ring.store string
-    	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
+    	[v1 storage only] Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
   -compactor.ring.wait-active-instance-timeout duration
-    	Timeout for waiting on compactor to become ACTIVE in the ring. (default 10m0s)
+    	[v1 storage only] Timeout for waiting on compactor to become ACTIVE in the ring. (default 10m0s)
   -compactor.ring.wait-stability-max-duration duration
-    	Maximum time to wait for ring stability at startup. If the compactor ring keeps changing after this period of time, the compactor will start anyway. (default 5m0s)
+    	[v1 storage only] Maximum time to wait for ring stability at startup. If the compactor ring keeps changing after this period of time, the compactor will start anyway. (default 5m0s)
   -compactor.ring.wait-stability-min-duration duration
-    	Minimum time to wait for ring stability at startup. 0 to disable.
+    	[v1 storage only] Minimum time to wait for ring stability at startup. 0 to disable.
   -compactor.shutdown-timeout duration
-    	Maximum time to wait for in-flight cleanup and ring operations to finish during shutdown. If the timeout is reached, the compactor will forcefully stop. 0 = no timeout (wait indefinitely).
+    	[v1 storage only] Maximum time to wait for in-flight cleanup and ring operations to finish during shutdown. If the timeout is reached, the compactor will forcefully stop. 0 = no timeout (wait indefinitely).
   -compactor.split-and-merge-shards int
-    	The number of shards to use when splitting blocks. 0 to disable splitting.
+    	[v1 storage only] The number of shards to use when splitting blocks. 0 to disable splitting.
   -compactor.split-and-merge-stage-size int
-    	Number of stages split shards will be written to. Number of output split shards is controlled by -compactor.split-and-merge-shards.
+    	[v1 storage only] Number of stages split shards will be written to. Number of output split shards is controlled by -compactor.split-and-merge-shards.
   -compactor.split-groups int
-    	Number of groups that blocks for splitting should be grouped into. Each group of blocks is then split separately. Number of output split shards is controlled by -compactor.split-and-merge-shards. (default 1)
+    	[v1 storage only] Number of groups that blocks for splitting should be grouped into. Each group of blocks is then split separately. Number of output split shards is controlled by -compactor.split-and-merge-shards. (default 1)
   -config.expand-env
     	Expands ${var} in config according to the values of the environment variables.
   -config.file string
@@ -374,41 +374,41 @@ Usage of ./pyroscope:
   -help-all
     	Print help, also including advanced and experimental parameters.
   -ingester.availability-zone string
-    	The availability zone where this instance is running.
+    	[v1 storage only] The availability zone where this instance is running.
   -ingester.enable-inet6
-    	Enable IPv6 support. Required to make use of IP addresses from IPv6 interfaces.
+    	[v1 storage only] Enable IPv6 support. Required to make use of IP addresses from IPv6 interfaces.
   -ingester.final-sleep duration
-    	Duration to sleep for before exiting, to ensure metrics are scraped.
+    	[v1 storage only] Duration to sleep for before exiting, to ensure metrics are scraped.
   -ingester.heartbeat-period duration
-    	Period at which to heartbeat to consul. (default 5s)
+    	[v1 storage only] Period at which to heartbeat to consul. (default 5s)
   -ingester.heartbeat-timeout duration
-    	Heartbeat timeout after which instance is assumed to be unhealthy. (default 1m0s)
+    	[v1 storage only] Heartbeat timeout after which instance is assumed to be unhealthy. (default 1m0s)
   -ingester.join-after duration
-    	Period to wait for a claim from another member; will join automatically after this.
+    	[v1 storage only] Period to wait for a claim from another member; will join automatically after this.
   -ingester.lifecycler.ID string
-    	ID to register in the ring. (default "<hostname>")
+    	[v1 storage only] ID to register in the ring. (default "<hostname>")
   -ingester.lifecycler.addr string
-    	IP address to advertise in the ring.
+    	[v1 storage only] IP address to advertise in the ring.
   -ingester.lifecycler.interface string
-    	Name of network interface to read address from. (default [<private network interfaces>])
+    	[v1 storage only] Name of network interface to read address from. (default [<private network interfaces>])
   -ingester.lifecycler.port int
-    	port to advertise in consul (defaults to server.grpc-listen-port).
+    	[v1 storage only] port to advertise in consul (defaults to server.grpc-listen-port).
   -ingester.max-global-series-per-tenant int
-    	Maximum number of active series of profiles per tenant, across the cluster. 0 to disable. When the global limit is enabled, each ingester is configured with a dynamic local limit based on the replication factor and the current number of healthy ingesters, and is kept updated whenever the number of ingesters change. (default 5000)
+    	[v1 storage only] Maximum number of active series of profiles per tenant, across the cluster. 0 to disable. When the global limit is enabled, each ingester is configured with a dynamic local limit based on the replication factor and the current number of healthy ingesters, and is kept updated whenever the number of ingesters change. (default 5000)
   -ingester.max-local-series-per-tenant int
-    	Maximum number of active series of profiles per tenant, per ingester. 0 to disable.
+    	[v1 storage only] Maximum number of active series of profiles per tenant, per ingester. 0 to disable.
   -ingester.min-ready-duration duration
-    	Minimum duration to wait after the internal readiness checks have passed but before succeeding the readiness endpoint. This is used to slowdown deployment controllers (eg. Kubernetes) after an instance is ready and before they proceed with a rolling update, to give the rest of the cluster instances enough time to receive ring updates. (default 15s)
+    	[v1 storage only] Minimum duration to wait after the internal readiness checks have passed but before succeeding the readiness endpoint. This is used to slowdown deployment controllers (eg. Kubernetes) after an instance is ready and before they proceed with a rolling update, to give the rest of the cluster instances enough time to receive ring updates. (default 15s)
   -ingester.num-tokens int
-    	Number of tokens for each ingester. (default 128)
+    	[v1 storage only] Number of tokens for each ingester. (default 128)
   -ingester.observe-period duration
-    	Observe tokens after generating to resolve collisions. Useful when using gossiping ring.
+    	[v1 storage only] Observe tokens after generating to resolve collisions. Useful when using gossiping ring.
   -ingester.readiness-check-ring-health
-    	When enabled the readiness probe succeeds only after all instances are ACTIVE and healthy in the ring, otherwise only the instance itself is checked. This option should be disabled if in your cluster multiple instances can be rolled out simultaneously, otherwise rolling updates may be slowed down. (default true)
+    	[v1 storage only] When enabled the readiness probe succeeds only after all instances are ACTIVE and healthy in the ring, otherwise only the instance itself is checked. This option should be disabled if in your cluster multiple instances can be rolled out simultaneously, otherwise rolling updates may be slowed down. (default true)
   -ingester.tokens-file-path string
-    	File path where tokens are stored. If empty, tokens are not stored at shutdown and restored at startup.
+    	[v1 storage only] File path where tokens are stored. If empty, tokens are not stored at shutdown and restored at startup.
   -ingester.unregister-on-shutdown
-    	Unregister from the ring upon clean shutdown. It can be useful to disable for rolling restarts with consistent naming in conjunction with -distributor.extend-writes=false. (default true)
+    	[v1 storage only] Unregister from the ring upon clean shutdown. It can be useful to disable for rolling restarts with consistent naming in conjunction with -distributor.extend-writes=false. (default true)
   -log.format string
     	Output log messages in the given format. Valid formats: [logfmt, json] (default "logfmt")
   -log.level value
@@ -722,21 +722,21 @@ Usage of ./pyroscope:
   -overrides-exporter.ring.wait-stability-min-duration duration
     	Minimum time to wait for ring stability at startup, if set to positive value. Set to 0 to disable.
   -pyroscopedb.data-path string
-    	Directory used for local storage. (default "./data")
+    	[v1 storage only] Directory used for local storage. (default "./data")
   -pyroscopedb.max-block-duration duration
-    	Upper limit to the duration of a Pyroscope block. (default 1h0m0s)
+    	[v1 storage only] Upper limit to the duration of a Pyroscope block. (default 1h0m0s)
   -pyroscopedb.retention-policy-disable
-    	Disable retention policy enforcement
+    	[v1 storage only] Disable retention policy enforcement
   -pyroscopedb.retention-policy-enforcement-interval duration
-    	How often to enforce disk retention (default 5m0s)
+    	[v1 storage only] How often to enforce disk retention (default 5m0s)
   -pyroscopedb.retention-policy-min-disk-available-percentage float
-    	Which percentage of free disk space to keep (default 0.05)
+    	[v1 storage only] Which percentage of free disk space to keep (default 0.05)
   -pyroscopedb.retention-policy-min-free-disk-gb uint
-    	How much available disk space to keep in GiB (default 10)
+    	[v1 storage only] How much available disk space to keep in GiB (default 10)
   -pyroscopedb.row-group-target-size uint
-    	How big should a single row group be uncompressed (default 1342177280)
+    	[v1 storage only] How big should a single row group be uncompressed (default 1342177280)
   -pyroscopedb.symbols-partition-label string
-    	Specifies the dimension by which symbols are partitioned. By default, the partitioning is determined automatically.
+    	[v1 storage only] Specifies the dimension by which symbols are partitioned. By default, the partitioning is determined automatically.
   -querier.client-cleanup-period duration
     	How frequently to clean up clients for ingesters that have gone away. (default 15s)
   -querier.frontend-client.backoff-max-period duration

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -14,35 +14,35 @@ Usage of ./pyroscope:
   -blocks-storage.bucket-store.sync-dir string
     	Directory to store synchronized pyroscope block headers. This directory is not required to be persisted between restarts, but it's highly recommended in order to improve the store-gateway startup time. (default "./data/pyroscope-sync/")
   -compactor.blocks-retention-period duration
-    	Delete blocks containing samples older than the specified retention period. 0 to disable.
+    	[v1 storage only] Delete blocks containing samples older than the specified retention period. 0 to disable.
   -compactor.compactor-downsampler-enabled
-    	If enabled, the compactor will downsample profiles in blocks at compaction level 3 and above. The original profiles are also kept. Note: This set the default for the teanant overrides, in order to be effective it also requires compactor.downsampler-enabled to be set to true. (default true)
+    	[v1 storage only] If enabled, the compactor will downsample profiles in blocks at compaction level 3 and above. The original profiles are also kept. Note: This set the default for the teanant overrides, in order to be effective it also requires compactor.downsampler-enabled to be set to true. (default true)
   -compactor.compactor-tenant-shard-size int
-    	Max number of compactors that can compact blocks for single tenant. 0 to disable the limit and use all compactors.
+    	[v1 storage only] Max number of compactors that can compact blocks for single tenant. 0 to disable the limit and use all compactors.
   -compactor.data-dir string
-    	Directory to temporarily store blocks during compaction. This directory is not required to be persisted between restarts. (default "./data-compactor")
+    	[v1 storage only] Directory to temporarily store blocks during compaction. This directory is not required to be persisted between restarts. (default "./data-compactor")
   -compactor.first-level-compaction-wait-period duration
-    	How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters. This configuration option allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. (default 25m0s)
+    	[v1 storage only] How long the compactor waits before compacting first-level blocks that are uploaded by the ingesters. This configuration option allows for the reduction of cases where the compactor begins to compact blocks before all ingesters have uploaded their blocks to the storage. (default 25m0s)
   -compactor.partial-block-deletion-delay duration
-    	If a partial block (unfinished block without meta.json file) hasn't been modified for this time, it will be marked for deletion. The minimum accepted value is 4h0m0s: a lower value will be ignored and the feature disabled. 0 to disable. (default 1d)
+    	[v1 storage only] If a partial block (unfinished block without meta.json file) hasn't been modified for this time, it will be marked for deletion. The minimum accepted value is 4h0m0s: a lower value will be ignored and the feature disabled. 0 to disable. (default 1d)
   -compactor.ring.consul.hostname string
-    	Hostname and port of Consul. (default "localhost:8500")
+    	[v1 storage only] Hostname and port of Consul. (default "localhost:8500")
   -compactor.ring.etcd.endpoints string
-    	The etcd endpoints to connect to.
+    	[v1 storage only] The etcd endpoints to connect to.
   -compactor.ring.etcd.password string
-    	Etcd password.
+    	[v1 storage only] Etcd password.
   -compactor.ring.etcd.username string
-    	Etcd username.
+    	[v1 storage only] Etcd username.
   -compactor.ring.instance-interface-names string
-    	List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
+    	[v1 storage only] List of network interface names to look up when finding the instance IP address. (default [<private network interfaces>])
   -compactor.ring.store string
-    	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
+    	[v1 storage only] Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
   -compactor.split-and-merge-shards int
-    	The number of shards to use when splitting blocks. 0 to disable splitting.
+    	[v1 storage only] The number of shards to use when splitting blocks. 0 to disable splitting.
   -compactor.split-and-merge-stage-size int
-    	Number of stages split shards will be written to. Number of output split shards is controlled by -compactor.split-and-merge-shards.
+    	[v1 storage only] Number of stages split shards will be written to. Number of output split shards is controlled by -compactor.split-and-merge-shards.
   -compactor.split-groups int
-    	Number of groups that blocks for splitting should be grouped into. Each group of blocks is then split separately. Number of output split shards is controlled by -compactor.split-and-merge-shards. (default 1)
+    	[v1 storage only] Number of groups that blocks for splitting should be grouped into. Each group of blocks is then split separately. Number of output split shards is controlled by -compactor.split-and-merge-shards. (default 1)
   -config.expand-env
     	Expands ${var} in config according to the values of the environment variables.
   -config.file string
@@ -106,15 +106,15 @@ Usage of ./pyroscope:
   -help-all
     	Print help, also including advanced and experimental parameters.
   -ingester.availability-zone string
-    	The availability zone where this instance is running.
+    	[v1 storage only] The availability zone where this instance is running.
   -ingester.lifecycler.interface string
-    	Name of network interface to read address from. (default [<private network interfaces>])
+    	[v1 storage only] Name of network interface to read address from. (default [<private network interfaces>])
   -ingester.max-global-series-per-tenant int
-    	Maximum number of active series of profiles per tenant, across the cluster. 0 to disable. When the global limit is enabled, each ingester is configured with a dynamic local limit based on the replication factor and the current number of healthy ingesters, and is kept updated whenever the number of ingesters change. (default 5000)
+    	[v1 storage only] Maximum number of active series of profiles per tenant, across the cluster. 0 to disable. When the global limit is enabled, each ingester is configured with a dynamic local limit based on the replication factor and the current number of healthy ingesters, and is kept updated whenever the number of ingesters change. (default 5000)
   -ingester.max-local-series-per-tenant int
-    	Maximum number of active series of profiles per tenant, per ingester. 0 to disable.
+    	[v1 storage only] Maximum number of active series of profiles per tenant, per ingester. 0 to disable.
   -ingester.tokens-file-path string
-    	File path where tokens are stored. If empty, tokens are not stored at shutdown and restored at startup.
+    	[v1 storage only] File path where tokens are stored. If empty, tokens are not stored at shutdown and restored at startup.
   -log.format string
     	Output log messages in the given format. Valid formats: [logfmt, json] (default "logfmt")
   -log.level value
@@ -152,21 +152,21 @@ Usage of ./pyroscope:
   -overrides-exporter.ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
   -pyroscopedb.data-path string
-    	Directory used for local storage. (default "./data")
+    	[v1 storage only] Directory used for local storage. (default "./data")
   -pyroscopedb.max-block-duration duration
-    	Upper limit to the duration of a Pyroscope block. (default 1h0m0s)
+    	[v1 storage only] Upper limit to the duration of a Pyroscope block. (default 1h0m0s)
   -pyroscopedb.retention-policy-disable
-    	Disable retention policy enforcement
+    	[v1 storage only] Disable retention policy enforcement
   -pyroscopedb.retention-policy-enforcement-interval duration
-    	How often to enforce disk retention (default 5m0s)
+    	[v1 storage only] How often to enforce disk retention (default 5m0s)
   -pyroscopedb.retention-policy-min-disk-available-percentage float
-    	Which percentage of free disk space to keep (default 0.05)
+    	[v1 storage only] Which percentage of free disk space to keep (default 0.05)
   -pyroscopedb.retention-policy-min-free-disk-gb uint
-    	How much available disk space to keep in GiB (default 10)
+    	[v1 storage only] How much available disk space to keep in GiB (default 10)
   -pyroscopedb.row-group-target-size uint
-    	How big should a single row group be uncompressed (default 1342177280)
+    	[v1 storage only] How big should a single row group be uncompressed (default 1342177280)
   -pyroscopedb.symbols-partition-label string
-    	Specifies the dimension by which symbols are partitioned. By default, the partitioning is determined automatically.
+    	[v1 storage only] Specifies the dimension by which symbols are partitioned. By default, the partitioning is determined automatically.
   -querier.client-cleanup-period duration
     	How frequently to clean up clients for ingesters that have gone away. (default 15s)
   -querier.health-check-ingesters

--- a/cmd/pyroscope/pyroscope.yaml
+++ b/cmd/pyroscope/pyroscope.yaml
@@ -356,15 +356,15 @@ limits:
   # ingesters and distributors. 0 disables shuffle sharding.
   # ingestion_tenant_shard_size: 0
 
-  # Maximum number of active series of profiles per tenant, per ingester. 0 to
-  # disable.
+  # [v1 storage only] Maximum number of active series of profiles per tenant,
+  # per ingester. 0 to disable.
   # max_local_series_per_tenant: 0
 
-  # Maximum number of active series of profiles per tenant, across the cluster.
-  # 0 to disable. When the global limit is enabled, each ingester is configured
-  # with a dynamic local limit based on the replication factor and the current
-  # number of healthy ingesters, and is kept updated whenever the number of
-  # ingesters change.
+  # [v1 storage only] Maximum number of active series of profiles per tenant,
+  # across the cluster. 0 to disable. When the global limit is enabled, each
+  # ingester is configured with a dynamic local limit based on the replication
+  # factor and the current number of healthy ingesters, and is kept updated
+  # whenever the number of ingesters change.
   # max_global_series_per_tenant: 5000
 
   # Limit how far back in profiling data can be queried, up until lookback
@@ -412,36 +412,37 @@ limits:
   # queries.
   # max_async_query_concurrency: 5
 
-  # Delete blocks containing samples older than the specified retention period.
-  # 0 to disable.
+  # [v1 storage only] Delete blocks containing samples older than the specified
+  # retention period. 0 to disable.
   # compactor_blocks_retention_period: 0s
 
-  # The number of shards to use when splitting blocks. 0 to disable splitting.
+  # [v1 storage only] The number of shards to use when splitting blocks. 0 to
+  # disable splitting.
   # compactor_split_and_merge_shards: 0
 
-  # Number of stages split shards will be written to. Number of output split
-  # shards is controlled by -compactor.split-and-merge-shards.
+  # [v1 storage only] Number of stages split shards will be written to. Number
+  # of output split shards is controlled by -compactor.split-and-merge-shards.
   # compactor_split_and_merge_stage_size: 0
 
-  # Number of groups that blocks for splitting should be grouped into. Each
-  # group of blocks is then split separately. Number of output split shards is
-  # controlled by -compactor.split-and-merge-shards.
+  # [v1 storage only] Number of groups that blocks for splitting should be
+  # grouped into. Each group of blocks is then split separately. Number of
+  # output split shards is controlled by -compactor.split-and-merge-shards.
   # compactor_split_groups: 1
 
-  # Max number of compactors that can compact blocks for single tenant. 0 to
-  # disable the limit and use all compactors.
+  # [v1 storage only] Max number of compactors that can compact blocks for
+  # single tenant. 0 to disable the limit and use all compactors.
   # compactor_tenant_shard_size: 0
 
-  # If a partial block (unfinished block without meta.json file) hasn't been
-  # modified for this time, it will be marked for deletion. The minimum accepted
-  # value is 4h0m0s: a lower value will be ignored and the feature disabled. 0
-  # to disable.
+  # [v1 storage only] If a partial block (unfinished block without meta.json
+  # file) hasn't been modified for this time, it will be marked for deletion.
+  # The minimum accepted value is 4h0m0s: a lower value will be ignored and the
+  # feature disabled. 0 to disable.
   # compactor_partial_block_deletion_delay: 1d
 
-  # If enabled, the compactor will downsample profiles in blocks at compaction
-  # level 3 and above. The original profiles are also kept. Note: This set the
-  # default for the teanant overrides, in order to be effective it also requires
-  # compactor.downsampler-enabled to be set to true.
+  # [v1 storage only] If enabled, the compactor will downsample profiles in
+  # blocks at compaction level 3 and above. The original profiles are also kept.
+  # Note: This set the default for the teanant overrides, in order to be
+  # effective it also requires compactor.downsampler-enabled to be set to true.
   # compactor_downsampler_enabled: true
 
   # S3 server-side encryption type. Required to enable server-side encryption
@@ -536,29 +537,29 @@ memberlist:
   # bind_port: 7946
 
 pyroscopedb:
-  # Directory used for local storage.
+  # [v1 storage only] Directory used for local storage.
   # data_path: "./data"
 
-  # Upper limit to the duration of a Pyroscope block.
+  # [v1 storage only] Upper limit to the duration of a Pyroscope block.
   # max_block_duration: 1h
 
-  # How big should a single row group be uncompressed
+  # [v1 storage only] How big should a single row group be uncompressed
   # row_group_target_size: 1342177280
 
-  # Specifies the dimension by which symbols are partitioned. By default, the
-  # partitioning is determined automatically.
+  # [v1 storage only] Specifies the dimension by which symbols are partitioned.
+  # By default, the partitioning is determined automatically.
   # symbols_partition_label: ""
 
-  # How much available disk space to keep in GiB
+  # [v1 storage only] How much available disk space to keep in GiB
   # min_free_disk_gb: 10
 
-  # Which percentage of free disk space to keep
+  # [v1 storage only] Which percentage of free disk space to keep
   # min_disk_available_percentage: 0.05
 
-  # How often to enforce disk retention
+  # [v1 storage only] How often to enforce disk retention
   # enforcement_interval: 5m
 
-  # Disable retention policy enforcement
+  # [v1 storage only] Disable retention policy enforcement
   # disable_enforcement: false
 
 tracing:

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -107,36 +107,36 @@ api:
 [memberlist: <memberlist>]
 
 pyroscopedb:
-  # Directory used for local storage.
+  # [v1 storage only] Directory used for local storage.
   # CLI flag: -pyroscopedb.data-path
   [data_path: <string> | default = "./data"]
 
-  # Upper limit to the duration of a Pyroscope block.
+  # [v1 storage only] Upper limit to the duration of a Pyroscope block.
   # CLI flag: -pyroscopedb.max-block-duration
   [max_block_duration: <duration> | default = 1h]
 
-  # How big should a single row group be uncompressed
+  # [v1 storage only] How big should a single row group be uncompressed
   # CLI flag: -pyroscopedb.row-group-target-size
   [row_group_target_size: <int> | default = 1342177280]
 
-  # Specifies the dimension by which symbols are partitioned. By default, the
-  # partitioning is determined automatically.
+  # [v1 storage only] Specifies the dimension by which symbols are partitioned.
+  # By default, the partitioning is determined automatically.
   # CLI flag: -pyroscopedb.symbols-partition-label
   [symbols_partition_label: <string> | default = ""]
 
-  # How much available disk space to keep in GiB
+  # [v1 storage only] How much available disk space to keep in GiB
   # CLI flag: -pyroscopedb.retention-policy-min-free-disk-gb
   [min_free_disk_gb: <int> | default = 10]
 
-  # Which percentage of free disk space to keep
+  # [v1 storage only] Which percentage of free disk space to keep
   # CLI flag: -pyroscopedb.retention-policy-min-disk-available-percentage
   [min_disk_available_percentage: <float> | default = 0.05]
 
-  # How often to enforce disk retention
+  # [v1 storage only] How often to enforce disk retention
   # CLI flag: -pyroscopedb.retention-policy-enforcement-interval
   [enforcement_interval: <duration> | default = 5m]
 
-  # Disable retention policy enforcement
+  # [v1 storage only] Disable retention policy enforcement
   # CLI flag: -pyroscopedb.retention-policy-disable
   [disable_enforcement: <boolean> | default = false]
 
@@ -1573,84 +1573,84 @@ lifecycler:
     # CLI flag: -distributor.excluded-zones
     [excluded_zones: <string> | default = ""]
 
-  # (advanced) Number of tokens for each ingester.
+  # (advanced) [v1 storage only] Number of tokens for each ingester.
   # CLI flag: -ingester.num-tokens
   [num_tokens: <int> | default = 128]
 
-  # (advanced) Period at which to heartbeat to consul.
+  # (advanced) [v1 storage only] Period at which to heartbeat to consul.
   # CLI flag: -ingester.heartbeat-period
   [heartbeat_period: <duration> | default = 5s]
 
-  # (advanced) Heartbeat timeout after which instance is assumed to be
-  # unhealthy.
+  # (advanced) [v1 storage only] Heartbeat timeout after which instance is
+  # assumed to be unhealthy.
   # CLI flag: -ingester.heartbeat-timeout
   [heartbeat_timeout: <duration> | default = 1m]
 
-  # (advanced) Observe tokens after generating to resolve collisions. Useful
-  # when using gossiping ring.
+  # (advanced) [v1 storage only] Observe tokens after generating to resolve
+  # collisions. Useful when using gossiping ring.
   # CLI flag: -ingester.observe-period
   [observe_period: <duration> | default = 0s]
 
-  # (advanced) Period to wait for a claim from another member; will join
-  # automatically after this.
+  # (advanced) [v1 storage only] Period to wait for a claim from another member;
+  # will join automatically after this.
   # CLI flag: -ingester.join-after
   [join_after: <duration> | default = 0s]
 
-  # (advanced) Minimum duration to wait after the internal readiness checks have
-  # passed but before succeeding the readiness endpoint. This is used to
-  # slowdown deployment controllers (eg. Kubernetes) after an instance is ready
-  # and before they proceed with a rolling update, to give the rest of the
-  # cluster instances enough time to receive ring updates.
+  # (advanced) [v1 storage only] Minimum duration to wait after the internal
+  # readiness checks have passed but before succeeding the readiness endpoint.
+  # This is used to slowdown deployment controllers (eg. Kubernetes) after an
+  # instance is ready and before they proceed with a rolling update, to give the
+  # rest of the cluster instances enough time to receive ring updates.
   # CLI flag: -ingester.min-ready-duration
   [min_ready_duration: <duration> | default = 15s]
 
-  # Name of network interface to read address from.
+  # [v1 storage only] Name of network interface to read address from.
   # CLI flag: -ingester.lifecycler.interface
   [interface_names: <list of strings> | default = [<private network interfaces>]]
 
-  # (advanced) Enable IPv6 support. Required to make use of IP addresses from
-  # IPv6 interfaces.
+  # (advanced) [v1 storage only] Enable IPv6 support. Required to make use of IP
+  # addresses from IPv6 interfaces.
   # CLI flag: -ingester.enable-inet6
   [enable_inet6: <boolean> | default = false]
 
-  # (advanced) Duration to sleep for before exiting, to ensure metrics are
-  # scraped.
+  # (advanced) [v1 storage only] Duration to sleep for before exiting, to ensure
+  # metrics are scraped.
   # CLI flag: -ingester.final-sleep
   [final_sleep: <duration> | default = 0s]
 
-  # File path where tokens are stored. If empty, tokens are not stored at
-  # shutdown and restored at startup.
+  # [v1 storage only] File path where tokens are stored. If empty, tokens are
+  # not stored at shutdown and restored at startup.
   # CLI flag: -ingester.tokens-file-path
   [tokens_file_path: <string> | default = ""]
 
-  # The availability zone where this instance is running.
+  # [v1 storage only] The availability zone where this instance is running.
   # CLI flag: -ingester.availability-zone
   [availability_zone: <string> | default = ""]
 
-  # (advanced) Unregister from the ring upon clean shutdown. It can be useful to
-  # disable for rolling restarts with consistent naming in conjunction with
-  # -distributor.extend-writes=false.
+  # (advanced) [v1 storage only] Unregister from the ring upon clean shutdown.
+  # It can be useful to disable for rolling restarts with consistent naming in
+  # conjunction with -distributor.extend-writes=false.
   # CLI flag: -ingester.unregister-on-shutdown
   [unregister_on_shutdown: <boolean> | default = true]
 
-  # (advanced) When enabled the readiness probe succeeds only after all
-  # instances are ACTIVE and healthy in the ring, otherwise only the instance
-  # itself is checked. This option should be disabled if in your cluster
-  # multiple instances can be rolled out simultaneously, otherwise rolling
-  # updates may be slowed down.
+  # (advanced) [v1 storage only] When enabled the readiness probe succeeds only
+  # after all instances are ACTIVE and healthy in the ring, otherwise only the
+  # instance itself is checked. This option should be disabled if in your
+  # cluster multiple instances can be rolled out simultaneously, otherwise
+  # rolling updates may be slowed down.
   # CLI flag: -ingester.readiness-check-ring-health
   [readiness_check_ring_health: <boolean> | default = true]
 
-  # (advanced) IP address to advertise in the ring.
+  # (advanced) [v1 storage only] IP address to advertise in the ring.
   # CLI flag: -ingester.lifecycler.addr
   [address: <string> | default = ""]
 
-  # (advanced) port to advertise in consul (defaults to
+  # (advanced) [v1 storage only] port to advertise in consul (defaults to
   # server.grpc-listen-port).
   # CLI flag: -ingester.lifecycler.port
   [port: <int> | default = 0]
 
-  # (advanced) ID to register in the ring.
+  # (advanced) [v1 storage only] ID to register in the ring.
   # CLI flag: -ingester.lifecycler.ID
   [id: <string> | default = "<hostname>"]
 ```
@@ -2063,189 +2063,196 @@ bucket_store:
 The `compactor` block configures the compactor.
 
 ```yaml
-# (advanced) List of compaction time ranges.
+# (advanced) [v1 storage only] List of compaction time ranges.
 # CLI flag: -compactor.block-ranges
 [block_ranges: <list of durations> | default = 1h0m0s,2h0m0s,8h0m0s]
 
-# (advanced) Number of Go routines to use when downloading blocks for compaction
-# and uploading resulting blocks.
+# (advanced) [v1 storage only] Number of Go routines to use when downloading
+# blocks for compaction and uploading resulting blocks.
 # CLI flag: -compactor.block-sync-concurrency
 [block_sync_concurrency: <int> | default = 8]
 
-# (advanced) Number of Go routines to use when syncing block meta files from the
-# long term storage.
+# (advanced) [v1 storage only] Number of Go routines to use when syncing block
+# meta files from the long term storage.
 # CLI flag: -compactor.meta-sync-concurrency
 [meta_sync_concurrency: <int> | default = 20]
 
-# Directory to temporarily store blocks during compaction. This directory is not
-# required to be persisted between restarts.
+# [v1 storage only] Directory to temporarily store blocks during compaction.
+# This directory is not required to be persisted between restarts.
 # CLI flag: -compactor.data-dir
 [data_dir: <string> | default = "./data-compactor"]
 
-# (advanced) The frequency at which the compaction runs
+# (advanced) [v1 storage only] The frequency at which the compaction runs
 # CLI flag: -compactor.compaction-interval
 [compaction_interval: <duration> | default = 30m]
 
-# (advanced) How many times to retry a failed compaction within a single
-# compaction run.
+# (advanced) [v1 storage only] How many times to retry a failed compaction
+# within a single compaction run.
 # CLI flag: -compactor.compaction-retries
 [compaction_retries: <int> | default = 3]
 
-# (advanced) Max number of concurrent compactions running.
+# (advanced) [v1 storage only] Max number of concurrent compactions running.
 # CLI flag: -compactor.compaction-concurrency
 [compaction_concurrency: <int> | default = 1]
 
-# How long the compactor waits before compacting first-level blocks that are
-# uploaded by the ingesters. This configuration option allows for the reduction
-# of cases where the compactor begins to compact blocks before all ingesters
-# have uploaded their blocks to the storage.
+# [v1 storage only] How long the compactor waits before compacting first-level
+# blocks that are uploaded by the ingesters. This configuration option allows
+# for the reduction of cases where the compactor begins to compact blocks before
+# all ingesters have uploaded their blocks to the storage.
 # CLI flag: -compactor.first-level-compaction-wait-period
 [first_level_compaction_wait_period: <duration> | default = 25m]
 
-# (advanced) How frequently compactor should run blocks cleanup and maintenance,
-# as well as update the bucket index.
+# (advanced) [v1 storage only] How frequently compactor should run blocks
+# cleanup and maintenance, as well as update the bucket index.
 # CLI flag: -compactor.cleanup-interval
 [cleanup_interval: <duration> | default = 15m]
 
-# (advanced) Max number of tenants for which blocks cleanup and maintenance
-# should run concurrently.
+# (advanced) [v1 storage only] Max number of tenants for which blocks cleanup
+# and maintenance should run concurrently.
 # CLI flag: -compactor.cleanup-concurrency
 [cleanup_concurrency: <int> | default = 20]
 
-# (advanced) Time before a block marked for deletion is deleted from bucket. If
-# not 0, blocks will be marked for deletion and compactor component will
-# permanently delete blocks marked for deletion from the bucket. If 0, blocks
-# will be deleted straight away. Note that deleting blocks immediately can cause
-# query failures.
+# (advanced) [v1 storage only] Time before a block marked for deletion is
+# deleted from bucket. If not 0, blocks will be marked for deletion and
+# compactor component will permanently delete blocks marked for deletion from
+# the bucket. If 0, blocks will be deleted straight away. Note that deleting
+# blocks immediately can cause query failures.
 # CLI flag: -compactor.deletion-delay
 [deletion_delay: <duration> | default = 12h]
 
 # (advanced)
 [tenant_cleanup_delay: <duration> | default = ]
 
-# (advanced) Max time for starting compactions for a single tenant. After this
-# time no new compactions for the tenant are started before next compaction
-# cycle. This can help in multi-tenant environments to avoid single tenant using
-# all compaction time, but also in single-tenant environments to force new
-# discovery of blocks more often. 0 = disabled.
+# (advanced) [v1 storage only] Max time for starting compactions for a single
+# tenant. After this time no new compactions for the tenant are started before
+# next compaction cycle. This can help in multi-tenant environments to avoid
+# single tenant using all compaction time, but also in single-tenant
+# environments to force new discovery of blocks more often. 0 = disabled.
 # CLI flag: -compactor.max-compaction-time
 [max_compaction_time: <duration> | default = 1h]
 
-# (advanced) Maximum time to wait for in-flight cleanup and ring operations to
-# finish during shutdown. If the timeout is reached, the compactor will
-# forcefully stop. 0 = no timeout (wait indefinitely).
+# (advanced) [v1 storage only] Maximum time to wait for in-flight cleanup and
+# ring operations to finish during shutdown. If the timeout is reached, the
+# compactor will forcefully stop. 0 = no timeout (wait indefinitely).
 # CLI flag: -compactor.shutdown-timeout
 [shutdown_timeout: <duration> | default = 0s]
 
-# (experimental) If enabled, will delete the bucket-index, markers and debug
-# files in the tenant bucket when there are no blocks left in the index.
+# (experimental) [v1 storage only] If enabled, will delete the bucket-index,
+# markers and debug files in the tenant bucket when there are no blocks left in
+# the index.
 # CLI flag: -compactor.no-blocks-file-cleanup-enabled
 [no_blocks_file_cleanup_enabled: <boolean> | default = false]
 
-# (advanced) If enabled, the compactor will downsample profiles in blocks at
-# compaction level 3 and above. The original profiles are also kept.
+# (advanced) [v1 storage only] If enabled, the compactor will downsample
+# profiles in blocks at compaction level 3 and above. The original profiles are
+# also kept.
 # CLI flag: -compactor.downsampler-enabled
 [downsampler_enabled: <boolean> | default = false]
 
-# (advanced) Number of goroutines opening blocks before compaction.
+# (advanced) [v1 storage only] Number of goroutines opening blocks before
+# compaction.
 # CLI flag: -compactor.max-opening-blocks-concurrency
 [max_opening_blocks_concurrency: <int> | default = 16]
 
-# (advanced) Comma separated list of tenants that can be compacted. If
-# specified, only these tenants will be compacted by compactor, otherwise all
-# tenants can be compacted. Subject to sharding.
+# (advanced) [v1 storage only] Comma separated list of tenants that can be
+# compacted. If specified, only these tenants will be compacted by compactor,
+# otherwise all tenants can be compacted. Subject to sharding.
 # CLI flag: -compactor.enabled-tenants
 [enabled_tenants: <string> | default = ""]
 
-# (advanced) Comma separated list of tenants that cannot be compacted by this
-# compactor. If specified, and compactor would normally pick given tenant for
-# compaction (via -compactor.enabled-tenants or sharding), it will be ignored
-# instead.
+# (advanced) [v1 storage only] Comma separated list of tenants that cannot be
+# compacted by this compactor. If specified, and compactor would normally pick
+# given tenant for compaction (via -compactor.enabled-tenants or sharding), it
+# will be ignored instead.
 # CLI flag: -compactor.disabled-tenants
 [disabled_tenants: <string> | default = ""]
 
 sharding_ring:
   # The key-value store used to share the hash ring across multiple instances.
   kvstore:
-    # Backend storage to use for the ring. Supported values are: consul, etcd,
-    # inmemory, memberlist, multi.
+    # [v1 storage only] Backend storage to use for the ring. Supported values
+    # are: consul, etcd, inmemory, memberlist, multi.
     # CLI flag: -compactor.ring.store
     [store: <string> | default = "memberlist"]
 
-    # (advanced) The prefix for the keys in the store. Should end with a /.
+    # (advanced) [v1 storage only] The prefix for the keys in the store. Should
+    # end with a /.
     # CLI flag: -compactor.ring.prefix
     [prefix: <string> | default = "collectors/"]
 
     consul:
-      # Hostname and port of Consul.
+      # [v1 storage only] Hostname and port of Consul.
       # CLI flag: -compactor.ring.consul.hostname
       [host: <string> | default = "localhost:8500"]
 
-      # (advanced) ACL Token used to interact with Consul.
+      # (advanced) [v1 storage only] ACL Token used to interact with Consul.
       # CLI flag: -compactor.ring.consul.acl-token
       [acl_token: <string> | default = ""]
 
-      # (advanced) HTTP timeout when talking to Consul
+      # (advanced) [v1 storage only] HTTP timeout when talking to Consul
       # CLI flag: -compactor.ring.consul.client-timeout
       [http_client_timeout: <duration> | default = 20s]
 
-      # (advanced) Enable consistent reads to Consul.
+      # (advanced) [v1 storage only] Enable consistent reads to Consul.
       # CLI flag: -compactor.ring.consul.consistent-reads
       [consistent_reads: <boolean> | default = false]
 
-      # (advanced) Rate limit when watching key or prefix in Consul, in requests
-      # per second. 0 disables the rate limit.
+      # (advanced) [v1 storage only] Rate limit when watching key or prefix in
+      # Consul, in requests per second. 0 disables the rate limit.
       # CLI flag: -compactor.ring.consul.watch-rate-limit
       [watch_rate_limit: <float> | default = 1]
 
-      # (advanced) Burst size used in rate limit. Values less than 1 are treated
-      # as 1.
+      # (advanced) [v1 storage only] Burst size used in rate limit. Values less
+      # than 1 are treated as 1.
       # CLI flag: -compactor.ring.consul.watch-burst-size
       [watch_burst_size: <int> | default = 1]
 
-      # (advanced) Maximum duration to wait before retrying a Compare And Swap
-      # (CAS) operation.
+      # (advanced) [v1 storage only] Maximum duration to wait before retrying a
+      # Compare And Swap (CAS) operation.
       # CLI flag: -compactor.ring.consul.cas-retry-delay
       [cas_retry_delay: <duration> | default = 1s]
 
     etcd:
-      # The etcd endpoints to connect to.
+      # [v1 storage only] The etcd endpoints to connect to.
       # CLI flag: -compactor.ring.etcd.endpoints
       [endpoints: <list of strings> | default = []]
 
-      # (advanced) The dial timeout for the etcd connection.
+      # (advanced) [v1 storage only] The dial timeout for the etcd connection.
       # CLI flag: -compactor.ring.etcd.dial-timeout
       [dial_timeout: <duration> | default = 10s]
 
-      # (advanced) The maximum number of retries to do for failed ops.
+      # (advanced) [v1 storage only] The maximum number of retries to do for
+      # failed ops.
       # CLI flag: -compactor.ring.etcd.max-retries
       [max_retries: <int> | default = 10]
 
-      # (advanced) Enable TLS.
+      # (advanced) [v1 storage only] Enable TLS.
       # CLI flag: -compactor.ring.etcd.tls-enabled
       [tls_enabled: <boolean> | default = false]
 
-      # (advanced) Path to the client certificate, which will be used for
-      # authenticating with the server. Also requires the key path to be
-      # configured.
+      # (advanced) [v1 storage only] Path to the client certificate, which will
+      # be used for authenticating with the server. Also requires the key path
+      # to be configured.
       # CLI flag: -compactor.ring.etcd.tls-cert-path
       [tls_cert_path: <string> | default = ""]
 
-      # (advanced) Path to the key for the client certificate. Also requires the
-      # client certificate to be configured.
+      # (advanced) [v1 storage only] Path to the key for the client certificate.
+      # Also requires the client certificate to be configured.
       # CLI flag: -compactor.ring.etcd.tls-key-path
       [tls_key_path: <string> | default = ""]
 
-      # (advanced) Path to the CA certificates to validate server certificate
-      # against. If not set, the host's root CA certificates are used.
+      # (advanced) [v1 storage only] Path to the CA certificates to validate
+      # server certificate against. If not set, the host's root CA certificates
+      # are used.
       # CLI flag: -compactor.ring.etcd.tls-ca-path
       [tls_ca_path: <string> | default = ""]
 
-      # (advanced) Override the expected name on the server certificate.
+      # (advanced) [v1 storage only] Override the expected name on the server
+      # certificate.
       # CLI flag: -compactor.ring.etcd.tls-server-name
       [tls_server_name: <string> | default = ""]
 
-      # (advanced) Skip validating server certificate.
+      # (advanced) [v1 storage only] Skip validating server certificate.
       # CLI flag: -compactor.ring.etcd.tls-insecure-skip-verify
       [tls_insecure_skip_verify: <boolean> | default = false]
 
@@ -2283,89 +2290,98 @@ sharding_ring:
       # CLI flag: -compactor.ring.etcd.tls-cipher-suites
       [tls_cipher_suites: <string> | default = ""]
 
-      # (advanced) Override the default minimum TLS version. Allowed values:
-      # VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
+      # (advanced) [v1 storage only] Override the default minimum TLS version.
+      # Allowed values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
       # CLI flag: -compactor.ring.etcd.tls-min-version
       [tls_min_version: <string> | default = ""]
 
-      # Etcd username.
+      # [v1 storage only] Etcd username.
       # CLI flag: -compactor.ring.etcd.username
       [username: <string> | default = ""]
 
-      # Etcd password.
+      # [v1 storage only] Etcd password.
       # CLI flag: -compactor.ring.etcd.password
       [password: <string> | default = ""]
 
     multi:
-      # (advanced) Primary backend storage used by multi-client.
+      # (advanced) [v1 storage only] Primary backend storage used by
+      # multi-client.
       # CLI flag: -compactor.ring.multi.primary
       [primary: <string> | default = ""]
 
-      # (advanced) Secondary backend storage used by multi-client.
+      # (advanced) [v1 storage only] Secondary backend storage used by
+      # multi-client.
       # CLI flag: -compactor.ring.multi.secondary
       [secondary: <string> | default = ""]
 
-      # (advanced) Mirror writes to the secondary store.
+      # (advanced) [v1 storage only] Mirror writes to the secondary store.
       # CLI flag: -compactor.ring.multi.mirror-enabled
       [mirror_enabled: <boolean> | default = false]
 
-      # (advanced) Timeout for storing a value to the secondary store.
+      # (advanced) [v1 storage only] Timeout for storing a value to the
+      # secondary store.
       # CLI flag: -compactor.ring.multi.mirror-timeout
       [mirror_timeout: <duration> | default = 2s]
 
-  # (advanced) Period at which to heartbeat to the ring. 0 = disabled.
+  # (advanced) [v1 storage only] Period at which to heartbeat to the ring. 0 =
+  # disabled.
   # CLI flag: -compactor.ring.heartbeat-period
   [heartbeat_period: <duration> | default = 15s]
 
-  # (advanced) The heartbeat timeout after which compactors are considered
-  # unhealthy within the ring. 0 = never (timeout disabled).
+  # (advanced) [v1 storage only] The heartbeat timeout after which compactors
+  # are considered unhealthy within the ring. 0 = never (timeout disabled).
   # CLI flag: -compactor.ring.heartbeat-timeout
   [heartbeat_timeout: <duration> | default = 1m]
 
-  # (advanced) Instance ID to register in the ring.
+  # (advanced) [v1 storage only] Instance ID to register in the ring.
   # CLI flag: -compactor.ring.instance-id
   [instance_id: <string> | default = "<hostname>"]
 
-  # List of network interface names to look up when finding the instance IP
-  # address.
+  # [v1 storage only] List of network interface names to look up when finding
+  # the instance IP address.
   # CLI flag: -compactor.ring.instance-interface-names
   [instance_interface_names: <list of strings> | default = [<private network interfaces>]]
 
-  # (advanced) Port to advertise in the ring (defaults to
+  # (advanced) [v1 storage only] Port to advertise in the ring (defaults to
   # -server.http-listen-port).
   # CLI flag: -compactor.ring.instance-port
   [instance_port: <int> | default = 0]
 
-  # (advanced) IP address to advertise in the ring. Default is auto-detected.
+  # (advanced) [v1 storage only] IP address to advertise in the ring. Default is
+  # auto-detected.
   # CLI flag: -compactor.ring.instance-addr
   [instance_addr: <string> | default = ""]
 
-  # (advanced) Enable using a IPv6 instance address. (default false)
+  # (advanced) [v1 storage only] Enable using a IPv6 instance address. (default
+  # false)
   # CLI flag: -compactor.ring.instance-enable-ipv6
   [instance_enable_ipv6: <boolean> | default = false]
 
-  # (advanced) Minimum time to wait for ring stability at startup. 0 to disable.
+  # (advanced) [v1 storage only] Minimum time to wait for ring stability at
+  # startup. 0 to disable.
   # CLI flag: -compactor.ring.wait-stability-min-duration
   [wait_stability_min_duration: <duration> | default = 0s]
 
-  # (advanced) Maximum time to wait for ring stability at startup. If the
-  # compactor ring keeps changing after this period of time, the compactor will
-  # start anyway.
+  # (advanced) [v1 storage only] Maximum time to wait for ring stability at
+  # startup. If the compactor ring keeps changing after this period of time, the
+  # compactor will start anyway.
   # CLI flag: -compactor.ring.wait-stability-max-duration
   [wait_stability_max_duration: <duration> | default = 5m]
 
-  # (advanced) Timeout for waiting on compactor to become ACTIVE in the ring.
+  # (advanced) [v1 storage only] Timeout for waiting on compactor to become
+  # ACTIVE in the ring.
   # CLI flag: -compactor.ring.wait-active-instance-timeout
   [wait_active_instance_timeout: <duration> | default = 10m]
 
-# (advanced) The sorting to use when deciding which compaction jobs should run
-# first for a given tenant. Supported values are:
+# (advanced) [v1 storage only] The sorting to use when deciding which compaction
+# jobs should run first for a given tenant. Supported values are:
 # smallest-range-oldest-blocks-first, newest-blocks-first.
 # CLI flag: -compactor.compaction-jobs-order
 [compaction_jobs_order: <string> | default = "smallest-range-oldest-blocks-first"]
 
-# (advanced) Experimental: The strategy to use when splitting blocks during
-# compaction. Supported values are: fingerprint, stacktracePartition.
+# (advanced) [v1 storage only] Experimental: The strategy to use when splitting
+# blocks during compaction. Supported values are: fingerprint,
+# stacktracePartition.
 # CLI flag: -compactor.compaction-split-by
 [compaction_split_by: <string> | default = "fingerprint"]
 ```
@@ -3215,16 +3231,16 @@ distributor_usage_groups:
 # CLI flag: -distributor.ingestion-tenant-shard-size
 [ingestion_tenant_shard_size: <int> | default = 0]
 
-# Maximum number of active series of profiles per tenant, per ingester. 0 to
-# disable.
+# [v1 storage only] Maximum number of active series of profiles per tenant, per
+# ingester. 0 to disable.
 # CLI flag: -ingester.max-local-series-per-tenant
 [max_local_series_per_tenant: <int> | default = 0]
 
-# Maximum number of active series of profiles per tenant, across the cluster. 0
-# to disable. When the global limit is enabled, each ingester is configured with
-# a dynamic local limit based on the replication factor and the current number
-# of healthy ingesters, and is kept updated whenever the number of ingesters
-# change.
+# [v1 storage only] Maximum number of active series of profiles per tenant,
+# across the cluster. 0 to disable. When the global limit is enabled, each
+# ingester is configured with a dynamic local limit based on the replication
+# factor and the current number of healthy ingesters, and is kept updated
+# whenever the number of ingesters change.
 # CLI flag: -ingester.max-global-series-per-tenant
 [max_global_series_per_tenant: <int> | default = 5000]
 
@@ -3283,42 +3299,43 @@ distributor_usage_groups:
 # CLI flag: -query-frontend.max-async-query-concurrency
 [max_async_query_concurrency: <int> | default = 5]
 
-# Delete blocks containing samples older than the specified retention period. 0
-# to disable.
+# [v1 storage only] Delete blocks containing samples older than the specified
+# retention period. 0 to disable.
 # CLI flag: -compactor.blocks-retention-period
 [compactor_blocks_retention_period: <duration> | default = 0s]
 
-# The number of shards to use when splitting blocks. 0 to disable splitting.
+# [v1 storage only] The number of shards to use when splitting blocks. 0 to
+# disable splitting.
 # CLI flag: -compactor.split-and-merge-shards
 [compactor_split_and_merge_shards: <int> | default = 0]
 
-# Number of stages split shards will be written to. Number of output split
-# shards is controlled by -compactor.split-and-merge-shards.
+# [v1 storage only] Number of stages split shards will be written to. Number of
+# output split shards is controlled by -compactor.split-and-merge-shards.
 # CLI flag: -compactor.split-and-merge-stage-size
 [compactor_split_and_merge_stage_size: <int> | default = 0]
 
-# Number of groups that blocks for splitting should be grouped into. Each group
-# of blocks is then split separately. Number of output split shards is
-# controlled by -compactor.split-and-merge-shards.
+# [v1 storage only] Number of groups that blocks for splitting should be grouped
+# into. Each group of blocks is then split separately. Number of output split
+# shards is controlled by -compactor.split-and-merge-shards.
 # CLI flag: -compactor.split-groups
 [compactor_split_groups: <int> | default = 1]
 
-# Max number of compactors that can compact blocks for single tenant. 0 to
-# disable the limit and use all compactors.
+# [v1 storage only] Max number of compactors that can compact blocks for single
+# tenant. 0 to disable the limit and use all compactors.
 # CLI flag: -compactor.compactor-tenant-shard-size
 [compactor_tenant_shard_size: <int> | default = 0]
 
-# If a partial block (unfinished block without meta.json file) hasn't been
-# modified for this time, it will be marked for deletion. The minimum accepted
-# value is 4h0m0s: a lower value will be ignored and the feature disabled. 0 to
-# disable.
+# [v1 storage only] If a partial block (unfinished block without meta.json file)
+# hasn't been modified for this time, it will be marked for deletion. The
+# minimum accepted value is 4h0m0s: a lower value will be ignored and the
+# feature disabled. 0 to disable.
 # CLI flag: -compactor.partial-block-deletion-delay
 [compactor_partial_block_deletion_delay: <duration> | default = 1d]
 
-# If enabled, the compactor will downsample profiles in blocks at compaction
-# level 3 and above. The original profiles are also kept. Note: This set the
-# default for the teanant overrides, in order to be effective it also requires
-# compactor.downsampler-enabled to be set to true.
+# [v1 storage only] If enabled, the compactor will downsample profiles in blocks
+# at compaction level 3 and above. The original profiles are also kept. Note:
+# This set the default for the teanant overrides, in order to be effective it
+# also requires compactor.downsampler-enabled to be set to true.
 # CLI flag: -compactor.compactor-downsampler-enabled
 [compactor_downsampler_enabled: <boolean> | default = true]
 

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -24,7 +24,7 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: pyroscope-dev-admin
+  name: pyroscope-dev-compactor
   namespace: default
   labels:
     helm.sh/chart: pyroscope-2.1.0
@@ -32,35 +32,14 @@ metadata:
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "admin"
+    app.kubernetes.io/component: "compactor"
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: pyroscope
       app.kubernetes.io/instance: pyroscope-dev
-      app.kubernetes.io/component: "admin"
----
-# Source: pyroscope/templates/deployments-statefulsets.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: pyroscope-dev-compaction-worker
-  namespace: default
-  labels:
-    helm.sh/chart: pyroscope-2.1.0
-    app.kubernetes.io/name: pyroscope
-    app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.1.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "compaction-worker"
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: pyroscope
-      app.kubernetes.io/instance: pyroscope-dev
-      app.kubernetes.io/component: "compaction-worker"
+      app.kubernetes.io/component: "compactor"
 ---
 # Source: pyroscope/templates/deployments-statefulsets.yaml
 apiVersion: policy/v1
@@ -87,7 +66,7 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: pyroscope-dev-metastore
+  name: pyroscope-dev-ingester
   namespace: default
   labels:
     helm.sh/chart: pyroscope-2.1.0
@@ -95,20 +74,20 @@ metadata:
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "metastore"
+    app.kubernetes.io/component: "ingester"
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: pyroscope
       app.kubernetes.io/instance: pyroscope-dev
-      app.kubernetes.io/component: "metastore"
+      app.kubernetes.io/component: "ingester"
 ---
 # Source: pyroscope/templates/deployments-statefulsets.yaml
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: pyroscope-dev-query-backend
+  name: pyroscope-dev-querier
   namespace: default
   labels:
     helm.sh/chart: pyroscope-2.1.0
@@ -116,14 +95,14 @@ metadata:
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "query-backend"
+    app.kubernetes.io/component: "querier"
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: pyroscope
       app.kubernetes.io/instance: pyroscope-dev
-      app.kubernetes.io/component: "query-backend"
+      app.kubernetes.io/component: "querier"
 ---
 # Source: pyroscope/templates/deployments-statefulsets.yaml
 apiVersion: policy/v1
@@ -150,7 +129,7 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: pyroscope-dev-segment-writer
+  name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
     helm.sh/chart: pyroscope-2.1.0
@@ -158,14 +137,35 @@ metadata:
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "segment-writer"
+    app.kubernetes.io/component: "query-scheduler"
 spec:
   maxUnavailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: pyroscope
       app.kubernetes.io/instance: pyroscope-dev
-      app.kubernetes.io/component: "segment-writer"
+      app.kubernetes.io/component: "query-scheduler"
+---
+# Source: pyroscope/templates/deployments-statefulsets.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: pyroscope-dev-store-gateway
+  namespace: default
+  labels:
+    helm.sh/chart: pyroscope-2.1.0
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "store-gateway"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pyroscope
+      app.kubernetes.io/instance: pyroscope-dev
+      app.kubernetes.io/component: "store-gateway"
 ---
 # Source: pyroscope/templates/deployments-statefulsets.yaml
 apiVersion: policy/v1
@@ -1592,51 +1592,6 @@ subjects:
     name: pyroscope-dev-alloy
     namespace: default
 ---
-# Source: pyroscope/templates/rbac-discovery.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: pyroscope-dev-discovery
-  labels:
-    helm.sh/chart: pyroscope-2.1.0
-    app.kubernetes.io/name: pyroscope
-    app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.1.0"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups:
-  - ""
-  - discovery.k8s.io
-  resources:
-  - endpointslices
-  - endpoints
-  - services
-  - pods
-  verbs:
-  - get
-  - watch
-  - list
----
-# Source: pyroscope/templates/rbac-discovery.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: pyroscope-dev-discovery
-  labels:
-    helm.sh/chart: pyroscope-2.1.0
-    app.kubernetes.io/name: pyroscope
-    app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.1.0"
-    app.kubernetes.io/managed-by: Helm
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: pyroscope-dev-discovery
-subjects:
-- kind: ServiceAccount
-  name: pyroscope-dev
-  namespace: default
----
 # Source: pyroscope/charts/alloy/templates/cluster_service.yaml
 apiVersion: v1
 kind: Service
@@ -1810,10 +1765,6 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
-    - port: 9095
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1840,10 +1791,6 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
-    - port: 9095
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1853,7 +1800,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: pyroscope-dev-admin
+  name: pyroscope-dev-compactor
   namespace: default
   labels:
     helm.sh/chart: pyroscope-2.1.0
@@ -1861,7 +1808,7 @@ metadata:
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "admin"
+    app.kubernetes.io/component: "compactor"
 spec:
   type: ClusterIP
   ports:
@@ -1869,20 +1816,16 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
-    - port: 9095
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/component: "admin"
+    app.kubernetes.io/component: "compactor"
 ---
 # Source: pyroscope/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: pyroscope-dev-admin-headless
+  name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
     helm.sh/chart: pyroscope-2.1.0
@@ -1890,7 +1833,7 @@ metadata:
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "admin"
+    app.kubernetes.io/component: "compactor"
 spec:
   type: ClusterIP
   clusterIP: None
@@ -1899,73 +1842,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
-    - port: 9095
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/component: "admin"
----
-# Source: pyroscope/templates/services.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: pyroscope-dev-compaction-worker
-  namespace: default
-  labels:
-    helm.sh/chart: pyroscope-2.1.0
-    app.kubernetes.io/name: pyroscope
-    app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.1.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "compaction-worker"
-spec:
-  type: ClusterIP
-  ports:
-    - port: 4040
-      targetPort: http2
-      protocol: TCP
-      name: http2
-    - port: 9095
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
-  selector:
-    app.kubernetes.io/name: pyroscope
-    app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/component: "compaction-worker"
----
-# Source: pyroscope/templates/services.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: pyroscope-dev-compaction-worker-headless
-  namespace: default
-  labels:
-    helm.sh/chart: pyroscope-2.1.0
-    app.kubernetes.io/name: pyroscope
-    app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.1.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "compaction-worker"
-spec:
-  type: ClusterIP
-  clusterIP: None
-  ports:
-    - port: 4040
-      targetPort: http2
-      protocol: TCP
-      name: http2
-    - port: 9095
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
-  selector:
-    app.kubernetes.io/name: pyroscope
-    app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/component: "compaction-worker"
+    app.kubernetes.io/component: "compactor"
 ---
 # Source: pyroscope/templates/services.yaml
 apiVersion: v1
@@ -1987,10 +1867,6 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
-    - port: 9095
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2017,10 +1893,6 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
-    - port: 9095
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2030,7 +1902,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: pyroscope-dev-metastore
+  name: pyroscope-dev-ingester
   namespace: default
   labels:
     helm.sh/chart: pyroscope-2.1.0
@@ -2038,7 +1910,7 @@ metadata:
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "metastore"
+    app.kubernetes.io/component: "ingester"
 spec:
   type: ClusterIP
   ports:
@@ -2046,24 +1918,16 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
-    - port: 9095
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
-    - port: 9099
-      targetPort: raft
-      protocol: TCP
-      name: raft
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/component: "metastore"
+    app.kubernetes.io/component: "ingester"
 ---
 # Source: pyroscope/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: pyroscope-dev-metastore-headless
+  name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
     helm.sh/chart: pyroscope-2.1.0
@@ -2071,7 +1935,7 @@ metadata:
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "metastore"
+    app.kubernetes.io/component: "ingester"
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2080,25 +1944,16 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
-    - port: 9095
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
-    - port: 9099
-      targetPort: raft
-      protocol: TCP
-      name: raft
-  publishNotReadyAddresses: true
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/component: "metastore"
+    app.kubernetes.io/component: "ingester"
 ---
 # Source: pyroscope/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: pyroscope-dev-query-backend
+  name: pyroscope-dev-querier
   namespace: default
   labels:
     helm.sh/chart: pyroscope-2.1.0
@@ -2106,7 +1961,7 @@ metadata:
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "query-backend"
+    app.kubernetes.io/component: "querier"
 spec:
   type: ClusterIP
   ports:
@@ -2114,20 +1969,16 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
-    - port: 9095
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/component: "query-backend"
+    app.kubernetes.io/component: "querier"
 ---
 # Source: pyroscope/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: pyroscope-dev-query-backend-headless
+  name: pyroscope-dev-querier-headless
   namespace: default
   labels:
     helm.sh/chart: pyroscope-2.1.0
@@ -2135,7 +1986,7 @@ metadata:
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "query-backend"
+    app.kubernetes.io/component: "querier"
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2144,14 +1995,10 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
-    - port: 9095
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/component: "query-backend"
+    app.kubernetes.io/component: "querier"
 ---
 # Source: pyroscope/templates/services.yaml
 apiVersion: v1
@@ -2173,10 +2020,6 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
-    - port: 9095
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2203,10 +2046,6 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
-    - port: 9095
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2216,7 +2055,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: pyroscope-dev-segment-writer
+  name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
     helm.sh/chart: pyroscope-2.1.0
@@ -2224,7 +2063,7 @@ metadata:
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "segment-writer"
+    app.kubernetes.io/component: "query-scheduler"
 spec:
   type: ClusterIP
   ports:
@@ -2232,20 +2071,16 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
-    - port: 9095
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/component: "segment-writer"
+    app.kubernetes.io/component: "query-scheduler"
 ---
 # Source: pyroscope/templates/services.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: pyroscope-dev-segment-writer-headless
+  name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
     helm.sh/chart: pyroscope-2.1.0
@@ -2253,7 +2088,7 @@ metadata:
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "segment-writer"
+    app.kubernetes.io/component: "query-scheduler"
 spec:
   type: ClusterIP
   clusterIP: None
@@ -2262,14 +2097,61 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
-    - port: 9095
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/component: "segment-writer"
+    app.kubernetes.io/component: "query-scheduler"
+---
+# Source: pyroscope/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: pyroscope-dev-store-gateway
+  namespace: default
+  labels:
+    helm.sh/chart: pyroscope-2.1.0
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "store-gateway"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 4040
+      targetPort: http2
+      protocol: TCP
+      name: http2
+  selector:
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/component: "store-gateway"
+---
+# Source: pyroscope/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: pyroscope-dev-store-gateway-headless
+  namespace: default
+  labels:
+    helm.sh/chart: pyroscope-2.1.0
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "store-gateway"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 4040
+      targetPort: http2
+      protocol: TCP
+      name: http2
+  selector:
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/component: "store-gateway"
 ---
 # Source: pyroscope/templates/services.yaml
 apiVersion: v1
@@ -2291,10 +2173,6 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
-    - port: 9095
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2321,10 +2199,6 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
-    - port: 9095
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -2389,9 +2263,8 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
-            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
-            - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
-            - "-architecture.storage=v2"
+            - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2399,17 +2272,12 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
-            - name: PYROSCOPE_METASTORE_SERVICE
-              value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
-              protocol: TCP
-            - name: grpc
-              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -2426,117 +2294,7 @@ spec:
               mountPath: /data
           resources:
             limits:
-              memory: 256Mi
-            requests:
-              cpu: 0.1
-              memory: 16Mi
-      volumes:
-        - name: config
-          configMap:
-            name: pyroscope-dev-config
-        - name: overrides-config
-          configMap:
-            name: pyroscope-dev-overrides-config
-        - name: data
-          emptyDir: {}
----
-# Source: pyroscope/templates/deployments-statefulsets.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: pyroscope-dev-admin
-  namespace: default
-  labels:
-    helm.sh/chart: pyroscope-2.1.0
-    app.kubernetes.io/name: pyroscope
-    app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.1.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "admin"
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: pyroscope
-      app.kubernetes.io/instance: pyroscope-dev
-      app.kubernetes.io/component: "admin"
-  template:
-    metadata:
-      annotations:
-        checksum/config: 20c57cee48587a8c7031bd9e58ae818ee8c3b13214bc7a2d8807b8a1c39a4d3a
-        profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.1.0"
-        profiles.grafana.com/cpu.port_name: http2
-        profiles.grafana.com/cpu.scrape: "true"
-        profiles.grafana.com/goroutine.port_name: http2
-        profiles.grafana.com/goroutine.scrape: "true"
-        profiles.grafana.com/memory.port_name: http2
-        profiles.grafana.com/memory.scrape: "true"
-      labels:
-        app.kubernetes.io/name: pyroscope
-        app.kubernetes.io/instance: pyroscope-dev
-        app.kubernetes.io/component: "admin"
-        name: "admin"
-    spec:
-      serviceAccountName: pyroscope-dev
-      securityContext:
-        fsGroup: 10001
-        runAsNonRoot: true
-        runAsUser: 10001
-      dnsPolicy: ClusterFirst
-      containers:
-        - name: "admin"
-          securityContext:
-            {}
-          image: "grafana/pyroscope:2.1.0"
-          imagePullPolicy: IfNotPresent
-          args:
-            - "-target=admin"
-            - "-self-profiling.disable-push=true"
-            - "-server.http-listen-port=4040"
-            - "-memberlist.cluster-label=default-pyroscope-dev-micro-services"
-            - "-memberlist.join=dns+pyroscope-dev-memberlist.default.svc.cluster.local.:7946"
-            - "-config.file=/etc/pyroscope/config.yaml"
-            - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
-            - "-log.level=debug"
-            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
-            - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
-            - "-architecture.storage=v2"
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE_FQDN
-              value: "default.svc.cluster.local."
-            - name: PYROSCOPE_METASTORE_SERVICE
-              value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
-          ports:
-            - name: http2
-              containerPort: 4040
-              protocol: TCP
-            - name: memberlist
-              containerPort: 7946
-              protocol: TCP
-            - name: grpc
-              containerPort: 9095
-              protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: http2
-              scheme: HTTP
-          volumeMounts:
-            - name: config
-              mountPath: /etc/pyroscope/config.yaml
-              subPath: config.yaml
-            - name: overrides-config
-              mountPath: /etc/pyroscope/overrides/
-            - name: data
-              mountPath: /data
-          resources:
-            limits:
-              memory: 256Mi
+              memory: 4Gi
             requests:
               cpu: 0.1
               memory: 16Mi
@@ -2609,9 +2367,8 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
-            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
-            - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
-            - "-architecture.storage=v2"
+            - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2619,17 +2376,12 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
-            - name: PYROSCOPE_METASTORE_SERVICE
-              value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
-              protocol: TCP
-            - name: grpc
-              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -2664,7 +2416,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: pyroscope-dev-query-backend
+  name: pyroscope-dev-querier
   namespace: default
   labels:
     helm.sh/chart: pyroscope-2.1.0
@@ -2672,14 +2424,14 @@ metadata:
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "query-backend"
+    app.kubernetes.io/component: "querier"
 spec:
   replicas: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: pyroscope
       app.kubernetes.io/instance: pyroscope-dev
-      app.kubernetes.io/component: "query-backend"
+      app.kubernetes.io/component: "querier"
   template:
     metadata:
       annotations:
@@ -2695,8 +2447,8 @@ spec:
       labels:
         app.kubernetes.io/name: pyroscope
         app.kubernetes.io/instance: pyroscope-dev
-        app.kubernetes.io/component: "query-backend"
-        name: "query-backend"
+        app.kubernetes.io/component: "querier"
+        name: "querier"
     spec:
       serviceAccountName: pyroscope-dev
       securityContext:
@@ -2705,13 +2457,13 @@ spec:
         runAsUser: 10001
       dnsPolicy: ClusterFirst
       containers:
-        - name: "query-backend"
+        - name: "querier"
           securityContext:
             {}
           image: "grafana/pyroscope:2.1.0"
           imagePullPolicy: IfNotPresent
           args:
-            - "-target=query-backend"
+            - "-target=querier"
             - "-self-profiling.disable-push=true"
             - "-server.http-listen-port=4040"
             - "-memberlist.cluster-label=default-pyroscope-dev-micro-services"
@@ -2719,9 +2471,9 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
-            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
-            - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
-            - "-architecture.storage=v2"
+            - "-store-gateway.sharding-ring.replication-factor=3"
+            - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2729,17 +2481,12 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
-            - name: PYROSCOPE_METASTORE_SERVICE
-              value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
-              protocol: TCP
-            - name: grpc
-              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -2829,9 +2576,8 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
-            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
-            - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
-            - "-architecture.storage=v2"
+            - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2839,8 +2585,6 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
-            - name: PYROSCOPE_METASTORE_SERVICE
-              value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
@@ -2848,8 +2592,109 @@ spec:
             - name: memberlist
               containerPort: 7946
               protocol: TCP
-            - name: grpc
-              containerPort: 9095
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http2
+              scheme: HTTP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/pyroscope/config.yaml
+              subPath: config.yaml
+            - name: overrides-config
+              mountPath: /etc/pyroscope/overrides/
+            - name: data
+              mountPath: /data
+          resources:
+            limits:
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+      volumes:
+        - name: config
+          configMap:
+            name: pyroscope-dev-config
+        - name: overrides-config
+          configMap:
+            name: pyroscope-dev-overrides-config
+        - name: data
+          emptyDir: {}
+---
+# Source: pyroscope/templates/deployments-statefulsets.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pyroscope-dev-query-scheduler
+  namespace: default
+  labels:
+    helm.sh/chart: pyroscope-2.1.0
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "query-scheduler"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pyroscope
+      app.kubernetes.io/instance: pyroscope-dev
+      app.kubernetes.io/component: "query-scheduler"
+  template:
+    metadata:
+      annotations:
+        checksum/config: 20c57cee48587a8c7031bd9e58ae818ee8c3b13214bc7a2d8807b8a1c39a4d3a
+        profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
+        profiles.grafana.com/service_git_ref: "v2.1.0"
+        profiles.grafana.com/cpu.port_name: http2
+        profiles.grafana.com/cpu.scrape: "true"
+        profiles.grafana.com/goroutine.port_name: http2
+        profiles.grafana.com/goroutine.scrape: "true"
+        profiles.grafana.com/memory.port_name: http2
+        profiles.grafana.com/memory.scrape: "true"
+      labels:
+        app.kubernetes.io/name: pyroscope
+        app.kubernetes.io/instance: pyroscope-dev
+        app.kubernetes.io/component: "query-scheduler"
+        name: "query-scheduler"
+    spec:
+      serviceAccountName: pyroscope-dev
+      securityContext:
+        fsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+      dnsPolicy: ClusterFirst
+      containers:
+        - name: "query-scheduler"
+          securityContext:
+            {}
+          image: "grafana/pyroscope:2.1.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=query-scheduler"
+            - "-self-profiling.disable-push=true"
+            - "-server.http-listen-port=4040"
+            - "-memberlist.cluster-label=default-pyroscope-dev-micro-services"
+            - "-memberlist.join=dns+pyroscope-dev-memberlist.default.svc.cluster.local.:7946"
+            - "-config.file=/etc/pyroscope/config.yaml"
+            - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
+            - "-log.level=debug"
+            - "-architecture.storage=v1"
+            - "-write-path=ingester"
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE_FQDN
+              value: "default.svc.cluster.local."
+          ports:
+            - name: http2
+              containerPort: 4040
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -2939,9 +2784,8 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
-            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
-            - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
-            - "-architecture.storage=v2"
+            - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2949,17 +2793,12 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
-            - name: PYROSCOPE_METASTORE_SERVICE
-              value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
-              protocol: TCP
-            - name: grpc
-              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -2976,7 +2815,7 @@ spec:
               mountPath: /data
           resources:
             limits:
-              memory: 256Mi
+              memory: 4Gi
             requests:
               cpu: 0.1
               memory: 16Mi
@@ -3177,7 +3016,7 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: pyroscope-dev-compaction-worker
+  name: pyroscope-dev-compactor
   namespace: default
   labels:
     helm.sh/chart: pyroscope-2.1.0
@@ -3185,16 +3024,16 @@ metadata:
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "compaction-worker"
+    app.kubernetes.io/component: "compactor"
 spec:
-  serviceName: pyroscope-dev-compaction-worker-headless
+  serviceName: pyroscope-dev-compactor-headless
   podManagementPolicy: Parallel
   replicas: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: pyroscope
       app.kubernetes.io/instance: pyroscope-dev
-      app.kubernetes.io/component: "compaction-worker"
+      app.kubernetes.io/component: "compactor"
   template:
     metadata:
       annotations:
@@ -3210,8 +3049,8 @@ spec:
       labels:
         app.kubernetes.io/name: pyroscope
         app.kubernetes.io/instance: pyroscope-dev
-        app.kubernetes.io/component: "compaction-worker"
-        name: "compaction-worker"
+        app.kubernetes.io/component: "compactor"
+        name: "compactor"
     spec:
       serviceAccountName: pyroscope-dev
       securityContext:
@@ -3220,13 +3059,13 @@ spec:
         runAsUser: 10001
       dnsPolicy: ClusterFirst
       containers:
-        - name: "compaction-worker"
+        - name: "compactor"
           securityContext:
             {}
           image: "grafana/pyroscope:2.1.0"
           imagePullPolicy: IfNotPresent
           args:
-            - "-target=compaction-worker"
+            - "-target=compactor"
             - "-self-profiling.disable-push=true"
             - "-server.http-listen-port=4040"
             - "-memberlist.cluster-label=default-pyroscope-dev-micro-services"
@@ -3234,9 +3073,8 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
-            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
-            - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
-            - "-architecture.storage=v2"
+            - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3244,17 +3082,12 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
-            - name: PYROSCOPE_METASTORE_SERVICE
-              value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
-              protocol: TCP
-            - name: grpc
-              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -3269,12 +3102,16 @@ spec:
               mountPath: /etc/pyroscope/overrides/
             - name: data
               mountPath: /data
+              subPath: default
+            - name: data
+              mountPath: /data-compactor
+              subPath: compactor
           resources:
             limits:
-              memory: 2Gi
+              memory: 16Gi
             requests:
               cpu: 1
-              memory: 1Gi
+              memory: 8Gi
       terminationGracePeriodSeconds: 1200
       volumes:
         - name: config
@@ -3290,7 +3127,7 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: pyroscope-dev-metastore
+  name: pyroscope-dev-ingester
   namespace: default
   labels:
     helm.sh/chart: pyroscope-2.1.0
@@ -3298,16 +3135,16 @@ metadata:
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.0"
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "metastore"
+    app.kubernetes.io/component: "ingester"
 spec:
-  serviceName: pyroscope-dev-metastore-headless
+  serviceName: pyroscope-dev-ingester-headless
   podManagementPolicy: Parallel
   replicas: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: pyroscope
       app.kubernetes.io/instance: pyroscope-dev
-      app.kubernetes.io/component: "metastore"
+      app.kubernetes.io/component: "ingester"
   template:
     metadata:
       annotations:
@@ -3323,8 +3160,8 @@ spec:
       labels:
         app.kubernetes.io/name: pyroscope
         app.kubernetes.io/instance: pyroscope-dev
-        app.kubernetes.io/component: "metastore"
-        name: "metastore"
+        app.kubernetes.io/component: "ingester"
+        name: "ingester"
     spec:
       serviceAccountName: pyroscope-dev
       securityContext:
@@ -3333,13 +3170,13 @@ spec:
         runAsUser: 10001
       dnsPolicy: ClusterFirst
       containers:
-        - name: "metastore"
+        - name: "ingester"
           securityContext:
             {}
           image: "grafana/pyroscope:2.1.0"
           imagePullPolicy: IfNotPresent
           args:
-            - "-target=metastore"
+            - "-target=ingester"
             - "-self-profiling.disable-push=true"
             - "-server.http-listen-port=4040"
             - "-memberlist.cluster-label=default-pyroscope-dev-micro-services"
@@ -3347,19 +3184,8 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
-            - "-metastore.index.cleanup-interval=1m"
-            - "-metastore.raft.bootstrap-expect-peers=3"
-            - "-metastore.snapshot-compact-on-restore=true"
-            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
-            - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
-            - "-metastore.data-dir=./data-metastore/data"
-            - "-metastore.raft.dir=./data-metastore/raft"
-            - "-metastore.raft.snapshots-dir=./data-metastore/raft"
-            - "-metastore.raft.bind-address=:9099"
-            - "-metastore.raft.server-id=$(POD_NAME).$(PYROSCOPE_METASTORE_SERVICE)"
-            - "-metastore.raft.advertise-address=$(POD_NAME).$(PYROSCOPE_METASTORE_SERVICE)"
-            - "-metastore.raft.bootstrap-peers=dnssrvnoa+_raft._tcp.$(PYROSCOPE_METASTORE_SERVICE)"
-            - "-architecture.storage=v2"
+            - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3367,136 +3193,12 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
-            - name: PYROSCOPE_METASTORE_SERVICE
-              value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
-              protocol: TCP
-            - name: grpc
-              containerPort: 9095
-              protocol: TCP
-            - name: raft
-              containerPort: 9099
-              protocol: TCP
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: http2
-              scheme: HTTP
-          volumeMounts:
-            - name: config
-              mountPath: /etc/pyroscope/config.yaml
-              subPath: config.yaml
-            - name: overrides-config
-              mountPath: /etc/pyroscope/overrides/
-            - name: data
-              mountPath: /data
-            - name: data
-              mountPath: /data-metastore
-              subPath: .metastore
-          resources:
-            limits:
-              memory: 2Gi
-            requests:
-              cpu: 1
-              memory: 1Gi
-      terminationGracePeriodSeconds: 1200
-      volumes:
-        - name: config
-          configMap:
-            name: pyroscope-dev-config
-        - name: overrides-config
-          configMap:
-            name: pyroscope-dev-overrides-config
-        - name: data
-          emptyDir: {}
----
-# Source: pyroscope/templates/deployments-statefulsets.yaml
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: pyroscope-dev-segment-writer
-  namespace: default
-  labels:
-    helm.sh/chart: pyroscope-2.1.0
-    app.kubernetes.io/name: pyroscope
-    app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.1.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: "segment-writer"
-spec:
-  serviceName: pyroscope-dev-segment-writer-headless
-  podManagementPolicy: Parallel
-  replicas: 3
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: pyroscope
-      app.kubernetes.io/instance: pyroscope-dev
-      app.kubernetes.io/component: "segment-writer"
-  template:
-    metadata:
-      annotations:
-        checksum/config: 20c57cee48587a8c7031bd9e58ae818ee8c3b13214bc7a2d8807b8a1c39a4d3a
-        profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.1.0"
-        profiles.grafana.com/cpu.port_name: http2
-        profiles.grafana.com/cpu.scrape: "true"
-        profiles.grafana.com/goroutine.port_name: http2
-        profiles.grafana.com/goroutine.scrape: "true"
-        profiles.grafana.com/memory.port_name: http2
-        profiles.grafana.com/memory.scrape: "true"
-      labels:
-        app.kubernetes.io/name: pyroscope
-        app.kubernetes.io/instance: pyroscope-dev
-        app.kubernetes.io/component: "segment-writer"
-        name: "segment-writer"
-    spec:
-      serviceAccountName: pyroscope-dev
-      securityContext:
-        fsGroup: 10001
-        runAsNonRoot: true
-        runAsUser: 10001
-      dnsPolicy: ClusterFirst
-      containers:
-        - name: "segment-writer"
-          securityContext:
-            {}
-          image: "grafana/pyroscope:2.1.0"
-          imagePullPolicy: IfNotPresent
-          args:
-            - "-target=segment-writer"
-            - "-self-profiling.disable-push=true"
-            - "-server.http-listen-port=4040"
-            - "-memberlist.cluster-label=default-pyroscope-dev-micro-services"
-            - "-memberlist.join=dns+pyroscope-dev-memberlist.default.svc.cluster.local.:7946"
-            - "-config.file=/etc/pyroscope/config.yaml"
-            - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
-            - "-log.level=debug"
-            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
-            - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
-            - "-architecture.storage=v2"
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: NAMESPACE_FQDN
-              value: "default.svc.cluster.local."
-            - name: PYROSCOPE_METASTORE_SERVICE
-              value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
-          ports:
-            - name: http2
-              containerPort: 4040
-              protocol: TCP
-            - name: memberlist
-              containerPort: 7946
-              protocol: TCP
-            - name: grpc
-              containerPort: 9095
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -3513,11 +3215,119 @@ spec:
               mountPath: /data
           resources:
             limits:
-              memory: 4Gi
+              memory: 16Gi
             requests:
               cpu: 1
-              memory: 2Gi
+              memory: 8Gi
       terminationGracePeriodSeconds: 600
+      volumes:
+        - name: config
+          configMap:
+            name: pyroscope-dev-config
+        - name: overrides-config
+          configMap:
+            name: pyroscope-dev-overrides-config
+        - name: data
+          emptyDir: {}
+---
+# Source: pyroscope/templates/deployments-statefulsets.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: pyroscope-dev-store-gateway
+  namespace: default
+  labels:
+    helm.sh/chart: pyroscope-2.1.0
+    app.kubernetes.io/name: pyroscope
+    app.kubernetes.io/instance: pyroscope-dev
+    app.kubernetes.io/version: "2.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "store-gateway"
+spec:
+  serviceName: pyroscope-dev-store-gateway-headless
+  podManagementPolicy: Parallel
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pyroscope
+      app.kubernetes.io/instance: pyroscope-dev
+      app.kubernetes.io/component: "store-gateway"
+  template:
+    metadata:
+      annotations:
+        checksum/config: 20c57cee48587a8c7031bd9e58ae818ee8c3b13214bc7a2d8807b8a1c39a4d3a
+        profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
+        profiles.grafana.com/service_git_ref: "v2.1.0"
+        profiles.grafana.com/cpu.port_name: http2
+        profiles.grafana.com/cpu.scrape: "true"
+        profiles.grafana.com/goroutine.port_name: http2
+        profiles.grafana.com/goroutine.scrape: "true"
+        profiles.grafana.com/memory.port_name: http2
+        profiles.grafana.com/memory.scrape: "true"
+      labels:
+        app.kubernetes.io/name: pyroscope
+        app.kubernetes.io/instance: pyroscope-dev
+        app.kubernetes.io/component: "store-gateway"
+        name: "store-gateway"
+    spec:
+      serviceAccountName: pyroscope-dev
+      securityContext:
+        fsGroup: 10001
+        runAsNonRoot: true
+        runAsUser: 10001
+      dnsPolicy: ClusterFirst
+      containers:
+        - name: "store-gateway"
+          securityContext:
+            {}
+          image: "grafana/pyroscope:2.1.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-target=store-gateway"
+            - "-self-profiling.disable-push=true"
+            - "-server.http-listen-port=4040"
+            - "-memberlist.cluster-label=default-pyroscope-dev-micro-services"
+            - "-memberlist.join=dns+pyroscope-dev-memberlist.default.svc.cluster.local.:7946"
+            - "-config.file=/etc/pyroscope/config.yaml"
+            - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
+            - "-log.level=debug"
+            - "-store-gateway.sharding-ring.replication-factor=3"
+            - "-architecture.storage=v1"
+            - "-write-path=ingester"
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE_FQDN
+              value: "default.svc.cluster.local."
+          ports:
+            - name: http2
+              containerPort: 4040
+              protocol: TCP
+            - name: memberlist
+              containerPort: 7946
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http2
+              scheme: HTTP
+            initialDelaySeconds: 60
+          volumeMounts:
+            - name: config
+              mountPath: /etc/pyroscope/config.yaml
+              subPath: config.yaml
+            - name: overrides-config
+              mountPath: /etc/pyroscope/overrides/
+            - name: data
+              mountPath: /data
+          resources:
+            limits:
+              memory: 16Gi
+            requests:
+              cpu: 1
+              memory: 8Gi
       volumes:
         - name: config
           configMap:

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
@@ -1076,51 +1076,6 @@ subjects:
     name: pyroscope-dev-alloy
     namespace: default
 ---
-# Source: pyroscope/templates/rbac-discovery.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: pyroscope-dev-discovery
-  labels:
-    helm.sh/chart: pyroscope-2.1.0
-    app.kubernetes.io/name: pyroscope
-    app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.1.0"
-    app.kubernetes.io/managed-by: Helm
-rules:
-- apiGroups:
-  - ""
-  - discovery.k8s.io
-  resources:
-  - endpointslices
-  - endpoints
-  - services
-  - pods
-  verbs:
-  - get
-  - watch
-  - list
----
-# Source: pyroscope/templates/rbac-discovery.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: pyroscope-dev-discovery
-  labels:
-    helm.sh/chart: pyroscope-2.1.0
-    app.kubernetes.io/name: pyroscope
-    app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.1.0"
-    app.kubernetes.io/managed-by: Helm
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: pyroscope-dev-discovery
-subjects:
-- kind: ServiceAccount
-  name: pyroscope-dev
-  namespace: default
----
 # Source: pyroscope/charts/alloy/templates/cluster_service.yaml
 apiVersion: v1
 kind: Service
@@ -1226,14 +1181,6 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
-    - port: 9095
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
-    - port: 9099
-      targetPort: raft
-      protocol: TCP
-      name: raft
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1260,15 +1207,6 @@ spec:
       targetPort: http2
       protocol: TCP
       name: http2
-    - port: 9095
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
-    - port: 9099
-      targetPort: raft
-      protocol: TCP
-      name: raft
-  publishNotReadyAddresses: true
   selector:
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
@@ -1425,16 +1363,8 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
-            - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
-            - "-metastore.address=kubernetes:///pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
-            - "-metastore.data-dir=./data-metastore/data"
-            - "-metastore.raft.dir=./data-metastore/raft"
-            - "-metastore.raft.snapshots-dir=./data-metastore/raft"
-            - "-metastore.raft.bind-address=:9099"
-            - "-metastore.raft.server-id=$(POD_NAME).$(PYROSCOPE_METASTORE_SERVICE)"
-            - "-metastore.raft.advertise-address=$(POD_NAME).$(PYROSCOPE_METASTORE_SERVICE)"
-            - "-metastore.raft.bootstrap-peers=dnssrvnoa+_raft._tcp.$(PYROSCOPE_METASTORE_SERVICE)"
-            - "-architecture.storage=v2"
+            - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -1442,20 +1372,12 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
-            - name: PYROSCOPE_METASTORE_SERVICE
-              value: "pyroscope-dev-headless.default.svc.cluster.local.:9099"
           ports:
             - name: http2
               containerPort: 4040
               protocol: TCP
             - name: memberlist
               containerPort: 7946
-              protocol: TCP
-            - name: grpc
-              containerPort: 9095
-              protocol: TCP
-            - name: raft
-              containerPort: 9099
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -1470,9 +1392,6 @@ spec:
               mountPath: /etc/pyroscope/overrides/
             - name: data
               mountPath: /data
-            - name: data
-              mountPath: /data-metastore
-              subPath: .metastore
           resources:
             {}
       volumes:

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -21,7 +21,7 @@ type Cloneable interface {
 	Clone() flagext.Registerer
 }
 
-type FlagSetRecorder interface {
+type SetFlagRecorder interface {
 	RecordSetFlag(name string)
 }
 

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -21,6 +21,10 @@ type Cloneable interface {
 	Clone() flagext.Registerer
 }
 
+type FlagSetRecorder interface {
+	RecordSetFlag(name string)
+}
+
 var (
 	ErrNotPointer = errors.New("dst is not a pointer")
 )

--- a/pkg/cfg/flag.go
+++ b/pkg/cfg/flag.go
@@ -37,7 +37,17 @@ func Flags(args []string, fs *flag.FlagSet) Source {
 func dFlags(fs *flag.FlagSet, args []string) Source {
 	return func(dst Cloneable) error {
 		// parse the final flagset
-		return fs.Parse(args)
+		if err := fs.Parse(args); err != nil {
+			return err
+		}
+
+		if recorder, ok := dst.(FlagSetRecorder); ok {
+			fs.Visit(func(f *flag.Flag) {
+				recorder.RecordSetFlag(f.Name)
+			})
+		}
+
+		return nil
 	}
 }
 

--- a/pkg/cfg/flag.go
+++ b/pkg/cfg/flag.go
@@ -41,7 +41,7 @@ func dFlags(fs *flag.FlagSet, args []string) Source {
 			return err
 		}
 
-		if recorder, ok := dst.(FlagSetRecorder); ok {
+		if recorder, ok := dst.(SetFlagRecorder); ok {
 			fs.Visit(func(f *flag.Flag) {
 				recorder.RecordSetFlag(f.Name)
 			})

--- a/pkg/pyroscope/pyroscope.go
+++ b/pkg/pyroscope/pyroscope.go
@@ -118,7 +118,8 @@ type Config struct {
 	ConfigFile      string `yaml:"-"`
 	ConfigExpandEnv bool   `yaml:"-"`
 
-	DebugInfo debuginfo.Config `yaml:"-"`
+	DebugInfo debuginfo.Config    `yaml:"-"`
+	SetFlags  map[string]struct{} `yaml:"-"`
 
 	// Legacy v1
 	Querier        querier.Config      `yaml:"querier,omitempty"`
@@ -271,6 +272,61 @@ func (c *Config) RegisterFlagsWithContext(f *flag.FlagSet) {
 	c.StoreGateway.RegisterFlags(f, util.Logger)
 	c.Querier.RegisterFlags(f)
 	c.Compactor.RegisterFlags(f, log.NewLogfmtLogger(os.Stderr))
+	markV1StorageOnlyFlagUsage(f)
+}
+
+const v1StorageOnlyFlagUsagePrefix = "[v1 storage only] "
+
+var v1StorageOnlyFlagPrefixes = []string{
+	"compactor.",
+	"ingester.",
+	"pyroscopedb.",
+}
+
+func markV1StorageOnlyFlagUsage(f *flag.FlagSet) {
+	f.VisitAll(func(flag *flag.Flag) {
+		for _, prefix := range v1StorageOnlyFlagPrefixes {
+			if strings.HasPrefix(flag.Name, prefix) {
+				if !strings.HasPrefix(flag.Usage, v1StorageOnlyFlagUsagePrefix) {
+					flag.Usage = v1StorageOnlyFlagUsagePrefix + flag.Usage
+				}
+				return
+			}
+		}
+	})
+}
+
+func (c *Config) RecordSetFlag(name string) {
+	if c.SetFlags == nil {
+		c.SetFlags = map[string]struct{}{}
+	}
+	c.SetFlags[name] = struct{}{}
+}
+
+func (c *Config) setV1StorageOnlyFlags() []string {
+	var flags []string
+	for flagName := range c.SetFlags {
+		for _, prefix := range v1StorageOnlyFlagPrefixes {
+			if strings.HasPrefix(flagName, prefix) {
+				flags = append(flags, flagName)
+				break
+			}
+		}
+	}
+	sort.Strings(flags)
+	return flags
+}
+
+func (c *Config) warnAboutV1StorageOnlyFlags(logger log.Logger) {
+	if c.ArchitectureStorage != V2 {
+		return
+	}
+	for _, flagName := range c.setV1StorageOnlyFlags() {
+		level.Warn(logger).Log(
+			"msg", "v1 storage only flag is set while using v2 storage architecture; flag has no effect",
+			"flag", flagName,
+		)
+	}
 }
 
 // registerServerFlagsWithChangedDefaultValues registers *Config.Server flags, but overrides some defaults set by the dskit package.
@@ -365,8 +421,10 @@ func (c *Config) Validate() error {
 		return err
 	}
 
-	if err := c.Compactor.Validate(c.PhlareDB.MaxBlockDuration); err != nil {
-		return err
+	if c.usesV1Storage() {
+		if err := c.Compactor.Validate(c.PhlareDB.MaxBlockDuration); err != nil {
+			return err
+		}
 	}
 
 	if err := c.Storage.Bucket.Validate(util.Logger); err != nil {
@@ -394,6 +452,10 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+func (c *Config) usesV1Storage() bool {
+	return c.ArchitectureStorage == V1 || c.ArchitectureStorage == V1V2Dual
 }
 
 func (c *Config) ApplyDynamicConfig() cfg.Source {
@@ -477,6 +539,7 @@ type Pyroscope struct {
 func New(cfg Config) (*Pyroscope, error) {
 	logger := initLogger(cfg.Server.LogFormat, cfg.Server.LogLevel)
 	cfg.Server.Log = logger
+	cfg.warnAboutV1StorageOnlyFlags(logger)
 	usagestats.Edition("oss")
 
 	phlare := &Pyroscope{

--- a/pkg/pyroscope/pyroscope_test.go
+++ b/pkg/pyroscope/pyroscope_test.go
@@ -9,10 +9,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	statusv1 "github.com/grafana/pyroscope/api/gen/proto/go/status/v1"
+	configpkg "github.com/grafana/pyroscope/v2/pkg/cfg"
 	objstoreclient "github.com/grafana/pyroscope/v2/pkg/objstore/client"
 )
 
@@ -136,6 +138,69 @@ func TestRegisterServerFlagsWithChangedDefaultValues_V2(t *testing.T) {
 	})
 }
 
+func TestRegisterFlags_MarksV1StorageOnlyFlags(t *testing.T) {
+	cfg := Config{}
+	fs := flag.NewFlagSet("test", flag.PanicOnError)
+	cfg.RegisterFlags(fs)
+
+	seenPrefixes := make(map[string]bool, len(v1StorageOnlyFlagPrefixes))
+	fs.VisitAll(func(f *flag.Flag) {
+		for _, prefix := range v1StorageOnlyFlagPrefixes {
+			if strings.HasPrefix(f.Name, prefix) {
+				seenPrefixes[prefix] = true
+				assert.Contains(t, f.Usage, v1StorageOnlyFlagUsagePrefix, "flag %s should be marked as V1-only", f.Name)
+			}
+		}
+	})
+
+	for _, prefix := range v1StorageOnlyFlagPrefixes {
+		assert.True(t, seenPrefixes[prefix], "expected at least one registered flag with prefix %s", prefix)
+	}
+}
+
+func TestDynamicUnmarshalRecordsSetFlags(t *testing.T) {
+	var cfg Config
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+
+	require.NoError(t, configpkg.DynamicUnmarshal(&cfg, []string{
+		"-architecture.storage=v2",
+		"-compactor.data-dir=/tmp/compactor",
+		"-pyroscopedb.data-path=/tmp/pyroscopedb",
+	}, fs))
+
+	assert.Contains(t, cfg.SetFlags, "architecture.storage")
+	assert.Contains(t, cfg.SetFlags, "compactor.data-dir")
+	assert.Contains(t, cfg.SetFlags, "pyroscopedb.data-path")
+	assert.ElementsMatch(t, []string{"compactor.data-dir", "pyroscopedb.data-path"}, cfg.setV1StorageOnlyFlags())
+}
+
+func TestConfig_WarnAboutV1StorageOnlyFlags(t *testing.T) {
+	t.Run("warns when v1-only flags are set with v2 storage", func(t *testing.T) {
+		cfg := Config{ArchitectureStorage: V2}
+		cfg.RecordSetFlag("compactor.data-dir")
+		cfg.RecordSetFlag("pyroscopedb.data-path")
+		cfg.RecordSetFlag("query-frontend.max-async-query-concurrency")
+
+		var buf bytes.Buffer
+		cfg.warnAboutV1StorageOnlyFlags(log.NewLogfmtLogger(&buf))
+
+		output := buf.String()
+		assert.Contains(t, output, "flag=compactor.data-dir")
+		assert.Contains(t, output, "flag=pyroscopedb.data-path")
+		assert.NotContains(t, output, "query-frontend.max-async-query-concurrency")
+	})
+
+	t.Run("does not warn when v1 storage is active", func(t *testing.T) {
+		cfg := Config{ArchitectureStorage: V1}
+		cfg.RecordSetFlag("compactor.data-dir")
+
+		var buf bytes.Buffer
+		cfg.warnAboutV1StorageOnlyFlags(log.NewLogfmtLogger(&buf))
+
+		assert.Empty(t, buf.String())
+	})
+}
+
 func TestConfigDiff(t *testing.T) {
 	defaultCfg := Config{}
 	f := flag.NewFlagSet("test", flag.PanicOnError)
@@ -207,4 +272,27 @@ func TestConfigValidate_StorageBackendRequired(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfigValidate_V2IgnoresV1OnlyCompactorConfig(t *testing.T) {
+	t.Run("v2 ignores invalid V1 compactor block range", func(t *testing.T) {
+		cfg := newTestConfig(t, []string{
+			"-architecture.storage=v2",
+			"-storage.backend=" + objstoreclient.Filesystem,
+			"-write-path=segment-writer",
+			"-compactor.block-ranges=30m",
+		})
+
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("v1 validates invalid V1 compactor block range", func(t *testing.T) {
+		cfg := newTestConfig(t, []string{
+			"-architecture.storage=v1",
+			"-write-path=ingester",
+			"-compactor.block-ranges=30m",
+		})
+
+		require.Error(t, cfg.Validate())
+	})
 }


### PR DESCRIPTION
## Summary
- Warn when user on v2 architecture and using v1 only flags
- Fixed a bug where we rendered v2 manifests for the v1 job.
- Updated help text of flags that are unused in v2