### PR TITLE
perf(pprof): make language detection deterministic and ~40% faster

### DIFF
--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -1240,22 +1240,27 @@ func ZeroLabelStrings(p *profilev1.Profile) {
 	}
 }
 
-var languageMatchers = map[string][]string{
-	"go":     {".go", "/usr/local/go/"},
-	"java":   {"java/", "sun/"},
-	"ruby":   {".rb", "gems/"},
-	"nodejs": {"./node_modules/", ".js"},
-	"dotnet": {"System.", "Microsoft."},
-	"python": {".py"},
-	"rust":   {"main.rs", "core.rs"},
+// languageMatchers is an ordered list so that per-symbol iteration is cheap
+// and the result is deterministic when a symbol matches several languages.
+var languageMatchers = []struct {
+	language string
+	patterns []string
+}{
+	{"go", []string{".go", "/usr/local/go/"}},
+	{"java", []string{"java/", "sun/"}},
+	{"ruby", []string{".rb", "gems/"}},
+	{"nodejs", []string{"./node_modules/", ".js"}},
+	{"dotnet", []string{"System.", "Microsoft."}},
+	{"python", []string{".py"}},
+	{"rust", []string{"main.rs", "core.rs"}},
 }
 
 func GetLanguage(profile *Profile) string {
 	for _, symbol := range profile.StringTable {
-		for lang, matcherPatterns := range languageMatchers {
-			for _, pattern := range matcherPatterns {
+		for _, m := range languageMatchers {
+			for _, pattern := range m.patterns {
 				if strings.HasPrefix(symbol, pattern) || strings.HasSuffix(symbol, pattern) {
-					return lang
+					return m.language
 				}
 			}
 		}


### PR DESCRIPTION
## What

`GetLanguage` iterated a `map[string][]string` of language matchers for every string-table entry. Two problems:

1. **Performance**: map-range overhead per symbol, for every pushed profile whose series language isn't already known.
2. **Determinism**: map iteration order is random, so a profile whose symbols match patterns of more than one language (e.g. a string matching both a `.js` suffix and a `Microsoft.` prefix) could be detected as a *different language on each push*. Since `FixGoProfile` is gated on the detected language in the distributor, that normalization was non-deterministic for such profiles.

This replaces the map with an ordered slice, preserving the previous map literal's order as the priority. The map was only ever ranged, never keyed by language.

## Benchmarks

Existing `Benchmark_GetProfileLanguage`, Apple M3 Pro, `benchstat` over `-count 8`:

| testdata | before | after | delta |
|---|---|---|---|
| go.cpu.labels.pprof | 762.1n | 404.8n | -46.9% |
| heap | 1086.5n | 636.4n | -41.4% |
| dotnet.labels.pprof | 1.585µ | 1.020µ | -35.7% |
| profile_java | 1109.5n | 671.6n | -39.5% |
| profile_nodejs | 1.596µ | 1.009µ | -36.8% |
| profile_python | 514.4n | 321.1n | -37.6% |
| profile_ruby | 498.6n | 276.4n | -44.6% |
| profile_rust | 856.9n | 544.5n | -36.5% |
| **geomean** | **919.4n** | **551.8n** | **-40.0%** (p=0.000) |

0 allocs/op before and after. All `Test_GetProfileLanguage_*` tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)