### PR TITLE
feat(symbolizer): expose address-level symbol resolution as a public API

### DIFF
--- a/pkg/symbolizer/debuginfod_client.go
+++ b/pkg/symbolizer/debuginfod_client.go
@@ -127,8 +127,13 @@ func (c *DebuginfodHTTPClient) FetchDebuginfo(ctx context.Context, buildID strin
 	}
 	c.metrics.cacheOperations.WithLabelValues("not_found", "get", "miss").Inc()
 
+	// The flight is shared by every concurrent caller for this build ID:
+	// detach it from the initiating caller's context so that one caller's
+	// cancellation cannot fail the others. The HTTP client's timeout and
+	// the bounded retries keep a detached flight from running unbounded.
+	flightCtx := context.WithoutCancel(ctx)
 	v, err, _ := c.group.Do(sanitizedBuildID, func() (interface{}, error) {
-		return c.fetchDebugInfoWithRetries(ctx, sanitizedBuildID)
+		return c.fetchDebugInfoWithRetries(flightCtx, sanitizedBuildID)
 	})
 
 	if err != nil {

--- a/pkg/symbolizer/debuginfod_client.go
+++ b/pkg/symbolizer/debuginfod_client.go
@@ -127,13 +127,14 @@ func (c *DebuginfodHTTPClient) FetchDebuginfo(ctx context.Context, buildID strin
 	}
 	c.metrics.cacheOperations.WithLabelValues("not_found", "get", "miss").Inc()
 
-	// The flight is shared by every concurrent caller for this build ID:
-	// detach it from the initiating caller's context so that one caller's
-	// cancellation cannot fail the others. The HTTP client's timeout and
-	// the bounded retries keep a detached flight from running unbounded.
-	flightCtx := context.WithoutCancel(ctx)
+	// c.group deduplicates the fetch: every concurrent caller for the same
+	// build ID shares one in-flight request, so it must not run on any
+	// single caller's context — one caller's cancellation would fail all of
+	// them. Detach it (context values are preserved); the HTTP client's
+	// timeout and the bounded retries keep the detached fetch finite.
+	localCtx := context.WithoutCancel(ctx)
 	v, err, _ := c.group.Do(sanitizedBuildID, func() (interface{}, error) {
-		return c.fetchDebugInfoWithRetries(flightCtx, sanitizedBuildID)
+		return c.fetchDebugInfoWithRetries(localCtx, sanitizedBuildID)
 	})
 
 	if err != nil {

--- a/pkg/symbolizer/debuginfod_client.go
+++ b/pkg/symbolizer/debuginfod_client.go
@@ -107,6 +107,13 @@ func NewDebuginfodClientWithConfig(logger log.Logger, cfg DebuginfodClientConfig
 }
 
 // FetchDebuginfo fetches the debuginfo file for a specific build ID.
+//
+// Concurrent callers for the same build ID share one fetch, detached from
+// any single caller's cancellation. The error contract follows from that:
+// a done caller gets its own context error without waiting for the shared
+// fetch to finish, and every other error comes from the shared fetch — it
+// may wrap a context error (e.g. the HTTP client's timeout) that says
+// nothing about the caller's own context.
 func (c *DebuginfodHTTPClient) FetchDebuginfo(ctx context.Context, buildID string) (io.ReadCloser, error) {
 	start := time.Now()
 	status := statusSuccess
@@ -127,15 +134,22 @@ func (c *DebuginfodHTTPClient) FetchDebuginfo(ctx context.Context, buildID strin
 	}
 	c.metrics.cacheOperations.WithLabelValues("not_found", "get", "miss").Inc()
 
-	// c.group deduplicates the fetch: every concurrent caller for the same
-	// build ID shares one in-flight request, so it must not run on any
-	// single caller's context — one caller's cancellation would fail all of
-	// them. Detach it (context values are preserved); the HTTP client's
-	// timeout and the bounded retries keep the detached fetch finite.
+	// Detached so one caller's cancellation cannot fail the fetch for the
+	// others; context values are preserved, and the HTTP client's timeout
+	// plus bounded retries keep the detached fetch finite.
 	localCtx := context.WithoutCancel(ctx)
-	v, err, _ := c.group.Do(sanitizedBuildID, func() (interface{}, error) {
+	resCh := c.group.DoChan(sanitizedBuildID, func() (interface{}, error) {
 		return c.fetchDebugInfoWithRetries(localCtx, sanitizedBuildID)
 	})
+
+	// A done caller stops waiting; the fetch keeps running for the rest.
+	var v interface{}
+	select {
+	case res := <-resCh:
+		v, err = res.Val, res.Err
+	case <-ctx.Done():
+		err = ctx.Err()
+	}
 
 	if err != nil {
 		var bnfErr buildIDNotFoundError

--- a/pkg/symbolizer/debuginfod_client_test.go
+++ b/pkg/symbolizer/debuginfod_client_test.go
@@ -219,6 +219,55 @@ func TestDebuginfodClientSingleflight(t *testing.T) {
 	assert.Equal(t, 1, requestCount, "Expected only one HTTP request")
 }
 
+func TestDebuginfodClientCanceledCallerDoesNotWaitForFetch(t *testing.T) {
+	requestStarted := make(chan struct{})
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		<-release
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("mock debug info"))
+	}))
+	defer server.Close()
+
+	metrics := newMetrics(prometheus.NewRegistry())
+	client, err := NewDebuginfodClient(log.NewNopLogger(), server.URL, metrics, validation.MockDefaultOverrides())
+	require.NoError(t, err)
+
+	buildID := "cancel-wait-test-id"
+
+	// A waiter with a live context stays on the shared fetch until it finishes.
+	type fetchResult struct {
+		data []byte
+		err  error
+	}
+	waiterCh := make(chan fetchResult, 1)
+	go func() {
+		reader, err := client.FetchDebuginfo(tenant.InjectTenantID(context.Background(), "tenant"), buildID)
+		if err != nil {
+			waiterCh <- fetchResult{err: err}
+			return
+		}
+		defer reader.Close()
+		data, err := io.ReadAll(reader)
+		waiterCh <- fetchResult{data: data, err: err}
+	}()
+
+	<-requestStarted
+
+	// A canceled caller joining the same in-flight fetch returns its own
+	// context error immediately instead of blocking until the fetch finishes.
+	canceledCtx, cancel := context.WithCancel(tenant.InjectTenantID(context.Background(), "tenant"))
+	cancel()
+	_, err = client.FetchDebuginfo(canceledCtx, buildID)
+	require.ErrorIs(t, err, context.Canceled)
+
+	close(release)
+	res := <-waiterCh
+	require.NoError(t, res.err)
+	require.Equal(t, "mock debug info", string(res.data))
+}
+
 func TestSanitizeBuildID(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/symbolizer/resolve_test.go
+++ b/pkg/symbolizer/resolve_test.go
@@ -107,9 +107,10 @@ func TestResolveContextCancellation(t *testing.T) {
 	t.Run("foreign context error degrades to fallback", func(t *testing.T) {
 		s, mockClient, mockBucket := newSymbolizerTest(t, nil)
 		mockBucket.On("Get", mock.Anything, lidiaObjectPath("tenant", "build-id")).Return(nil, fmt.Errorf("not found")).Once()
-		// A debuginfod flight shared with other callers can surface another
-		// caller's cancellation; with this caller's context alive it must
-		// degrade to unresolved slots like any other fetch failure.
+		// The deduplicated debuginfod fetch is shared with other callers and
+		// can surface another caller's cancellation; with this caller's
+		// context alive it must degrade to unresolved slots like any other
+		// fetch failure.
 		mockClient.On("FetchDebuginfo", mock.Anything, "build-id").Return(nil, context.Canceled).Once()
 
 		frames, err := s.Resolve(tenant.InjectTenantID(context.Background(), "tenant"), "build-id", "binary", []uint64{0x1500})

--- a/pkg/symbolizer/resolve_test.go
+++ b/pkg/symbolizer/resolve_test.go
@@ -83,6 +83,43 @@ func TestResolveContextCancellation(t *testing.T) {
 		require.Nil(t, res.frames)
 	})
 
+	t.Run("canceled mid-fetch with successful fetch", func(t *testing.T) {
+		s, mockClient, mockBucket := newSymbolizerTest(t, nil)
+		mockBucket.On("Get", mock.Anything, lidiaObjectPath("tenant", "build-id")).Return(nil, fmt.Errorf("not found")).Once()
+
+		// The deduplicated fetch is detached from caller cancellation, so it
+		// can complete successfully after the caller's context is done; the
+		// canceled caller must still get an error, not the fetched result.
+		fetchStarted := make(chan struct{})
+		mockClient.On("FetchDebuginfo", mock.Anything, "build-id").Return(
+			func(ctx context.Context, buildID string) (io.ReadCloser, error) {
+				close(fetchStarted)
+				<-ctx.Done()
+				return openTestFile(t), nil
+			},
+		).Once()
+		mockBucket.On("Upload", mock.Anything, lidiaObjectPath("tenant", "build-id"), mock.Anything).Return(nil).Once()
+
+		ctx, cancel := context.WithCancel(tenant.InjectTenantID(context.Background(), "tenant"))
+		type result struct {
+			frames [][]lidia.SourceInfoFrame
+			err    error
+		}
+		resCh := make(chan result, 1)
+		go func() {
+			frames, err := s.Resolve(ctx, "build-id", "binary", []uint64{0x1500})
+			resCh <- result{frames, err}
+		}()
+
+		<-fetchStarted
+		cancel()
+		res := <-resCh
+
+		require.Error(t, res.err)
+		require.ErrorIs(t, res.err, context.Canceled)
+		require.Nil(t, res.frames)
+	})
+
 	t.Run("deadline exceeded mid-fetch", func(t *testing.T) {
 		s, mockClient, mockBucket := newSymbolizerTest(t, nil)
 		mockBucket.On("Get", mock.Anything, lidiaObjectPath("tenant", "build-id")).Return(nil, fmt.Errorf("not found")).Once()

--- a/pkg/symbolizer/resolve_test.go
+++ b/pkg/symbolizer/resolve_test.go
@@ -1,0 +1,230 @@
+package symbolizer
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	googlev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	"github.com/grafana/pyroscope/lidia"
+	"github.com/grafana/pyroscope/v2/pkg/tenant"
+	"github.com/grafana/pyroscope/v2/pkg/validation"
+)
+
+func TestResolveSizeLimitExceeded(t *testing.T) {
+	limits := validation.MockOverrides(func(_ *validation.Limits, tenantLimits map[string]*validation.Limits) {
+		l := validation.MockDefaultLimits()
+		l.Symbolizer.MaxSymbolSizeBytes = 4
+		tenantLimits["tenant-limited"] = l
+	})
+	s, mockClient, mockBucket := newSymbolizerTest(t, &symbolizerInputs{Limits: limits})
+
+	mockBucket.On("Get", mock.Anything, lidiaObjectPath("tenant-limited", "build-id")).Return(nil, fmt.Errorf("not found")).Once()
+	mockClient.On("FetchDebuginfo", mock.Anything, "build-id").Return(openTestFile(t), nil).Once()
+
+	ctx := tenant.InjectTenantID(context.Background(), "tenant-limited")
+	frames, err := s.Resolve(ctx, "build-id", "some-binary", []uint64{0x1500})
+
+	require.NoError(t, err)
+	require.Len(t, frames, 1)
+	require.Nil(t, frames[0])
+}
+
+func TestResolveContextCancellation(t *testing.T) {
+	t.Run("already canceled", func(t *testing.T) {
+		s, _, _ := newSymbolizerTest(t, nil)
+		ctx, cancel := context.WithCancel(tenant.InjectTenantID(context.Background(), "tenant"))
+		cancel()
+
+		frames, err := s.Resolve(ctx, "build-id", "binary", []uint64{0x1500})
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.Canceled)
+		require.Nil(t, frames)
+	})
+
+	t.Run("canceled mid-fetch", func(t *testing.T) {
+		s, mockClient, mockBucket := newSymbolizerTest(t, nil)
+		mockBucket.On("Get", mock.Anything, lidiaObjectPath("tenant", "build-id")).Return(nil, fmt.Errorf("not found")).Once()
+
+		fetchStarted := make(chan struct{})
+		mockClient.On("FetchDebuginfo", mock.Anything, "build-id").Return(
+			func(ctx context.Context, buildID string) (io.ReadCloser, error) {
+				close(fetchStarted)
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+		).Once()
+
+		ctx, cancel := context.WithCancel(tenant.InjectTenantID(context.Background(), "tenant"))
+		type result struct {
+			frames [][]lidia.SourceInfoFrame
+			err    error
+		}
+		resCh := make(chan result, 1)
+		go func() {
+			frames, err := s.Resolve(ctx, "build-id", "binary", []uint64{0x1500})
+			resCh <- result{frames, err}
+		}()
+
+		<-fetchStarted
+		cancel()
+		res := <-resCh
+
+		require.Error(t, res.err)
+		require.ErrorIs(t, res.err, context.Canceled)
+		require.Nil(t, res.frames)
+	})
+
+	t.Run("deadline exceeded mid-fetch", func(t *testing.T) {
+		s, mockClient, mockBucket := newSymbolizerTest(t, nil)
+		mockBucket.On("Get", mock.Anything, lidiaObjectPath("tenant", "build-id")).Return(nil, fmt.Errorf("not found")).Once()
+
+		mockClient.On("FetchDebuginfo", mock.Anything, "build-id").Return(
+			func(ctx context.Context, buildID string) (io.ReadCloser, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+		).Once()
+
+		ctx, cancel := context.WithTimeout(tenant.InjectTenantID(context.Background(), "tenant"), 1*time.Millisecond)
+		defer cancel()
+
+		frames, err := s.Resolve(ctx, "build-id", "binary", []uint64{0x1500})
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Nil(t, frames)
+	})
+}
+
+func TestResolveInvalidBuildID(t *testing.T) {
+	s, mockClient, mockBucket := newSymbolizerTest(t, nil)
+	ctx := tenant.InjectTenantID(context.Background(), "tenant")
+
+	frames, err := s.Resolve(ctx, "../traversal", "binary", []uint64{0x1500, 0x3c5a})
+
+	require.NoError(t, err)
+	require.Len(t, frames, 2)
+	require.Nil(t, frames[0])
+	require.Nil(t, frames[1])
+	require.Equal(t, float64(1), testutil.ToFloat64(s.metrics.debugSymbolResolutionErrors.WithLabelValues("invalid_build_id")))
+
+	// No mockClient/mockBucket expectations configured above: AssertExpectations here
+	// (and the mocks' own t.Cleanup) prove Resolve rejected the malformed buildID before
+	// touching the bucket or debuginfod.
+	mockClient.AssertExpectations(t)
+	mockBucket.AssertExpectations(t)
+}
+
+func TestSymbolizePprofPropagatesContextCancellation(t *testing.T) {
+	s, _, _ := newSymbolizerTest(t, nil)
+	profile := &googlev1.Profile{
+		Mapping: []*googlev1.Mapping{{
+			BuildId:     1,
+			MemoryStart: 0x0,
+			MemoryLimit: 0x1000000,
+		}},
+		Location:    []*googlev1.Location{{Id: 1, MappingId: 1, Address: 0x1500}},
+		StringTable: []string{"", "build-id"},
+	}
+
+	ctx, cancel := context.WithCancel(tenant.InjectTenantID(context.Background(), "tenant"))
+	cancel()
+
+	err := s.SymbolizePprof(ctx, profile)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestSymbolizeMappingsConcurrentFanOut(t *testing.T) {
+	elfFile := openTestFile(t)
+	elfData, err := io.ReadAll(elfFile)
+	require.NoError(t, err)
+	require.NoError(t, elfFile.Close())
+
+	s, mockClient, mockBucket := newSymbolizerTest(t, nil)
+	s.cfg.MaxDebuginfodConcurrency = 4
+
+	// addrs per build ID; 0x1500 resolves to "main", 0x3c5a resolves to "atoll_b"
+	// (see testdata/symbols.debug, also used by TestSymbolizePprof).
+	buildIDAddrs := map[string][]uint64{
+		"build-id-1": {0x1500, 0x3c5a},
+		"build-id-2": {0x1500},
+		"build-id-3": {0x1500},
+	}
+	buildIDs := []string{"build-id-1", "build-id-2", "build-id-3"}
+
+	fetchStarted := make(chan struct{}, len(buildIDs))
+	release := make(chan struct{})
+	blockUntilReleased := func(context.Context, string) (io.ReadCloser, error) {
+		fetchStarted <- struct{}{}
+		<-release
+		return io.NopCloser(bytes.NewReader(elfData)), nil
+	}
+
+	stringTable := []string{""}
+	mappings := make([]*googlev1.Mapping, len(buildIDs))
+	var locations []*googlev1.Location
+	nextLocID := uint64(1)
+
+	for i, buildID := range buildIDs {
+		buildIDIdx := int64(len(stringTable))
+		stringTable = append(stringTable, buildID)
+
+		mappings[i] = &googlev1.Mapping{
+			BuildId:     buildIDIdx,
+			MemoryStart: 0x0,
+			MemoryLimit: 0x1000000,
+		}
+		mappingID := uint64(i + 1)
+
+		for _, addr := range buildIDAddrs[buildID] {
+			locations = append(locations, &googlev1.Location{
+				Id:        nextLocID,
+				MappingId: mappingID,
+				Address:   addr,
+			})
+			nextLocID++
+		}
+
+		mockBucket.On("Get", mock.Anything, lidiaObjectPath("tenant", buildID)).Return(nil, fmt.Errorf("not found")).Once()
+		mockClient.On("FetchDebuginfo", mock.Anything, buildID).Return(blockUntilReleased).Once()
+		mockBucket.On("Upload", mock.Anything, lidiaObjectPath("tenant", buildID), mock.Anything).Return(nil).Once()
+	}
+
+	profile := &googlev1.Profile{
+		Mapping:     mappings,
+		Location:    locations,
+		StringTable: stringTable,
+	}
+
+	ctx := tenant.InjectTenantID(context.Background(), "tenant")
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- s.SymbolizePprof(ctx, profile)
+	}()
+
+	for range buildIDs {
+		<-fetchStarted
+	}
+	close(release)
+
+	require.NoError(t, <-errCh)
+
+	for _, mapping := range mappings {
+		require.True(t, mapping.HasFunctions)
+	}
+	assertLocationHasFunction(t, profile, locations[0], "main", "main")
+	assertLocationHasFunction(t, profile, locations[1], "atoll_b", "atoll_b")
+	assertLocationHasFunction(t, profile, locations[2], "main", "main")
+	assertLocationHasFunction(t, profile, locations[3], "main", "main")
+}

--- a/pkg/symbolizer/resolve_test.go
+++ b/pkg/symbolizer/resolve_test.go
@@ -103,6 +103,21 @@ func TestResolveContextCancellation(t *testing.T) {
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 		require.Nil(t, frames)
 	})
+
+	t.Run("foreign context error degrades to fallback", func(t *testing.T) {
+		s, mockClient, mockBucket := newSymbolizerTest(t, nil)
+		mockBucket.On("Get", mock.Anything, lidiaObjectPath("tenant", "build-id")).Return(nil, fmt.Errorf("not found")).Once()
+		// A debuginfod flight shared with other callers can surface another
+		// caller's cancellation; with this caller's context alive it must
+		// degrade to unresolved slots like any other fetch failure.
+		mockClient.On("FetchDebuginfo", mock.Anything, "build-id").Return(nil, context.Canceled).Once()
+
+		frames, err := s.Resolve(tenant.InjectTenantID(context.Background(), "tenant"), "build-id", "binary", []uint64{0x1500})
+
+		require.NoError(t, err)
+		require.Len(t, frames, 1)
+		require.Nil(t, frames[0])
+	})
 }
 
 func TestResolveInvalidBuildID(t *testing.T) {

--- a/pkg/symbolizer/symbolizer.go
+++ b/pkg/symbolizer/symbolizer.go
@@ -32,6 +32,73 @@ type DebuginfodClient interface {
 	FetchDebuginfo(ctx context.Context, buildID string) (io.ReadCloser, error)
 }
 
+// Resolver resolves debug symbols for addresses within a single binary (identified by
+// buildID). result[i] is aligned to addrs[i]; a nil/empty slice at index i means address i
+// could not be resolved. A non-nil error is returned only when ctx is done
+// (context.Canceled or context.DeadlineExceeded), in which case result is nil.
+// A buildID that is empty or fails validation resolves nothing: every result slot is nil.
+type Resolver interface {
+	Resolve(ctx context.Context, buildID, binaryName string, addrs []uint64) ([][]lidia.SourceInfoFrame, error)
+}
+
+var _ Resolver = (*Symbolizer)(nil)
+
+// Resolve implements Resolver.
+func (s *Symbolizer) Resolve(ctx context.Context, buildID, binaryName string, addrs []uint64) ([][]lidia.SourceInfoFrame, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("resolve symbols: %w", err)
+	}
+
+	if buildID == "" {
+		s.metrics.debugSymbolResolutionErrors.WithLabelValues("empty_build_id").Inc()
+		return make([][]lidia.SourceInfoFrame, len(addrs)), nil
+	}
+
+	if _, err := sanitizeBuildID(buildID); err != nil {
+		s.metrics.debugSymbolResolutionErrors.WithLabelValues("invalid_build_id").Inc()
+		return make([][]lidia.SourceInfoFrame, len(addrs)), nil
+	}
+
+	lidiaBytes, err := s.getLidiaBytes(ctx, buildID)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("resolve symbols: %w", err)
+		}
+		level.Warn(s.logger).Log("msg", "Failed to get debug info", "buildID", buildID, "binaryName", binaryName, "err", err)
+		return make([][]lidia.SourceInfoFrame, len(addrs)), nil
+	}
+
+	lidiaReader := NewReaderAtCloser(lidiaBytes)
+	table, err := lidia.OpenReader(lidiaReader, lidia.WithCRC())
+	if err != nil {
+		s.metrics.debugSymbolResolutionErrors.WithLabelValues("lidia_error").Inc()
+		level.Warn(s.logger).Log("msg", "Failed to open Lidia file", "err", err)
+		return make([][]lidia.SourceInfoFrame, len(addrs)), nil
+	}
+	defer table.Close()
+
+	return s.resolveWithTable(table, addrs), nil
+}
+
+func (s *Symbolizer) resolveWithTable(table *lidia.Table, addrs []uint64) [][]lidia.SourceInfoFrame {
+	result := make([][]lidia.SourceInfoFrame, len(addrs))
+	var framesBuf []lidia.SourceInfoFrame
+
+	resolveStart := time.Now()
+	defer func() {
+		s.metrics.debugSymbolResolution.WithLabelValues(statusSuccess).Observe(time.Since(resolveStart).Seconds())
+	}()
+
+	for i, addr := range addrs {
+		frames, err := table.Lookup(framesBuf, addr)
+		if err != nil || len(frames) == 0 {
+			continue // result[i] stays nil
+		}
+		result[i] = frames
+	}
+	return result
+}
+
 type Config struct {
 	DebuginfodURL            string `yaml:"debuginfod_url" category:"advanced"`
 	MaxDebuginfodConcurrency int    `yaml:"max_debuginfod_concurrency" category:"advanced"`
@@ -180,15 +247,26 @@ func (s *Symbolizer) symbolizeMappingsConcurrently(
 				return fmt.Errorf("extract build ID for mapping %d: %w", job.mappingID, err)
 			}
 
-			req := s.createSymbolizationRequest(binaryName, buildID, job.locations)
-			s.symbolize(ctx, &req)
+			addrs := make([]uint64, len(job.locations))
+			for i, loc := range job.locations {
+				addrs[i] = loc.Address
+			}
+
+			frames, err := s.Resolve(ctx, buildID, binaryName, addrs)
+			if err != nil {
+				return fmt.Errorf("resolve mapping %d: %w", job.mappingID, err)
+			}
 
 			// Collect symbolized locations for this mapping
 			symbolizedLocs := make([]symbolizedLocation, len(job.locations))
 			for i, loc := range job.locations {
+				lines := frames[i]
+				if len(lines) == 0 {
+					lines = s.createFallbackSymbol(binaryName, loc.Address)
+				}
 				symbolizedLocs[i] = symbolizedLocation{
 					loc:     loc,
-					symLoc:  req.locations[i],
+					lines:   lines,
 					mapping: mapping,
 				}
 			}
@@ -273,23 +351,6 @@ func (s *Symbolizer) extractBuildID(profile *googlev1.Profile, mapping *googlev1
 	return sanitizedBuildID, nil
 }
 
-// createSymbolizationRequest creates a symbolization request for a mapping group
-func (s *Symbolizer) createSymbolizationRequest(binaryName, buildID string, locs []*googlev1.Location) request {
-	req := request{
-		buildID:    buildID,
-		binaryName: binaryName,
-		locations:  make([]*location, len(locs)),
-	}
-
-	for i, loc := range locs {
-		req.locations[i] = &location{
-			address: loc.Address,
-		}
-	}
-
-	return req
-}
-
 func (s *Symbolizer) updateAllSymbolsInProfile(
 	profile *googlev1.Profile,
 	symbolizedLocs []symbolizedLocation,
@@ -301,7 +362,7 @@ func (s *Symbolizer) updateAllSymbolsInProfile(
 
 	for _, item := range symbolizedLocs {
 		loc := item.loc
-		symLoc := item.symLoc
+		lines := item.lines
 		mapping := item.mapping
 
 		locIdx := loc.Id - 1
@@ -309,9 +370,9 @@ func (s *Symbolizer) updateAllSymbolsInProfile(
 			continue
 		}
 
-		profile.Location[locIdx].Line = make([]*googlev1.Line, len(symLoc.lines))
+		profile.Location[locIdx].Line = make([]*googlev1.Line, len(lines))
 
-		for j, line := range symLoc.lines {
+		for j, line := range lines {
 			nameIdx, ok := stringMap[line.FunctionName]
 			if !ok {
 				nameIdx = int64(len(profile.StringTable))
@@ -360,63 +421,6 @@ func (s *Symbolizer) updateAllSymbolsInProfile(
 		}
 
 		mapping.HasFunctions = true
-	}
-}
-
-func (s *Symbolizer) symbolize(ctx context.Context, req *request) {
-	if req.buildID == "" {
-		s.metrics.debugSymbolResolutionErrors.WithLabelValues("empty_build_id").Inc()
-		s.setFallbackSymbols(req)
-		return
-	}
-
-	lidiaBytes, err := s.getLidiaBytes(ctx, req.buildID)
-	if err != nil {
-		level.Warn(s.logger).Log("msg", "Failed to get debug info", "buildID", req.buildID, "err", err)
-		s.setFallbackSymbols(req)
-		return
-	}
-
-	lidiaReader := NewReaderAtCloser(lidiaBytes)
-	table, err := lidia.OpenReader(lidiaReader, lidia.WithCRC())
-	if err != nil {
-		s.metrics.debugSymbolResolutionErrors.WithLabelValues("lidia_error").Inc()
-		level.Warn(s.logger).Log("msg", "Failed to open Lidia file", "err", err)
-		s.setFallbackSymbols(req)
-		return
-	}
-	defer table.Close()
-
-	s.symbolizeWithTable(table, req)
-}
-
-// setFallbackSymbols sets fallback symbols for all locations in the request
-func (s *Symbolizer) setFallbackSymbols(req *request) {
-	for _, loc := range req.locations {
-		loc.lines = s.createFallbackSymbol(req.binaryName, loc)
-	}
-}
-
-func (s *Symbolizer) symbolizeWithTable(table *lidia.Table, req *request) {
-	var framesBuf []lidia.SourceInfoFrame
-
-	resolveStart := time.Now()
-	defer func() {
-		s.metrics.debugSymbolResolution.WithLabelValues(statusSuccess).Observe(time.Since(resolveStart).Seconds())
-	}()
-
-	for _, loc := range req.locations {
-		frames, err := table.Lookup(framesBuf, loc.address)
-		if err != nil {
-			loc.lines = s.createFallbackSymbol(req.binaryName, loc)
-			continue
-		}
-
-		if len(frames) == 0 {
-			loc.lines = s.createFallbackSymbol(req.binaryName, loc)
-			continue
-		}
-		loc.lines = frames
 	}
 }
 
@@ -561,14 +565,14 @@ func (s *Symbolizer) processELFData(data []byte, maxSize int64) (lidiaData []byt
 	return memBuffer.Bytes(), nil
 }
 
-func (s *Symbolizer) createFallbackSymbol(binaryName string, loc *location) []lidia.SourceInfoFrame {
+func (s *Symbolizer) createFallbackSymbol(binaryName string, address uint64) []lidia.SourceInfoFrame {
 	prefix := "unknown"
 	if binaryName != "" {
 		prefix = binaryName
 	}
 
 	return []lidia.SourceInfoFrame{{
-		FunctionName: fmt.Sprintf("%s!0x%x", prefix, loc.address),
+		FunctionName: fmt.Sprintf("%s!0x%x", prefix, address),
 		LineNumber:   0,
 	}}
 }

--- a/pkg/symbolizer/symbolizer.go
+++ b/pkg/symbolizer/symbolizer.go
@@ -34,8 +34,9 @@ type DebuginfodClient interface {
 
 // Resolver resolves debug symbols for addresses within a single binary (identified by
 // buildID). result[i] is aligned to addrs[i]; a nil/empty slice at index i means address i
-// could not be resolved. A non-nil error is returned only when ctx is done
-// (context.Canceled or context.DeadlineExceeded), in which case result is nil.
+// could not be resolved. A non-nil error is returned only when the caller's own
+// ctx is done (context.Canceled or context.DeadlineExceeded), in which case
+// result is nil; any other failure degrades to unresolved slots.
 // A buildID that is empty or fails validation resolves nothing: every result slot is nil.
 type Resolver interface {
 	Resolve(ctx context.Context, buildID, binaryName string, addrs []uint64) ([][]lidia.SourceInfoFrame, error)
@@ -61,8 +62,12 @@ func (s *Symbolizer) Resolve(ctx context.Context, buildID, binaryName string, ad
 
 	lidiaBytes, err := s.getLidiaBytes(ctx, buildID)
 	if err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return nil, fmt.Errorf("resolve symbols: %w", err)
+		// Only the caller's own context ends the call: a context error
+		// propagated from below may belong to another caller sharing the
+		// debuginfod flight, and must degrade to fallback like any other
+		// fetch failure.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("resolve symbols: %w", ctxErr)
 		}
 		level.Warn(s.logger).Log("msg", "Failed to get debug info", "buildID", buildID, "binaryName", binaryName, "err", err)
 		return make([][]lidia.SourceInfoFrame, len(addrs)), nil

--- a/pkg/symbolizer/symbolizer.go
+++ b/pkg/symbolizer/symbolizer.go
@@ -64,8 +64,9 @@ func (s *Symbolizer) Resolve(ctx context.Context, buildID, binaryName string, ad
 	if err != nil {
 		// Only the caller's own context ends the call: a context error
 		// propagated from below may belong to another caller sharing the
-		// deduplicated debuginfod fetch, and must degrade to fallback like
-		// any other fetch failure.
+		// deduplicated debuginfod fetch, and must degrade to unresolved
+		// slots like any other fetch failure; callers render those as
+		// fallback symbols.
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, fmt.Errorf("resolve symbols: %w", ctxErr)
 		}

--- a/pkg/symbolizer/symbolizer.go
+++ b/pkg/symbolizer/symbolizer.go
@@ -64,8 +64,8 @@ func (s *Symbolizer) Resolve(ctx context.Context, buildID, binaryName string, ad
 	if err != nil {
 		// Only the caller's own context ends the call: a context error
 		// propagated from below may belong to another caller sharing the
-		// debuginfod flight, and must degrade to fallback like any other
-		// fetch failure.
+		// deduplicated debuginfod fetch, and must degrade to fallback like
+		// any other fetch failure.
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, fmt.Errorf("resolve symbols: %w", ctxErr)
 		}

--- a/pkg/symbolizer/symbolizer.go
+++ b/pkg/symbolizer/symbolizer.go
@@ -61,15 +61,13 @@ func (s *Symbolizer) Resolve(ctx context.Context, buildID, binaryName string, ad
 	}
 
 	lidiaBytes, err := s.getLidiaBytes(ctx, buildID)
+	// Whatever the fetch outcome, only this caller's own context ends the
+	// call: errors from below may carry context errors that are not ours,
+	// and the shared fetch can succeed after our context is done.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, fmt.Errorf("resolve symbols: %w", ctxErr)
+	}
 	if err != nil {
-		// Only the caller's own context ends the call: a context error
-		// propagated from below may belong to another caller sharing the
-		// deduplicated debuginfod fetch, and must degrade to unresolved
-		// slots like any other fetch failure; callers render those as
-		// fallback symbols.
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return nil, fmt.Errorf("resolve symbols: %w", ctxErr)
-		}
 		level.Warn(s.logger).Log("msg", "Failed to get debug info", "buildID", buildID, "binaryName", binaryName, "err", err)
 		return make([][]lidia.SourceInfoFrame, len(addrs)), nil
 	}

--- a/pkg/symbolizer/symbolizer_test.go
+++ b/pkg/symbolizer/symbolizer_test.go
@@ -406,33 +406,15 @@ func TestSymbolizationWithLidiaData(t *testing.T) {
 	mockBucket.On("Get", mock.Anything, lidiaObjectPath("tenant", buildID)).Return(getLidiaData(), nil).Once()
 	mockBucket.On("Get", mock.Anything, lidiaObjectPath("tenant", buildID)).Return(getLidiaData(), nil).Once()
 
-	req := &request{
-		buildID:    buildID,
-		binaryName: "test-binary",
-		locations: []*location{
-			{
-				address: 0x1b743d6,
-			},
-		},
-	}
-
 	ctx := tenant.InjectTenantID(context.Background(), "tenant")
-	sym.symbolize(ctx, req)
-	require.NotEmpty(t, req.locations[0].lines)
+	frames, err := sym.Resolve(ctx, buildID, "test-binary", []uint64{0x1b743d6})
+	require.NoError(t, err)
+	require.NotEmpty(t, frames[0])
 
 	// Second request should also fetch from store
-	req2 := &request{
-		buildID:    buildID,
-		binaryName: "test-binary",
-		locations: []*location{
-			{
-				address: 0x1b743d6,
-			},
-		},
-	}
-
-	sym.symbolize(ctx, req2)
-	require.NotEmpty(t, req2.locations[0].lines)
+	frames2, err := sym.Resolve(ctx, buildID, "test-binary", []uint64{0x1b743d6})
+	require.NoError(t, err)
+	require.NotEmpty(t, frames2[0])
 }
 
 // TestSymbolizeWithObjectStore validates the symbolizer's behavior with the object store
@@ -462,9 +444,9 @@ func TestSymbolizeWithObjectStore(t *testing.T) {
 			require.NoError(t, err)
 		}).Return(nil).Once()
 
-		req1 := createRequest(t, "build-id", 0x1500)
-		s.symbolize(ctx, req1)
-		require.NotEmpty(t, req1.locations[0].lines)
+		frames, err := s.Resolve(ctx, "build-id", "", []uint64{0x1500})
+		require.NoError(t, err)
+		require.NotEmpty(t, frames[0])
 		require.NotEmpty(t, capturedLidiaData)
 
 		mockClient.AssertExpectations(t)
@@ -480,9 +462,9 @@ func TestSymbolizeWithObjectStore(t *testing.T) {
 			io.NopCloser(bytes.NewReader(capturedLidiaData)), nil,
 		).Once()
 
-		req2 := createRequest(t, "build-id", 0x1500)
-		s.symbolize(ctx, req2)
-		require.NotEmpty(t, req2.locations[0].lines)
+		frames, err := s.Resolve(ctx, "build-id", "", []uint64{0x1500})
+		require.NoError(t, err)
+		require.NotEmpty(t, frames[0])
 
 		mockClient.AssertExpectations(t)
 		mockBucket.AssertExpectations(t)
@@ -495,9 +477,9 @@ func TestSymbolizeWithObjectStore(t *testing.T) {
 			io.NopCloser(bytes.NewReader(capturedLidiaData)), nil,
 		).Once()
 
-		req3 := createRequest(t, "build-id", 0x3c5a)
-		s.symbolize(ctx, req3)
-		require.NotEmpty(t, req3.locations[0].lines)
+		frames, err := s.Resolve(ctx, "build-id", "", []uint64{0x3c5a})
+		require.NoError(t, err)
+		require.NotEmpty(t, frames[0])
 
 		mockClient.AssertExpectations(t)
 		mockBucket.AssertExpectations(t)
@@ -520,9 +502,9 @@ func TestSymbolizeWithObjectStore(t *testing.T) {
 			require.NoError(t, err)
 		}).Return(nil).Once()
 
-		req4 := createRequest(t, "different-build-id", 0x1500)
-		s.symbolize(ctx, req4)
-		require.NotEmpty(t, req4.locations[0].lines)
+		frames, err := s.Resolve(ctx, "different-build-id", "", []uint64{0x1500})
+		require.NoError(t, err)
+		require.NotEmpty(t, frames[0])
 		require.NotEmpty(t, capturedLidiaData2)
 
 		mockClient.AssertExpectations(t)
@@ -569,11 +551,11 @@ func TestSymbolizerMetrics(t *testing.T) {
 				).Once()
 			},
 			setupTest: func(s *Symbolizer, ctx context.Context) {
-				req1 := createRequest(t, "build-id", 0x1500)
-				s.symbolize(ctx, req1)
+				_, err := s.Resolve(ctx, "build-id", "", []uint64{0x1500})
+				require.NoError(t, err)
 
-				req2 := createRequest(t, "build-id", 0x1500)
-				s.symbolize(ctx, req2)
+				_, err = s.Resolve(ctx, "build-id", "", []uint64{0x1500})
+				require.NoError(t, err)
 			},
 			expected: map[string]int{
 				"pyroscope_profile_symbolization_duration_seconds":   0,
@@ -589,8 +571,10 @@ func TestSymbolizerMetrics(t *testing.T) {
 					Return(nil, buildIDNotFoundError{buildID: "unknown-build-id"}).Once()
 			},
 			setupTest: func(s *Symbolizer, ctx context.Context) {
-				req := createRequest(t, "unknown-build-id", 0x1500)
-				s.symbolize(ctx, req)
+				frames, err := s.Resolve(ctx, "unknown-build-id", "some-binary", []uint64{0x1500})
+				require.NoError(t, err)
+				require.Len(t, frames, 1)
+				require.Nil(t, frames[0])
 			},
 			expected: map[string]int{
 				"pyroscope_profile_symbolization_duration_seconds":   0,
@@ -609,8 +593,8 @@ func TestSymbolizerMetrics(t *testing.T) {
 				).Once()
 			},
 			setupTest: func(s *Symbolizer, ctx context.Context) {
-				req := createRequest(t, "invalid-elf", 0x1500)
-				s.symbolize(ctx, req)
+				_, err := s.Resolve(ctx, "invalid-elf", "", []uint64{0x1500})
+				require.NoError(t, err)
 			},
 			expected: map[string]int{
 				"pyroscope_profile_symbolization_duration_seconds": 0,
@@ -705,18 +689,6 @@ func extractGzipFile(t *testing.T, gzipPath string) ([]byte, error) {
 	return io.ReadAll(gzipReader)
 }
 
-func createRequest(t *testing.T, buildID string, address uint64) *request {
-	t.Helper()
-	return &request{
-		buildID: buildID,
-		locations: []*location{
-			{
-				address: address,
-			},
-		},
-	}
-}
-
 func TestConfigValidate(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -769,13 +741,8 @@ func TestUpdateAllSymbolsInProfile(t *testing.T) {
 		}
 
 		symbolizedLocs := []symbolizedLocation{{
-			loc: profile.Location[0],
-			symLoc: &location{
-				address: 0x1500,
-				lines: []lidia.SourceInfoFrame{{
-					LineNumber: 42, FunctionName: "testFunction", FilePath: "/path/to/test.go",
-				}},
-			},
+			loc:     profile.Location[0],
+			lines:   []lidia.SourceInfoFrame{{LineNumber: 42, FunctionName: "testFunction", FilePath: "/path/to/test.go"}},
 			mapping: profile.Mapping[0],
 		}}
 
@@ -807,17 +774,13 @@ func TestUpdateAllSymbolsInProfile(t *testing.T) {
 
 		symbolizedLocs := []symbolizedLocation{
 			{
-				loc: profile.Location[0],
-				symLoc: &location{address: 0x1500, lines: []lidia.SourceInfoFrame{{
-					LineNumber: 100, FunctionName: "testFunction", FilePath: "/path/to/test.go",
-				}}},
+				loc:     profile.Location[0],
+				lines:   []lidia.SourceInfoFrame{{LineNumber: 100, FunctionName: "testFunction", FilePath: "/path/to/test.go"}},
 				mapping: profile.Mapping[0],
 			},
 			{
-				loc: profile.Location[1],
-				symLoc: &location{address: 0x1600, lines: []lidia.SourceInfoFrame{{
-					LineNumber: 50, FunctionName: "testFunction", FilePath: "/path/to/test.go",
-				}}},
+				loc:     profile.Location[1],
+				lines:   []lidia.SourceInfoFrame{{LineNumber: 50, FunctionName: "testFunction", FilePath: "/path/to/test.go"}},
 				mapping: profile.Mapping[0],
 			},
 		}

--- a/pkg/symbolizer/types.go
+++ b/pkg/symbolizer/types.go
@@ -10,23 +10,10 @@ type LidiaTableCacheEntry struct {
 	Data []byte // Processed Lidia table data
 }
 
-// location represents a memory address to be symbolized
-type location struct {
-	address uint64
-	lines   []lidia.SourceInfoFrame
-}
-
-// request represents a symbolization request for multiple addresses
-type request struct {
-	buildID    string
-	binaryName string
-	locations  []*location
-}
-
 // symbolizedLocation represents a location that has been symbolized
 type symbolizedLocation struct {
 	loc     *googlev1.Location
-	symLoc  *location
+	lines   []lidia.SourceInfoFrame
 	mapping *googlev1.Mapping
 }
 


### PR DESCRIPTION

## Part of a series: symbol-aware tree references (1 of 8)

**The full picture.** Native and eBPF profiles are ingested with raw memory addresses; function
names are resolved at query time from debug info. Today that resolution only triggers when the
query-frontend sees an `__unsymbolized__` dataset label — which queryless queries (`{}`) never
surface, so their results silently lose symbolization — and it works by rewriting the whole TREE
query into PPROF and back, which makes every dataset in the query pay the pprof cost and silently
drops any query selector that isn't hand-mirrored between the two query types. This series changes
the tree representation instead: tree nodes can reference unresolved `{buildID, address}` locations
directly, partial trees carry those references through every merge (with truncation deferred), and
the frontend resolves them once after the final merge, then rewrites and truncates the tree.
Correct for every query shape, no pprof detour, and the wire format stays a tree. Tracking issue:
grafana/pyroscope-squad#487.

The series, in order (each PR stands alone for review; no new behavior activates until 6):

1. **symbolizer: expose address-level `Resolve` API ← this PR.**
   Extracts per-address symbol lookup from behind `SymbolizePprof` into a public `Resolver`
   interface that later PRs consume directly. Pure refactor: no caller change, no new behavior.
2. **proto: `SymbolRefTable` + tree query/report fields.**
   The wire schema for trees that carry unresolved references — a compact side table of resolved
   names, interned build IDs, and addresses. Schema + generated code only; no consumers yet.
3. **`model/symbolref`: intern table + merge rebasing.**
   New package implementing the reference table and deterministic reference rebasing when partial
   trees from different backends merge.
4. **`model/symbolref`: job grouping + rebuild.**
   Groups unresolved references into per-build-ID resolution jobs, and rebuilds the final resolved
   tree — expanding inline-frame chains, merging newly-identical nodes, truncating exactly once.
5. **symdb + querybackend: produce and aggregate symbol-ref trees.**
   Backends emit trees with unresolved references for unsymbolized datasets (deferring truncation)
   and merge partials of both shapes; fully-symbolized datasets keep today's exact path.
6. **frontend: orchestration behind a default-off per-tenant flag.**
   The frontend requests symbol-ref trees, resolves post-merge via this PR's API, and rewrites the
   result. The first PR where any new behavior can be switched on.
7. **integration tests + docs.** (#5335)
   End-to-end coverage — including the queryless-query case that motivated the issue — plus an
   equivalence test pinning the new path's output against the legacy one.
8. **symdb: compaction preserves line-less locations (#5337) — merges first.**
   Fixes a pre-existing bug (#4051) in the shared compaction symbols rewriter that replaced every
   location of a partition without functions — exactly the fully-unsymbolized native datasets this
   series serves — with a zero value, permanently destroying the addresses symbolization needs.
   Found during end-to-end validation of this series; stacked at the bottom so it lands before the
   feature can be enabled anywhere.

---

## What / Why

`pkg/symbolizer` could previously only be driven through `SymbolizePprof`, which takes a whole
pprof profile. Anything that wants symbols for a set of `{buildID, address}` pairs — for example,
resolving symbols for a tree-shaped query result — had no way to ask for that directly; it would
have had to synthesize a throwaway pprof profile just to reuse the lookup path.

This PR extracts that lookup into a narrow, exported interface:

```go
type Resolver interface {
    Resolve(ctx context.Context, buildID, binaryName string, addrs []uint64) ([][]lidia.SourceInfoFrame, error)
}
```

`SymbolizePprof` is refactored to call `Resolve` internally instead of duplicating the lookup
logic. `Resolve` is defined on `*Symbolizer` in the producer package (`pkg/symbolizer`), the same
pattern `pkg/objstore.Bucket` already uses, so a later out-of-process implementation can satisfy
`Resolver` without importing this package.

**What moved:** fallback-symbol synthesis (the `binary!0xaddr` placeholder text). `Resolve` itself
never produces it — a nil/empty slot in its result means "could not resolve this address," full
stop. Rendering the placeholder is now the caller's job: `SymbolizePprof`'s per-mapping goroutine
calls the existing `createFallbackSymbol` helper immediately after `Resolve` returns, for every nil
slot. This is a mechanical relocation of an existing call, not a change to what it computes.

**What stayed byte-identical:**
- `SymbolizePprof`'s emitted profile, on every existing fixture — same metric names/label values,
  same log message text, same check order as the code this replaces.
- The pre-existing, deliberately-unreused lookup buffer in the per-address loop
  (`var framesBuf []lidia.SourceInfoFrame` is never reassigned, so each `table.Lookup` call gets
  `nil`) — preserved exactly as-is; not something this PR changes or "fixes."

---

## Behavior changes

There is exactly **one** externally-visible behavior change:

> Context cancellation or a deadline firing while `Resolve` is resolving symbols now surfaces as a
> real `error`, and that error now propagates out of `SymbolizePprof` instead of being silently
> swallowed into a fallback-filled profile with a `nil` error.

Concretely: `Resolve` returns a non-nil error **only** when `ctx.Err() != nil` (checked at entry
and again around the debug-info fetch, via `errors.Is` against `context.Canceled` /
`context.DeadlineExceeded`); every other failure mode (empty/invalid buildID, fetch failure,
malformed debug info, a specific address not resolving) keeps degrading to a nil/empty result slot
with a `nil` error, exactly like the code it replaces.

This matters today at the three real call sites that invoke `SymbolizePprof`, all of which already
treat any error it returns as fatal to the request:
- `pkg/frontend/readpath/queryfrontend/symbolizer.go:82`
- `pkg/frontend/readpath/queryfrontend/query_select_merge_profile.go:112`
- `pkg/frontend/readpath/queryfrontend/query_select_merge_profile.go:237`

Before this PR, a query whose context was canceled or timed out mid-symbolization would silently
get back a profile full of `binary!0xaddr` placeholders and no error. After this PR, that same
request now fails with a wrapped `context.Canceled`/`context.DeadlineExceeded` error, matching how
these call sites already handle every other symbolization failure.

Internal contract note (not observable from outside `pkg/symbolizer`, since `SymbolizePprof`'s
output is unaffected): whenever `Resolve` returns a `nil` error, the returned outer slice always has
`len(result) == len(addrs)`, and `result[i] == nil` means address `i` didn't resolve, for any reason
short of context cancellation.

---

## Security hardening

`Resolve` is a new public entry point into a buildID-driven object-store path
(`getLidiaBytes` → `fetchLidiaFromObjectStore` → `path.Join(bucketPrefix, tenantID, buildID)`).
Previously, this path was only reachable through `SymbolizePprof`, whose one caller always
sanitized `buildID` first — so encapsulation, not validation, was what kept it safe. Now that
`Resolve` is exported, `Resolve` validates `buildID` itself (same sanitizer `extractBuildID` already
applies) before doing any object-store or debuginfod I/O, and degrades to a nil-per-miss result
instead of trusting the caller. A test asserts zero mock calls on the storage/debuginfod clients
when `buildID` fails validation, proving the rejection happens before any I/O — the property that
actually matters for a future caller that might source `buildID` from less-trusted input.

---

## Testing

- Full `pkg/symbolizer` suite passes under `-race`, including the pre-existing golden-baseline
  tests (`TestSymbolizePprof`, `TestSymbolizationKeepsSequentialFunctionIDs`) with **zero edits** to
  any existing assertion.
- New tests added for gaps the old private lookup path had no way to exercise directly:
  - size-limit-exceeded degrades to a nil result with no error (does not take the cancellation-error
    path).
  - context cancellation, in two forms: already-canceled at entry, and canceled mid-fetch
    (deterministic, channel-coordinated, no sleeps) — plus a third subtest for
    `context.DeadlineExceeded` via a real timeout.
  - cancellation propagating through `SymbolizePprof` end-to-end.
  - concurrent fan-out: three mappings with distinct build IDs resolved concurrently
    (`MaxDebuginfodConcurrency = 4`), with a blocking-mock/channel handshake that forces genuine
    3-way overlap (a regression to serialized execution hangs the test rather than passing).
  - an invalid/malformed buildID degrades to a nil-per-miss result with zero calls to the
    debuginfod client or bucket, plus the new `invalid_build_id` metric label incrementing exactly
    once.
- Coverage: 84.7% of statements in `pkg/symbolizer`.
- `go build ./...` and `make lint` (`golangci-lint run ./...`) are both clean across the whole repo,
  not just this package.

---

## Follow-ups

None deferred from review. `Resolve`'s two adjacent `string` parameters (`buildID`, `binaryName`)
were flagged as a general API-ergonomics observation during review and deliberately left as-is —
the signature is pinned across the rest of this series and the one call site already threads both
arguments correctly.

