### PR TITLE
feat(query): add SymbolRefTable and symbol_refs tree fields to the query API

### DIFF
--- a/api/connect-openapi/gen/query/v1/query.openapi.yaml
+++ b/api/connect-openapi/gen/query/v1/query.openapi.yaml
@@ -1205,6 +1205,15 @@ components:
           title: series_labels
       title: SeriesLabelsReport
       additionalProperties: false
+    query.v1.SymbolMode:
+      type: string
+      title: SymbolMode
+      enum:
+        - SYMBOL_MODE_UNSPECIFIED
+        - SYMBOL_MODE_NAME
+        - SYMBOL_MODE_FULL
+        - SYMBOL_MODE_REFS
+      description: SymbolMode selects how a TreeQuery reports frame symbols.
     query.v1.SymbolRefTable:
       type: object
       properties:
@@ -1213,27 +1222,21 @@ components:
           items:
             type: string
           title: names
-          description: 'Resolved refs: 0 <= ref < len(names); names[ref] is the frame name.'
         buildIds:
           type: array
           items:
             type: string
           title: build_ids
-          description: |-
-            Unresolved refs: i = ref - len(names);
-               build_ids[unresolved_build_id[i]], unresolved_address[i]. distinct, each exactly once
         binaryNames:
           type: array
           items:
             type: string
           title: binary_names
-          description: parallel to build_ids; fallback display
         unresolvedBuildId:
           type: array
           items:
             type: integer
           title: unresolved_build_id
-          description: per unresolved entry
         unresolvedAddress:
           type: array
           items:
@@ -1242,9 +1245,23 @@ components:
               - string
             format: int64
           title: unresolved_address
-          description: parallel to unresolved_build_id
       title: SymbolRefTable
       additionalProperties: false
+      description: |-
+        SymbolRefTable resolves the integer frame references in a symbol-ref tree.
+         Each tree node stores one frame reference r; whether r is resolved depends on
+         whether it falls inside the names slice:
+
+           r <  len(names): resolved   -> names[r] is the frame name.
+           r >= len(names): unresolved -> u = r - len(names) indexes the parallel
+                            unresolved_* arrays:
+                              build_ids[unresolved_build_id[u]]  build ID of the binary
+                              unresolved_address[u]              address within it
+
+         build_ids and binary_names are parallel and 1:1 (binary_names[k] is the
+         "binary!0xaddr" fallback display for build_ids[k]); each build ID appears
+         once. unresolved_build_id and unresolved_address are parallel, one pair per
+         unresolved entry, sorted by (build ID, address).
     query.v1.TimeSeriesCompactReport:
       type: object
       properties:
@@ -1323,15 +1340,20 @@ components:
         fullSymbols:
           type: boolean
           title: full_symbols
+          description: |-
+            Deprecated: use symbol_mode = SYMBOL_MODE_FULL. Retained for wire
+             compatibility; will be removed in a couple of releases.
         traceIdSelector:
           type: array
           items:
             type: string
           title: trace_id_selector
-        symbolRefs:
-          type: boolean
-          title: symbol_refs
-          description: symbol_refs and full_symbols are mutually exclusive.
+        symbolMode:
+          title: symbol_mode
+          description: |-
+            symbol_mode selects the symbol output. When unset, full_symbols is honored
+             for back-compat.
+          $ref: '#/components/schemas/query.v1.SymbolMode'
       title: TreeQuery
       additionalProperties: false
     query.v1.TreeReport:

--- a/api/connect-openapi/gen/query/v1/query.openapi.yaml
+++ b/api/connect-openapi/gen/query/v1/query.openapi.yaml
@@ -1259,9 +1259,11 @@ components:
                               unresolved_address[u]              address within it
 
          build_ids and binary_names are parallel and 1:1 (binary_names[k] is the
-         "binary!0xaddr" fallback display for build_ids[k]); each build ID appears
-         once. unresolved_build_id and unresolved_address are parallel, one pair per
-         unresolved entry, sorted by (build ID, address).
+         "binary!0xaddr" fallback display for build_ids[k]); each (build ID,
+         binary name) pair appears once — the same build ID may repeat under
+         different binary names, each retained exactly as stored.
+         unresolved_build_id and unresolved_address are parallel, one entry per
+         unresolved location, sorted by (build ID, binary name, address).
     query.v1.TimeSeriesCompactReport:
       type: object
       properties:

--- a/api/connect-openapi/gen/query/v1/query.openapi.yaml
+++ b/api/connect-openapi/gen/query/v1/query.openapi.yaml
@@ -1356,6 +1356,16 @@ components:
             symbol_mode selects the symbol output. When unset, full_symbols is honored
              for back-compat.
           $ref: '#/components/schemas/query.v1.SymbolMode'
+        maxUnresolvedLocations:
+          type:
+            - integer
+            - string
+          title: max_unresolved_locations
+          format: int64
+          description: |-
+            max_unresolved_locations bounds the distinct unresolved locations a
+             symbol-ref tree result may carry; the query fails past it. Zero means
+             unlimited. Effective only with SYMBOL_MODE_REFS.
       title: TreeQuery
       additionalProperties: false
     query.v1.TreeReport:

--- a/api/connect-openapi/gen/query/v1/query.openapi.yaml
+++ b/api/connect-openapi/gen/query/v1/query.openapi.yaml
@@ -1205,6 +1205,46 @@ components:
           title: series_labels
       title: SeriesLabelsReport
       additionalProperties: false
+    query.v1.SymbolRefTable:
+      type: object
+      properties:
+        names:
+          type: array
+          items:
+            type: string
+          title: names
+          description: 'Resolved refs: 0 <= ref < len(names); names[ref] is the frame name.'
+        buildIds:
+          type: array
+          items:
+            type: string
+          title: build_ids
+          description: |-
+            Unresolved refs: i = ref - len(names);
+               build_ids[unresolved_build_id[i]], unresolved_address[i]. distinct, each exactly once
+        binaryNames:
+          type: array
+          items:
+            type: string
+          title: binary_names
+          description: parallel to build_ids; fallback display
+        unresolvedBuildId:
+          type: array
+          items:
+            type: integer
+          title: unresolved_build_id
+          description: per unresolved entry
+        unresolvedAddress:
+          type: array
+          items:
+            type:
+              - integer
+              - string
+            format: int64
+          title: unresolved_address
+          description: parallel to unresolved_build_id
+      title: SymbolRefTable
+      additionalProperties: false
     query.v1.TimeSeriesCompactReport:
       type: object
       properties:
@@ -1288,6 +1328,10 @@ components:
           items:
             type: string
           title: trace_id_selector
+        symbolRefs:
+          type: boolean
+          title: symbol_refs
+          description: symbol_refs and full_symbols are mutually exclusive.
       title: TreeQuery
       additionalProperties: false
     query.v1.TreeReport:
@@ -1304,6 +1348,10 @@ components:
           title: symbols
           nullable: true
           $ref: '#/components/schemas/query.v1.TreeSymbols'
+        symbolRefs:
+          title: symbol_refs
+          nullable: true
+          $ref: '#/components/schemas/query.v1.SymbolRefTable'
       title: TreeReport
       additionalProperties: false
     query.v1.TreeSymbols:

--- a/api/gen/proto/go/query/v1/query.pb.go
+++ b/api/gen/proto/go/query/v1/query.pb.go
@@ -1820,9 +1820,11 @@ func (x *TreeSymbols) GetStringHashes() []uint64 {
 //	                   unresolved_address[u]              address within it
 //
 // build_ids and binary_names are parallel and 1:1 (binary_names[k] is the
-// "binary!0xaddr" fallback display for build_ids[k]); each build ID appears
-// once. unresolved_build_id and unresolved_address are parallel, one pair per
-// unresolved entry, sorted by (build ID, address).
+// "binary!0xaddr" fallback display for build_ids[k]); each (build ID,
+// binary name) pair appears once — the same build ID may repeat under
+// different binary names, each retained exactly as stored.
+// unresolved_build_id and unresolved_address are parallel, one entry per
+// unresolved location, sorted by (build ID, binary name, address).
 type SymbolRefTable struct {
 	state             protoimpl.MessageState `protogen:"open.v1"`
 	Names             []string               `protobuf:"bytes,1,rep,name=names,proto3" json:"names,omitempty"`

--- a/api/gen/proto/go/query/v1/query.pb.go
+++ b/api/gen/proto/go/query/v1/query.pb.go
@@ -1568,8 +1568,10 @@ type TreeQuery struct {
 	ProfileIdSelector  []string                `protobuf:"bytes,4,rep,name=profile_id_selector,json=profileIdSelector,proto3" json:"profile_id_selector,omitempty"`
 	FullSymbols        bool                    `protobuf:"varint,5,opt,name=full_symbols,json=fullSymbols,proto3" json:"full_symbols,omitempty"`
 	TraceIdSelector    []string                `protobuf:"bytes,6,rep,name=trace_id_selector,json=traceIdSelector,proto3" json:"trace_id_selector,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// symbol_refs and full_symbols are mutually exclusive.
+	SymbolRefs    bool `protobuf:"varint,7,opt,name=symbol_refs,json=symbolRefs,proto3" json:"symbol_refs,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TreeQuery) Reset() {
@@ -1642,6 +1644,13 @@ func (x *TreeQuery) GetTraceIdSelector() []string {
 		return x.TraceIdSelector
 	}
 	return nil
+}
+
+func (x *TreeQuery) GetSymbolRefs() bool {
+	if x != nil {
+		return x.SymbolRefs
+	}
+	return false
 }
 
 type TreeSymbols struct {
@@ -1744,18 +1753,99 @@ func (x *TreeSymbols) GetStringHashes() []uint64 {
 	return nil
 }
 
+type SymbolRefTable struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Resolved refs: 0 <= ref < len(names); names[ref] is the frame name.
+	Names []string `protobuf:"bytes,1,rep,name=names,proto3" json:"names,omitempty"`
+	// Unresolved refs: i = ref - len(names);
+	//
+	//	build_ids[unresolved_build_id[i]], unresolved_address[i].
+	BuildIds          []string `protobuf:"bytes,2,rep,name=build_ids,json=buildIds,proto3" json:"build_ids,omitempty"`                                      // distinct, each exactly once
+	BinaryNames       []string `protobuf:"bytes,3,rep,name=binary_names,json=binaryNames,proto3" json:"binary_names,omitempty"`                             // parallel to build_ids; fallback display
+	UnresolvedBuildId []uint32 `protobuf:"varint,4,rep,packed,name=unresolved_build_id,json=unresolvedBuildId,proto3" json:"unresolved_build_id,omitempty"` // per unresolved entry
+	UnresolvedAddress []uint64 `protobuf:"varint,5,rep,packed,name=unresolved_address,json=unresolvedAddress,proto3" json:"unresolved_address,omitempty"`   // parallel to unresolved_build_id
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *SymbolRefTable) Reset() {
+	*x = SymbolRefTable{}
+	mi := &file_query_v1_query_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SymbolRefTable) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SymbolRefTable) ProtoMessage() {}
+
+func (x *SymbolRefTable) ProtoReflect() protoreflect.Message {
+	mi := &file_query_v1_query_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SymbolRefTable.ProtoReflect.Descriptor instead.
+func (*SymbolRefTable) Descriptor() ([]byte, []int) {
+	return file_query_v1_query_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *SymbolRefTable) GetNames() []string {
+	if x != nil {
+		return x.Names
+	}
+	return nil
+}
+
+func (x *SymbolRefTable) GetBuildIds() []string {
+	if x != nil {
+		return x.BuildIds
+	}
+	return nil
+}
+
+func (x *SymbolRefTable) GetBinaryNames() []string {
+	if x != nil {
+		return x.BinaryNames
+	}
+	return nil
+}
+
+func (x *SymbolRefTable) GetUnresolvedBuildId() []uint32 {
+	if x != nil {
+		return x.UnresolvedBuildId
+	}
+	return nil
+}
+
+func (x *SymbolRefTable) GetUnresolvedAddress() []uint64 {
+	if x != nil {
+		return x.UnresolvedAddress
+	}
+	return nil
+}
+
 type TreeReport struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Query         *TreeQuery             `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty"`
 	Tree          []byte                 `protobuf:"bytes,2,opt,name=tree,proto3" json:"tree,omitempty"`
 	Symbols       *TreeSymbols           `protobuf:"bytes,3,opt,name=symbols,proto3,oneof" json:"symbols,omitempty"`
+	SymbolRefs    *SymbolRefTable        `protobuf:"bytes,4,opt,name=symbol_refs,json=symbolRefs,proto3,oneof" json:"symbol_refs,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *TreeReport) Reset() {
 	*x = TreeReport{}
-	mi := &file_query_v1_query_proto_msgTypes[23]
+	mi := &file_query_v1_query_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1767,7 +1857,7 @@ func (x *TreeReport) String() string {
 func (*TreeReport) ProtoMessage() {}
 
 func (x *TreeReport) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[23]
+	mi := &file_query_v1_query_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1780,7 +1870,7 @@ func (x *TreeReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TreeReport.ProtoReflect.Descriptor instead.
 func (*TreeReport) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{23}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *TreeReport) GetQuery() *TreeQuery {
@@ -1804,6 +1894,13 @@ func (x *TreeReport) GetSymbols() *TreeSymbols {
 	return nil
 }
 
+func (x *TreeReport) GetSymbolRefs() *SymbolRefTable {
+	if x != nil {
+		return x.SymbolRefs
+	}
+	return nil
+}
+
 type PprofQuery struct {
 	state              protoimpl.MessageState  `protogen:"open.v1"`
 	MaxNodes           int64                   `protobuf:"varint,1,opt,name=max_nodes,json=maxNodes,proto3" json:"max_nodes,omitempty"`
@@ -1817,7 +1914,7 @@ type PprofQuery struct {
 
 func (x *PprofQuery) Reset() {
 	*x = PprofQuery{}
-	mi := &file_query_v1_query_proto_msgTypes[24]
+	mi := &file_query_v1_query_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1829,7 +1926,7 @@ func (x *PprofQuery) String() string {
 func (*PprofQuery) ProtoMessage() {}
 
 func (x *PprofQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[24]
+	mi := &file_query_v1_query_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1842,7 +1939,7 @@ func (x *PprofQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PprofQuery.ProtoReflect.Descriptor instead.
 func (*PprofQuery) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{24}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *PprofQuery) GetMaxNodes() int64 {
@@ -1890,7 +1987,7 @@ type PprofReport struct {
 
 func (x *PprofReport) Reset() {
 	*x = PprofReport{}
-	mi := &file_query_v1_query_proto_msgTypes[25]
+	mi := &file_query_v1_query_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1902,7 +1999,7 @@ func (x *PprofReport) String() string {
 func (*PprofReport) ProtoMessage() {}
 
 func (x *PprofReport) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[25]
+	mi := &file_query_v1_query_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1915,7 +2012,7 @@ func (x *PprofReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PprofReport.ProtoReflect.Descriptor instead.
 func (*PprofReport) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{25}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *PprofReport) GetQuery() *PprofQuery {
@@ -1945,7 +2042,7 @@ type HeatmapQuery struct {
 
 func (x *HeatmapQuery) Reset() {
 	*x = HeatmapQuery{}
-	mi := &file_query_v1_query_proto_msgTypes[26]
+	mi := &file_query_v1_query_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1957,7 +2054,7 @@ func (x *HeatmapQuery) String() string {
 func (*HeatmapQuery) ProtoMessage() {}
 
 func (x *HeatmapQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[26]
+	mi := &file_query_v1_query_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1970,7 +2067,7 @@ func (x *HeatmapQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeatmapQuery.ProtoReflect.Descriptor instead.
 func (*HeatmapQuery) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{26}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *HeatmapQuery) GetStep() float64 {
@@ -2018,7 +2115,7 @@ type AttributeTable struct {
 
 func (x *AttributeTable) Reset() {
 	*x = AttributeTable{}
-	mi := &file_query_v1_query_proto_msgTypes[27]
+	mi := &file_query_v1_query_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2030,7 +2127,7 @@ func (x *AttributeTable) String() string {
 func (*AttributeTable) ProtoMessage() {}
 
 func (x *AttributeTable) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[27]
+	mi := &file_query_v1_query_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2043,7 +2140,7 @@ func (x *AttributeTable) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttributeTable.ProtoReflect.Descriptor instead.
 func (*AttributeTable) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{27}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *AttributeTable) GetKeys() []string {
@@ -2074,7 +2171,7 @@ type HeatmapPoint struct {
 
 func (x *HeatmapPoint) Reset() {
 	*x = HeatmapPoint{}
-	mi := &file_query_v1_query_proto_msgTypes[28]
+	mi := &file_query_v1_query_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2086,7 +2183,7 @@ func (x *HeatmapPoint) String() string {
 func (*HeatmapPoint) ProtoMessage() {}
 
 func (x *HeatmapPoint) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[28]
+	mi := &file_query_v1_query_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2099,7 +2196,7 @@ func (x *HeatmapPoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeatmapPoint.ProtoReflect.Descriptor instead.
 func (*HeatmapPoint) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{28}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *HeatmapPoint) GetTimestamp() int64 {
@@ -2154,7 +2251,7 @@ type HeatmapSeries struct {
 
 func (x *HeatmapSeries) Reset() {
 	*x = HeatmapSeries{}
-	mi := &file_query_v1_query_proto_msgTypes[29]
+	mi := &file_query_v1_query_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2166,7 +2263,7 @@ func (x *HeatmapSeries) String() string {
 func (*HeatmapSeries) ProtoMessage() {}
 
 func (x *HeatmapSeries) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[29]
+	mi := &file_query_v1_query_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2179,7 +2276,7 @@ func (x *HeatmapSeries) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeatmapSeries.ProtoReflect.Descriptor instead.
 func (*HeatmapSeries) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{29}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *HeatmapSeries) GetAttributeRefs() []int64 {
@@ -2207,7 +2304,7 @@ type HeatmapReport struct {
 
 func (x *HeatmapReport) Reset() {
 	*x = HeatmapReport{}
-	mi := &file_query_v1_query_proto_msgTypes[30]
+	mi := &file_query_v1_query_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2219,7 +2316,7 @@ func (x *HeatmapReport) String() string {
 func (*HeatmapReport) ProtoMessage() {}
 
 func (x *HeatmapReport) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[30]
+	mi := &file_query_v1_query_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2232,7 +2329,7 @@ func (x *HeatmapReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeatmapReport.ProtoReflect.Descriptor instead.
 func (*HeatmapReport) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{30}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *HeatmapReport) GetQuery() *HeatmapQuery {
@@ -2270,7 +2367,7 @@ type Exemplar struct {
 
 func (x *Exemplar) Reset() {
 	*x = Exemplar{}
-	mi := &file_query_v1_query_proto_msgTypes[31]
+	mi := &file_query_v1_query_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2282,7 +2379,7 @@ func (x *Exemplar) String() string {
 func (*Exemplar) ProtoMessage() {}
 
 func (x *Exemplar) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[31]
+	mi := &file_query_v1_query_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2295,7 +2392,7 @@ func (x *Exemplar) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Exemplar.ProtoReflect.Descriptor instead.
 func (*Exemplar) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{31}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *Exemplar) GetTimestamp() int64 {
@@ -2348,7 +2445,7 @@ type Point struct {
 
 func (x *Point) Reset() {
 	*x = Point{}
-	mi := &file_query_v1_query_proto_msgTypes[32]
+	mi := &file_query_v1_query_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2360,7 +2457,7 @@ func (x *Point) String() string {
 func (*Point) ProtoMessage() {}
 
 func (x *Point) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[32]
+	mi := &file_query_v1_query_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2373,7 +2470,7 @@ func (x *Point) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Point.ProtoReflect.Descriptor instead.
 func (*Point) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{32}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *Point) GetValue() float64 {
@@ -2417,7 +2514,7 @@ type Series struct {
 
 func (x *Series) Reset() {
 	*x = Series{}
-	mi := &file_query_v1_query_proto_msgTypes[33]
+	mi := &file_query_v1_query_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2429,7 +2526,7 @@ func (x *Series) String() string {
 func (*Series) ProtoMessage() {}
 
 func (x *Series) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[33]
+	mi := &file_query_v1_query_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2442,7 +2539,7 @@ func (x *Series) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Series.ProtoReflect.Descriptor instead.
 func (*Series) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{33}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *Series) GetAttributeRefs() []int64 {
@@ -2470,7 +2567,7 @@ type TimeSeriesCompactReport struct {
 
 func (x *TimeSeriesCompactReport) Reset() {
 	*x = TimeSeriesCompactReport{}
-	mi := &file_query_v1_query_proto_msgTypes[34]
+	mi := &file_query_v1_query_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2482,7 +2579,7 @@ func (x *TimeSeriesCompactReport) String() string {
 func (*TimeSeriesCompactReport) ProtoMessage() {}
 
 func (x *TimeSeriesCompactReport) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[34]
+	mi := &file_query_v1_query_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2495,7 +2592,7 @@ func (x *TimeSeriesCompactReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TimeSeriesCompactReport.ProtoReflect.Descriptor instead.
 func (*TimeSeriesCompactReport) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{34}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *TimeSeriesCompactReport) GetQuery() *TimeSeriesQuery {
@@ -2635,14 +2732,16 @@ const file_query_v1_query_proto_rawDesc = "" +
 	"\x10TimeSeriesReport\x12/\n" +
 	"\x05query\x18\x01 \x01(\v2\x19.query.v1.TimeSeriesQueryR\x05query\x121\n" +
 	"\vtime_series\x18\x02 \x03(\v2\x10.types.v1.SeriesR\n" +
-	"timeSeries\"\xba\x02\n" +
+	"timeSeries\"\xdb\x02\n" +
 	"\tTreeQuery\x12\x1b\n" +
 	"\tmax_nodes\x18\x01 \x01(\x03R\bmaxNodes\x12#\n" +
 	"\rspan_selector\x18\x02 \x03(\tR\fspanSelector\x12S\n" +
 	"\x14stack_trace_selector\x18\x03 \x01(\v2\x1c.types.v1.StackTraceSelectorH\x00R\x12stackTraceSelector\x88\x01\x01\x12.\n" +
 	"\x13profile_id_selector\x18\x04 \x03(\tR\x11profileIdSelector\x12!\n" +
 	"\ffull_symbols\x18\x05 \x01(\bR\vfullSymbols\x12*\n" +
-	"\x11trace_id_selector\x18\x06 \x03(\tR\x0ftraceIdSelectorB\x17\n" +
+	"\x11trace_id_selector\x18\x06 \x03(\tR\x0ftraceIdSelector\x12\x1f\n" +
+	"\vsymbol_refs\x18\a \x01(\bR\n" +
+	"symbolRefsB\x17\n" +
 	"\x15_stack_trace_selector\"\xdb\x02\n" +
 	"\vTreeSymbols\x12.\n" +
 	"\bmappings\x18\x01 \x03(\v2\x12.google.v1.MappingR\bmappings\x121\n" +
@@ -2652,14 +2751,23 @@ const file_query_v1_query_proto_rawDesc = "" +
 	"\x0emapping_hashes\x18\x05 \x03(\x04R\rmappingHashes\x12'\n" +
 	"\x0flocation_hashes\x18\x06 \x03(\x04R\x0elocationHashes\x12'\n" +
 	"\x0ffunction_hashes\x18\a \x03(\x04R\x0efunctionHashes\x12#\n" +
-	"\rstring_hashes\x18\b \x03(\x04R\fstringHashes\"\x8d\x01\n" +
+	"\rstring_hashes\x18\b \x03(\x04R\fstringHashes\"\xc5\x01\n" +
+	"\x0eSymbolRefTable\x12\x14\n" +
+	"\x05names\x18\x01 \x03(\tR\x05names\x12\x1b\n" +
+	"\tbuild_ids\x18\x02 \x03(\tR\bbuildIds\x12!\n" +
+	"\fbinary_names\x18\x03 \x03(\tR\vbinaryNames\x12.\n" +
+	"\x13unresolved_build_id\x18\x04 \x03(\rR\x11unresolvedBuildId\x12-\n" +
+	"\x12unresolved_address\x18\x05 \x03(\x04R\x11unresolvedAddress\"\xdd\x01\n" +
 	"\n" +
 	"TreeReport\x12)\n" +
 	"\x05query\x18\x01 \x01(\v2\x13.query.v1.TreeQueryR\x05query\x12\x12\n" +
 	"\x04tree\x18\x02 \x01(\fR\x04tree\x124\n" +
-	"\asymbols\x18\x03 \x01(\v2\x15.query.v1.TreeSymbolsH\x00R\asymbols\x88\x01\x01B\n" +
+	"\asymbols\x18\x03 \x01(\v2\x15.query.v1.TreeSymbolsH\x00R\asymbols\x88\x01\x01\x12>\n" +
+	"\vsymbol_refs\x18\x04 \x01(\v2\x18.query.v1.SymbolRefTableH\x01R\n" +
+	"symbolRefs\x88\x01\x01B\n" +
 	"\n" +
-	"\b_symbols\"\x98\x02\n" +
+	"\b_symbolsB\x0e\n" +
+	"\f_symbol_refs\"\x98\x02\n" +
 	"\n" +
 	"PprofQuery\x12\x1b\n" +
 	"\tmax_nodes\x18\x01 \x01(\x03R\bmaxNodes\x12S\n" +
@@ -2758,7 +2866,7 @@ func file_query_v1_query_proto_rawDescGZIP() []byte {
 }
 
 var file_query_v1_query_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_query_v1_query_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
+var file_query_v1_query_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
 var file_query_v1_query_proto_goTypes = []any{
 	(QueryType)(0),                  // 0: query.v1.QueryType
 	(ReportType)(0),                 // 1: query.v1.ReportType
@@ -2786,27 +2894,28 @@ var file_query_v1_query_proto_goTypes = []any{
 	(*TimeSeriesReport)(nil),        // 23: query.v1.TimeSeriesReport
 	(*TreeQuery)(nil),               // 24: query.v1.TreeQuery
 	(*TreeSymbols)(nil),             // 25: query.v1.TreeSymbols
-	(*TreeReport)(nil),              // 26: query.v1.TreeReport
-	(*PprofQuery)(nil),              // 27: query.v1.PprofQuery
-	(*PprofReport)(nil),             // 28: query.v1.PprofReport
-	(*HeatmapQuery)(nil),            // 29: query.v1.HeatmapQuery
-	(*AttributeTable)(nil),          // 30: query.v1.AttributeTable
-	(*HeatmapPoint)(nil),            // 31: query.v1.HeatmapPoint
-	(*HeatmapSeries)(nil),           // 32: query.v1.HeatmapSeries
-	(*HeatmapReport)(nil),           // 33: query.v1.HeatmapReport
-	(*Exemplar)(nil),                // 34: query.v1.Exemplar
-	(*Point)(nil),                   // 35: query.v1.Point
-	(*Series)(nil),                  // 36: query.v1.Series
-	(*TimeSeriesCompactReport)(nil), // 37: query.v1.TimeSeriesCompactReport
-	(*v1.BlockMeta)(nil),            // 38: metastore.v1.BlockMeta
-	(*v11.Labels)(nil),              // 39: types.v1.Labels
-	(v11.ExemplarType)(0),           // 40: types.v1.ExemplarType
-	(*v11.Series)(nil),              // 41: types.v1.Series
-	(*v11.StackTraceSelector)(nil),  // 42: types.v1.StackTraceSelector
-	(*v12.Mapping)(nil),             // 43: google.v1.Mapping
-	(*v12.Location)(nil),            // 44: google.v1.Location
-	(*v12.Function)(nil),            // 45: google.v1.Function
-	(v13.HeatmapQueryType)(0),       // 46: querier.v1.HeatmapQueryType
+	(*SymbolRefTable)(nil),          // 26: query.v1.SymbolRefTable
+	(*TreeReport)(nil),              // 27: query.v1.TreeReport
+	(*PprofQuery)(nil),              // 28: query.v1.PprofQuery
+	(*PprofReport)(nil),             // 29: query.v1.PprofReport
+	(*HeatmapQuery)(nil),            // 30: query.v1.HeatmapQuery
+	(*AttributeTable)(nil),          // 31: query.v1.AttributeTable
+	(*HeatmapPoint)(nil),            // 32: query.v1.HeatmapPoint
+	(*HeatmapSeries)(nil),           // 33: query.v1.HeatmapSeries
+	(*HeatmapReport)(nil),           // 34: query.v1.HeatmapReport
+	(*Exemplar)(nil),                // 35: query.v1.Exemplar
+	(*Point)(nil),                   // 36: query.v1.Point
+	(*Series)(nil),                  // 37: query.v1.Series
+	(*TimeSeriesCompactReport)(nil), // 38: query.v1.TimeSeriesCompactReport
+	(*v1.BlockMeta)(nil),            // 39: metastore.v1.BlockMeta
+	(*v11.Labels)(nil),              // 40: types.v1.Labels
+	(v11.ExemplarType)(0),           // 41: types.v1.ExemplarType
+	(*v11.Series)(nil),              // 42: types.v1.Series
+	(*v11.StackTraceSelector)(nil),  // 43: types.v1.StackTraceSelector
+	(*v12.Mapping)(nil),             // 44: google.v1.Mapping
+	(*v12.Location)(nil),            // 45: google.v1.Location
+	(*v12.Function)(nil),            // 46: google.v1.Function
+	(v13.HeatmapQueryType)(0),       // 47: querier.v1.HeatmapQueryType
 }
 var file_query_v1_query_proto_depIdxs = []int32{
 	9,  // 0: query.v1.QueryRequest.query:type_name -> query.v1.Query
@@ -2817,15 +2926,15 @@ var file_query_v1_query_proto_depIdxs = []int32{
 	8,  // 5: query.v1.QueryPlan.root:type_name -> query.v1.QueryNode
 	2,  // 6: query.v1.QueryNode.type:type_name -> query.v1.QueryNode.Type
 	8,  // 7: query.v1.QueryNode.children:type_name -> query.v1.QueryNode
-	38, // 8: query.v1.QueryNode.blocks:type_name -> metastore.v1.BlockMeta
+	39, // 8: query.v1.QueryNode.blocks:type_name -> metastore.v1.BlockMeta
 	0,  // 9: query.v1.Query.query_type:type_name -> query.v1.QueryType
 	16, // 10: query.v1.Query.label_names:type_name -> query.v1.LabelNamesQuery
 	18, // 11: query.v1.Query.label_values:type_name -> query.v1.LabelValuesQuery
 	20, // 12: query.v1.Query.series_labels:type_name -> query.v1.SeriesLabelsQuery
 	22, // 13: query.v1.Query.time_series:type_name -> query.v1.TimeSeriesQuery
 	24, // 14: query.v1.Query.tree:type_name -> query.v1.TreeQuery
-	27, // 15: query.v1.Query.pprof:type_name -> query.v1.PprofQuery
-	29, // 16: query.v1.Query.heatmap:type_name -> query.v1.HeatmapQuery
+	28, // 15: query.v1.Query.pprof:type_name -> query.v1.PprofQuery
+	30, // 16: query.v1.Query.heatmap:type_name -> query.v1.HeatmapQuery
 	22, // 17: query.v1.Query.time_series_compact:type_name -> query.v1.TimeSeriesQuery
 	15, // 18: query.v1.InvokeResponse.reports:type_name -> query.v1.Report
 	11, // 19: query.v1.InvokeResponse.diagnostics:type_name -> query.v1.Diagnostics
@@ -2840,45 +2949,46 @@ var file_query_v1_query_proto_depIdxs = []int32{
 	19, // 28: query.v1.Report.label_values:type_name -> query.v1.LabelValuesReport
 	21, // 29: query.v1.Report.series_labels:type_name -> query.v1.SeriesLabelsReport
 	23, // 30: query.v1.Report.time_series:type_name -> query.v1.TimeSeriesReport
-	26, // 31: query.v1.Report.tree:type_name -> query.v1.TreeReport
-	28, // 32: query.v1.Report.pprof:type_name -> query.v1.PprofReport
-	33, // 33: query.v1.Report.heatmap:type_name -> query.v1.HeatmapReport
-	37, // 34: query.v1.Report.time_series_compact:type_name -> query.v1.TimeSeriesCompactReport
+	27, // 31: query.v1.Report.tree:type_name -> query.v1.TreeReport
+	29, // 32: query.v1.Report.pprof:type_name -> query.v1.PprofReport
+	34, // 33: query.v1.Report.heatmap:type_name -> query.v1.HeatmapReport
+	38, // 34: query.v1.Report.time_series_compact:type_name -> query.v1.TimeSeriesCompactReport
 	16, // 35: query.v1.LabelNamesReport.query:type_name -> query.v1.LabelNamesQuery
 	18, // 36: query.v1.LabelValuesReport.query:type_name -> query.v1.LabelValuesQuery
 	20, // 37: query.v1.SeriesLabelsReport.query:type_name -> query.v1.SeriesLabelsQuery
-	39, // 38: query.v1.SeriesLabelsReport.series_labels:type_name -> types.v1.Labels
-	40, // 39: query.v1.TimeSeriesQuery.exemplar_type:type_name -> types.v1.ExemplarType
+	40, // 38: query.v1.SeriesLabelsReport.series_labels:type_name -> types.v1.Labels
+	41, // 39: query.v1.TimeSeriesQuery.exemplar_type:type_name -> types.v1.ExemplarType
 	22, // 40: query.v1.TimeSeriesReport.query:type_name -> query.v1.TimeSeriesQuery
-	41, // 41: query.v1.TimeSeriesReport.time_series:type_name -> types.v1.Series
-	42, // 42: query.v1.TreeQuery.stack_trace_selector:type_name -> types.v1.StackTraceSelector
-	43, // 43: query.v1.TreeSymbols.mappings:type_name -> google.v1.Mapping
-	44, // 44: query.v1.TreeSymbols.locations:type_name -> google.v1.Location
-	45, // 45: query.v1.TreeSymbols.functions:type_name -> google.v1.Function
+	42, // 41: query.v1.TimeSeriesReport.time_series:type_name -> types.v1.Series
+	43, // 42: query.v1.TreeQuery.stack_trace_selector:type_name -> types.v1.StackTraceSelector
+	44, // 43: query.v1.TreeSymbols.mappings:type_name -> google.v1.Mapping
+	45, // 44: query.v1.TreeSymbols.locations:type_name -> google.v1.Location
+	46, // 45: query.v1.TreeSymbols.functions:type_name -> google.v1.Function
 	24, // 46: query.v1.TreeReport.query:type_name -> query.v1.TreeQuery
 	25, // 47: query.v1.TreeReport.symbols:type_name -> query.v1.TreeSymbols
-	42, // 48: query.v1.PprofQuery.stack_trace_selector:type_name -> types.v1.StackTraceSelector
-	27, // 49: query.v1.PprofReport.query:type_name -> query.v1.PprofQuery
-	46, // 50: query.v1.HeatmapQuery.query_type:type_name -> querier.v1.HeatmapQueryType
-	40, // 51: query.v1.HeatmapQuery.exemplar_type:type_name -> types.v1.ExemplarType
-	31, // 52: query.v1.HeatmapSeries.points:type_name -> query.v1.HeatmapPoint
-	29, // 53: query.v1.HeatmapReport.query:type_name -> query.v1.HeatmapQuery
-	32, // 54: query.v1.HeatmapReport.heatmap_series:type_name -> query.v1.HeatmapSeries
-	30, // 55: query.v1.HeatmapReport.attribute_table:type_name -> query.v1.AttributeTable
-	34, // 56: query.v1.Point.exemplars:type_name -> query.v1.Exemplar
-	35, // 57: query.v1.Series.points:type_name -> query.v1.Point
-	22, // 58: query.v1.TimeSeriesCompactReport.query:type_name -> query.v1.TimeSeriesQuery
-	36, // 59: query.v1.TimeSeriesCompactReport.time_series:type_name -> query.v1.Series
-	30, // 60: query.v1.TimeSeriesCompactReport.attribute_table:type_name -> query.v1.AttributeTable
-	3,  // 61: query.v1.QueryFrontendService.Query:input_type -> query.v1.QueryRequest
-	6,  // 62: query.v1.QueryBackendService.Invoke:input_type -> query.v1.InvokeRequest
-	4,  // 63: query.v1.QueryFrontendService.Query:output_type -> query.v1.QueryResponse
-	10, // 64: query.v1.QueryBackendService.Invoke:output_type -> query.v1.InvokeResponse
-	63, // [63:65] is the sub-list for method output_type
-	61, // [61:63] is the sub-list for method input_type
-	61, // [61:61] is the sub-list for extension type_name
-	61, // [61:61] is the sub-list for extension extendee
-	0,  // [0:61] is the sub-list for field type_name
+	26, // 48: query.v1.TreeReport.symbol_refs:type_name -> query.v1.SymbolRefTable
+	43, // 49: query.v1.PprofQuery.stack_trace_selector:type_name -> types.v1.StackTraceSelector
+	28, // 50: query.v1.PprofReport.query:type_name -> query.v1.PprofQuery
+	47, // 51: query.v1.HeatmapQuery.query_type:type_name -> querier.v1.HeatmapQueryType
+	41, // 52: query.v1.HeatmapQuery.exemplar_type:type_name -> types.v1.ExemplarType
+	32, // 53: query.v1.HeatmapSeries.points:type_name -> query.v1.HeatmapPoint
+	30, // 54: query.v1.HeatmapReport.query:type_name -> query.v1.HeatmapQuery
+	33, // 55: query.v1.HeatmapReport.heatmap_series:type_name -> query.v1.HeatmapSeries
+	31, // 56: query.v1.HeatmapReport.attribute_table:type_name -> query.v1.AttributeTable
+	35, // 57: query.v1.Point.exemplars:type_name -> query.v1.Exemplar
+	36, // 58: query.v1.Series.points:type_name -> query.v1.Point
+	22, // 59: query.v1.TimeSeriesCompactReport.query:type_name -> query.v1.TimeSeriesQuery
+	37, // 60: query.v1.TimeSeriesCompactReport.time_series:type_name -> query.v1.Series
+	31, // 61: query.v1.TimeSeriesCompactReport.attribute_table:type_name -> query.v1.AttributeTable
+	3,  // 62: query.v1.QueryFrontendService.Query:input_type -> query.v1.QueryRequest
+	6,  // 63: query.v1.QueryBackendService.Invoke:input_type -> query.v1.InvokeRequest
+	4,  // 64: query.v1.QueryFrontendService.Query:output_type -> query.v1.QueryResponse
+	10, // 65: query.v1.QueryBackendService.Invoke:output_type -> query.v1.InvokeResponse
+	64, // [64:66] is the sub-list for method output_type
+	62, // [62:64] is the sub-list for method input_type
+	62, // [62:62] is the sub-list for extension type_name
+	62, // [62:62] is the sub-list for extension extendee
+	0,  // [0:62] is the sub-list for field type_name
 }
 
 func init() { file_query_v1_query_proto_init() }
@@ -2887,15 +2997,15 @@ func file_query_v1_query_proto_init() {
 		return
 	}
 	file_query_v1_query_proto_msgTypes[21].OneofWrappers = []any{}
-	file_query_v1_query_proto_msgTypes[23].OneofWrappers = []any{}
 	file_query_v1_query_proto_msgTypes[24].OneofWrappers = []any{}
+	file_query_v1_query_proto_msgTypes[25].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_query_v1_query_proto_rawDesc), len(file_query_v1_query_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   35,
+			NumMessages:   36,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/api/gen/proto/go/query/v1/query.pb.go
+++ b/api/gen/proto/go/query/v1/query.pb.go
@@ -1625,9 +1625,13 @@ type TreeQuery struct {
 	TraceIdSelector []string `protobuf:"bytes,6,rep,name=trace_id_selector,json=traceIdSelector,proto3" json:"trace_id_selector,omitempty"`
 	// symbol_mode selects the symbol output. When unset, full_symbols is honored
 	// for back-compat.
-	SymbolMode    SymbolMode `protobuf:"varint,7,opt,name=symbol_mode,json=symbolMode,proto3,enum=query.v1.SymbolMode" json:"symbol_mode,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	SymbolMode SymbolMode `protobuf:"varint,7,opt,name=symbol_mode,json=symbolMode,proto3,enum=query.v1.SymbolMode" json:"symbol_mode,omitempty"`
+	// max_unresolved_locations bounds the distinct unresolved locations a
+	// symbol-ref tree result may carry; the query fails past it. Zero means
+	// unlimited. Effective only with SYMBOL_MODE_REFS.
+	MaxUnresolvedLocations int64 `protobuf:"varint,8,opt,name=max_unresolved_locations,json=maxUnresolvedLocations,proto3" json:"max_unresolved_locations,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *TreeQuery) Reset() {
@@ -1707,6 +1711,13 @@ func (x *TreeQuery) GetSymbolMode() SymbolMode {
 		return x.SymbolMode
 	}
 	return SymbolMode_SYMBOL_MODE_UNSPECIFIED
+}
+
+func (x *TreeQuery) GetMaxUnresolvedLocations() int64 {
+	if x != nil {
+		return x.MaxUnresolvedLocations
+	}
+	return 0
 }
 
 type TreeSymbols struct {
@@ -2800,7 +2811,7 @@ const file_query_v1_query_proto_rawDesc = "" +
 	"\x10TimeSeriesReport\x12/\n" +
 	"\x05query\x18\x01 \x01(\v2\x19.query.v1.TimeSeriesQueryR\x05query\x121\n" +
 	"\vtime_series\x18\x02 \x03(\v2\x10.types.v1.SeriesR\n" +
-	"timeSeries\"\xf1\x02\n" +
+	"timeSeries\"\xab\x03\n" +
 	"\tTreeQuery\x12\x1b\n" +
 	"\tmax_nodes\x18\x01 \x01(\x03R\bmaxNodes\x12#\n" +
 	"\rspan_selector\x18\x02 \x03(\tR\fspanSelector\x12S\n" +
@@ -2809,7 +2820,8 @@ const file_query_v1_query_proto_rawDesc = "" +
 	"\ffull_symbols\x18\x05 \x01(\bR\vfullSymbols\x12*\n" +
 	"\x11trace_id_selector\x18\x06 \x03(\tR\x0ftraceIdSelector\x125\n" +
 	"\vsymbol_mode\x18\a \x01(\x0e2\x14.query.v1.SymbolModeR\n" +
-	"symbolModeB\x17\n" +
+	"symbolMode\x128\n" +
+	"\x18max_unresolved_locations\x18\b \x01(\x03R\x16maxUnresolvedLocationsB\x17\n" +
 	"\x15_stack_trace_selector\"\xdb\x02\n" +
 	"\vTreeSymbols\x12.\n" +
 	"\bmappings\x18\x01 \x03(\v2\x12.google.v1.MappingR\bmappings\x121\n" +

--- a/api/gen/proto/go/query/v1/query.pb.go
+++ b/api/gen/proto/go/query/v1/query.pb.go
@@ -159,6 +159,59 @@ func (ReportType) EnumDescriptor() ([]byte, []int) {
 	return file_query_v1_query_proto_rawDescGZIP(), []int{1}
 }
 
+// SymbolMode selects how a TreeQuery reports frame symbols.
+type SymbolMode int32
+
+const (
+	SymbolMode_SYMBOL_MODE_UNSPECIFIED SymbolMode = 0
+	SymbolMode_SYMBOL_MODE_NAME        SymbolMode = 1 // frame names only
+	SymbolMode_SYMBOL_MODE_FULL        SymbolMode = 2 // full pprof symbol tables alongside the tree
+	SymbolMode_SYMBOL_MODE_REFS        SymbolMode = 3 // compact symbol-ref side table for deferred resolution
+)
+
+// Enum value maps for SymbolMode.
+var (
+	SymbolMode_name = map[int32]string{
+		0: "SYMBOL_MODE_UNSPECIFIED",
+		1: "SYMBOL_MODE_NAME",
+		2: "SYMBOL_MODE_FULL",
+		3: "SYMBOL_MODE_REFS",
+	}
+	SymbolMode_value = map[string]int32{
+		"SYMBOL_MODE_UNSPECIFIED": 0,
+		"SYMBOL_MODE_NAME":        1,
+		"SYMBOL_MODE_FULL":        2,
+		"SYMBOL_MODE_REFS":        3,
+	}
+)
+
+func (x SymbolMode) Enum() *SymbolMode {
+	p := new(SymbolMode)
+	*p = x
+	return p
+}
+
+func (x SymbolMode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SymbolMode) Descriptor() protoreflect.EnumDescriptor {
+	return file_query_v1_query_proto_enumTypes[2].Descriptor()
+}
+
+func (SymbolMode) Type() protoreflect.EnumType {
+	return &file_query_v1_query_proto_enumTypes[2]
+}
+
+func (x SymbolMode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SymbolMode.Descriptor instead.
+func (SymbolMode) EnumDescriptor() ([]byte, []int) {
+	return file_query_v1_query_proto_rawDescGZIP(), []int{2}
+}
+
 type QueryNode_Type int32
 
 const (
@@ -192,11 +245,11 @@ func (x QueryNode_Type) String() string {
 }
 
 func (QueryNode_Type) Descriptor() protoreflect.EnumDescriptor {
-	return file_query_v1_query_proto_enumTypes[2].Descriptor()
+	return file_query_v1_query_proto_enumTypes[3].Descriptor()
 }
 
 func (QueryNode_Type) Type() protoreflect.EnumType {
-	return &file_query_v1_query_proto_enumTypes[2]
+	return &file_query_v1_query_proto_enumTypes[3]
 }
 
 func (x QueryNode_Type) Number() protoreflect.EnumNumber {
@@ -1566,10 +1619,13 @@ type TreeQuery struct {
 	SpanSelector       []string                `protobuf:"bytes,2,rep,name=span_selector,json=spanSelector,proto3" json:"span_selector,omitempty"`
 	StackTraceSelector *v11.StackTraceSelector `protobuf:"bytes,3,opt,name=stack_trace_selector,json=stackTraceSelector,proto3,oneof" json:"stack_trace_selector,omitempty"`
 	ProfileIdSelector  []string                `protobuf:"bytes,4,rep,name=profile_id_selector,json=profileIdSelector,proto3" json:"profile_id_selector,omitempty"`
-	FullSymbols        bool                    `protobuf:"varint,5,opt,name=full_symbols,json=fullSymbols,proto3" json:"full_symbols,omitempty"`
-	TraceIdSelector    []string                `protobuf:"bytes,6,rep,name=trace_id_selector,json=traceIdSelector,proto3" json:"trace_id_selector,omitempty"`
-	// symbol_refs and full_symbols are mutually exclusive.
-	SymbolRefs    bool `protobuf:"varint,7,opt,name=symbol_refs,json=symbolRefs,proto3" json:"symbol_refs,omitempty"`
+	// Deprecated: use symbol_mode = SYMBOL_MODE_FULL. Retained for wire
+	// compatibility; will be removed in a couple of releases.
+	FullSymbols     bool     `protobuf:"varint,5,opt,name=full_symbols,json=fullSymbols,proto3" json:"full_symbols,omitempty"`
+	TraceIdSelector []string `protobuf:"bytes,6,rep,name=trace_id_selector,json=traceIdSelector,proto3" json:"trace_id_selector,omitempty"`
+	// symbol_mode selects the symbol output. When unset, full_symbols is honored
+	// for back-compat.
+	SymbolMode    SymbolMode `protobuf:"varint,7,opt,name=symbol_mode,json=symbolMode,proto3,enum=query.v1.SymbolMode" json:"symbol_mode,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1646,11 +1702,11 @@ func (x *TreeQuery) GetTraceIdSelector() []string {
 	return nil
 }
 
-func (x *TreeQuery) GetSymbolRefs() bool {
+func (x *TreeQuery) GetSymbolMode() SymbolMode {
 	if x != nil {
-		return x.SymbolRefs
+		return x.SymbolMode
 	}
-	return false
+	return SymbolMode_SYMBOL_MODE_UNSPECIFIED
 }
 
 type TreeSymbols struct {
@@ -1753,17 +1809,27 @@ func (x *TreeSymbols) GetStringHashes() []uint64 {
 	return nil
 }
 
+// SymbolRefTable resolves the integer frame references in a symbol-ref tree.
+// Each tree node stores one frame reference r; whether r is resolved depends on
+// whether it falls inside the names slice:
+//
+//	r <  len(names): resolved   -> names[r] is the frame name.
+//	r >= len(names): unresolved -> u = r - len(names) indexes the parallel
+//	                 unresolved_* arrays:
+//	                   build_ids[unresolved_build_id[u]]  build ID of the binary
+//	                   unresolved_address[u]              address within it
+//
+// build_ids and binary_names are parallel and 1:1 (binary_names[k] is the
+// "binary!0xaddr" fallback display for build_ids[k]); each build ID appears
+// once. unresolved_build_id and unresolved_address are parallel, one pair per
+// unresolved entry, sorted by (build ID, address).
 type SymbolRefTable struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Resolved refs: 0 <= ref < len(names); names[ref] is the frame name.
-	Names []string `protobuf:"bytes,1,rep,name=names,proto3" json:"names,omitempty"`
-	// Unresolved refs: i = ref - len(names);
-	//
-	//	build_ids[unresolved_build_id[i]], unresolved_address[i].
-	BuildIds          []string `protobuf:"bytes,2,rep,name=build_ids,json=buildIds,proto3" json:"build_ids,omitempty"`                                      // distinct, each exactly once
-	BinaryNames       []string `protobuf:"bytes,3,rep,name=binary_names,json=binaryNames,proto3" json:"binary_names,omitempty"`                             // parallel to build_ids; fallback display
-	UnresolvedBuildId []uint32 `protobuf:"varint,4,rep,packed,name=unresolved_build_id,json=unresolvedBuildId,proto3" json:"unresolved_build_id,omitempty"` // per unresolved entry
-	UnresolvedAddress []uint64 `protobuf:"varint,5,rep,packed,name=unresolved_address,json=unresolvedAddress,proto3" json:"unresolved_address,omitempty"`   // parallel to unresolved_build_id
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	Names             []string               `protobuf:"bytes,1,rep,name=names,proto3" json:"names,omitempty"`
+	BuildIds          []string               `protobuf:"bytes,2,rep,name=build_ids,json=buildIds,proto3" json:"build_ids,omitempty"`
+	BinaryNames       []string               `protobuf:"bytes,3,rep,name=binary_names,json=binaryNames,proto3" json:"binary_names,omitempty"`
+	UnresolvedBuildId []uint32               `protobuf:"varint,4,rep,packed,name=unresolved_build_id,json=unresolvedBuildId,proto3" json:"unresolved_build_id,omitempty"`
+	UnresolvedAddress []uint64               `protobuf:"varint,5,rep,packed,name=unresolved_address,json=unresolvedAddress,proto3" json:"unresolved_address,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -2732,16 +2798,16 @@ const file_query_v1_query_proto_rawDesc = "" +
 	"\x10TimeSeriesReport\x12/\n" +
 	"\x05query\x18\x01 \x01(\v2\x19.query.v1.TimeSeriesQueryR\x05query\x121\n" +
 	"\vtime_series\x18\x02 \x03(\v2\x10.types.v1.SeriesR\n" +
-	"timeSeries\"\xdb\x02\n" +
+	"timeSeries\"\xf1\x02\n" +
 	"\tTreeQuery\x12\x1b\n" +
 	"\tmax_nodes\x18\x01 \x01(\x03R\bmaxNodes\x12#\n" +
 	"\rspan_selector\x18\x02 \x03(\tR\fspanSelector\x12S\n" +
 	"\x14stack_trace_selector\x18\x03 \x01(\v2\x1c.types.v1.StackTraceSelectorH\x00R\x12stackTraceSelector\x88\x01\x01\x12.\n" +
 	"\x13profile_id_selector\x18\x04 \x03(\tR\x11profileIdSelector\x12!\n" +
 	"\ffull_symbols\x18\x05 \x01(\bR\vfullSymbols\x12*\n" +
-	"\x11trace_id_selector\x18\x06 \x03(\tR\x0ftraceIdSelector\x12\x1f\n" +
-	"\vsymbol_refs\x18\a \x01(\bR\n" +
-	"symbolRefsB\x17\n" +
+	"\x11trace_id_selector\x18\x06 \x03(\tR\x0ftraceIdSelector\x125\n" +
+	"\vsymbol_mode\x18\a \x01(\x0e2\x14.query.v1.SymbolModeR\n" +
+	"symbolModeB\x17\n" +
 	"\x15_stack_trace_selector\"\xdb\x02\n" +
 	"\vTreeSymbols\x12.\n" +
 	"\bmappings\x18\x01 \x03(\v2\x12.google.v1.MappingR\bmappings\x121\n" +
@@ -2845,7 +2911,13 @@ const file_query_v1_query_proto_rawDesc = "" +
 	"\vREPORT_TREE\x10\x05\x12\x10\n" +
 	"\fREPORT_PPROF\x10\x06\x12\x12\n" +
 	"\x0eREPORT_HEATMAP\x10\a\x12\x1e\n" +
-	"\x1aREPORT_TIME_SERIES_COMPACT\x10\b2R\n" +
+	"\x1aREPORT_TIME_SERIES_COMPACT\x10\b*k\n" +
+	"\n" +
+	"SymbolMode\x12\x1b\n" +
+	"\x17SYMBOL_MODE_UNSPECIFIED\x10\x00\x12\x14\n" +
+	"\x10SYMBOL_MODE_NAME\x10\x01\x12\x14\n" +
+	"\x10SYMBOL_MODE_FULL\x10\x02\x12\x14\n" +
+	"\x10SYMBOL_MODE_REFS\x10\x032R\n" +
 	"\x14QueryFrontendService\x12:\n" +
 	"\x05Query\x12\x16.query.v1.QueryRequest\x1a\x17.query.v1.QueryResponse\"\x002T\n" +
 	"\x13QueryBackendService\x12=\n" +
@@ -2865,130 +2937,132 @@ func file_query_v1_query_proto_rawDescGZIP() []byte {
 	return file_query_v1_query_proto_rawDescData
 }
 
-var file_query_v1_query_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_query_v1_query_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
 var file_query_v1_query_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
 var file_query_v1_query_proto_goTypes = []any{
 	(QueryType)(0),                  // 0: query.v1.QueryType
 	(ReportType)(0),                 // 1: query.v1.ReportType
-	(QueryNode_Type)(0),             // 2: query.v1.QueryNode.Type
-	(*QueryRequest)(nil),            // 3: query.v1.QueryRequest
-	(*QueryResponse)(nil),           // 4: query.v1.QueryResponse
-	(*InvokeOptions)(nil),           // 5: query.v1.InvokeOptions
-	(*InvokeRequest)(nil),           // 6: query.v1.InvokeRequest
-	(*QueryPlan)(nil),               // 7: query.v1.QueryPlan
-	(*QueryNode)(nil),               // 8: query.v1.QueryNode
-	(*Query)(nil),                   // 9: query.v1.Query
-	(*InvokeResponse)(nil),          // 10: query.v1.InvokeResponse
-	(*Diagnostics)(nil),             // 11: query.v1.Diagnostics
-	(*ExecutionNode)(nil),           // 12: query.v1.ExecutionNode
-	(*ExecutionStats)(nil),          // 13: query.v1.ExecutionStats
-	(*BlockExecution)(nil),          // 14: query.v1.BlockExecution
-	(*Report)(nil),                  // 15: query.v1.Report
-	(*LabelNamesQuery)(nil),         // 16: query.v1.LabelNamesQuery
-	(*LabelNamesReport)(nil),        // 17: query.v1.LabelNamesReport
-	(*LabelValuesQuery)(nil),        // 18: query.v1.LabelValuesQuery
-	(*LabelValuesReport)(nil),       // 19: query.v1.LabelValuesReport
-	(*SeriesLabelsQuery)(nil),       // 20: query.v1.SeriesLabelsQuery
-	(*SeriesLabelsReport)(nil),      // 21: query.v1.SeriesLabelsReport
-	(*TimeSeriesQuery)(nil),         // 22: query.v1.TimeSeriesQuery
-	(*TimeSeriesReport)(nil),        // 23: query.v1.TimeSeriesReport
-	(*TreeQuery)(nil),               // 24: query.v1.TreeQuery
-	(*TreeSymbols)(nil),             // 25: query.v1.TreeSymbols
-	(*SymbolRefTable)(nil),          // 26: query.v1.SymbolRefTable
-	(*TreeReport)(nil),              // 27: query.v1.TreeReport
-	(*PprofQuery)(nil),              // 28: query.v1.PprofQuery
-	(*PprofReport)(nil),             // 29: query.v1.PprofReport
-	(*HeatmapQuery)(nil),            // 30: query.v1.HeatmapQuery
-	(*AttributeTable)(nil),          // 31: query.v1.AttributeTable
-	(*HeatmapPoint)(nil),            // 32: query.v1.HeatmapPoint
-	(*HeatmapSeries)(nil),           // 33: query.v1.HeatmapSeries
-	(*HeatmapReport)(nil),           // 34: query.v1.HeatmapReport
-	(*Exemplar)(nil),                // 35: query.v1.Exemplar
-	(*Point)(nil),                   // 36: query.v1.Point
-	(*Series)(nil),                  // 37: query.v1.Series
-	(*TimeSeriesCompactReport)(nil), // 38: query.v1.TimeSeriesCompactReport
-	(*v1.BlockMeta)(nil),            // 39: metastore.v1.BlockMeta
-	(*v11.Labels)(nil),              // 40: types.v1.Labels
-	(v11.ExemplarType)(0),           // 41: types.v1.ExemplarType
-	(*v11.Series)(nil),              // 42: types.v1.Series
-	(*v11.StackTraceSelector)(nil),  // 43: types.v1.StackTraceSelector
-	(*v12.Mapping)(nil),             // 44: google.v1.Mapping
-	(*v12.Location)(nil),            // 45: google.v1.Location
-	(*v12.Function)(nil),            // 46: google.v1.Function
-	(v13.HeatmapQueryType)(0),       // 47: querier.v1.HeatmapQueryType
+	(SymbolMode)(0),                 // 2: query.v1.SymbolMode
+	(QueryNode_Type)(0),             // 3: query.v1.QueryNode.Type
+	(*QueryRequest)(nil),            // 4: query.v1.QueryRequest
+	(*QueryResponse)(nil),           // 5: query.v1.QueryResponse
+	(*InvokeOptions)(nil),           // 6: query.v1.InvokeOptions
+	(*InvokeRequest)(nil),           // 7: query.v1.InvokeRequest
+	(*QueryPlan)(nil),               // 8: query.v1.QueryPlan
+	(*QueryNode)(nil),               // 9: query.v1.QueryNode
+	(*Query)(nil),                   // 10: query.v1.Query
+	(*InvokeResponse)(nil),          // 11: query.v1.InvokeResponse
+	(*Diagnostics)(nil),             // 12: query.v1.Diagnostics
+	(*ExecutionNode)(nil),           // 13: query.v1.ExecutionNode
+	(*ExecutionStats)(nil),          // 14: query.v1.ExecutionStats
+	(*BlockExecution)(nil),          // 15: query.v1.BlockExecution
+	(*Report)(nil),                  // 16: query.v1.Report
+	(*LabelNamesQuery)(nil),         // 17: query.v1.LabelNamesQuery
+	(*LabelNamesReport)(nil),        // 18: query.v1.LabelNamesReport
+	(*LabelValuesQuery)(nil),        // 19: query.v1.LabelValuesQuery
+	(*LabelValuesReport)(nil),       // 20: query.v1.LabelValuesReport
+	(*SeriesLabelsQuery)(nil),       // 21: query.v1.SeriesLabelsQuery
+	(*SeriesLabelsReport)(nil),      // 22: query.v1.SeriesLabelsReport
+	(*TimeSeriesQuery)(nil),         // 23: query.v1.TimeSeriesQuery
+	(*TimeSeriesReport)(nil),        // 24: query.v1.TimeSeriesReport
+	(*TreeQuery)(nil),               // 25: query.v1.TreeQuery
+	(*TreeSymbols)(nil),             // 26: query.v1.TreeSymbols
+	(*SymbolRefTable)(nil),          // 27: query.v1.SymbolRefTable
+	(*TreeReport)(nil),              // 28: query.v1.TreeReport
+	(*PprofQuery)(nil),              // 29: query.v1.PprofQuery
+	(*PprofReport)(nil),             // 30: query.v1.PprofReport
+	(*HeatmapQuery)(nil),            // 31: query.v1.HeatmapQuery
+	(*AttributeTable)(nil),          // 32: query.v1.AttributeTable
+	(*HeatmapPoint)(nil),            // 33: query.v1.HeatmapPoint
+	(*HeatmapSeries)(nil),           // 34: query.v1.HeatmapSeries
+	(*HeatmapReport)(nil),           // 35: query.v1.HeatmapReport
+	(*Exemplar)(nil),                // 36: query.v1.Exemplar
+	(*Point)(nil),                   // 37: query.v1.Point
+	(*Series)(nil),                  // 38: query.v1.Series
+	(*TimeSeriesCompactReport)(nil), // 39: query.v1.TimeSeriesCompactReport
+	(*v1.BlockMeta)(nil),            // 40: metastore.v1.BlockMeta
+	(*v11.Labels)(nil),              // 41: types.v1.Labels
+	(v11.ExemplarType)(0),           // 42: types.v1.ExemplarType
+	(*v11.Series)(nil),              // 43: types.v1.Series
+	(*v11.StackTraceSelector)(nil),  // 44: types.v1.StackTraceSelector
+	(*v12.Mapping)(nil),             // 45: google.v1.Mapping
+	(*v12.Location)(nil),            // 46: google.v1.Location
+	(*v12.Function)(nil),            // 47: google.v1.Function
+	(v13.HeatmapQueryType)(0),       // 48: querier.v1.HeatmapQueryType
 }
 var file_query_v1_query_proto_depIdxs = []int32{
-	9,  // 0: query.v1.QueryRequest.query:type_name -> query.v1.Query
-	15, // 1: query.v1.QueryResponse.reports:type_name -> query.v1.Report
-	9,  // 2: query.v1.InvokeRequest.query:type_name -> query.v1.Query
-	7,  // 3: query.v1.InvokeRequest.query_plan:type_name -> query.v1.QueryPlan
-	5,  // 4: query.v1.InvokeRequest.options:type_name -> query.v1.InvokeOptions
-	8,  // 5: query.v1.QueryPlan.root:type_name -> query.v1.QueryNode
-	2,  // 6: query.v1.QueryNode.type:type_name -> query.v1.QueryNode.Type
-	8,  // 7: query.v1.QueryNode.children:type_name -> query.v1.QueryNode
-	39, // 8: query.v1.QueryNode.blocks:type_name -> metastore.v1.BlockMeta
+	10, // 0: query.v1.QueryRequest.query:type_name -> query.v1.Query
+	16, // 1: query.v1.QueryResponse.reports:type_name -> query.v1.Report
+	10, // 2: query.v1.InvokeRequest.query:type_name -> query.v1.Query
+	8,  // 3: query.v1.InvokeRequest.query_plan:type_name -> query.v1.QueryPlan
+	6,  // 4: query.v1.InvokeRequest.options:type_name -> query.v1.InvokeOptions
+	9,  // 5: query.v1.QueryPlan.root:type_name -> query.v1.QueryNode
+	3,  // 6: query.v1.QueryNode.type:type_name -> query.v1.QueryNode.Type
+	9,  // 7: query.v1.QueryNode.children:type_name -> query.v1.QueryNode
+	40, // 8: query.v1.QueryNode.blocks:type_name -> metastore.v1.BlockMeta
 	0,  // 9: query.v1.Query.query_type:type_name -> query.v1.QueryType
-	16, // 10: query.v1.Query.label_names:type_name -> query.v1.LabelNamesQuery
-	18, // 11: query.v1.Query.label_values:type_name -> query.v1.LabelValuesQuery
-	20, // 12: query.v1.Query.series_labels:type_name -> query.v1.SeriesLabelsQuery
-	22, // 13: query.v1.Query.time_series:type_name -> query.v1.TimeSeriesQuery
-	24, // 14: query.v1.Query.tree:type_name -> query.v1.TreeQuery
-	28, // 15: query.v1.Query.pprof:type_name -> query.v1.PprofQuery
-	30, // 16: query.v1.Query.heatmap:type_name -> query.v1.HeatmapQuery
-	22, // 17: query.v1.Query.time_series_compact:type_name -> query.v1.TimeSeriesQuery
-	15, // 18: query.v1.InvokeResponse.reports:type_name -> query.v1.Report
-	11, // 19: query.v1.InvokeResponse.diagnostics:type_name -> query.v1.Diagnostics
-	7,  // 20: query.v1.Diagnostics.query_plan:type_name -> query.v1.QueryPlan
-	12, // 21: query.v1.Diagnostics.execution_node:type_name -> query.v1.ExecutionNode
-	2,  // 22: query.v1.ExecutionNode.type:type_name -> query.v1.QueryNode.Type
-	12, // 23: query.v1.ExecutionNode.children:type_name -> query.v1.ExecutionNode
-	13, // 24: query.v1.ExecutionNode.stats:type_name -> query.v1.ExecutionStats
-	14, // 25: query.v1.ExecutionStats.block_executions:type_name -> query.v1.BlockExecution
+	17, // 10: query.v1.Query.label_names:type_name -> query.v1.LabelNamesQuery
+	19, // 11: query.v1.Query.label_values:type_name -> query.v1.LabelValuesQuery
+	21, // 12: query.v1.Query.series_labels:type_name -> query.v1.SeriesLabelsQuery
+	23, // 13: query.v1.Query.time_series:type_name -> query.v1.TimeSeriesQuery
+	25, // 14: query.v1.Query.tree:type_name -> query.v1.TreeQuery
+	29, // 15: query.v1.Query.pprof:type_name -> query.v1.PprofQuery
+	31, // 16: query.v1.Query.heatmap:type_name -> query.v1.HeatmapQuery
+	23, // 17: query.v1.Query.time_series_compact:type_name -> query.v1.TimeSeriesQuery
+	16, // 18: query.v1.InvokeResponse.reports:type_name -> query.v1.Report
+	12, // 19: query.v1.InvokeResponse.diagnostics:type_name -> query.v1.Diagnostics
+	8,  // 20: query.v1.Diagnostics.query_plan:type_name -> query.v1.QueryPlan
+	13, // 21: query.v1.Diagnostics.execution_node:type_name -> query.v1.ExecutionNode
+	3,  // 22: query.v1.ExecutionNode.type:type_name -> query.v1.QueryNode.Type
+	13, // 23: query.v1.ExecutionNode.children:type_name -> query.v1.ExecutionNode
+	14, // 24: query.v1.ExecutionNode.stats:type_name -> query.v1.ExecutionStats
+	15, // 25: query.v1.ExecutionStats.block_executions:type_name -> query.v1.BlockExecution
 	1,  // 26: query.v1.Report.report_type:type_name -> query.v1.ReportType
-	17, // 27: query.v1.Report.label_names:type_name -> query.v1.LabelNamesReport
-	19, // 28: query.v1.Report.label_values:type_name -> query.v1.LabelValuesReport
-	21, // 29: query.v1.Report.series_labels:type_name -> query.v1.SeriesLabelsReport
-	23, // 30: query.v1.Report.time_series:type_name -> query.v1.TimeSeriesReport
-	27, // 31: query.v1.Report.tree:type_name -> query.v1.TreeReport
-	29, // 32: query.v1.Report.pprof:type_name -> query.v1.PprofReport
-	34, // 33: query.v1.Report.heatmap:type_name -> query.v1.HeatmapReport
-	38, // 34: query.v1.Report.time_series_compact:type_name -> query.v1.TimeSeriesCompactReport
-	16, // 35: query.v1.LabelNamesReport.query:type_name -> query.v1.LabelNamesQuery
-	18, // 36: query.v1.LabelValuesReport.query:type_name -> query.v1.LabelValuesQuery
-	20, // 37: query.v1.SeriesLabelsReport.query:type_name -> query.v1.SeriesLabelsQuery
-	40, // 38: query.v1.SeriesLabelsReport.series_labels:type_name -> types.v1.Labels
-	41, // 39: query.v1.TimeSeriesQuery.exemplar_type:type_name -> types.v1.ExemplarType
-	22, // 40: query.v1.TimeSeriesReport.query:type_name -> query.v1.TimeSeriesQuery
-	42, // 41: query.v1.TimeSeriesReport.time_series:type_name -> types.v1.Series
-	43, // 42: query.v1.TreeQuery.stack_trace_selector:type_name -> types.v1.StackTraceSelector
-	44, // 43: query.v1.TreeSymbols.mappings:type_name -> google.v1.Mapping
-	45, // 44: query.v1.TreeSymbols.locations:type_name -> google.v1.Location
-	46, // 45: query.v1.TreeSymbols.functions:type_name -> google.v1.Function
-	24, // 46: query.v1.TreeReport.query:type_name -> query.v1.TreeQuery
-	25, // 47: query.v1.TreeReport.symbols:type_name -> query.v1.TreeSymbols
-	26, // 48: query.v1.TreeReport.symbol_refs:type_name -> query.v1.SymbolRefTable
-	43, // 49: query.v1.PprofQuery.stack_trace_selector:type_name -> types.v1.StackTraceSelector
-	28, // 50: query.v1.PprofReport.query:type_name -> query.v1.PprofQuery
-	47, // 51: query.v1.HeatmapQuery.query_type:type_name -> querier.v1.HeatmapQueryType
-	41, // 52: query.v1.HeatmapQuery.exemplar_type:type_name -> types.v1.ExemplarType
-	32, // 53: query.v1.HeatmapSeries.points:type_name -> query.v1.HeatmapPoint
-	30, // 54: query.v1.HeatmapReport.query:type_name -> query.v1.HeatmapQuery
-	33, // 55: query.v1.HeatmapReport.heatmap_series:type_name -> query.v1.HeatmapSeries
-	31, // 56: query.v1.HeatmapReport.attribute_table:type_name -> query.v1.AttributeTable
-	35, // 57: query.v1.Point.exemplars:type_name -> query.v1.Exemplar
-	36, // 58: query.v1.Series.points:type_name -> query.v1.Point
-	22, // 59: query.v1.TimeSeriesCompactReport.query:type_name -> query.v1.TimeSeriesQuery
-	37, // 60: query.v1.TimeSeriesCompactReport.time_series:type_name -> query.v1.Series
-	31, // 61: query.v1.TimeSeriesCompactReport.attribute_table:type_name -> query.v1.AttributeTable
-	3,  // 62: query.v1.QueryFrontendService.Query:input_type -> query.v1.QueryRequest
-	6,  // 63: query.v1.QueryBackendService.Invoke:input_type -> query.v1.InvokeRequest
-	4,  // 64: query.v1.QueryFrontendService.Query:output_type -> query.v1.QueryResponse
-	10, // 65: query.v1.QueryBackendService.Invoke:output_type -> query.v1.InvokeResponse
-	64, // [64:66] is the sub-list for method output_type
-	62, // [62:64] is the sub-list for method input_type
-	62, // [62:62] is the sub-list for extension type_name
-	62, // [62:62] is the sub-list for extension extendee
-	0,  // [0:62] is the sub-list for field type_name
+	18, // 27: query.v1.Report.label_names:type_name -> query.v1.LabelNamesReport
+	20, // 28: query.v1.Report.label_values:type_name -> query.v1.LabelValuesReport
+	22, // 29: query.v1.Report.series_labels:type_name -> query.v1.SeriesLabelsReport
+	24, // 30: query.v1.Report.time_series:type_name -> query.v1.TimeSeriesReport
+	28, // 31: query.v1.Report.tree:type_name -> query.v1.TreeReport
+	30, // 32: query.v1.Report.pprof:type_name -> query.v1.PprofReport
+	35, // 33: query.v1.Report.heatmap:type_name -> query.v1.HeatmapReport
+	39, // 34: query.v1.Report.time_series_compact:type_name -> query.v1.TimeSeriesCompactReport
+	17, // 35: query.v1.LabelNamesReport.query:type_name -> query.v1.LabelNamesQuery
+	19, // 36: query.v1.LabelValuesReport.query:type_name -> query.v1.LabelValuesQuery
+	21, // 37: query.v1.SeriesLabelsReport.query:type_name -> query.v1.SeriesLabelsQuery
+	41, // 38: query.v1.SeriesLabelsReport.series_labels:type_name -> types.v1.Labels
+	42, // 39: query.v1.TimeSeriesQuery.exemplar_type:type_name -> types.v1.ExemplarType
+	23, // 40: query.v1.TimeSeriesReport.query:type_name -> query.v1.TimeSeriesQuery
+	43, // 41: query.v1.TimeSeriesReport.time_series:type_name -> types.v1.Series
+	44, // 42: query.v1.TreeQuery.stack_trace_selector:type_name -> types.v1.StackTraceSelector
+	2,  // 43: query.v1.TreeQuery.symbol_mode:type_name -> query.v1.SymbolMode
+	45, // 44: query.v1.TreeSymbols.mappings:type_name -> google.v1.Mapping
+	46, // 45: query.v1.TreeSymbols.locations:type_name -> google.v1.Location
+	47, // 46: query.v1.TreeSymbols.functions:type_name -> google.v1.Function
+	25, // 47: query.v1.TreeReport.query:type_name -> query.v1.TreeQuery
+	26, // 48: query.v1.TreeReport.symbols:type_name -> query.v1.TreeSymbols
+	27, // 49: query.v1.TreeReport.symbol_refs:type_name -> query.v1.SymbolRefTable
+	44, // 50: query.v1.PprofQuery.stack_trace_selector:type_name -> types.v1.StackTraceSelector
+	29, // 51: query.v1.PprofReport.query:type_name -> query.v1.PprofQuery
+	48, // 52: query.v1.HeatmapQuery.query_type:type_name -> querier.v1.HeatmapQueryType
+	42, // 53: query.v1.HeatmapQuery.exemplar_type:type_name -> types.v1.ExemplarType
+	33, // 54: query.v1.HeatmapSeries.points:type_name -> query.v1.HeatmapPoint
+	31, // 55: query.v1.HeatmapReport.query:type_name -> query.v1.HeatmapQuery
+	34, // 56: query.v1.HeatmapReport.heatmap_series:type_name -> query.v1.HeatmapSeries
+	32, // 57: query.v1.HeatmapReport.attribute_table:type_name -> query.v1.AttributeTable
+	36, // 58: query.v1.Point.exemplars:type_name -> query.v1.Exemplar
+	37, // 59: query.v1.Series.points:type_name -> query.v1.Point
+	23, // 60: query.v1.TimeSeriesCompactReport.query:type_name -> query.v1.TimeSeriesQuery
+	38, // 61: query.v1.TimeSeriesCompactReport.time_series:type_name -> query.v1.Series
+	32, // 62: query.v1.TimeSeriesCompactReport.attribute_table:type_name -> query.v1.AttributeTable
+	4,  // 63: query.v1.QueryFrontendService.Query:input_type -> query.v1.QueryRequest
+	7,  // 64: query.v1.QueryBackendService.Invoke:input_type -> query.v1.InvokeRequest
+	5,  // 65: query.v1.QueryFrontendService.Query:output_type -> query.v1.QueryResponse
+	11, // 66: query.v1.QueryBackendService.Invoke:output_type -> query.v1.InvokeResponse
+	65, // [65:67] is the sub-list for method output_type
+	63, // [63:65] is the sub-list for method input_type
+	63, // [63:63] is the sub-list for extension type_name
+	63, // [63:63] is the sub-list for extension extendee
+	0,  // [0:63] is the sub-list for field type_name
 }
 
 func init() { file_query_v1_query_proto_init() }
@@ -3004,7 +3078,7 @@ func file_query_v1_query_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_query_v1_query_proto_rawDesc), len(file_query_v1_query_proto_rawDesc)),
-			NumEnums:      3,
+			NumEnums:      4,
 			NumMessages:   36,
 			NumExtensions: 0,
 			NumServices:   2,

--- a/api/gen/proto/go/query/v1/query_vtproto.pb.go
+++ b/api/gen/proto/go/query/v1/query_vtproto.pb.go
@@ -536,6 +536,7 @@ func (m *TreeQuery) CloneVT() *TreeQuery {
 	r := new(TreeQuery)
 	r.MaxNodes = m.MaxNodes
 	r.FullSymbols = m.FullSymbols
+	r.SymbolRefs = m.SymbolRefs
 	if rhs := m.SpanSelector; rhs != nil {
 		tmpContainer := make([]string, len(rhs))
 		copy(tmpContainer, rhs)
@@ -645,6 +646,47 @@ func (m *TreeSymbols) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *SymbolRefTable) CloneVT() *SymbolRefTable {
+	if m == nil {
+		return (*SymbolRefTable)(nil)
+	}
+	r := new(SymbolRefTable)
+	if rhs := m.Names; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.Names = tmpContainer
+	}
+	if rhs := m.BuildIds; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.BuildIds = tmpContainer
+	}
+	if rhs := m.BinaryNames; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.BinaryNames = tmpContainer
+	}
+	if rhs := m.UnresolvedBuildId; rhs != nil {
+		tmpContainer := make([]uint32, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnresolvedBuildId = tmpContainer
+	}
+	if rhs := m.UnresolvedAddress; rhs != nil {
+		tmpContainer := make([]uint64, len(rhs))
+		copy(tmpContainer, rhs)
+		r.UnresolvedAddress = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *SymbolRefTable) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *TreeReport) CloneVT() *TreeReport {
 	if m == nil {
 		return (*TreeReport)(nil)
@@ -652,6 +694,7 @@ func (m *TreeReport) CloneVT() *TreeReport {
 	r := new(TreeReport)
 	r.Query = m.Query.CloneVT()
 	r.Symbols = m.Symbols.CloneVT()
+	r.SymbolRefs = m.SymbolRefs.CloneVT()
 	if rhs := m.Tree; rhs != nil {
 		tmpBytes := make([]byte, len(rhs))
 		copy(tmpBytes, rhs)
@@ -1755,6 +1798,9 @@ func (this *TreeQuery) EqualVT(that *TreeQuery) bool {
 			return false
 		}
 	}
+	if this.SymbolRefs != that.SymbolRefs {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -1889,6 +1935,67 @@ func (this *TreeSymbols) EqualMessageVT(thatMsg proto.Message) bool {
 	}
 	return this.EqualVT(that)
 }
+func (this *SymbolRefTable) EqualVT(that *SymbolRefTable) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if len(this.Names) != len(that.Names) {
+		return false
+	}
+	for i, vx := range this.Names {
+		vy := that.Names[i]
+		if vx != vy {
+			return false
+		}
+	}
+	if len(this.BuildIds) != len(that.BuildIds) {
+		return false
+	}
+	for i, vx := range this.BuildIds {
+		vy := that.BuildIds[i]
+		if vx != vy {
+			return false
+		}
+	}
+	if len(this.BinaryNames) != len(that.BinaryNames) {
+		return false
+	}
+	for i, vx := range this.BinaryNames {
+		vy := that.BinaryNames[i]
+		if vx != vy {
+			return false
+		}
+	}
+	if len(this.UnresolvedBuildId) != len(that.UnresolvedBuildId) {
+		return false
+	}
+	for i, vx := range this.UnresolvedBuildId {
+		vy := that.UnresolvedBuildId[i]
+		if vx != vy {
+			return false
+		}
+	}
+	if len(this.UnresolvedAddress) != len(that.UnresolvedAddress) {
+		return false
+	}
+	for i, vx := range this.UnresolvedAddress {
+		vy := that.UnresolvedAddress[i]
+		if vx != vy {
+			return false
+		}
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *SymbolRefTable) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*SymbolRefTable)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
 func (this *TreeReport) EqualVT(that *TreeReport) bool {
 	if this == that {
 		return true
@@ -1902,6 +2009,9 @@ func (this *TreeReport) EqualVT(that *TreeReport) bool {
 		return false
 	}
 	if !this.Symbols.EqualVT(that.Symbols) {
+		return false
+	}
+	if !this.SymbolRefs.EqualVT(that.SymbolRefs) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -3894,6 +4004,16 @@ func (m *TreeQuery) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.SymbolRefs {
+		i--
+		if m.SymbolRefs {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x38
+	}
 	if len(m.TraceIdSelector) > 0 {
 		for iNdEx := len(m.TraceIdSelector) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.TraceIdSelector[iNdEx])
@@ -4155,6 +4275,106 @@ func (m *TreeSymbols) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *SymbolRefTable) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SymbolRefTable) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *SymbolRefTable) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.UnresolvedAddress) > 0 {
+		var pksize2 int
+		for _, num := range m.UnresolvedAddress {
+			pksize2 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize2
+		j1 := i
+		for _, num := range m.UnresolvedAddress {
+			for num >= 1<<7 {
+				dAtA[j1] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j1++
+			}
+			dAtA[j1] = uint8(num)
+			j1++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.UnresolvedBuildId) > 0 {
+		var pksize4 int
+		for _, num := range m.UnresolvedBuildId {
+			pksize4 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize4
+		j3 := i
+		for _, num := range m.UnresolvedBuildId {
+			for num >= 1<<7 {
+				dAtA[j3] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j3++
+			}
+			dAtA[j3] = uint8(num)
+			j3++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize4))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.BinaryNames) > 0 {
+		for iNdEx := len(m.BinaryNames) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.BinaryNames[iNdEx])
+			copy(dAtA[i:], m.BinaryNames[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.BinaryNames[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if len(m.BuildIds) > 0 {
+		for iNdEx := len(m.BuildIds) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.BuildIds[iNdEx])
+			copy(dAtA[i:], m.BuildIds[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.BuildIds[iNdEx])))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if len(m.Names) > 0 {
+		for iNdEx := len(m.Names) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Names[iNdEx])
+			copy(dAtA[i:], m.Names[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.Names[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *TreeReport) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -4184,6 +4404,16 @@ func (m *TreeReport) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.SymbolRefs != nil {
+		size, err := m.SymbolRefs.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x22
 	}
 	if m.Symbols != nil {
 		size, err := m.Symbols.MarshalToSizedBufferVT(dAtA[:i])
@@ -5526,6 +5756,9 @@ func (m *TreeQuery) SizeVT() (n int) {
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
+	if m.SymbolRefs {
+		n += 2
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -5610,6 +5843,48 @@ func (m *TreeSymbols) SizeVT() (n int) {
 	return n
 }
 
+func (m *SymbolRefTable) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Names) > 0 {
+		for _, s := range m.Names {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if len(m.BuildIds) > 0 {
+		for _, s := range m.BuildIds {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if len(m.BinaryNames) > 0 {
+		for _, s := range m.BinaryNames {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	if len(m.UnresolvedBuildId) > 0 {
+		l = 0
+		for _, e := range m.UnresolvedBuildId {
+			l += protohelpers.SizeOfVarint(uint64(e))
+		}
+		n += 1 + protohelpers.SizeOfVarint(uint64(l)) + l
+	}
+	if len(m.UnresolvedAddress) > 0 {
+		l = 0
+		for _, e := range m.UnresolvedAddress {
+			l += protohelpers.SizeOfVarint(uint64(e))
+		}
+		n += 1 + protohelpers.SizeOfVarint(uint64(l)) + l
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *TreeReport) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -5626,6 +5901,10 @@ func (m *TreeReport) SizeVT() (n int) {
 	}
 	if m.Symbols != nil {
 		l = m.Symbols.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.SymbolRefs != nil {
+		l = m.SymbolRefs.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -9345,6 +9624,26 @@ func (m *TreeQuery) UnmarshalVT(dAtA []byte) error {
 			}
 			m.TraceIdSelector = append(m.TraceIdSelector, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
+		case 7:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SymbolRefs", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.SymbolRefs = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -9880,6 +10179,305 @@ func (m *TreeSymbols) UnmarshalVT(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *SymbolRefTable) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SymbolRefTable: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SymbolRefTable: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Names", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Names = append(m.Names, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BuildIds", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.BuildIds = append(m.BuildIds, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BinaryNames", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.BinaryNames = append(m.BinaryNames, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		case 4:
+			if wireType == 0 {
+				var v uint32
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					v |= uint32(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				m.UnresolvedBuildId = append(m.UnresolvedBuildId, v)
+			} else if wireType == 2 {
+				var packedLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					packedLen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if packedLen < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				postIndex := iNdEx + packedLen
+				if postIndex < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				if postIndex > l {
+					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				var count int
+				for _, integer := range dAtA[iNdEx:postIndex] {
+					if integer < 128 {
+						count++
+					}
+				}
+				elementCount = count
+				if elementCount != 0 && len(m.UnresolvedBuildId) == 0 {
+					m.UnresolvedBuildId = make([]uint32, 0, elementCount)
+				}
+				for iNdEx < postIndex {
+					var v uint32
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						v |= uint32(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					m.UnresolvedBuildId = append(m.UnresolvedBuildId, v)
+				}
+			} else {
+				return fmt.Errorf("proto: wrong wireType = %d for field UnresolvedBuildId", wireType)
+			}
+		case 5:
+			if wireType == 0 {
+				var v uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					v |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				m.UnresolvedAddress = append(m.UnresolvedAddress, v)
+			} else if wireType == 2 {
+				var packedLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					packedLen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if packedLen < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				postIndex := iNdEx + packedLen
+				if postIndex < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				if postIndex > l {
+					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				var count int
+				for _, integer := range dAtA[iNdEx:postIndex] {
+					if integer < 128 {
+						count++
+					}
+				}
+				elementCount = count
+				if elementCount != 0 && len(m.UnresolvedAddress) == 0 {
+					m.UnresolvedAddress = make([]uint64, 0, elementCount)
+				}
+				for iNdEx < postIndex {
+					var v uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						v |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					m.UnresolvedAddress = append(m.UnresolvedAddress, v)
+				}
+			} else {
+				return fmt.Errorf("proto: wrong wireType = %d for field UnresolvedAddress", wireType)
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *TreeReport) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -10012,6 +10610,42 @@ func (m *TreeReport) UnmarshalVT(dAtA []byte) error {
 				m.Symbols = &TreeSymbols{}
 			}
 			if err := m.Symbols.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SymbolRefs", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.SymbolRefs == nil {
+				m.SymbolRefs = &SymbolRefTable{}
+			}
+			if err := m.SymbolRefs.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/api/gen/proto/go/query/v1/query_vtproto.pb.go
+++ b/api/gen/proto/go/query/v1/query_vtproto.pb.go
@@ -536,7 +536,7 @@ func (m *TreeQuery) CloneVT() *TreeQuery {
 	r := new(TreeQuery)
 	r.MaxNodes = m.MaxNodes
 	r.FullSymbols = m.FullSymbols
-	r.SymbolRefs = m.SymbolRefs
+	r.SymbolMode = m.SymbolMode
 	if rhs := m.SpanSelector; rhs != nil {
 		tmpContainer := make([]string, len(rhs))
 		copy(tmpContainer, rhs)
@@ -1798,7 +1798,7 @@ func (this *TreeQuery) EqualVT(that *TreeQuery) bool {
 			return false
 		}
 	}
-	if this.SymbolRefs != that.SymbolRefs {
+	if this.SymbolMode != that.SymbolMode {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -4004,13 +4004,8 @@ func (m *TreeQuery) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
-	if m.SymbolRefs {
-		i--
-		if m.SymbolRefs {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
+	if m.SymbolMode != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.SymbolMode))
 		i--
 		dAtA[i] = 0x38
 	}
@@ -5756,8 +5751,8 @@ func (m *TreeQuery) SizeVT() (n int) {
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
-	if m.SymbolRefs {
-		n += 2
+	if m.SymbolMode != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.SymbolMode))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -9626,9 +9621,9 @@ func (m *TreeQuery) UnmarshalVT(dAtA []byte) error {
 			iNdEx = postIndex
 		case 7:
 			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field SymbolRefs", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field SymbolMode", wireType)
 			}
-			var v int
+			m.SymbolMode = 0
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return protohelpers.ErrIntOverflow
@@ -9638,12 +9633,11 @@ func (m *TreeQuery) UnmarshalVT(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= int(b&0x7F) << shift
+				m.SymbolMode |= SymbolMode(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
-			m.SymbolRefs = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/api/gen/proto/go/query/v1/query_vtproto.pb.go
+++ b/api/gen/proto/go/query/v1/query_vtproto.pb.go
@@ -537,6 +537,7 @@ func (m *TreeQuery) CloneVT() *TreeQuery {
 	r.MaxNodes = m.MaxNodes
 	r.FullSymbols = m.FullSymbols
 	r.SymbolMode = m.SymbolMode
+	r.MaxUnresolvedLocations = m.MaxUnresolvedLocations
 	if rhs := m.SpanSelector; rhs != nil {
 		tmpContainer := make([]string, len(rhs))
 		copy(tmpContainer, rhs)
@@ -1799,6 +1800,9 @@ func (this *TreeQuery) EqualVT(that *TreeQuery) bool {
 		}
 	}
 	if this.SymbolMode != that.SymbolMode {
+		return false
+	}
+	if this.MaxUnresolvedLocations != that.MaxUnresolvedLocations {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -4004,6 +4008,11 @@ func (m *TreeQuery) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.MaxUnresolvedLocations != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.MaxUnresolvedLocations))
+		i--
+		dAtA[i] = 0x40
+	}
 	if m.SymbolMode != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.SymbolMode))
 		i--
@@ -5753,6 +5762,9 @@ func (m *TreeQuery) SizeVT() (n int) {
 	}
 	if m.SymbolMode != 0 {
 		n += 1 + protohelpers.SizeOfVarint(uint64(m.SymbolMode))
+	}
+	if m.MaxUnresolvedLocations != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.MaxUnresolvedLocations))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -9634,6 +9646,25 @@ func (m *TreeQuery) UnmarshalVT(dAtA []byte) error {
 				b := dAtA[iNdEx]
 				iNdEx++
 				m.SymbolMode |= SymbolMode(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 8:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MaxUnresolvedLocations", wireType)
+			}
+			m.MaxUnresolvedLocations = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.MaxUnresolvedLocations |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}

--- a/api/query/v1/query.proto
+++ b/api/query/v1/query.proto
@@ -258,9 +258,11 @@ message TreeSymbols {
 //                      unresolved_address[u]              address within it
 //
 // build_ids and binary_names are parallel and 1:1 (binary_names[k] is the
-// "binary!0xaddr" fallback display for build_ids[k]); each build ID appears
-// once. unresolved_build_id and unresolved_address are parallel, one pair per
-// unresolved entry, sorted by (build ID, address).
+// "binary!0xaddr" fallback display for build_ids[k]); each (build ID,
+// binary name) pair appears once — the same build ID may repeat under
+// different binary names, each retained exactly as stored.
+// unresolved_build_id and unresolved_address are parallel, one entry per
+// unresolved location, sorted by (build ID, binary name, address).
 message SymbolRefTable {
   repeated string names = 1;
   repeated string build_ids = 2;

--- a/api/query/v1/query.proto
+++ b/api/query/v1/query.proto
@@ -214,15 +214,26 @@ message TimeSeriesReport {
   repeated types.v1.Series time_series = 2;
 }
 
+// SymbolMode selects how a TreeQuery reports frame symbols.
+enum SymbolMode {
+  SYMBOL_MODE_UNSPECIFIED = 0;
+  SYMBOL_MODE_NAME = 1; // frame names only
+  SYMBOL_MODE_FULL = 2; // full pprof symbol tables alongside the tree
+  SYMBOL_MODE_REFS = 3; // compact symbol-ref side table for deferred resolution
+}
+
 message TreeQuery {
   int64 max_nodes = 1;
   repeated string span_selector = 2;
   optional types.v1.StackTraceSelector stack_trace_selector = 3;
   repeated string profile_id_selector = 4;
+  // Deprecated: use symbol_mode = SYMBOL_MODE_FULL. Retained for wire
+  // compatibility; will be removed in a couple of releases.
   bool full_symbols = 5;
   repeated string trace_id_selector = 6;
-  // symbol_refs and full_symbols are mutually exclusive.
-  bool symbol_refs = 7;
+  // symbol_mode selects the symbol output. When unset, full_symbols is honored
+  // for back-compat.
+  SymbolMode symbol_mode = 7;
 }
 
 message TreeSymbols {
@@ -236,15 +247,26 @@ message TreeSymbols {
   repeated uint64 string_hashes = 8;
 }
 
+// SymbolRefTable resolves the integer frame references in a symbol-ref tree.
+// Each tree node stores one frame reference r; whether r is resolved depends on
+// whether it falls inside the names slice:
+//
+//   r <  len(names): resolved   -> names[r] is the frame name.
+//   r >= len(names): unresolved -> u = r - len(names) indexes the parallel
+//                    unresolved_* arrays:
+//                      build_ids[unresolved_build_id[u]]  build ID of the binary
+//                      unresolved_address[u]              address within it
+//
+// build_ids and binary_names are parallel and 1:1 (binary_names[k] is the
+// "binary!0xaddr" fallback display for build_ids[k]); each build ID appears
+// once. unresolved_build_id and unresolved_address are parallel, one pair per
+// unresolved entry, sorted by (build ID, address).
 message SymbolRefTable {
-  // Resolved refs: 0 <= ref < len(names); names[ref] is the frame name.
   repeated string names = 1;
-  // Unresolved refs: i = ref - len(names);
-  //   build_ids[unresolved_build_id[i]], unresolved_address[i].
-  repeated string build_ids = 2; // distinct, each exactly once
-  repeated string binary_names = 3; // parallel to build_ids; fallback display
-  repeated uint32 unresolved_build_id = 4; // per unresolved entry
-  repeated uint64 unresolved_address = 5; // parallel to unresolved_build_id
+  repeated string build_ids = 2;
+  repeated string binary_names = 3;
+  repeated uint32 unresolved_build_id = 4;
+  repeated uint64 unresolved_address = 5;
 }
 
 message TreeReport {

--- a/api/query/v1/query.proto
+++ b/api/query/v1/query.proto
@@ -234,6 +234,10 @@ message TreeQuery {
   // symbol_mode selects the symbol output. When unset, full_symbols is honored
   // for back-compat.
   SymbolMode symbol_mode = 7;
+  // max_unresolved_locations bounds the distinct unresolved locations a
+  // symbol-ref tree result may carry; the query fails past it. Zero means
+  // unlimited. Effective only with SYMBOL_MODE_REFS.
+  int64 max_unresolved_locations = 8;
 }
 
 message TreeSymbols {

--- a/api/query/v1/query.proto
+++ b/api/query/v1/query.proto
@@ -221,6 +221,8 @@ message TreeQuery {
   repeated string profile_id_selector = 4;
   bool full_symbols = 5;
   repeated string trace_id_selector = 6;
+  // symbol_refs and full_symbols are mutually exclusive.
+  bool symbol_refs = 7;
 }
 
 message TreeSymbols {
@@ -234,10 +236,22 @@ message TreeSymbols {
   repeated uint64 string_hashes = 8;
 }
 
+message SymbolRefTable {
+  // Resolved refs: 0 <= ref < len(names); names[ref] is the frame name.
+  repeated string names = 1;
+  // Unresolved refs: i = ref - len(names);
+  //   build_ids[unresolved_build_id[i]], unresolved_address[i].
+  repeated string build_ids = 2; // distinct, each exactly once
+  repeated string binary_names = 3; // parallel to build_ids; fallback display
+  repeated uint32 unresolved_build_id = 4; // per unresolved entry
+  repeated uint64 unresolved_address = 5; // parallel to unresolved_build_id
+}
+
 message TreeReport {
   TreeQuery query = 1;
   bytes tree = 2;
   optional TreeSymbols symbols = 3;
+  optional SymbolRefTable symbol_refs = 4;
 }
 
 message PprofQuery {

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_profile.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_profile.go
@@ -164,7 +164,7 @@ func (q *QueryFrontend) selectMergeProfileTree(
 					ProfileIdSelector:  req.ProfileIdSelector,
 					TraceIdSelector:    req.TraceIdSelector,
 					SpanSelector:       req.SpanSelector,
-					FullSymbols:        true,
+					SymbolMode:         queryv1.SymbolMode_SYMBOL_MODE_FULL,
 				},
 			}},
 		},

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_profile_test.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_profile_test.go
@@ -393,7 +393,7 @@ func TestSelectMergeStacktraces_PprofTreePathForwardsSpanSelector(t *testing.T) 
 	require.NotNil(t, resp.Msg.GetPprof().GetProfile())
 	require.NotNil(t, capturedQuery)
 	assert.Equal(t, queryv1.QueryType_QUERY_TREE, capturedQuery.QueryType)
-	assert.True(t, capturedQuery.Tree.GetFullSymbols(), "tree path must request full symbols")
+	assert.Equal(t, queryv1.SymbolMode_SYMBOL_MODE_FULL, capturedQuery.Tree.GetSymbolMode(), "tree path must request full symbols")
 	assert.Equal(t, spanSelector, capturedQuery.Tree.GetSpanSelector())
 }
 

--- a/pkg/querybackend/query_tree.go
+++ b/pkg/querybackend/query_tree.go
@@ -32,7 +32,29 @@ func init() {
 	)
 }
 
+// treeSymbolMode resolves the symbol output requested by a tree query. When
+// symbol_mode is unset it falls back to the deprecated full_symbols bool for
+// wire compatibility; setting both is rejected.
+func treeSymbolMode(t *queryv1.TreeQuery) (queryv1.SymbolMode, error) {
+	mode := t.GetSymbolMode()
+	if t.GetFullSymbols() { //nolint:staticcheck // bridges the deprecated full_symbols bool
+		if mode != queryv1.SymbolMode_SYMBOL_MODE_UNSPECIFIED {
+			return 0, fmt.Errorf("full_symbols must not be combined with symbol_mode")
+		}
+		return queryv1.SymbolMode_SYMBOL_MODE_FULL, nil
+	}
+	if mode == queryv1.SymbolMode_SYMBOL_MODE_UNSPECIFIED {
+		return queryv1.SymbolMode_SYMBOL_MODE_NAME, nil
+	}
+	return mode, nil
+}
+
 func queryTree(q *queryContext, query *queryv1.Query) (*queryv1.Report, error) {
+	mode, err := treeSymbolMode(query.Tree)
+	if err != nil {
+		return nil, err
+	}
+
 	otelSpan := trace.SpanFromContext(q.ctx)
 
 	profileOpts := []profileIteratorOption{withExcludeSampled()}
@@ -142,7 +164,7 @@ func queryTree(q *queryContext, query *queryv1.Query) (*queryv1.Report, error) {
 	}
 
 	// output full pprof tree if that's requested
-	if query.Tree.FullSymbols {
+	if mode == queryv1.SymbolMode_SYMBOL_MODE_FULL {
 		tree, symbolBuilder, err := resolver.LocationRefNameTree()
 		if err != nil {
 			return nil, err
@@ -174,6 +196,7 @@ func queryTree(q *queryContext, query *queryv1.Query) (*queryv1.Report, error) {
 
 type treeAggregator struct {
 	init  sync.Once
+	mode  queryv1.SymbolMode
 	query *queryv1.TreeQuery
 	tree  *model.TreeMerger[model.FunctionName, model.FunctionNameI]
 
@@ -186,8 +209,13 @@ func newTreeAggregator(*queryv1.InvokeRequest) aggregator { return new(treeAggre
 
 func (a *treeAggregator) aggregate(report *queryv1.Report) error {
 	r := report.Tree
-	if r.Query.FullSymbols {
+	mode, err := treeSymbolMode(r.Query)
+	if err != nil {
+		return err
+	}
+	if mode == queryv1.SymbolMode_SYMBOL_MODE_FULL {
 		a.init.Do(func() {
+			a.mode = mode
 			a.lrTree = model.NewTreeMerger[model.LocationRefName, model.LocationRefNameI]()
 			a.query = r.Query.CloneVT()
 			a.symbolMerger = symdb.NewSymbolMerger()
@@ -202,6 +230,7 @@ func (a *treeAggregator) aggregate(report *queryv1.Report) error {
 	}
 
 	a.init.Do(func() {
+		a.mode = mode
 		a.tree = model.NewTreeMerger[model.FunctionName, model.FunctionNameI]()
 		a.query = r.Query.CloneVT()
 	})
@@ -215,7 +244,7 @@ func (a *treeAggregator) build() *queryv1.Report {
 		},
 	}
 
-	if a.query.FullSymbols {
+	if a.mode == queryv1.SymbolMode_SYMBOL_MODE_FULL {
 		builder := a.symbolMerger.ResultBuilder()
 		result.Tree.Tree = a.lrTree.Tree().Bytes(a.query.GetMaxNodes(), builder.KeepSymbol)
 		result.Tree.Symbols = new(queryv1.TreeSymbols)

--- a/pkg/querybackend/query_tree.go
+++ b/pkg/querybackend/query_tree.go
@@ -34,7 +34,8 @@ func init() {
 
 // treeSymbolMode resolves the symbol output requested by a tree query. When
 // symbol_mode is unset it falls back to the deprecated full_symbols bool for
-// wire compatibility; setting both is rejected.
+// wire compatibility; setting both is rejected, as is any mode this backend
+// does not implement.
 func treeSymbolMode(t *queryv1.TreeQuery) (queryv1.SymbolMode, error) {
 	mode := t.GetSymbolMode()
 	if t.GetFullSymbols() { //nolint:staticcheck // bridges the deprecated full_symbols bool
@@ -43,10 +44,15 @@ func treeSymbolMode(t *queryv1.TreeQuery) (queryv1.SymbolMode, error) {
 		}
 		return queryv1.SymbolMode_SYMBOL_MODE_FULL, nil
 	}
-	if mode == queryv1.SymbolMode_SYMBOL_MODE_UNSPECIFIED {
+	switch mode {
+	case queryv1.SymbolMode_SYMBOL_MODE_UNSPECIFIED:
 		return queryv1.SymbolMode_SYMBOL_MODE_NAME, nil
+	case queryv1.SymbolMode_SYMBOL_MODE_NAME, queryv1.SymbolMode_SYMBOL_MODE_FULL:
+		return mode, nil
+	default:
+		// SYMBOL_MODE_REFS is schema-defined but not implemented here yet.
+		return 0, fmt.Errorf("unsupported symbol_mode %s", mode)
 	}
-	return mode, nil
 }
 
 func queryTree(q *queryContext, query *queryv1.Query) (*queryv1.Report, error) {

--- a/pkg/querybackend/query_tree_test.go
+++ b/pkg/querybackend/query_tree_test.go
@@ -16,7 +16,7 @@ func (s *testSuite) Test_QueryTree_FullSymbols_Basic() {
 		QueryPlan:     s.plan,
 		Query: []*queryv1.Query{{
 			QueryType: queryv1.QueryType_QUERY_TREE,
-			Tree:      &queryv1.TreeQuery{FullSymbols: true},
+			Tree:      &queryv1.TreeQuery{SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_FULL},
 		}},
 		Tenant: s.tenant,
 	})
@@ -62,14 +62,14 @@ func (s *testSuite) Test_QueryTree_FullSymbols_NotSetByDefault() {
 // path (LocationRefName tree) and the standard path (FuntionName tree) produce the
 // same total sample count for identical queries, since both resolve the same samples.
 func (s *testSuite) Test_QueryTree_FullSymbols_TotalsMatchNonFullSymbols() {
-	invoke := func(fullSymbols bool) *queryv1.TreeReport {
+	invoke := func(mode queryv1.SymbolMode) *queryv1.TreeReport {
 		resp, err := s.reader.Invoke(s.ctx, &queryv1.InvokeRequest{
 			EndTime:       time.Now().UnixMilli(),
 			LabelSelector: "{}",
 			QueryPlan:     s.plan,
 			Query: []*queryv1.Query{{
 				QueryType: queryv1.QueryType_QUERY_TREE,
-				Tree:      &queryv1.TreeQuery{FullSymbols: fullSymbols},
+				Tree:      &queryv1.TreeQuery{SymbolMode: mode},
 			}},
 			Tenant: s.tenant,
 		})
@@ -78,9 +78,9 @@ func (s *testSuite) Test_QueryTree_FullSymbols_TotalsMatchNonFullSymbols() {
 		return resp.Reports[0].Tree
 	}
 
-	lrTree, err := phlaremodel.UnmarshalTree[phlaremodel.LocationRefName, phlaremodel.LocationRefNameI](invoke(true).Tree)
+	lrTree, err := phlaremodel.UnmarshalTree[phlaremodel.LocationRefName, phlaremodel.LocationRefNameI](invoke(queryv1.SymbolMode_SYMBOL_MODE_FULL).Tree)
 	s.Require().NoError(err)
-	fnTree, err := phlaremodel.UnmarshalTree[phlaremodel.FunctionName, phlaremodel.FunctionNameI](invoke(false).Tree)
+	fnTree, err := phlaremodel.UnmarshalTree[phlaremodel.FunctionName, phlaremodel.FunctionNameI](invoke(queryv1.SymbolMode_SYMBOL_MODE_NAME).Tree)
 	s.Require().NoError(err)
 
 	s.Assert().Equal(fnTree.Total(), lrTree.Total())
@@ -96,7 +96,7 @@ func (s *testSuite) Test_QueryTree_FullSymbols_SymbolConsistency() {
 		QueryPlan:     s.plan,
 		Query: []*queryv1.Query{{
 			QueryType: queryv1.QueryType_QUERY_TREE,
-			Tree:      &queryv1.TreeQuery{FullSymbols: true},
+			Tree:      &queryv1.TreeQuery{SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_FULL},
 		}},
 		Tenant: s.tenant,
 	})
@@ -135,7 +135,7 @@ func (s *testSuite) Test_QueryTree_FullSymbols_NoDuplicateStrings() {
 		QueryPlan:     s.plan,
 		Query: []*queryv1.Query{{
 			QueryType: queryv1.QueryType_QUERY_TREE,
-			Tree:      &queryv1.TreeQuery{FullSymbols: true},
+			Tree:      &queryv1.TreeQuery{SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_FULL},
 		}},
 		Tenant: s.tenant,
 	})
@@ -161,7 +161,7 @@ func (s *testSuite) Test_QueryTree_FullSymbols_Filter() {
 			QueryPlan:     s.plan,
 			Query: []*queryv1.Query{{
 				QueryType: queryv1.QueryType_QUERY_TREE,
-				Tree:      &queryv1.TreeQuery{FullSymbols: true},
+				Tree:      &queryv1.TreeQuery{SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_FULL},
 			}},
 			Tenant: s.tenant,
 		})

--- a/pkg/querybackend/query_tree_test.go
+++ b/pkg/querybackend/query_tree_test.go
@@ -1,7 +1,10 @@
 package querybackend
 
 import (
+	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
 	phlaremodel "github.com/grafana/pyroscope/v2/pkg/model"
@@ -180,4 +183,47 @@ func (s *testSuite) Test_QueryTree_FullSymbols_Filter() {
 
 	s.Assert().Greater(allTree.Total(), filteredTree.Total())
 	s.Assert().Less(len(filtered.Symbols.Locations), len(all.Symbols.Locations))
+}
+
+func TestTreeSymbolMode(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		query   *queryv1.TreeQuery
+		want    queryv1.SymbolMode
+		wantErr string
+	}{
+		{name: "unset defaults to name", query: &queryv1.TreeQuery{}, want: queryv1.SymbolMode_SYMBOL_MODE_NAME},
+		{name: "name", query: &queryv1.TreeQuery{SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_NAME}, want: queryv1.SymbolMode_SYMBOL_MODE_NAME},
+		{name: "full", query: &queryv1.TreeQuery{SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_FULL}, want: queryv1.SymbolMode_SYMBOL_MODE_FULL},
+		{
+			name:  "deprecated full_symbols maps to full",
+			query: &queryv1.TreeQuery{FullSymbols: true}, //nolint:staticcheck // exercises the deprecated bridge
+			want:  queryv1.SymbolMode_SYMBOL_MODE_FULL,
+		},
+		{
+			name:    "full_symbols combined with symbol_mode is rejected",
+			query:   &queryv1.TreeQuery{FullSymbols: true, SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_FULL}, //nolint:staticcheck // exercises the deprecated bridge
+			wantErr: "must not be combined",
+		},
+		{
+			name:    "refs is not implemented yet",
+			query:   &queryv1.TreeQuery{SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_REFS},
+			wantErr: "unsupported symbol_mode",
+		},
+		{
+			name:    "unknown mode is rejected",
+			query:   &queryv1.TreeQuery{SymbolMode: queryv1.SymbolMode(99)},
+			wantErr: "unsupported symbol_mode",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mode, err := treeSymbolMode(tc.query)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, mode)
+		})
+	}
 }


### PR DESCRIPTION
## Part of a series: symbol-aware tree references (2 of 8)

Full context and series overview: #5317 (PR 1 of the series). Compact map:

1. symbolizer: expose address-level `Resolve` API (#5317)
2. **proto: `SymbolRefTable` + tree query/report fields ← this PR**
3. `model/symbolref`: intern table + merge rebasing
4. `model/symbolref`: job grouping + tree rebuild
5. symdb + querybackend: produce and aggregate symbol-ref trees
6. frontend: orchestration behind a default-off per-tenant flag — nothing activates before this
7. integration tests + docs (#5335)
8. symdb: compaction preserves line-less locations (#5337) — stacked at the bottom of the series, merges first

Tracking issue: grafana/pyroscope-squad#487.

## What

The wire schema for tree reports that carry unresolved symbol references — a compact side table
alongside the existing tree bytes:

```proto
message SymbolRefTable {
  // Resolved refs: 0 <= ref < len(names); names[ref] is the frame name.
  repeated string names = 1;
  // Unresolved refs: i = ref - len(names);
  //   build_ids[unresolved_build_id[i]], unresolved_address[i].
  repeated string build_ids = 2;            // distinct, each exactly once
  repeated string binary_names = 3;         // parallel to build_ids; fallback display
  repeated uint32 unresolved_build_id = 4;  // per unresolved entry
  repeated uint64 unresolved_address = 5;   // parallel to unresolved_build_id
}
```

A tree node reference is a single integer: references below `len(names)` are resolved frame
names; references at or above it index the unresolved `(build ID, address)` entries.
`TreeQuery.symbol_refs` requests the new report shape (mutually exclusive with `full_symbols`);
`TreeReport.symbol_refs` carries the table.

Schema and generated code only — nothing reads or writes these fields until later PRs in the
series, so this is inert on its own.

## Why this shape

- **Build IDs are interned** (each once, with per-entry indexes) instead of repeating a 40-64
  character string per reference. Later PRs defer tree truncation while unresolved references
  exist, so side tables travel through every merge uncapped — per-entry weight matters.
- **`binary_names`** (one per build ID) preserves the existing `binary!0xaddr` fallback rendering
  for addresses that fail to resolve.
- **Unresolved entries are sorted by `(build ID, address)`** at marshal time, giving deterministic
  merge output and single-scan grouping into per-build-ID resolution jobs.

## Testing

`make generate` with zero spillover outside `api/`; `go build` clean in the root and `api/`
modules. Field numbers verified against current `main` (`TreeQuery.symbol_refs = 7`,
`TreeReport.symbol_refs = 4`). No behavioral surface to test yet.

