### PR TITLE
[release/v2.1] docs: add docs for supported platforms

### DIFF
--- a/docs/sources/configure-client/language-sdks/_index.md
+++ b/docs/sources/configure-client/language-sdks/_index.md
@@ -59,7 +59,7 @@ The following languages SDKs provide support for sending profiles from your appl
 </table>
 
 {{< admonition type="note" >}}
-Refer to [Available profiling types](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/profile-types/) for a list of profile types supported by each language.
+Refer to [Available profiling types](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/profile-types/) for a list of profile types supported by each language, and to [Supported operating systems and architectures](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/supported-platforms/) for platform support.
 {{< /admonition >}}
 
 If you're interested in integrating other ecosystems, reach out to us on [GitHub](https://github.com/grafana/pyroscope/).

--- a/docs/sources/configure-client/language-sdks/dotnet.md
+++ b/docs/sources/configure-client/language-sdks/dotnet.md
@@ -28,13 +28,23 @@ The .NET Profiler supports the following profiling types:
 
 ### Compatibility
 
-The only compatible operating system and architecture combination is Linux running on amd64 architecture.
+The .NET Profiler supports the following operating systems and architectures:
+
+* Linux on `x86_64` and `aarch64`, with both `glibc` and `musl` builds
+* Windows on `x64` (public preview)
 
 Our .NET profiler works with the following .NET versions:
 
 * .NET 8
 * .NET 9
 * .NET 10
+* .NET Framework 4.8 (Windows only)
+
+{{< admonition type="caution" >}}
+Windows support is in [public preview](https://grafana.com/docs/release-life-cycle/), starting with version 1.3.0 of the profiler. On .NET 8 and later, all profiling types work the same as on Linux. On .NET Framework 4.8, only CPU profiling is available.
+{{< /admonition >}}
+
+For platform support across all SDKs, refer to [Supported operating systems and architectures](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/supported-platforms/).
 
 
 ## Before you begin
@@ -44,6 +54,8 @@ To capture and analyze profiling data, you need either a hosted Pyroscope OSS se
 The Pyroscope server can be a local server for development or a remote server for production use.
 
 ## Configure the .NET client
+
+### Linux
 
 1. Obtain `Pyroscope.Profiler.Native.so` and `Pyroscope.Linux.ApiWrapper.x64.so` from the [latest tarball](https://github.com/grafana/pyroscope-dotnet/releases/):
 
@@ -68,6 +80,34 @@ LD_LIBRARY_PATH=/dotnet
 {{< admonition type="note" >}}
 The `LD_LIBRARY_PATH` environment variable should point to the directory containing the `Pyroscope.Profiler.Native.so` file. This ensures that the dynamic linker can locate the profiler's shared libraries at runtime.
 {{< /admonition >}}
+
+### Windows (public preview)
+
+1. Obtain `Pyroscope.Profiler.Native.dll` from the [latest release](https://github.com/grafana/pyroscope-dotnet/releases/). The profiler is a single DLL, signed by Grafana Labs. No other native libraries are needed: 
+
+```powershell
+Invoke-WebRequest -Uri https://github.com/grafana/pyroscope-dotnet/releases/download/pyroscope-1.3.0/pyroscope.1.3.0-windows-x64.zip -OutFile pyroscope-windows-x64.zip
+Expand-Archive pyroscope-windows-x64.zip -DestinationPath C:\pyroscope
+```
+
+2. Set the following required environment variables to enable the profiler:
+
+```shell
+PYROSCOPE_APPLICATION_NAME=rideshare.dotnet.app
+PYROSCOPE_SERVER_ADDRESS=http://localhost:4040
+PYROSCOPE_PROFILING_ENABLED=1
+CORECLR_ENABLE_PROFILING=1
+CORECLR_PROFILER={BD1A650D-AC5D-4896-B64F-D6FA25D6B26A}
+CORECLR_PROFILER_PATH=C:\pyroscope\Pyroscope.Profiler.Native.dll
+```
+
+For .NET Framework 4.8 applications, use the `COR_*` attach variables instead of the `CORECLR_*` ones:
+
+```shell
+COR_ENABLE_PROFILING=1
+COR_PROFILER={BD1A650D-AC5D-4896-B64F-D6FA25D6B26A}
+COR_PROFILER_PATH=C:\pyroscope\Pyroscope.Profiler.Native.dll
+```
 
 {{< admonition type="note" >}}
 Since .NET version 8 the environment variable `DOTNET_EnableDiagnostics=0` (or its legacy equivalent `COMPlus_EnableDiagnostics=0`) will also disable the profiler. In order to get the previous behaviour (allowing profiling, but switch off IPC and Debugging) the following environment variables should be set instead:
@@ -167,7 +207,7 @@ Here is a simple [example](https://github.com/grafana/pyroscope/blob/main/exampl
 
 | ENVIRONMENT VARIABLE                   | Type         | DESCRIPTION                                                                                                                       |
 |----------------------------------------|--------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| PYROSCOPE_PROFILING_LOG_DIR            | String       | Sets the directory for .NET Profiler logs. Defaults to /var/log/pyroscope/.                                                       |
+| PYROSCOPE_PROFILING_LOG_DIR            | String       | Sets the directory for .NET Profiler logs. Defaults to `/var/log/pyroscope/` on Linux and `%PROGRAMDATA%\Pyroscope\logs` on Windows. |
 | PYROSCOPE_LABELS                       | String       | Static labels to apply to an uploaded profile. Must be a list of key:value separated by commas such as: layer:api or team:intake. |
 | PYROSCOPE_SERVER_ADDRESS               | String       | Address of the Pyroscope Server                                                                                                   |
 | PYROSCOPE_PROFILING_ENABLED            | Boolean      | If set to true, enables the .NET Profiler. Defaults to false.                                                                     |

--- a/docs/sources/configure-client/profile-types.md
+++ b/docs/sources/configure-client/profile-types.md
@@ -67,7 +67,7 @@ This table lists the available profile types based on auto instrumentation using
 
 Using the Pyroscope language SDKs lets you instrument your application directly for precise profiling. You can customize the profiling process according to your application’s specific requirements.
 
-For more information on the language SDKs, refer to [Pyroscope language SDKs](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/language-sdks/).
+For more information on the language SDKs, refer to [Pyroscope language SDKs](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/language-sdks/). For the operating systems and CPU architectures each SDK supports, refer to [Supported operating systems and architectures](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/supported-platforms/).
 
 This table lists the available profile types based on the language SDK.
 

--- a/docs/sources/configure-client/supported-platforms.md
+++ b/docs/sources/configure-client/supported-platforms.md
@@ -1,0 +1,55 @@
+---
+title: Supported operating systems and architectures
+menuTitle: Supported platforms
+description: Operating system, CPU architecture, and libc support for each Pyroscope language SDK.
+weight: 120
+keywords:
+  - pyroscope
+  - language sdks
+  - supported platforms
+  - operating systems
+  - architecture
+---
+
+# Supported operating systems and architectures
+
+The Pyroscope [language SDKs](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/language-sdks/) instrument your application in-process to send profiles to Pyroscope. Because most SDKs rely on a native profiling engine, the operating systems and CPU architectures they support vary. This page summarizes what each SDK supports.
+
+For the list of profile types each SDK produces, refer to [Profile types and instrumentation](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/profile-types/).
+
+## Support matrix
+
+| SDK | Linux x86_64 | Linux ARM64 | macOS x86_64 | macOS ARM64 | Windows x64 |
+| --- | --- | --- | --- | --- | --- |
+| Go | Yes | Yes | Yes | Yes | Yes |
+| Java | Yes | Yes | Yes | Yes | No |
+| .NET | Yes | Yes | No | No | Public preview (see note) |
+| Python | Yes | Yes | Yes | Yes | No |
+| Ruby | Yes | Yes | Yes | Yes | No |
+| Rust | Yes | Yes | Yes | Yes | No |
+| Node.js | Yes | Yes | Yes | Yes | Yes |
+
+{{< admonition type="note" >}}
+Windows support for the .NET SDK is in [public preview](https://grafana.com/docs/release-life-cycle/), starting with profiler version 1.3.0. On .NET 8 and later it has full parity with Linux; on .NET Framework 4.8 only CPU profiling is available. Refer to the [.NET SDK documentation](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/language-sdks/dotnet/).
+{{< /admonition >}}
+
+
+## Linux libc: glibc and musl (Alpine)
+
+Most containerized deployments run on either `glibc` (for example, Debian or Ubuntu) or `musl` (Alpine) Linux. All SDKs support both, but they package it differently:
+
+* **Go** and **Java** work on both from a single build. Go is pure Go, and the Java agent bundles one native library per architecture that runs on either `libc`.
+* **.NET**, **Python**, and **Node.js** publish separate `glibc` and `musl` builds. For .NET, download the tarball that matches your base image; for Python (`pip`) and Node.js (`npm`), the matching build is selected automatically.
+* **Ruby** ships precompiled gems for `glibc` Linux only. On Alpine, the `gem` compiles its native extension at install time, which requires a Rust toolchain.
+
+## macOS
+
+macOS is intended for local development, not production. The Go, Java, Python, Ruby, and Rust SDKs run on macOS for both Intel and Apple Silicon. The .NET SDK does not support macOS.
+
+## Windows
+
+The Go and Node.js SDKs run on Windows. The .NET SDK supports Windows x64 in [public preview](https://grafana.com/docs/release-life-cycle/) (see the note under the support matrix). The Java, Python, Ruby, and Rust SDKs don't support Windows.
+
+## Auto-instrumentation with Grafana Alloy and eBPF
+
+The support above applies to the language SDKs, which instrument your application in-process. [Auto-instrumentation with Grafana Alloy](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-client/grafana-alloy/), including the eBPF profiler, runs only on Linux because it depends on Linux kernel features. It isn't available on macOS or Windows.


### PR DESCRIPTION
Backport 380aa9464dbbe5ea80f46e6a2dbad0e492d977d5 from #5316

---

Adds a new "Supported platforms" page for instrumentation, documenting what platforms and architectures each instrumentation method supports.

Also adds a few notes to the .NET SDK page documenting the newly added Windows support.
