### PR TITLE
feat(model): add symbolref package for symbol-aware tree references

### DIFF
--- a/pkg/model/symbolref/bench_test.go
+++ b/pkg/model/symbolref/bench_test.go
@@ -1,0 +1,105 @@
+package symbolref_test
+
+// Benchmarks below cover Table's intern/merge throughput and
+// ResultBuilder's marshal-time compaction. Rebuild's own memory/throughput
+// benchmark, and a wire-size-vs-literal-encoding benchmark, are deferred
+// until Rebuild is implemented.
+
+import (
+	"fmt"
+	"testing"
+
+	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+	"github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/model/symbolref"
+)
+
+// benchNames is the fixed set of resolved names every benchmark variant
+// interns alongside its unresolved addresses, approximating a realistic
+// resolved/unresolved mix.
+var benchNames = []string{
+	"main", "runtime.gopark", "runtime.mallocgc", "net/http.(*conn).serve", "runtime.selectgo",
+}
+
+// buildBenchTree interns benchNames plus numAddresses addresses (spread
+// across numBuildIDs build IDs, starting at addrBase) into table, and
+// inserts one two-level stack per address (rooted at a name, cycling
+// through benchNames) so every interned ref is referenced by the tree.
+func buildBenchTree(table *symbolref.Table, numAddresses, numBuildIDs int, addrBase uint64) *model.LocationRefNameTree {
+	nameRefs := make([]model.LocationRefName, len(benchNames))
+	for i, n := range benchNames {
+		nameRefs[i] = table.InternName(n)
+	}
+	tree := new(model.LocationRefNameTree)
+	for a := range numAddresses {
+		buildID := fmt.Sprintf("build-%d", a%numBuildIDs)
+		ref := table.InternUnresolved(buildID, "binary-"+buildID, addrBase+uint64(a))
+		tree.InsertStack(1, nameRefs[a%len(nameRefs)], ref)
+	}
+	return tree
+}
+
+// benchmarkInternAndAdd measures combined InternName+InternUnresolved+Add
+// throughput at a given cardinality.
+func benchmarkInternAndAdd(b *testing.B, numAddresses, numBuildIDs int) {
+	// Pre-build the "second table"'s wire form once: Add's cost scales with
+	// its size, not its content, so it need not vary per iteration. Its
+	// addresses are offset past dst's own range so each iteration's Add
+	// call grows dst by numAddresses new entries (a realistic mixed-dataset
+	// merge) rather than only exercising the dedup path.
+	source := buildPartial(func(table *symbolref.Table) *model.LocationRefNameTree {
+		return buildBenchTree(table, numAddresses, numBuildIDs, uint64(numAddresses))
+	})
+
+	inputSize := numAddresses
+	b.ReportAllocs()
+	for b.Loop() {
+		dst := symbolref.NewTable()
+		for _, n := range benchNames {
+			dst.InternName(n)
+		}
+		for a := range numAddresses {
+			buildID := fmt.Sprintf("build-%d", a%numBuildIDs)
+			dst.InternUnresolved(buildID, "binary-"+buildID, uint64(a))
+		}
+		if _, err := dst.Add(source.pb); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	opsPerSec := float64(b.N*inputSize) / b.Elapsed().Seconds()
+	b.ReportMetric(opsPerSec, "ops/sec")
+	b.ReportMetric(float64(inputSize), "input_size")
+}
+
+// BenchmarkInternAndAdd_small: single-dataset, lightly unsymbolized.
+func BenchmarkInternAndAdd_small(b *testing.B) { benchmarkInternAndAdd(b, 100, 1) }
+
+// BenchmarkInternAndAdd_medium: typical mixed-language service.
+func BenchmarkInternAndAdd_medium(b *testing.B) { benchmarkInternAndAdd(b, 10_000, 10) }
+
+// BenchmarkInternAndAdd_large: eBPF whole-host profile, worst case for
+// deferred truncation.
+func BenchmarkInternAndAdd_large(b *testing.B) { benchmarkInternAndAdd(b, 1_000_000, 100) }
+
+// BenchmarkResultBuilderBuild builds a 100,000-node LocationRefNameTree with
+// a realistic resolved/unresolved mix, and measures
+// tree.Bytes(0, rb.KeepRef) + rb.Build(pb) wall time and allocations.
+func BenchmarkResultBuilderBuild(b *testing.B) {
+	const (
+		numNodes    = 100_000
+		numBuildIDs = 10
+	)
+	table := symbolref.NewTable()
+	tree := buildBenchTree(table, numNodes, numBuildIDs, 0)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		rb := table.ResultBuilder()
+		tree.Bytes(0, rb.KeepRef)
+		pb := new(queryv1.SymbolRefTable)
+		rb.Build(pb)
+	}
+
+	b.ReportMetric(float64(numNodes), "input_size")
+}

--- a/pkg/model/symbolref/doc.go
+++ b/pkg/model/symbolref/doc.go
@@ -1,0 +1,23 @@
+// Package symbolref implements symbol-aware tree references: a
+// model.LocationRefNameTree node name can refer to either a resolved frame
+// name or an unresolved native {buildID, address} location, sharing a
+// single integer reference space (model.LocationRefName) alongside a side
+// table (queryv1.SymbolRefTable). This lets a partial or merged tree carry
+// unresolved locations through query-plan merges without leaving the
+// native tree representation, deferring resolution and truncation until
+// after the final merge.
+//
+// Responsibility boundary:
+//
+// Owns: the symbol-reference table (interning and deduplication), ref-space
+// partitioning (resolved vs. unresolved vs. the truncation "other"
+// sentinel), merge-time ref rebasing, marshal-time compaction and
+// ordering, deferred-truncation bookkeeping, grouping unresolved
+// references into per-build-ID resolution jobs, and rebuilding/truncating
+// the final resolved tree.
+//
+// Does NOT own: the generic tree node/marshal format (pkg/model's Tree,
+// reused unchanged), building per-dataset trees from block data
+// (pkg/phlaredb/symdb, pkg/querybackend), fetching or resolving debug info
+// (pkg/symbolizer), or query orchestration (pkg/frontend/...).
+package symbolref

--- a/pkg/model/symbolref/symbolref_test.go
+++ b/pkg/model/symbolref/symbolref_test.go
@@ -339,7 +339,9 @@ func TestEmptyTable(t *testing.T) {
 	require.False(t, table.HasUnresolved())
 
 	rb := table.ResultBuilder()
-	require.NotPanics(t, func() { rb.Build(nil) })
+	built := rb.Build(nil)
+	require.NotNil(t, built)
+	require.Equal(t, []string{""}, built.GetNames())
 
 	pb := new(queryv1.SymbolRefTable)
 	symbolref.NewTable().ResultBuilder().Build(pb)

--- a/pkg/model/symbolref/symbolref_test.go
+++ b/pkg/model/symbolref/symbolref_test.go
@@ -332,9 +332,12 @@ func TestWireOrderingMultipleBuildIDs(t *testing.T) {
 // rather than collapsing to whichever name arrived first.
 func TestBinaryNamesRetainedAsStored(t *testing.T) {
 	table := symbolref.NewTable()
+	require.Zero(t, table.UnresolvedCount())
 	a := table.InternUnresolved("build1", "pyroscope", 0x100)
 	b := table.InternUnresolved("build1", "pyroscope-server", 0x100)
 	require.NotEqual(t, a, b)
+	require.Equal(t, 2, table.UnresolvedCount(),
+		"the same location under two binary names is two distinct unresolved entries")
 
 	tree := new(model.LocationRefNameTree)
 	tree.InsertStack(1, a)

--- a/pkg/model/symbolref/symbolref_test.go
+++ b/pkg/model/symbolref/symbolref_test.go
@@ -386,8 +386,10 @@ func TestOnlyResolvedTable(t *testing.T) {
 // TestAddRemapIsTotal verifies the remap Add returns is safe for any ref,
 // not only those pb describes: the merge machinery invokes it on the marshal
 // format's zero-valued root frame even when pb is nil or empty, and a skewed
-// peer can send a tree whose refs exceed its table. Both must degrade to the
-// reserved ref 0, not panic.
+// peer can send a tree whose refs exceed its table or carry negatives other
+// than OtherLocationRef — which would alias the destination table's internal
+// unresolved encoding (-2-idx) if passed through. All must degrade to the
+// reserved ref 0, not panic or alias.
 func TestAddRemapIsTotal(t *testing.T) {
 	t.Run("nil and empty tables", func(t *testing.T) {
 		for name, pb := range map[string]*queryv1.SymbolRefTable{
@@ -399,7 +401,8 @@ func TestAddRemapIsTotal(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, model.LocationRefName(0), remap(0))
 				require.Equal(t, model.LocationRefName(0), remap(7))
-				require.Equal(t, model.LocationRefName(-1), remap(-1))
+				require.Equal(t, model.OtherLocationRef, remap(model.OtherLocationRef))
+				require.Equal(t, model.LocationRefName(0), remap(-2))
 			})
 		}
 	})
@@ -415,6 +418,16 @@ func TestAddRemapIsTotal(t *testing.T) {
 		require.NoError(t, err)
 		outOfRange := model.LocationRefName(int32(len(p.pb.GetNames())) + int32(len(p.pb.GetUnresolvedAddress())))
 		require.Equal(t, model.LocationRefName(0), remap(outOfRange))
+	})
+
+	t.Run("negative wire ref other than OtherLocationRef degrades", func(t *testing.T) {
+		// The destination has an unresolved entry at internal ref -2; a wire
+		// ref -2 from a malformed tree must not alias it.
+		dst := symbolref.NewTable()
+		dst.InternUnresolved("buildA", "binA", 0x100)
+		remap, err := dst.Add(new(queryv1.SymbolRefTable))
+		require.NoError(t, err)
+		require.Equal(t, model.LocationRefName(0), remap(-2))
 	})
 
 	t.Run("merging tree bytes against an absent table does not panic", func(t *testing.T) {

--- a/pkg/model/symbolref/symbolref_test.go
+++ b/pkg/model/symbolref/symbolref_test.go
@@ -1,0 +1,437 @@
+package symbolref_test
+
+// Jobs and Rebuild are not implemented in this package yet; tests exercising
+// them, and the parts of the tests below that would need them, are deferred
+// to a follow-up change.
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+	"github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/model/symbolref"
+)
+
+// identity renders ref as a string uniquely identifying the resolved name or
+// (buildID, address) location it stands for, for stack-shape comparisons
+// that must survive a change of ref space.
+func identity(t *testing.T, pb *queryv1.SymbolRefTable, ref model.LocationRefName) string {
+	t.Helper()
+	if ref == model.OtherLocationRef {
+		return "other"
+	}
+	names := pb.GetNames()
+	if int(ref) < len(names) {
+		return "name:" + names[ref]
+	}
+	i := int(ref) - len(names)
+	require.Less(t, i, len(pb.GetUnresolvedAddress()), "ref %d out of range", ref)
+	bi := pb.GetUnresolvedBuildId()[i]
+	require.Less(t, int(bi), len(pb.GetBuildIds()), "build id index %d out of range", bi)
+	return fmt.Sprintf("loc:%s@%#x", pb.GetBuildIds()[bi], pb.GetUnresolvedAddress()[i])
+}
+
+// stacksByIdentity walks every stack in tree and sums self values keyed by
+// the root-to-leaf sequence of identity() strings, so two trees using
+// different (arbitrary) ref numbering can be compared for the same logical
+// content. Drops a spurious root-most ref-0 frame that a tree carries after
+// going through UnmarshalTree; safe since Table reserves ref 0.
+func stacksByIdentity(t *testing.T, tree *model.LocationRefNameTree, pb *queryv1.SymbolRefTable) map[string]int64 {
+	t.Helper()
+	out := make(map[string]int64)
+	tree.IterateStacks(func(_ model.LocationRefName, self int64, stack []model.LocationRefName) {
+		slices.Reverse(stack)
+		if len(stack) > 0 && stack[0] == 0 {
+			stack = stack[1:]
+		}
+		ids := make([]string, len(stack))
+		for i, ref := range stack {
+			ids[i] = identity(t, pb, ref)
+		}
+		out[strings.Join(ids, "/")] += self
+	})
+	return out
+}
+
+// marshalWire marshals tree via rb.KeepRef and unmarshals the result,
+// returning both the marshaled bytes and a tree whose node names are in the
+// wire encoding (matching whatever rb.Build subsequently writes), unlike
+// tree's own (Table-internal) node names.
+func marshalWire(t *testing.T, tree *model.LocationRefNameTree, rb *symbolref.ResultBuilder) ([]byte, *model.LocationRefNameTree) {
+	t.Helper()
+	b := tree.Bytes(0, rb.KeepRef)
+	out, err := model.UnmarshalTree[model.LocationRefName, model.LocationRefNameI](b)
+	require.NoError(t, err)
+	return b, out
+}
+
+// testPartial is a marshaled (tree, table) pair, as a producer would send
+// one over the wire in a queryv1.TreeReport.
+type testPartial struct {
+	tree []byte
+	pb   *queryv1.SymbolRefTable
+}
+
+// buildPartial constructs a fresh Table, lets build populate a tree using
+// the table's Intern* methods, and marshals both via ResultBuilder — the
+// same sequence a real producer would follow.
+func buildPartial(build func(*symbolref.Table) *model.LocationRefNameTree) testPartial {
+	table := symbolref.NewTable()
+	tree := build(table)
+	rb := table.ResultBuilder()
+	treeBytes := tree.Bytes(0, rb.KeepRef)
+	pb := new(queryv1.SymbolRefTable)
+	rb.Build(pb)
+	return testPartial{tree: treeBytes, pb: pb}
+}
+
+// TestInternIdempotencyAndDedup verifies InternName and InternUnresolved are
+// idempotent and content-addressed, and that the wire encoding they end up
+// producing splits resolved and unresolved refs into disjoint ranges.
+func TestInternIdempotencyAndDedup(t *testing.T) {
+	table := symbolref.NewTable()
+
+	foo1 := table.InternName("foo")
+	bar := table.InternName("bar")
+	loc2000a := table.InternUnresolved("build1", "bin1", 0x2000)
+	foo2 := table.InternName("foo")
+	loc1000a := table.InternUnresolved("build1", "bin1", 0x1000)
+	foo3 := table.InternName("foo")
+	loc2000b := table.InternUnresolved("build1", "bin1", 0x2000)
+	loc1000b := table.InternUnresolved("build1", "bin1", 0x1000)
+	loc1000c := table.InternUnresolved("build1", "bin1", 0x1000)
+
+	require.Equal(t, foo1, foo2)
+	require.Equal(t, foo1, foo3)
+	require.Equal(t, loc1000a, loc1000b)
+	require.Equal(t, loc1000a, loc1000c)
+	require.Equal(t, loc2000a, loc2000b)
+	require.NotEqual(t, foo1, bar)
+	require.NotEqual(t, loc1000a, loc2000a)
+
+	tree := new(model.LocationRefNameTree)
+	tree.InsertStack(1, foo1)
+	tree.InsertStack(1, bar)
+	tree.InsertStack(1, loc1000a)
+	tree.InsertStack(1, loc2000a)
+
+	// InternName/InternUnresolved's return values are Table's internal
+	// representation, meaningful only as tree node names; the resolved/
+	// unresolved range split applies to the wire encoding
+	// ResultBuilder.KeepRef produces during a real marshal, so capture what
+	// it actually assigns each ref.
+	rb := table.ResultBuilder()
+	wireOf := make(map[model.LocationRefName]model.LocationRefName)
+	keepRef := func(ref model.LocationRefName) model.LocationRefName {
+		out := rb.KeepRef(ref)
+		wireOf[ref] = out
+		return out
+	}
+	tree.Bytes(0, keepRef)
+	pb := new(queryv1.SymbolRefTable)
+	rb.Build(pb)
+
+	for _, resolved := range []model.LocationRefName{foo1, bar} {
+		require.Less(t, int(wireOf[resolved]), len(pb.GetNames()), "resolved ref %d must be < len(pb.Names)", resolved)
+	}
+	for _, unresolved := range []model.LocationRefName{loc1000a, loc2000a} {
+		require.GreaterOrEqual(t, int(wireOf[unresolved]), len(pb.GetNames()), "unresolved ref %d must be >= len(pb.Names)", unresolved)
+	}
+}
+
+// TestAddRemapRoundTrip verifies Add's returned remap function, used with
+// model.TreeMerger.MergeTreeBytes, preserves per-stack identity and values
+// across a change of ref space.
+func TestAddRemapRoundTrip(t *testing.T) {
+	src := symbolref.NewTable()
+	nameA := src.InternName("a")
+	nameB := src.InternName("b")
+	loc := src.InternUnresolved("build1", "bin1", 0x1000)
+
+	srcTree := new(model.LocationRefNameTree)
+	srcTree.InsertStack(3, nameA, nameB)
+	srcTree.InsertStack(5, nameA, loc)
+	srcTree.InsertStack(2, loc)
+
+	srcRB := src.ResultBuilder()
+	treeBytes, srcWireTree := marshalWire(t, srcTree, srcRB)
+	srcPB := new(queryv1.SymbolRefTable)
+	srcRB.Build(srcPB)
+	want := stacksByIdentity(t, srcWireTree, srcPB)
+
+	dst := symbolref.NewTable()
+	remap, err := dst.Add(srcPB)
+	require.NoError(t, err)
+
+	merger := model.NewTreeMerger[model.LocationRefName, model.LocationRefNameI]()
+	require.NoError(t, merger.MergeTreeBytes(treeBytes, model.WithTreeMergeFormatNodeNames(remap)))
+
+	dstRB := dst.ResultBuilder()
+	_, dstWireTree := marshalWire(t, merger.Tree(), dstRB)
+	dstPB := new(queryv1.SymbolRefTable)
+	dstRB.Build(dstPB)
+
+	got := stacksByIdentity(t, dstWireTree, dstPB)
+	require.Equal(t, want, got)
+}
+
+// TestMergeDeterminismUnderPermutedArrival verifies that merging the same
+// set of partials in any order produces the same per-stack values, the same
+// set of resolved names, and the same unresolved wire encoding.
+func TestMergeDeterminismUnderPermutedArrival(t *testing.T) {
+	partials := []testPartial{
+		buildPartial(func(table *symbolref.Table) *model.LocationRefNameTree {
+			shared := table.InternName("shared_fn")
+			p1 := table.InternName("p1_fn")
+			loc := table.InternUnresolved("buildA", "binA", 0x100)
+			tree := new(model.LocationRefNameTree)
+			tree.InsertStack(3, shared, p1)
+			tree.InsertStack(1, shared, loc)
+			return tree
+		}),
+		buildPartial(func(table *symbolref.Table) *model.LocationRefNameTree {
+			shared := table.InternName("shared_fn")
+			p2 := table.InternName("p2_fn")
+			locA := table.InternUnresolved("buildA", "binA", 0x100)
+			locB := table.InternUnresolved("buildB", "binB", 0x200)
+			tree := new(model.LocationRefNameTree)
+			tree.InsertStack(4, shared, p2)
+			tree.InsertStack(2, shared, locA)
+			tree.InsertStack(6, p2, locB)
+			return tree
+		}),
+		buildPartial(func(table *symbolref.Table) *model.LocationRefNameTree {
+			p3 := table.InternName("p3_fn")
+			locB := table.InternUnresolved("buildB", "binB", 0x200)
+			tree := new(model.LocationRefNameTree)
+			tree.InsertStack(5, p3, locB)
+			return tree
+		}),
+	}
+
+	orderings := [][3]int{
+		{0, 1, 2}, {0, 2, 1}, {1, 0, 2}, {1, 2, 0}, {2, 0, 1}, {2, 1, 0},
+	}
+
+	// merge reports the merged result's logical content: per-stack values,
+	// the set of resolved names, and pb's content-sorted unresolved fields.
+	// tree.Bytes' raw output and pb.Names' order are deliberately not
+	// compared: both depend on the merged tree's sibling order, which
+	// pkg/model's Tree sorts by raw ref value — and that raw value depends
+	// on how many other names had already been interned in the destination
+	// table, which is arrival-order-dependent even though the underlying
+	// data is not.
+	type mergeResult struct {
+		stacks     map[string]int64
+		names      map[string]struct{}
+		unresolved *queryv1.SymbolRefTable
+	}
+
+	merge := func(ordering [3]int) mergeResult {
+		dst := symbolref.NewTable()
+		merger := model.NewTreeMerger[model.LocationRefName, model.LocationRefNameI]()
+		for _, i := range ordering {
+			remap, err := dst.Add(partials[i].pb)
+			require.NoError(t, err)
+			require.NoError(t, merger.MergeTreeBytes(partials[i].tree, model.WithTreeMergeFormatNodeNames(remap)))
+		}
+		rb := dst.ResultBuilder()
+		_, wire := marshalWire(t, merger.Tree(), rb)
+		pb := new(queryv1.SymbolRefTable)
+		rb.Build(pb)
+
+		names := make(map[string]struct{}, len(pb.GetNames()))
+		for _, n := range pb.GetNames() {
+			names[n] = struct{}{}
+		}
+		return mergeResult{
+			stacks: stacksByIdentity(t, wire, pb),
+			names:  names,
+			unresolved: &queryv1.SymbolRefTable{
+				BuildIds:          pb.GetBuildIds(),
+				BinaryNames:       pb.GetBinaryNames(),
+				UnresolvedBuildId: pb.GetUnresolvedBuildId(),
+				UnresolvedAddress: pb.GetUnresolvedAddress(),
+			},
+		}
+	}
+
+	want := merge(orderings[0])
+	for _, ordering := range orderings[1:] {
+		got := merge(ordering)
+		require.Equal(t, want.stacks, got.stacks, "ordering %v produced different stack values", ordering)
+		require.Equal(t, want.names, got.names, "ordering %v produced a different set of resolved names", ordering)
+		require.True(t, proto.Equal(want.unresolved, got.unresolved),
+			"ordering %v produced different unresolved wire ordering (the (buildID, address) sort should make this arrival-independent): %v vs %v",
+			ordering, want.unresolved, got.unresolved)
+	}
+}
+
+// TestWireOrderingMultipleBuildIDs verifies unresolved wire entries are
+// sorted by (buildID, address) regardless of intern order, and that
+// resolved names never contain a build ID string.
+func TestWireOrderingMultipleBuildIDs(t *testing.T) {
+	table := symbolref.NewTable()
+
+	n1 := table.InternName("n1")
+	locBbb2 := table.InternUnresolved("bbb", "bin-bbb", 0x2000)
+	n2 := table.InternName("n2")
+	locAaa1 := table.InternUnresolved("aaa", "bin-aaa", 0x1000)
+	locCcc1 := table.InternUnresolved("ccc", "bin-ccc", 0x1000)
+	locBbb1 := table.InternUnresolved("bbb", "bin-bbb", 0x1000)
+	locAaa2 := table.InternUnresolved("aaa", "bin-aaa", 0x2000)
+
+	tree := new(model.LocationRefNameTree)
+	for _, ref := range []model.LocationRefName{n1, n2, locBbb2, locAaa1, locCcc1, locBbb1, locAaa2} {
+		tree.InsertStack(1, ref)
+	}
+
+	rb := table.ResultBuilder()
+	tree.Bytes(0, rb.KeepRef)
+	pb := new(queryv1.SymbolRefTable)
+	rb.Build(pb)
+
+	for _, name := range pb.GetNames() {
+		require.NotContains(t, []string{"aaa", "bbb", "ccc"}, name, "pb.Names must never contain an unresolved build ID")
+	}
+
+	require.Equal(t, len(pb.GetUnresolvedBuildId()), len(pb.GetUnresolvedAddress()))
+	for i := 1; i < len(pb.GetUnresolvedAddress()); i++ {
+		prevKey := fmt.Sprintf("%s|%020d", pb.GetBuildIds()[pb.GetUnresolvedBuildId()[i-1]], pb.GetUnresolvedAddress()[i-1])
+		key := fmt.Sprintf("%s|%020d", pb.GetBuildIds()[pb.GetUnresolvedBuildId()[i]], pb.GetUnresolvedAddress()[i])
+		require.LessOrEqual(t, prevKey, key, "unresolved entries must be sorted by (buildID, address)")
+	}
+}
+
+// TestNegativeRefPassthrough verifies model.OtherLocationRef is never
+// remapped, reassigned, or dropped by ResultBuilder.KeepRef or by an
+// Add-returned remap function.
+func TestNegativeRefPassthrough(t *testing.T) {
+	table := symbolref.NewTable()
+	table.InternName("foo")
+	table.InternUnresolved("build1", "bin1", 0x1000)
+
+	rb := table.ResultBuilder()
+	require.Equal(t, model.OtherLocationRef, rb.KeepRef(model.OtherLocationRef))
+
+	remap, err := table.Add(&queryv1.SymbolRefTable{
+		Names:             []string{"bar"},
+		BuildIds:          []string{"build2"},
+		BinaryNames:       []string{"bin2"},
+		UnresolvedBuildId: []uint32{0},
+		UnresolvedAddress: []uint64{0x2000},
+	})
+	require.NoError(t, err)
+	require.Equal(t, model.OtherLocationRef, remap(model.OtherLocationRef))
+}
+
+// TestEmptyTable verifies a fresh Table and its ResultBuilder behave safely
+// with nothing interned. Jobs and Rebuild are not implemented in this
+// package yet, so their behavior on an empty table is not covered here.
+func TestEmptyTable(t *testing.T) {
+	table := symbolref.NewTable()
+	require.False(t, table.HasUnresolved())
+
+	rb := table.ResultBuilder()
+	require.NotPanics(t, func() { rb.Build(nil) })
+
+	pb := new(queryv1.SymbolRefTable)
+	symbolref.NewTable().ResultBuilder().Build(pb)
+	require.Empty(t, pb.GetNames())
+	require.Empty(t, pb.GetBuildIds())
+	require.Empty(t, pb.GetBinaryNames())
+	require.Empty(t, pb.GetUnresolvedBuildId())
+	require.Empty(t, pb.GetUnresolvedAddress())
+}
+
+// TestOnlyResolvedTable verifies a table built purely from InternName calls
+// reports HasUnresolved() == false and produces no unresolved wire fields.
+func TestOnlyResolvedTable(t *testing.T) {
+	table := symbolref.NewTable()
+	a := table.InternName("a")
+	b := table.InternName("b")
+	c := table.InternName("c")
+	require.False(t, table.HasUnresolved())
+
+	tree := new(model.LocationRefNameTree)
+	tree.InsertStack(1, a)
+	tree.InsertStack(1, b)
+	tree.InsertStack(1, c)
+
+	rb := table.ResultBuilder()
+	// HasUnresolved() is false here, so real truncation (maxNodes > 0) is a
+	// legitimate use of this same ResultBuilder.
+	tree.Bytes(2, rb.KeepRef)
+	pb := new(queryv1.SymbolRefTable)
+	rb.Build(pb)
+
+	require.False(t, table.HasUnresolved())
+	require.Empty(t, pb.GetBuildIds())
+	require.Empty(t, pb.GetBinaryNames())
+	require.Empty(t, pb.GetUnresolvedBuildId())
+	require.Empty(t, pb.GetUnresolvedAddress())
+}
+
+// TestPlainFunctionNameAbsorption verifies a plain FunctionName-tree partial
+// (as an old backend, or a fully-symbolized dataset, would produce) can be
+// absorbed into the symbol-ref space via InternName and merged alongside a
+// genuine unresolved partial without sample loss. The Rebuild-dependent
+// assertion (that the absorbed samples also survive a final rebuild) is
+// deferred: Rebuild is not implemented in this package yet.
+func TestPlainFunctionNameAbsorption(t *testing.T) {
+	plainTree := new(model.FunctionNameTree)
+	plainTree.InsertStack(7, model.FunctionName("main"), model.FunctionName("plainFn"))
+	plainTreeBytes := plainTree.Bytes(0, nil)
+
+	refTable := symbolref.NewTable()
+	locName := refTable.InternName("main")
+	locUnresolved := refTable.InternUnresolved("buildB", "binB", 0x9000)
+	refTree := new(model.LocationRefNameTree)
+	refTree.InsertStack(4, locName, locUnresolved)
+	refRB := refTable.ResultBuilder()
+	refTreeBytes := refTree.Bytes(0, refRB.KeepRef)
+	refPB := new(queryv1.SymbolRefTable)
+	refRB.Build(refPB)
+
+	dst := symbolref.NewTable()
+	merger := model.NewTreeMerger[model.LocationRefName, model.LocationRefNameI]()
+
+	// Unmarshal the plain partial and re-insert every stack into a
+	// LocationRefNameTree via InternName, dropping the spurious root-most
+	// "" frame that pkg/model's Tree marshal format introduces on unmarshal.
+	plain, err := model.UnmarshalTree[model.FunctionName, model.FunctionNameI](plainTreeBytes)
+	require.NoError(t, err)
+	absorbed := new(model.LocationRefNameTree)
+	plain.IterateStacks(func(_ model.FunctionName, self int64, stack []model.FunctionName) {
+		slices.Reverse(stack)
+		if len(stack) > 0 && stack[0] == "" {
+			stack = stack[1:]
+		}
+		refs := make([]model.LocationRefName, len(stack))
+		for i, n := range stack {
+			refs[i] = dst.InternName(string(n))
+		}
+		absorbed.InsertStack(self, refs...)
+	})
+	merger.MergeTree(absorbed)
+
+	remap, err := dst.Add(refPB)
+	require.NoError(t, err)
+	require.NoError(t, merger.MergeTreeBytes(refTreeBytes, model.WithTreeMergeFormatNodeNames(remap)))
+
+	require.True(t, dst.HasUnresolved())
+
+	rb := dst.ResultBuilder()
+	_, mergedWireTree := marshalWire(t, merger.Tree(), rb)
+	mergedPB := new(queryv1.SymbolRefTable)
+	rb.Build(mergedPB)
+
+	stacks := stacksByIdentity(t, mergedWireTree, mergedPB)
+	require.Equal(t, int64(7), stacks["name:main/name:plainFn"], "partial A's stack must survive absorption with its original self value")
+}

--- a/pkg/model/symbolref/symbolref_test.go
+++ b/pkg/model/symbolref/symbolref_test.go
@@ -381,6 +381,54 @@ func TestOnlyResolvedTable(t *testing.T) {
 	require.Empty(t, pb.GetUnresolvedAddress())
 }
 
+// TestAddRemapIsTotal verifies the remap Add returns is safe for any ref,
+// not only those pb describes: the merge machinery invokes it on the marshal
+// format's zero-valued root frame even when pb is nil or empty, and a skewed
+// peer can send a tree whose refs exceed its table. Both must degrade to the
+// reserved ref 0, not panic.
+func TestAddRemapIsTotal(t *testing.T) {
+	t.Run("nil and empty tables", func(t *testing.T) {
+		for name, pb := range map[string]*queryv1.SymbolRefTable{
+			"nil":   nil,
+			"empty": new(queryv1.SymbolRefTable),
+		} {
+			t.Run(name, func(t *testing.T) {
+				remap, err := symbolref.NewTable().Add(pb)
+				require.NoError(t, err)
+				require.Equal(t, model.LocationRefName(0), remap(0))
+				require.Equal(t, model.LocationRefName(0), remap(7))
+				require.Equal(t, model.LocationRefName(-1), remap(-1))
+			})
+		}
+	})
+
+	t.Run("ref beyond the table degrades", func(t *testing.T) {
+		p := buildPartial(func(table *symbolref.Table) *model.LocationRefNameTree {
+			n := table.InternName("fn")
+			tree := new(model.LocationRefNameTree)
+			tree.InsertStack(1, n)
+			return tree
+		})
+		remap, err := symbolref.NewTable().Add(p.pb)
+		require.NoError(t, err)
+		outOfRange := model.LocationRefName(int32(len(p.pb.GetNames())) + int32(len(p.pb.GetUnresolvedAddress())))
+		require.Equal(t, model.LocationRefName(0), remap(outOfRange))
+	})
+
+	t.Run("merging tree bytes against an absent table does not panic", func(t *testing.T) {
+		p := buildPartial(func(table *symbolref.Table) *model.LocationRefNameTree {
+			n := table.InternName("fn")
+			tree := new(model.LocationRefNameTree)
+			tree.InsertStack(1, n)
+			return tree
+		})
+		remap, err := symbolref.NewTable().Add(nil)
+		require.NoError(t, err)
+		merger := model.NewTreeMerger[model.LocationRefName, model.LocationRefNameI]()
+		require.NoError(t, merger.MergeTreeBytes(p.tree, model.WithTreeMergeFormatNodeNames(remap)))
+	})
+}
+
 // TestPlainFunctionNameAbsorption verifies a plain FunctionName-tree partial
 // (as an old backend, or a fully-symbolized dataset, would produce) can be
 // absorbed into the symbol-ref space via InternName and merged alongside a

--- a/pkg/model/symbolref/symbolref_test.go
+++ b/pkg/model/symbolref/symbolref_test.go
@@ -41,16 +41,12 @@ func identity(t *testing.T, pb *queryv1.SymbolRefTable, ref model.LocationRefNam
 // stacksByIdentity walks every stack in tree and sums self values keyed by
 // the root-to-leaf sequence of identity() strings, so two trees using
 // different (arbitrary) ref numbering can be compared for the same logical
-// content. Drops a spurious root-most ref-0 frame that a tree carries after
-// going through UnmarshalTree; safe since Table reserves ref 0.
+// content.
 func stacksByIdentity(t *testing.T, tree *model.LocationRefNameTree, pb *queryv1.SymbolRefTable) map[string]int64 {
 	t.Helper()
 	out := make(map[string]int64)
 	tree.IterateStacks(func(_ model.LocationRefName, self int64, stack []model.LocationRefName) {
 		slices.Reverse(stack)
-		if len(stack) > 0 && stack[0] == 0 {
-			stack = stack[1:]
-		}
 		ids := make([]string, len(stack))
 		for i, ref := range stack {
 			ids[i] = identity(t, pb, ref)
@@ -429,8 +425,9 @@ func TestOnlyResolvedTable(t *testing.T) {
 }
 
 // TestAddRemapIsTotal verifies the remap Add returns is safe for any ref,
-// not only those pb describes: the merge machinery invokes it on the marshal
-// format's zero-valued root frame even when pb is nil or empty, and a skewed
+// not only those pb describes: the merge machinery invokes it on a synthetic
+// zero-valued name (model.Tree.FormatNodeNames visits its virtual root node)
+// even when pb is nil or empty, and a skewed
 // peer can send a tree whose refs exceed its table or carry negatives other
 // than OtherLocationRef — which would alias the destination table's internal
 // unresolved encoding (-2-idx) if passed through. All must degrade to the
@@ -514,16 +511,12 @@ func TestPlainFunctionNameAbsorption(t *testing.T) {
 	merger := model.NewTreeMerger[model.LocationRefName, model.LocationRefNameI]()
 
 	// Unmarshal the plain partial and re-insert every stack into a
-	// LocationRefNameTree via InternName, dropping the spurious root-most
-	// "" frame that pkg/model's Tree marshal format introduces on unmarshal.
+	// LocationRefNameTree via InternName.
 	plain, err := model.UnmarshalTree[model.FunctionName, model.FunctionNameI](plainTreeBytes)
 	require.NoError(t, err)
 	absorbed := new(model.LocationRefNameTree)
 	plain.IterateStacks(func(_ model.FunctionName, self int64, stack []model.FunctionName) {
 		slices.Reverse(stack)
-		if len(stack) > 0 && stack[0] == "" {
-			stack = stack[1:]
-		}
 		refs := make([]model.LocationRefName, len(stack))
 		for i, n := range stack {
 			refs[i] = dst.InternName(string(n))

--- a/pkg/model/symbolref/symbolref_test.go
+++ b/pkg/model/symbolref/symbolref_test.go
@@ -343,7 +343,10 @@ func TestEmptyTable(t *testing.T) {
 
 	pb := new(queryv1.SymbolRefTable)
 	symbolref.NewTable().ResultBuilder().Build(pb)
-	require.Empty(t, pb.GetNames())
+	// Build writes the full name snapshot, which always includes the
+	// reserved ref-0 placeholder, so wire refs stay aligned with
+	// len(pb.Names) no matter which refs a marshaled tree keeps.
+	require.Equal(t, []string{""}, pb.GetNames())
 	require.Empty(t, pb.GetBuildIds())
 	require.Empty(t, pb.GetBinaryNames())
 	require.Empty(t, pb.GetUnresolvedBuildId())
@@ -434,4 +437,34 @@ func TestPlainFunctionNameAbsorption(t *testing.T) {
 
 	stacks := stacksByIdentity(t, mergedWireTree, mergedPB)
 	require.Equal(t, int64(7), stacks["name:main/name:plainFn"], "partial A's stack must survive absorption with its original self value")
+}
+
+// Wire refs must decode to the right SymbolRefTable rows regardless of
+// which refs the marshaled tree keeps: a truncating marshal (or any keep
+// set smaller than the table) must not shift unresolved refs relative to
+// pb.Names, since the wire contract reads unresolved entry i as
+// ref - len(names).
+func TestResultBuilder_wireRefsIndependentOfKeptSet(t *testing.T) {
+	table := symbolref.NewTable()
+	dropped := table.InternName("dropped_by_truncation")
+	kept := table.InternName("kept")
+	droppedU := table.InternUnresolved("build-id-a", "liba.so", 0x10)
+	keptU := table.InternUnresolved("build-id-b", "libb.so", 0x20)
+
+	rb := table.ResultBuilder()
+	keptWire := rb.KeepRef(kept)
+	keptUWire := rb.KeepRef(keptU)
+	pb := new(queryv1.SymbolRefTable)
+	rb.Build(pb)
+
+	require.Less(t, int(keptWire), len(pb.Names))
+	require.Equal(t, "kept", pb.Names[keptWire])
+
+	i := int(keptUWire) - len(pb.Names)
+	require.GreaterOrEqual(t, i, 0, "unresolved wire ref must be >= len(pb.Names)")
+	require.Less(t, i, len(pb.UnresolvedAddress))
+	require.Equal(t, uint64(0x20), pb.UnresolvedAddress[i])
+	require.Equal(t, "build-id-b", pb.BuildIds[pb.UnresolvedBuildId[i]])
+
+	_, _ = dropped, droppedU // interned but never kept: must not shift the wire encoding
 }

--- a/pkg/model/symbolref/symbolref_test.go
+++ b/pkg/model/symbolref/symbolref_test.go
@@ -5,6 +5,7 @@ package symbolref_test
 // to a follow-up change.
 
 import (
+	"cmp"
 	"fmt"
 	"slices"
 	"strings"
@@ -19,8 +20,8 @@ import (
 )
 
 // identity renders ref as a string uniquely identifying the resolved name or
-// (buildID, address) location it stands for, for stack-shape comparisons
-// that must survive a change of ref space.
+// (buildID, binaryName, address) location it stands for, for stack-shape
+// comparisons that must survive a change of ref space.
 func identity(t *testing.T, pb *queryv1.SymbolRefTable, ref model.LocationRefName) string {
 	t.Helper()
 	if ref == model.OtherLocationRef {
@@ -34,7 +35,7 @@ func identity(t *testing.T, pb *queryv1.SymbolRefTable, ref model.LocationRefNam
 	require.Less(t, i, len(pb.GetUnresolvedAddress()), "ref %d out of range", ref)
 	bi := pb.GetUnresolvedBuildId()[i]
 	require.Less(t, int(bi), len(pb.GetBuildIds()), "build id index %d out of range", bi)
-	return fmt.Sprintf("loc:%s@%#x", pb.GetBuildIds()[bi], pb.GetUnresolvedAddress()[i])
+	return fmt.Sprintf("loc:%s|%s@%#x", pb.GetBuildIds()[bi], pb.GetBinaryNames()[bi], pb.GetUnresolvedAddress()[i])
 }
 
 // stacksByIdentity walks every stack in tree and sums self values keyed by
@@ -106,6 +107,7 @@ func TestInternIdempotencyAndDedup(t *testing.T) {
 	loc2000b := table.InternUnresolved("build1", "bin1", 0x2000)
 	loc1000b := table.InternUnresolved("build1", "bin1", 0x1000)
 	loc1000c := table.InternUnresolved("build1", "bin1", 0x1000)
+	loc1000renamed := table.InternUnresolved("build1", "bin1-renamed", 0x1000)
 
 	require.Equal(t, foo1, foo2)
 	require.Equal(t, foo1, foo3)
@@ -114,6 +116,8 @@ func TestInternIdempotencyAndDedup(t *testing.T) {
 	require.Equal(t, loc2000a, loc2000b)
 	require.NotEqual(t, foo1, bar)
 	require.NotEqual(t, loc1000a, loc2000a)
+	require.NotEqual(t, loc1000a, loc1000renamed,
+		"same (buildID, addr) under a different binary name must be a distinct ref")
 
 	tree := new(model.LocationRefNameTree)
 	tree.InsertStack(1, foo1)
@@ -209,8 +213,13 @@ func TestMergeDeterminismUnderPermutedArrival(t *testing.T) {
 		buildPartial(func(table *symbolref.Table) *model.LocationRefNameTree {
 			p3 := table.InternName("p3_fn")
 			locB := table.InternUnresolved("buildB", "binB", 0x200)
+			// Same (buildID, addr) as partials 1 and 2, but stored under a
+			// renamed binary: the kept name must not depend on which partial
+			// arrives first.
+			locA := table.InternUnresolved("buildA", "binA-renamed", 0x100)
 			tree := new(model.LocationRefNameTree)
 			tree.InsertStack(5, p3, locB)
+			tree.InsertStack(7, p3, locA)
 			return tree
 		}),
 	}
@@ -268,14 +277,14 @@ func TestMergeDeterminismUnderPermutedArrival(t *testing.T) {
 		require.Equal(t, want.stacks, got.stacks, "ordering %v produced different stack values", ordering)
 		require.Equal(t, want.names, got.names, "ordering %v produced a different set of resolved names", ordering)
 		require.True(t, proto.Equal(want.unresolved, got.unresolved),
-			"ordering %v produced different unresolved wire ordering (the (buildID, address) sort should make this arrival-independent): %v vs %v",
+			"ordering %v produced different unresolved wire ordering (the (buildID, binaryName, address) sort should make this arrival-independent): %v vs %v",
 			ordering, want.unresolved, got.unresolved)
 	}
 }
 
 // TestWireOrderingMultipleBuildIDs verifies unresolved wire entries are
-// sorted by (buildID, address) regardless of intern order, and that
-// resolved names never contain a build ID string.
+// sorted by (buildID, binaryName, address) regardless of intern order, and
+// that resolved names never contain a build ID string.
 func TestWireOrderingMultipleBuildIDs(t *testing.T) {
 	table := symbolref.NewTable()
 
@@ -286,9 +295,12 @@ func TestWireOrderingMultipleBuildIDs(t *testing.T) {
 	locCcc1 := table.InternUnresolved("ccc", "bin-ccc", 0x1000)
 	locBbb1 := table.InternUnresolved("bbb", "bin-bbb", 0x1000)
 	locAaa2 := table.InternUnresolved("aaa", "bin-aaa", 0x2000)
+	// bbb again under a renamed binary, at an address between bbb's other
+	// two: must sort after both bin-bbb entries, not between them.
+	locBbbRenamed := table.InternUnresolved("bbb", "bin-bbb-renamed", 0x1500)
 
 	tree := new(model.LocationRefNameTree)
-	for _, ref := range []model.LocationRefName{n1, n2, locBbb2, locAaa1, locCcc1, locBbb1, locAaa2} {
+	for _, ref := range []model.LocationRefName{n1, n2, locBbb2, locAaa1, locCcc1, locBbb1, locAaa2, locBbbRenamed} {
 		tree.InsertStack(1, ref)
 	}
 
@@ -302,11 +314,44 @@ func TestWireOrderingMultipleBuildIDs(t *testing.T) {
 	}
 
 	require.Equal(t, len(pb.GetUnresolvedBuildId()), len(pb.GetUnresolvedAddress()))
-	for i := 1; i < len(pb.GetUnresolvedAddress()); i++ {
-		prevKey := fmt.Sprintf("%s|%020d", pb.GetBuildIds()[pb.GetUnresolvedBuildId()[i-1]], pb.GetUnresolvedAddress()[i-1])
-		key := fmt.Sprintf("%s|%020d", pb.GetBuildIds()[pb.GetUnresolvedBuildId()[i]], pb.GetUnresolvedAddress()[i])
-		require.LessOrEqual(t, prevKey, key, "unresolved entries must be sorted by (buildID, address)")
+	keyAt := func(i int) (string, string, uint64) {
+		row := pb.GetUnresolvedBuildId()[i]
+		return pb.GetBuildIds()[row], pb.GetBinaryNames()[row], pb.GetUnresolvedAddress()[i]
 	}
+	for i := 1; i < len(pb.GetUnresolvedAddress()); i++ {
+		prevBuildID, prevName, prevAddr := keyAt(i - 1)
+		buildID, name, addr := keyAt(i)
+		order := cmp.Or(
+			cmp.Compare(prevBuildID, buildID),
+			cmp.Compare(prevName, name),
+			cmp.Compare(prevAddr, addr),
+		)
+		require.LessOrEqual(t, order, 0, "unresolved entries must be sorted by (buildID, binaryName, address); entry %d (%s, %s, %#x) sorts after (%s, %s, %#x)",
+			i, prevBuildID, prevName, prevAddr, buildID, name, addr)
+	}
+}
+
+// TestBinaryNamesRetainedAsStored verifies the renamed-binary case: the same
+// build ID stored under two binary names keeps both rows, exactly as stored,
+// rather than collapsing to whichever name arrived first.
+func TestBinaryNamesRetainedAsStored(t *testing.T) {
+	table := symbolref.NewTable()
+	a := table.InternUnresolved("build1", "pyroscope", 0x100)
+	b := table.InternUnresolved("build1", "pyroscope-server", 0x100)
+	require.NotEqual(t, a, b)
+
+	tree := new(model.LocationRefNameTree)
+	tree.InsertStack(1, a)
+	tree.InsertStack(1, b)
+
+	rb := table.ResultBuilder()
+	tree.Bytes(0, rb.KeepRef)
+	pb := rb.Build(nil)
+
+	require.Equal(t, []string{"build1", "build1"}, pb.GetBuildIds())
+	require.Equal(t, []string{"pyroscope", "pyroscope-server"}, pb.GetBinaryNames())
+	require.Equal(t, []uint32{0, 1}, pb.GetUnresolvedBuildId())
+	require.Equal(t, []uint64{0x100, 0x100}, pb.GetUnresolvedAddress())
 }
 
 // TestNegativeRefPassthrough verifies model.OtherLocationRef is never

--- a/pkg/model/symbolref/table.go
+++ b/pkg/model/symbolref/table.go
@@ -240,19 +240,18 @@ func (c *tableCore) newResultBuilder() *ResultBuilder {
 		binaryNames:      c.binaryNames,
 		unresolvedBI:     c.unresolvedBI,
 		unresolvedAd:     c.unresolvedAd,
-		nameLookup:       make(map[int32]int32),
 		sortedUnresolved: sorted,
 		rank:             rank,
 	}
 }
 
-// ResultBuilder compacts and orders a Table's contents into a
-// queryv1.SymbolRefTable at marshal time. It is built from a point-in-time
-// snapshot of its Table's state, taken under the Table's lock (see
-// tableCore.newResultBuilder); ResultBuilder itself holds no reference back
-// to the Table and takes no lock of its own, so it is not safe for
-// concurrent use — it is meant to be driven single-threaded, once, after
-// every Add/Intern* call on its Table has completed.
+// ResultBuilder encodes a Table's contents into a queryv1.SymbolRefTable at
+// marshal time. It is built from a point-in-time snapshot of its Table's
+// state, taken under the Table's lock (see tableCore.newResultBuilder);
+// ResultBuilder itself holds no reference back to the Table and takes no
+// lock of its own, so it is not safe for concurrent use — it is meant to be
+// driven single-threaded, once, after every Add/Intern* call on its Table
+// has completed.
 type ResultBuilder struct {
 	namesLen int // snapshot of len(names) at construction; the resolved/unresolved dividing line
 
@@ -263,31 +262,28 @@ type ResultBuilder struct {
 	unresolvedBI []int32  // snapshot: build ID index per unresolved entry
 	unresolvedAd []uint64 // snapshot: address per unresolved entry
 
-	nameLookup map[int32]int32 // input name index -> output index, in observation order
-	names      []int32         // ordered list of kept name indices
-
 	sortedUnresolved []int32 // permutation of [0, len(unresolvedBI)), sorted by (buildID, address)
 	rank             []int32 // rank[idx] = position of idx within sortedUnresolved
 }
 
-// KeepRef marks ref as reachable and returns its compacted wire-encoding
-// ref, for use as the keepName callback to Tree.Bytes/MarshalTruncate. ref
-// is Table's internal encoding (resolved: >= 0; model.OtherLocationRef
-// (-1): passed through unchanged; unresolved: <= -2, see
-// tableCore.unresolvedRef).
+// KeepRef returns ref's wire encoding, for use as the keepName callback to
+// Tree.Bytes/MarshalTruncate. ref is Table's internal encoding (resolved:
+// >= 0; model.OtherLocationRef (-1): passed through unchanged; unresolved:
+// <= -2, see tableCore.unresolvedRef).
+//
+// Wire refs are assigned from the snapshot alone — resolved refs keep their
+// table index, unresolved refs are offset by the snapshot's name count —
+// and Build writes the full snapshot, so the encoding does not depend on
+// which refs the marshaled tree keeps. Unresolved wire refs must be final
+// the moment they are first returned, while the kept set is still unknown,
+// so a kept-set-compacted encoding could not be assigned in this single
+// pass without breaking the (buildID, address) wire order.
 func (rb *ResultBuilder) KeepRef(ref model.LocationRefName) model.LocationRefName {
 	switch {
 	case ref == model.OtherLocationRef:
 		return ref
 	case ref >= 0:
-		idx := int32(ref)
-		if out, ok := rb.nameLookup[idx]; ok {
-			return model.LocationRefName(out)
-		}
-		out := int32(len(rb.names))
-		rb.nameLookup[idx] = out
-		rb.names = append(rb.names, idx)
-		return model.LocationRefName(out)
+		return ref
 	default:
 		idx := -2 - int(ref)
 		return model.LocationRefName(rb.namesLen + int(rb.rank[idx]))
@@ -295,20 +291,20 @@ func (rb *ResultBuilder) KeepRef(ref model.LocationRefName) model.LocationRefNam
 }
 
 // Build writes pb.Names, pb.BuildIds, pb.BinaryNames, pb.UnresolvedBuildId
-// and pb.UnresolvedAddress from the refs kept by KeepRef, allocating a new
-// queryv1.SymbolRefTable when pb == nil. Resolved names are written in the
-// order KeepRef first observed them; unresolved entries are sorted by
-// (buildID, address), which is what makes the unresolved side of the wire
-// encoding independent of intern or merge arrival order.
+// and pb.UnresolvedAddress from the snapshot, allocating a new
+// queryv1.SymbolRefTable when pb == nil. Every interned name is written, in
+// intern order, so resolved wire refs are the table's own name indices and
+// len(pb.Names) always equals the offset KeepRef applies to unresolved
+// refs; unresolved entries are sorted by (buildID, address), which is what
+// makes the unresolved side of the wire encoding independent of intern or
+// merge arrival order.
 func (rb *ResultBuilder) Build(pb *queryv1.SymbolRefTable) {
 	if pb == nil {
 		pb = &queryv1.SymbolRefTable{}
 	}
 
-	pb.Names = make([]string, len(rb.names))
-	for out, idx := range rb.names {
-		pb.Names[out] = rb.namesSl[idx]
-	}
+	pb.Names = make([]string, rb.namesLen)
+	copy(pb.Names, rb.namesSl)
 
 	n := len(rb.sortedUnresolved)
 	pb.BuildIds = make([]string, 0, n)

--- a/pkg/model/symbolref/table.go
+++ b/pkg/model/symbolref/table.go
@@ -63,10 +63,11 @@ type unresolvedKey struct {
 }
 
 // NewTable returns an empty table. Ref 0 is reserved as an unused sentinel:
-// pkg/model's Tree marshal format introduces a spurious zero-valued frame at
-// the root of every stack in a tree that has gone through a merge, and
-// reserving ref 0 keeps that frame distinguishable from a genuine name — so
-// InternName's first call for real content returns 1, not 0.
+// the tree-merge machinery invokes remap functions on synthetic zero-valued
+// names (model.Tree.FormatNodeNames visits its virtual root node), and Add
+// remaps refs its input does not describe to the reserved ref — so a real
+// name must never land on ref 0. InternName's first call for real content
+// returns 1, not 0.
 func NewTable() *Table {
 	return &Table{core: newTableCore()}
 }

--- a/pkg/model/symbolref/table.go
+++ b/pkg/model/symbolref/table.go
@@ -297,14 +297,14 @@ func (rb *ResultBuilder) KeepRef(ref model.LocationRefName) model.LocationRefNam
 }
 
 // Build writes pb.Names, pb.BuildIds, pb.BinaryNames, pb.UnresolvedBuildId
-// and pb.UnresolvedAddress from the snapshot, allocating a new
-// queryv1.SymbolRefTable when pb == nil. Every interned name is written, in
-// intern order, so resolved wire refs are the table's own name indices and
-// len(pb.Names) always equals the offset KeepRef applies to unresolved
-// refs; unresolved entries are sorted by (buildID, address), which is what
-// makes the unresolved side of the wire encoding independent of intern or
-// merge arrival order.
-func (rb *ResultBuilder) Build(pb *queryv1.SymbolRefTable) {
+// and pb.UnresolvedAddress from the snapshot and returns pb, allocating the
+// returned queryv1.SymbolRefTable when pb == nil. Every interned name is
+// written, in intern order, so resolved wire refs are the table's own name
+// indices and len(pb.Names) always equals the offset KeepRef applies to
+// unresolved refs; unresolved entries are sorted by (buildID, address),
+// which is what makes the unresolved side of the wire encoding independent
+// of intern or merge arrival order.
+func (rb *ResultBuilder) Build(pb *queryv1.SymbolRefTable) *queryv1.SymbolRefTable {
 	if pb == nil {
 		pb = &queryv1.SymbolRefTable{}
 	}
@@ -331,6 +331,8 @@ func (rb *ResultBuilder) Build(pb *queryv1.SymbolRefTable) {
 		pb.UnresolvedBuildId[out] = uint32(biOut)
 		pb.UnresolvedAddress[out] = rb.unresolvedAd[idx]
 	}
+
+	return pb
 }
 
 // hashedSlice is a content-addressed intern table for strings: repeated add

--- a/pkg/model/symbolref/table.go
+++ b/pkg/model/symbolref/table.go
@@ -138,10 +138,11 @@ func (c *tableCore) hasUnresolved() bool {
 
 // Add merges pb into t, returning a remap function from pb's ref space into
 // t's ref space, suitable for model.WithTreeMergeFormatNodeNames. The
-// returned remap passes negative refs (model.OtherLocationRef) through
-// unchanged and maps refs pb does not describe — every non-negative ref,
-// when pb is nil or empty — to the reserved ref 0; err is non-nil only for
-// structurally malformed input, never to signal "nothing to merge".
+// returned remap passes model.OtherLocationRef through unchanged and maps
+// every other ref pb does not describe — any other negative, or any
+// non-negative when pb is nil or empty — to the reserved ref 0; err is
+// non-nil only for structurally malformed input, never to signal "nothing
+// to merge".
 func (t *Table) Add(pb *queryv1.SymbolRefTable) (func(model.LocationRefName) model.LocationRefName, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -173,17 +174,19 @@ func (c *tableCore) add(pb *queryv1.SymbolRefTable) (func(model.LocationRefName)
 	}
 
 	return func(in model.LocationRefName) model.LocationRefName {
-		if in < 0 {
+		if in == model.OtherLocationRef {
 			return in
 		}
-		if int(in) < numNames {
+		if in >= 0 && int(in) < numNames {
 			return model.LocationRefName(nameRemap[in])
 		}
-		if u := int(in) - numNames; u < len(unresolvedRemap) {
+		if u := int(in) - numNames; in >= 0 && u < len(unresolvedRemap) {
 			return unresolvedRemap[u]
 		}
-		// A ref pb does not describe (nil/empty or truncated input from a
-		// skewed peer) degrades to the reserved ref 0 instead of panicking.
+		// A ref pb does not describe degrades to the reserved ref 0: a
+		// non-negative ref beyond pb's ranges (nil/empty or truncated input
+		// from a skewed peer) would panic, and a negative ref other than
+		// OtherLocationRef would alias t's internal unresolved encoding.
 		return 0
 	}, nil
 }

--- a/pkg/model/symbolref/table.go
+++ b/pkg/model/symbolref/table.go
@@ -25,21 +25,41 @@ type Table struct {
 // tableCore is Table's lock-free state; it must only be reached through
 // Table, which guards every access with its mutex.
 type tableCore struct {
-	names   *hashedslice.Slice[string]
-	buildID *hashedslice.Slice[string]
+	names    *hashedslice.Slice[string]
+	binaries *hashedslice.Slice[binaryKey]
 
-	binaryNames []string // parallel to buildID.Values; first-writer-wins
+	unresolved    map[unresolvedKey]int32 // (binary, addr) -> unresolved index
+	unresolvedBin []int32                 // parallel slices, in intern order
+	unresolvedAd  []uint64
+}
 
-	unresolved   map[unresolvedKey]int32 // (buildID, addr) -> unresolved index
-	unresolvedBI []int32                 // parallel slices, in intern order
-	unresolvedAd []uint64
+// binaryKey identifies a binary exactly as stored in the profile data. The
+// same build ID may appear under several binary names (e.g. a binary renamed
+// between deployments); every (build ID, name) combination is a distinct
+// row, so no arrival order can make one stored name overwrite another.
+type binaryKey struct {
+	buildID string
+	name    string
+}
+
+func binaryKeyEq(a, b binaryKey) bool { return a == b }
+
+var binaryKeySep = []byte{0}
+
+func (k binaryKey) hash() uint64 {
+	var d xxhash.Digest
+	d.Reset()
+	_, _ = d.WriteString(k.buildID)
+	_, _ = d.Write(binaryKeySep) // so ("ab","c") and ("a","bc") hash apart
+	_, _ = d.WriteString(k.name)
+	return d.Sum64()
 }
 
 // unresolvedKey identifies a distinct unresolved location by its interned
-// build ID index and address.
+// binary row index and address.
 type unresolvedKey struct {
-	buildID int32
-	addr    uint64
+	binary int32
+	addr   uint64
 }
 
 // NewTable returns an empty table. Ref 0 is reserved as an unused sentinel:
@@ -54,7 +74,7 @@ func NewTable() *Table {
 func newTableCore() tableCore {
 	c := tableCore{
 		names:      hashedslice.New(stringEq),
-		buildID:    hashedslice.New(stringEq),
+		binaries:   hashedslice.New(binaryKeyEq),
 		unresolved: make(map[unresolvedKey]int32),
 	}
 	c.internName("")
@@ -76,10 +96,11 @@ func (c *tableCore) internName(name string) model.LocationRefName {
 	return model.LocationRefName(c.names.Add(xxhash.Sum64String(name), name))
 }
 
-// InternUnresolved idempotently interns an unresolved (buildID, addr)
-// location, keyed on the pair. binaryName is recorded the first time a
-// given buildID is seen; later calls for the same buildID keep that first
-// binaryName even if a different value is passed.
+// InternUnresolved idempotently interns an unresolved location, keyed on the
+// (buildID, binaryName, addr) triple. The binary name is part of the key —
+// the same build ID under two different names yields two distinct refs — so
+// every name is retained exactly as stored and the table's content is
+// independent of intern or merge arrival order.
 func (t *Table) InternUnresolved(buildID, binaryName string, addr uint64) model.LocationRefName {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -87,34 +108,26 @@ func (t *Table) InternUnresolved(buildID, binaryName string, addr uint64) model.
 }
 
 func (c *tableCore) internUnresolved(buildID, binaryName string, addr uint64) model.LocationRefName {
-	bi := c.internBuildID(buildID, binaryName)
-	return c.internUnresolvedRef(bi, addr)
+	bin := c.internBinary(binaryKey{buildID: buildID, name: binaryName})
+	return c.internUnresolvedRef(bin, addr)
 }
 
-// internUnresolvedRef interns (bi, addr), where bi is already an interned
-// build ID index.
-func (c *tableCore) internUnresolvedRef(bi int32, addr uint64) model.LocationRefName {
-	key := unresolvedKey{buildID: bi, addr: addr}
+// internUnresolvedRef interns (bin, addr), where bin is already an interned
+// binary row index.
+func (c *tableCore) internUnresolvedRef(bin int32, addr uint64) model.LocationRefName {
+	key := unresolvedKey{binary: bin, addr: addr}
 	if idx, ok := c.unresolved[key]; ok {
 		return c.unresolvedRef(idx)
 	}
-	idx := int32(len(c.unresolvedBI))
+	idx := int32(len(c.unresolvedBin))
 	c.unresolved[key] = idx
-	c.unresolvedBI = append(c.unresolvedBI, bi)
+	c.unresolvedBin = append(c.unresolvedBin, bin)
 	c.unresolvedAd = append(c.unresolvedAd, addr)
 	return c.unresolvedRef(idx)
 }
 
-// internBuildID interns buildID (deduplicated) and records binaryName the
-// first time a given buildID is seen; later calls for the same buildID
-// keep the first binaryName.
-func (c *tableCore) internBuildID(buildID, binaryName string) int32 {
-	before := c.buildID.Len()
-	bi := c.buildID.Add(xxhash.Sum64String(buildID), buildID)
-	if int(bi) == before {
-		c.binaryNames = append(c.binaryNames, binaryName)
-	}
-	return bi
+func (c *tableCore) internBinary(k binaryKey) int32 {
+	return c.binaries.Add(k.hash(), k)
 }
 
 // unresolvedRef converts an unresolved entry's slot index into Table's
@@ -136,7 +149,7 @@ func (t *Table) HasUnresolved() bool {
 }
 
 func (c *tableCore) hasUnresolved() bool {
-	return len(c.unresolvedBI) > 0
+	return len(c.unresolvedBin) > 0
 }
 
 // Add merges pb into t, returning a remap function from pb's ref space into
@@ -162,18 +175,18 @@ func (c *tableCore) add(pb *queryv1.SymbolRefTable) (func(model.LocationRefName)
 		nameRemap[i] = c.names.Add(xxhash.Sum64String(name), name)
 	}
 
-	buildIDRemap := make([]int32, len(pb.GetBuildIds()))
+	binRemap := make([]int32, len(pb.GetBuildIds()))
 	binaryNames := pb.GetBinaryNames()
 	for i, buildID := range pb.GetBuildIds() {
-		buildIDRemap[i] = c.internBuildID(buildID, binaryNames[i])
+		binRemap[i] = c.internBinary(binaryKey{buildID: buildID, name: binaryNames[i]})
 	}
 
 	numNames := len(pb.GetNames())
 	unresolvedAddr := pb.GetUnresolvedAddress()
 	unresolvedRemap := make([]model.LocationRefName, len(unresolvedAddr))
 	for i, addr := range unresolvedAddr {
-		bi := buildIDRemap[pb.GetUnresolvedBuildId()[i]]
-		unresolvedRemap[i] = c.internUnresolvedRef(bi, addr)
+		bin := binRemap[pb.GetUnresolvedBuildId()[i]]
+		unresolvedRemap[i] = c.internUnresolvedRef(bin, addr)
 	}
 
 	return func(in model.LocationRefName) model.LocationRefName {
@@ -225,18 +238,20 @@ func (t *Table) ResultBuilder() *ResultBuilder {
 }
 
 // newResultBuilder snapshots the state a ResultBuilder needs — including the
-// (buildID, address) sort order over every unresolved entry interned so
-// far — so that ResultBuilder holds no reference back to tableCore and can
-// safely be used without holding Table's lock.
+// (buildID, binaryName, address) sort order over every unresolved entry
+// interned so far — so that ResultBuilder holds no reference back to
+// tableCore and can safely be used without holding Table's lock.
 func (c *tableCore) newResultBuilder() *ResultBuilder {
-	n := len(c.unresolvedBI)
+	n := len(c.unresolvedBin)
 	sorted := make([]int32, n)
 	for i := range sorted {
 		sorted[i] = int32(i)
 	}
 	slices.SortFunc(sorted, func(a, b int32) int {
+		ka, kb := c.binaries.Values[c.unresolvedBin[a]], c.binaries.Values[c.unresolvedBin[b]]
 		return cmp.Or(
-			cmp.Compare(c.buildID.Values[c.unresolvedBI[a]], c.buildID.Values[c.unresolvedBI[b]]),
+			cmp.Compare(ka.buildID, kb.buildID),
+			cmp.Compare(ka.name, kb.name),
 			cmp.Compare(c.unresolvedAd[a], c.unresolvedAd[b]),
 		)
 	})
@@ -248,9 +263,8 @@ func (c *tableCore) newResultBuilder() *ResultBuilder {
 	return &ResultBuilder{
 		namesLen:         c.names.Len(),
 		namesSl:          c.names.Values,
-		buildIDSl:        c.buildID.Values,
-		binaryNames:      c.binaryNames,
-		unresolvedBI:     c.unresolvedBI,
+		binaries:         c.binaries.Values,
+		unresolvedBin:    c.unresolvedBin,
 		unresolvedAd:     c.unresolvedAd,
 		sortedUnresolved: sorted,
 		rank:             rank,
@@ -267,14 +281,13 @@ func (c *tableCore) newResultBuilder() *ResultBuilder {
 type ResultBuilder struct {
 	namesLen int // snapshot of len(names) at construction; the resolved/unresolved dividing line
 
-	namesSl     []string // snapshot of the table's interned names
-	buildIDSl   []string // snapshot of the table's interned build IDs
-	binaryNames []string // snapshot of the table's per-build-ID binary names
+	namesSl  []string    // snapshot of the table's interned names
+	binaries []binaryKey // snapshot of the table's interned (build ID, binary name) rows
 
-	unresolvedBI []int32  // snapshot: build ID index per unresolved entry
-	unresolvedAd []uint64 // snapshot: address per unresolved entry
+	unresolvedBin []int32  // snapshot: binary row index per unresolved entry
+	unresolvedAd  []uint64 // snapshot: address per unresolved entry
 
-	sortedUnresolved []int32 // permutation of [0, len(unresolvedBI)), sorted by (buildID, address)
+	sortedUnresolved []int32 // permutation of [0, len(unresolvedBin)), sorted by (buildID, binaryName, address)
 	rank             []int32 // rank[idx] = position of idx within sortedUnresolved
 }
 
@@ -289,7 +302,7 @@ type ResultBuilder struct {
 // which refs the marshaled tree keeps. Unresolved wire refs must be final
 // the moment they are first returned, while the kept set is still unknown,
 // so a kept-set-compacted encoding could not be assigned in this single
-// pass without breaking the (buildID, address) wire order.
+// pass without breaking the (buildID, binaryName, address) wire order.
 func (rb *ResultBuilder) KeepRef(ref model.LocationRefName) model.LocationRefName {
 	switch {
 	case ref == model.OtherLocationRef:
@@ -307,9 +320,11 @@ func (rb *ResultBuilder) KeepRef(ref model.LocationRefName) model.LocationRefNam
 // returned queryv1.SymbolRefTable when pb == nil. Every interned name is
 // written, in intern order, so resolved wire refs are the table's own name
 // indices and len(pb.Names) always equals the offset KeepRef applies to
-// unresolved refs; unresolved entries are sorted by (buildID, address),
-// which is what makes the unresolved side of the wire encoding independent
-// of intern or merge arrival order.
+// unresolved refs; unresolved entries are sorted by (buildID, binaryName,
+// address), which is what makes the unresolved side of the wire encoding
+// independent of intern or merge arrival order. Equal binary rows form one
+// contiguous run each under that order, so build_ids/binary_names carry
+// exactly one row per distinct (build ID, binary name) pair referenced.
 func (rb *ResultBuilder) Build(pb *queryv1.SymbolRefTable) *queryv1.SymbolRefTable {
 	if pb == nil {
 		pb = &queryv1.SymbolRefTable{}
@@ -319,22 +334,23 @@ func (rb *ResultBuilder) Build(pb *queryv1.SymbolRefTable) *queryv1.SymbolRefTab
 	copy(pb.Names, rb.namesSl)
 
 	n := len(rb.sortedUnresolved)
-	pb.BuildIds = make([]string, 0, n)
-	pb.BinaryNames = make([]string, 0, n)
+	// Reset any rows a reused pb may carry.
+	pb.BuildIds = nil
+	pb.BinaryNames = nil
 	pb.UnresolvedBuildId = make([]uint32, n)
 	pb.UnresolvedAddress = make([]uint64, n)
 
-	buildIDOut := make(map[int32]int32, n)
+	last := int32(-1)
+	var row uint32
 	for out, idx := range rb.sortedUnresolved {
-		bi := rb.unresolvedBI[idx]
-		biOut, ok := buildIDOut[bi]
-		if !ok {
-			biOut = int32(len(pb.BuildIds))
-			buildIDOut[bi] = biOut
-			pb.BuildIds = append(pb.BuildIds, rb.buildIDSl[bi])
-			pb.BinaryNames = append(pb.BinaryNames, rb.binaryNames[bi])
+		if bin := rb.unresolvedBin[idx]; bin != last {
+			row = uint32(len(pb.BuildIds))
+			b := rb.binaries[bin]
+			pb.BuildIds = append(pb.BuildIds, b.buildID)
+			pb.BinaryNames = append(pb.BinaryNames, b.name)
+			last = bin
 		}
-		pb.UnresolvedBuildId[out] = uint32(biOut)
+		pb.UnresolvedBuildId[out] = row
 		pb.UnresolvedAddress[out] = rb.unresolvedAd[idx]
 	}
 

--- a/pkg/model/symbolref/table.go
+++ b/pkg/model/symbolref/table.go
@@ -139,8 +139,9 @@ func (c *tableCore) hasUnresolved() bool {
 // Add merges pb into t, returning a remap function from pb's ref space into
 // t's ref space, suitable for model.WithTreeMergeFormatNodeNames. The
 // returned remap passes negative refs (model.OtherLocationRef) through
-// unchanged; err is non-nil only for structurally malformed input, never to
-// signal "nothing to merge".
+// unchanged and maps refs pb does not describe — every non-negative ref,
+// when pb is nil or empty — to the reserved ref 0; err is non-nil only for
+// structurally malformed input, never to signal "nothing to merge".
 func (t *Table) Add(pb *queryv1.SymbolRefTable) (func(model.LocationRefName) model.LocationRefName, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -178,7 +179,12 @@ func (c *tableCore) add(pb *queryv1.SymbolRefTable) (func(model.LocationRefName)
 		if int(in) < numNames {
 			return model.LocationRefName(nameRemap[in])
 		}
-		return unresolvedRemap[int(in)-numNames]
+		if u := int(in) - numNames; u < len(unresolvedRemap) {
+			return unresolvedRemap[u]
+		}
+		// A ref pb does not describe (nil/empty or truncated input from a
+		// skewed peer) degrades to the reserved ref 0 instead of panicking.
+		return 0
 	}, nil
 }
 

--- a/pkg/model/symbolref/table.go
+++ b/pkg/model/symbolref/table.go
@@ -1,0 +1,366 @@
+package symbolref
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+	"sync"
+
+	"github.com/cespare/xxhash/v2"
+
+	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+	"github.com/grafana/pyroscope/v2/pkg/model"
+)
+
+// Table is a content-addressed intern table pairing a model.LocationRefNameTree
+// with the wire-format queryv1.SymbolRefTable it represents. Safe for
+// concurrent use: every method locks an internal mutex before touching its
+// state.
+type Table struct {
+	mu   sync.Mutex
+	core tableCore
+}
+
+// tableCore is Table's lock-free state; it must only be reached through
+// Table, which guards every access with its mutex.
+type tableCore struct {
+	names   *hashedSlice
+	buildID *hashedSlice
+
+	binaryNames []string // parallel to buildID.sl; first-writer-wins
+
+	unresolved   map[unresolvedKey]int32 // (buildID, addr) -> unresolved index
+	unresolvedBI []int32                 // parallel slices, in intern order
+	unresolvedAd []uint64
+}
+
+// unresolvedKey identifies a distinct unresolved location by its interned
+// build ID index and address.
+type unresolvedKey struct {
+	buildID int32
+	addr    uint64
+}
+
+// NewTable returns an empty table. Ref 0 is reserved as an unused sentinel:
+// pkg/model's Tree marshal format introduces a spurious zero-valued frame at
+// the root of every stack in a tree that has gone through a merge, and
+// reserving ref 0 keeps that frame distinguishable from a genuine name — so
+// InternName's first call for real content returns 1, not 0.
+func NewTable() *Table {
+	return &Table{core: newTableCore()}
+}
+
+func newTableCore() tableCore {
+	c := tableCore{
+		names:      newHashedSlice(),
+		buildID:    newHashedSlice(),
+		unresolved: make(map[unresolvedKey]int32),
+	}
+	c.names.add("")
+	return c
+}
+
+// InternName idempotently interns a resolved frame name: the same name
+// always returns the same ref, and a name not seen before is assigned a new
+// one.
+func (t *Table) InternName(name string) model.LocationRefName {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.core.internName(name)
+}
+
+func (c *tableCore) internName(name string) model.LocationRefName {
+	return model.LocationRefName(c.names.add(name))
+}
+
+// InternUnresolved idempotently interns an unresolved (buildID, addr)
+// location, keyed on the pair. binaryName is recorded the first time a
+// given buildID is seen; later calls for the same buildID keep that first
+// binaryName even if a different value is passed.
+func (t *Table) InternUnresolved(buildID, binaryName string, addr uint64) model.LocationRefName {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.core.internUnresolved(buildID, binaryName, addr)
+}
+
+func (c *tableCore) internUnresolved(buildID, binaryName string, addr uint64) model.LocationRefName {
+	bi := c.internBuildID(buildID, binaryName)
+	return c.internUnresolvedRef(bi, addr)
+}
+
+// internUnresolvedRef interns (bi, addr), where bi is already an interned
+// build ID index.
+func (c *tableCore) internUnresolvedRef(bi int32, addr uint64) model.LocationRefName {
+	key := unresolvedKey{buildID: bi, addr: addr}
+	if idx, ok := c.unresolved[key]; ok {
+		return c.unresolvedRef(idx)
+	}
+	idx := int32(len(c.unresolvedBI))
+	c.unresolved[key] = idx
+	c.unresolvedBI = append(c.unresolvedBI, bi)
+	c.unresolvedAd = append(c.unresolvedAd, addr)
+	return c.unresolvedRef(idx)
+}
+
+// internBuildID interns buildID (deduplicated) and records binaryName the
+// first time a given buildID is seen; later calls for the same buildID
+// keep the first binaryName.
+func (c *tableCore) internBuildID(buildID, binaryName string) int32 {
+	before := c.buildID.len()
+	bi := c.buildID.add(buildID)
+	if int(bi) == before {
+		c.binaryNames = append(c.binaryNames, binaryName)
+	}
+	return bi
+}
+
+// unresolvedRef converts an unresolved entry's slot index into Table's
+// internal ref representation, model.LocationRefName(-2-idx) — i.e. -2, -3,
+// -4, ... — disjoint from resolved refs (always >= 0) and from
+// model.OtherLocationRef (-1), and stable regardless of how many more names
+// are interned afterward. This is Table's internal encoding; ResultBuilder
+// translates it into the wire encoding once the table is frozen.
+func (c *tableCore) unresolvedRef(idx int32) model.LocationRefName {
+	return model.LocationRefName(-2 - int(idx))
+}
+
+// HasUnresolved reports whether any unresolved entry has ever landed in t,
+// whether via InternUnresolved directly or absorbed via Add.
+func (t *Table) HasUnresolved() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.core.hasUnresolved()
+}
+
+func (c *tableCore) hasUnresolved() bool {
+	return len(c.unresolvedBI) > 0
+}
+
+// Add merges pb into t, returning a remap function from pb's ref space into
+// t's ref space, suitable for model.WithTreeMergeFormatNodeNames. The
+// returned remap passes negative refs (model.OtherLocationRef) through
+// unchanged; err is non-nil only for structurally malformed input, never to
+// signal "nothing to merge".
+func (t *Table) Add(pb *queryv1.SymbolRefTable) (func(model.LocationRefName) model.LocationRefName, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.core.add(pb)
+}
+
+func (c *tableCore) add(pb *queryv1.SymbolRefTable) (func(model.LocationRefName) model.LocationRefName, error) {
+	if err := validateSymbolRefTable(pb); err != nil {
+		return nil, err
+	}
+
+	nameRemap := make([]int32, len(pb.GetNames()))
+	for i, name := range pb.GetNames() {
+		nameRemap[i] = c.names.add(name)
+	}
+
+	buildIDRemap := make([]int32, len(pb.GetBuildIds()))
+	binaryNames := pb.GetBinaryNames()
+	for i, buildID := range pb.GetBuildIds() {
+		buildIDRemap[i] = c.internBuildID(buildID, binaryNames[i])
+	}
+
+	numNames := len(pb.GetNames())
+	unresolvedAddr := pb.GetUnresolvedAddress()
+	unresolvedRemap := make([]model.LocationRefName, len(unresolvedAddr))
+	for i, addr := range unresolvedAddr {
+		bi := buildIDRemap[pb.GetUnresolvedBuildId()[i]]
+		unresolvedRemap[i] = c.internUnresolvedRef(bi, addr)
+	}
+
+	return func(in model.LocationRefName) model.LocationRefName {
+		if in < 0 {
+			return in
+		}
+		if int(in) < numNames {
+			return model.LocationRefName(nameRemap[in])
+		}
+		return unresolvedRemap[int(in)-numNames]
+	}, nil
+}
+
+// validateSymbolRefTable rejects structurally malformed input: mismatched
+// parallel-slice lengths or an out-of-range build ID index.
+func validateSymbolRefTable(pb *queryv1.SymbolRefTable) error {
+	if pb == nil {
+		return nil
+	}
+	if len(pb.GetBinaryNames()) != len(pb.GetBuildIds()) {
+		return fmt.Errorf("symbolref: binary_names length %d does not match build_ids length %d",
+			len(pb.GetBinaryNames()), len(pb.GetBuildIds()))
+	}
+	if len(pb.GetUnresolvedBuildId()) != len(pb.GetUnresolvedAddress()) {
+		return fmt.Errorf("symbolref: unresolved_build_id length %d does not match unresolved_address length %d",
+			len(pb.GetUnresolvedBuildId()), len(pb.GetUnresolvedAddress()))
+	}
+	for _, bi := range pb.GetUnresolvedBuildId() {
+		if int(bi) >= len(pb.GetBuildIds()) {
+			return fmt.Errorf("symbolref: unresolved_build_id %d out of range (len=%d)", bi, len(pb.GetBuildIds()))
+		}
+	}
+	return nil
+}
+
+// ResultBuilder returns a fresh ResultBuilder snapshotting t for one marshal
+// pass.
+func (t *Table) ResultBuilder() *ResultBuilder {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.core.newResultBuilder()
+}
+
+// newResultBuilder snapshots the state a ResultBuilder needs — including the
+// (buildID, address) sort order over every unresolved entry interned so
+// far — so that ResultBuilder holds no reference back to tableCore and can
+// safely be used without holding Table's lock.
+func (c *tableCore) newResultBuilder() *ResultBuilder {
+	n := len(c.unresolvedBI)
+	sorted := make([]int32, n)
+	for i := range sorted {
+		sorted[i] = int32(i)
+	}
+	slices.SortFunc(sorted, func(a, b int32) int {
+		return cmp.Or(
+			cmp.Compare(c.buildID.sl[c.unresolvedBI[a]], c.buildID.sl[c.unresolvedBI[b]]),
+			cmp.Compare(c.unresolvedAd[a], c.unresolvedAd[b]),
+		)
+	})
+	rank := make([]int32, n)
+	for pos, idx := range sorted {
+		rank[idx] = int32(pos)
+	}
+
+	return &ResultBuilder{
+		namesLen:         c.names.len(),
+		namesSl:          c.names.sl,
+		buildIDSl:        c.buildID.sl,
+		binaryNames:      c.binaryNames,
+		unresolvedBI:     c.unresolvedBI,
+		unresolvedAd:     c.unresolvedAd,
+		nameLookup:       make(map[int32]int32),
+		sortedUnresolved: sorted,
+		rank:             rank,
+	}
+}
+
+// ResultBuilder compacts and orders a Table's contents into a
+// queryv1.SymbolRefTable at marshal time. It is built from a point-in-time
+// snapshot of its Table's state, taken under the Table's lock (see
+// tableCore.newResultBuilder); ResultBuilder itself holds no reference back
+// to the Table and takes no lock of its own, so it is not safe for
+// concurrent use — it is meant to be driven single-threaded, once, after
+// every Add/Intern* call on its Table has completed.
+type ResultBuilder struct {
+	namesLen int // snapshot of len(names) at construction; the resolved/unresolved dividing line
+
+	namesSl     []string // snapshot of the table's interned names
+	buildIDSl   []string // snapshot of the table's interned build IDs
+	binaryNames []string // snapshot of the table's per-build-ID binary names
+
+	unresolvedBI []int32  // snapshot: build ID index per unresolved entry
+	unresolvedAd []uint64 // snapshot: address per unresolved entry
+
+	nameLookup map[int32]int32 // input name index -> output index, in observation order
+	names      []int32         // ordered list of kept name indices
+
+	sortedUnresolved []int32 // permutation of [0, len(unresolvedBI)), sorted by (buildID, address)
+	rank             []int32 // rank[idx] = position of idx within sortedUnresolved
+}
+
+// KeepRef marks ref as reachable and returns its compacted wire-encoding
+// ref, for use as the keepName callback to Tree.Bytes/MarshalTruncate. ref
+// is Table's internal encoding (resolved: >= 0; model.OtherLocationRef
+// (-1): passed through unchanged; unresolved: <= -2, see
+// tableCore.unresolvedRef).
+func (rb *ResultBuilder) KeepRef(ref model.LocationRefName) model.LocationRefName {
+	switch {
+	case ref == model.OtherLocationRef:
+		return ref
+	case ref >= 0:
+		idx := int32(ref)
+		if out, ok := rb.nameLookup[idx]; ok {
+			return model.LocationRefName(out)
+		}
+		out := int32(len(rb.names))
+		rb.nameLookup[idx] = out
+		rb.names = append(rb.names, idx)
+		return model.LocationRefName(out)
+	default:
+		idx := -2 - int(ref)
+		return model.LocationRefName(rb.namesLen + int(rb.rank[idx]))
+	}
+}
+
+// Build writes pb.Names, pb.BuildIds, pb.BinaryNames, pb.UnresolvedBuildId
+// and pb.UnresolvedAddress from the refs kept by KeepRef, allocating a new
+// queryv1.SymbolRefTable when pb == nil. Resolved names are written in the
+// order KeepRef first observed them; unresolved entries are sorted by
+// (buildID, address), which is what makes the unresolved side of the wire
+// encoding independent of intern or merge arrival order.
+func (rb *ResultBuilder) Build(pb *queryv1.SymbolRefTable) {
+	if pb == nil {
+		pb = &queryv1.SymbolRefTable{}
+	}
+
+	pb.Names = make([]string, len(rb.names))
+	for out, idx := range rb.names {
+		pb.Names[out] = rb.namesSl[idx]
+	}
+
+	n := len(rb.sortedUnresolved)
+	pb.BuildIds = make([]string, 0, n)
+	pb.BinaryNames = make([]string, 0, n)
+	pb.UnresolvedBuildId = make([]uint32, n)
+	pb.UnresolvedAddress = make([]uint64, n)
+
+	buildIDOut := make(map[int32]int32, n)
+	for out, idx := range rb.sortedUnresolved {
+		bi := rb.unresolvedBI[idx]
+		biOut, ok := buildIDOut[bi]
+		if !ok {
+			biOut = int32(len(pb.BuildIds))
+			buildIDOut[bi] = biOut
+			pb.BuildIds = append(pb.BuildIds, rb.buildIDSl[bi])
+			pb.BinaryNames = append(pb.BinaryNames, rb.binaryNames[bi])
+		}
+		pb.UnresolvedBuildId[out] = uint32(biOut)
+		pb.UnresolvedAddress[out] = rb.unresolvedAd[idx]
+	}
+}
+
+// hashedSlice is a content-addressed intern table for strings: repeated add
+// calls with equal values return the same index. Modeled on the hashedSlice
+// pattern in pkg/phlaredb/symdb/symbol_merger.go, specialized to strings
+// since both names and build IDs interned here are strings.
+type hashedSlice struct {
+	m  map[uint64]int32
+	sl []string
+}
+
+func newHashedSlice() *hashedSlice {
+	return &hashedSlice{m: make(map[uint64]int32)}
+}
+
+func (h *hashedSlice) len() int {
+	return len(h.sl)
+}
+
+func (h *hashedSlice) add(s string) int32 {
+	hash := xxhash.Sum64String(s)
+	for probeHash := hash; ; probeHash++ {
+		idx, found := h.m[probeHash]
+		if !found {
+			idx = int32(len(h.sl))
+			h.m[probeHash] = idx
+			h.sl = append(h.sl, s)
+			return idx
+		}
+		if h.sl[idx] == s {
+			return idx
+		}
+		// hash collision: probe next slot
+	}
+}

--- a/pkg/model/symbolref/table.go
+++ b/pkg/model/symbolref/table.go
@@ -153,6 +153,14 @@ func (c *tableCore) hasUnresolved() bool {
 	return len(c.unresolvedBin) > 0
 }
 
+// UnresolvedCount reports the number of distinct unresolved locations
+// interned in t, whether via InternUnresolved directly or absorbed via Add.
+func (t *Table) UnresolvedCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.core.unresolvedBin)
+}
+
 // Add merges pb into t, returning a remap function from pb's ref space into
 // t's ref space, suitable for model.WithTreeMergeFormatNodeNames. The
 // returned remap passes model.OtherLocationRef through unchanged and maps

--- a/pkg/model/symbolref/table.go
+++ b/pkg/model/symbolref/table.go
@@ -10,6 +10,7 @@ import (
 
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
 	"github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/util/hashedslice"
 )
 
 // Table is a content-addressed intern table pairing a model.LocationRefNameTree
@@ -24,10 +25,10 @@ type Table struct {
 // tableCore is Table's lock-free state; it must only be reached through
 // Table, which guards every access with its mutex.
 type tableCore struct {
-	names   *hashedSlice
-	buildID *hashedSlice
+	names   *hashedslice.Slice[string]
+	buildID *hashedslice.Slice[string]
 
-	binaryNames []string // parallel to buildID.sl; first-writer-wins
+	binaryNames []string // parallel to buildID.Values; first-writer-wins
 
 	unresolved   map[unresolvedKey]int32 // (buildID, addr) -> unresolved index
 	unresolvedBI []int32                 // parallel slices, in intern order
@@ -52,13 +53,15 @@ func NewTable() *Table {
 
 func newTableCore() tableCore {
 	c := tableCore{
-		names:      newHashedSlice(),
-		buildID:    newHashedSlice(),
+		names:      hashedslice.New(stringEq),
+		buildID:    hashedslice.New(stringEq),
 		unresolved: make(map[unresolvedKey]int32),
 	}
-	c.names.add("")
+	c.internName("")
 	return c
 }
+
+func stringEq(a, b string) bool { return a == b }
 
 // InternName idempotently interns a resolved frame name: the same name
 // always returns the same ref, and a name not seen before is assigned a new
@@ -70,7 +73,7 @@ func (t *Table) InternName(name string) model.LocationRefName {
 }
 
 func (c *tableCore) internName(name string) model.LocationRefName {
-	return model.LocationRefName(c.names.add(name))
+	return model.LocationRefName(c.names.Add(xxhash.Sum64String(name), name))
 }
 
 // InternUnresolved idempotently interns an unresolved (buildID, addr)
@@ -106,8 +109,8 @@ func (c *tableCore) internUnresolvedRef(bi int32, addr uint64) model.LocationRef
 // first time a given buildID is seen; later calls for the same buildID
 // keep the first binaryName.
 func (c *tableCore) internBuildID(buildID, binaryName string) int32 {
-	before := c.buildID.len()
-	bi := c.buildID.add(buildID)
+	before := c.buildID.Len()
+	bi := c.buildID.Add(xxhash.Sum64String(buildID), buildID)
 	if int(bi) == before {
 		c.binaryNames = append(c.binaryNames, binaryName)
 	}
@@ -156,7 +159,7 @@ func (c *tableCore) add(pb *queryv1.SymbolRefTable) (func(model.LocationRefName)
 
 	nameRemap := make([]int32, len(pb.GetNames()))
 	for i, name := range pb.GetNames() {
-		nameRemap[i] = c.names.add(name)
+		nameRemap[i] = c.names.Add(xxhash.Sum64String(name), name)
 	}
 
 	buildIDRemap := make([]int32, len(pb.GetBuildIds()))
@@ -233,7 +236,7 @@ func (c *tableCore) newResultBuilder() *ResultBuilder {
 	}
 	slices.SortFunc(sorted, func(a, b int32) int {
 		return cmp.Or(
-			cmp.Compare(c.buildID.sl[c.unresolvedBI[a]], c.buildID.sl[c.unresolvedBI[b]]),
+			cmp.Compare(c.buildID.Values[c.unresolvedBI[a]], c.buildID.Values[c.unresolvedBI[b]]),
 			cmp.Compare(c.unresolvedAd[a], c.unresolvedAd[b]),
 		)
 	})
@@ -243,9 +246,9 @@ func (c *tableCore) newResultBuilder() *ResultBuilder {
 	}
 
 	return &ResultBuilder{
-		namesLen:         c.names.len(),
-		namesSl:          c.names.sl,
-		buildIDSl:        c.buildID.sl,
+		namesLen:         c.names.Len(),
+		namesSl:          c.names.Values,
+		buildIDSl:        c.buildID.Values,
 		binaryNames:      c.binaryNames,
 		unresolvedBI:     c.unresolvedBI,
 		unresolvedAd:     c.unresolvedAd,
@@ -336,38 +339,4 @@ func (rb *ResultBuilder) Build(pb *queryv1.SymbolRefTable) *queryv1.SymbolRefTab
 	}
 
 	return pb
-}
-
-// hashedSlice is a content-addressed intern table for strings: repeated add
-// calls with equal values return the same index. Modeled on the hashedSlice
-// pattern in pkg/phlaredb/symdb/symbol_merger.go, specialized to strings
-// since both names and build IDs interned here are strings.
-type hashedSlice struct {
-	m  map[uint64]int32
-	sl []string
-}
-
-func newHashedSlice() *hashedSlice {
-	return &hashedSlice{m: make(map[uint64]int32)}
-}
-
-func (h *hashedSlice) len() int {
-	return len(h.sl)
-}
-
-func (h *hashedSlice) add(s string) int32 {
-	hash := xxhash.Sum64String(s)
-	for probeHash := hash; ; probeHash++ {
-		idx, found := h.m[probeHash]
-		if !found {
-			idx = int32(len(h.sl))
-			h.m[probeHash] = idx
-			h.sl = append(h.sl, s)
-			return idx
-		}
-		if h.sl[idx] == s {
-			return idx
-		}
-		// hash collision: probe next slot
-	}
 }

--- a/pkg/model/tree.go
+++ b/pkg/model/tree.go
@@ -571,8 +571,12 @@ func UnmarshalTree[N NodeName, I NodeNameI[N]](b []byte) (*Tree[N, I], error) {
 		}
 	}
 
-	// Remove the virtual root.
-	t.root = root.children[0].children
+	// Remove the virtual root and detach it: parent-pointer walks
+	// (IterateStacks) must stop at the real roots instead of surfacing
+	// the marshal format's zero-valued node in every stack.
+	vr := root.children[0]
+	vr.parent = nil
+	t.root = vr.children
 
 	return t, nil
 }

--- a/pkg/model/tree_test.go
+++ b/pkg/model/tree_test.go
@@ -3,7 +3,9 @@ package model
 import (
 	"bytes"
 	"math"
+	"slices"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -421,6 +423,43 @@ func Test_IterateStacks_LargeRootCount(t *testing.T) {
 	})
 
 	require.Equal(t, rootCount, visitedCount, "should visit all %d root nodes", rootCount)
+}
+
+// Test_UnmarshalTree_IterateStacks_NoVirtualRootFrame verifies stacks from
+// an unmarshaled tree match the stacks of the tree that was marshaled: the
+// marshal format's virtual root node is removed from the tree structure and
+// must also be detached from the parent chain, or IterateStacks' parent
+// walk surfaces it as a spurious zero-valued root frame in every stack.
+func Test_UnmarshalTree_IterateStacks_NoVirtualRootFrame(t *testing.T) {
+	src := emptyTree()
+	src.InsertStack(1, "a", "b")
+	src.InsertStack(2, "a", "c")
+
+	collect := func(tr *Tree[FunctionName, FunctionNameI]) map[string]int64 {
+		out := make(map[string]int64)
+		tr.IterateStacks(func(_ FunctionName, self int64, stack []FunctionName) {
+			slices.Reverse(stack)
+			parts := make([]string, len(stack))
+			for i, s := range stack {
+				parts[i] = string(s)
+			}
+			out[strings.Join(parts, "/")] += self
+		})
+		return out
+	}
+
+	want := collect(src)
+	require.Equal(t, map[string]int64{"a/b": 1, "a/c": 2}, want)
+
+	unmarshaled, err := UnmarshalTree[FunctionName, FunctionNameI](src.Bytes(0, nil))
+	require.NoError(t, err)
+	require.Equal(t, want, collect(unmarshaled))
+
+	// MergeTreeBytes adopts the unmarshaled tree wholesale on first merge,
+	// so it exercises the same parent-chain path.
+	m := NewTreeMerger[FunctionName, FunctionNameI]()
+	require.NoError(t, m.MergeTreeBytes(src.Bytes(0, nil)))
+	require.Equal(t, want, collect(m.Tree()))
 }
 
 func Test_TreeFromBackendProfileSampleType(t *testing.T) {

--- a/pkg/phlaredb/symdb/symbol_merger.go
+++ b/pkg/phlaredb/symdb/symbol_merger.go
@@ -12,6 +12,7 @@ import (
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
 	"github.com/grafana/pyroscope/v2/pkg/model"
 	schemav1 "github.com/grafana/pyroscope/v2/pkg/phlaredb/schemas/v1"
+	"github.com/grafana/pyroscope/v2/pkg/util/hashedslice"
 )
 
 var hashZero = xxhash.New().Sum64()
@@ -25,11 +26,11 @@ func (sm *SymbolMerger) hashMapping(h *xxhash.Digest, m *schemav1.InMemoryMappin
 	if _, err := h.Write(buf); err != nil {
 		return err
 	}
-	binary.LittleEndian.PutUint64(buf, sm.strings.hashes[m.Filename])
+	binary.LittleEndian.PutUint64(buf, sm.strings.Hashes[m.Filename])
 	if _, err := h.Write(buf); err != nil {
 		return err
 	}
-	binary.LittleEndian.PutUint64(buf, sm.strings.hashes[m.BuildId])
+	binary.LittleEndian.PutUint64(buf, sm.strings.Hashes[m.BuildId])
 	if _, err := h.Write(buf); err != nil {
 		return err
 	}
@@ -60,15 +61,15 @@ func (sm *SymbolMerger) hashMapping(h *xxhash.Digest, m *schemav1.InMemoryMappin
 }
 
 func (sm *SymbolMerger) hashFunction(h *xxhash.Digest, f *schemav1.InMemoryFunction, buf []byte) error {
-	binary.LittleEndian.PutUint64(buf, sm.strings.hashes[f.Name])
+	binary.LittleEndian.PutUint64(buf, sm.strings.Hashes[f.Name])
 	if _, err := h.Write(buf); err != nil {
 		return err
 	}
-	binary.LittleEndian.PutUint64(buf, sm.strings.hashes[f.SystemName])
+	binary.LittleEndian.PutUint64(buf, sm.strings.Hashes[f.SystemName])
 	if _, err := h.Write(buf); err != nil {
 		return err
 	}
-	binary.LittleEndian.PutUint64(buf, sm.strings.hashes[f.Filename])
+	binary.LittleEndian.PutUint64(buf, sm.strings.Hashes[f.Filename])
 	if _, err := h.Write(buf); err != nil {
 		return err
 	}
@@ -85,7 +86,7 @@ func (sm *SymbolMerger) hashLocation(h *xxhash.Digest, loc *schemav1.InMemoryLoc
 	if _, err := h.Write(buf); err != nil {
 		return err
 	}
-	binary.LittleEndian.PutUint64(buf, sm.mappings.hashes[loc.MappingId])
+	binary.LittleEndian.PutUint64(buf, sm.mappings.Hashes[loc.MappingId])
 	if _, err := h.Write(buf); err != nil {
 		return err
 	}
@@ -101,7 +102,7 @@ func (sm *SymbolMerger) hashLocation(h *xxhash.Digest, loc *schemav1.InMemoryLoc
 
 	// Hash all lines
 	for _, line := range loc.Line {
-		binary.LittleEndian.PutUint64(buf, sm.functions.hashes[line.FunctionId])
+		binary.LittleEndian.PutUint64(buf, sm.functions.Hashes[line.FunctionId])
 		if _, err := h.Write(buf); err != nil {
 			return err
 		}
@@ -114,61 +115,19 @@ func (sm *SymbolMerger) hashLocation(h *xxhash.Digest, loc *schemav1.InMemoryLoc
 	return nil
 }
 
-func newHashedSlice[A any](equal equalityFn[A]) *hashedSlice[A] {
-	return &hashedSlice[A]{
-		m:     make(map[uint64]int),
-		equal: equal,
-	}
-}
-
-type equalityFn[A any] func(A, A) bool
-
-type hashedSlice[A any] struct {
-	m      map[uint64]int
-	sl     []A
-	hashes []uint64
-	equal  equalityFn[A]
-}
-
-func (h *hashedSlice[A]) len() int {
-	return len(h.sl)
-}
-
-func (h *hashedSlice[A]) grow(size int) {
-	h.sl = slices.Grow(h.sl, size)
-	h.hashes = slices.Grow(h.hashes, size)
-}
-
-func (h *hashedSlice[A]) add(hash uint64, v A) int32 {
-	for probeHash := hash; ; probeHash++ {
-		idx, found := h.m[probeHash]
-		if !found {
-			idx = len(h.sl)
-			h.m[probeHash] = idx
-			h.sl = append(h.sl, v)
-			h.hashes = append(h.hashes, hash) // store original hash, not probe offset
-			return int32(idx)
-		}
-		if h.equal(h.sl[idx], v) {
-			return int32(idx)
-		}
-		// hash collision: probe next slot
-	}
-}
-
 type SymbolMerger struct {
 	mu sync.Mutex
 
-	strings   *hashedSlice[string]
-	mappings  *hashedSlice[schemav1.InMemoryMapping]
-	functions *hashedSlice[schemav1.InMemoryFunction]
-	locations *hashedSlice[schemav1.InMemoryLocation]
+	strings   *hashedslice.Slice[string]
+	mappings  *hashedslice.Slice[schemav1.InMemoryMapping]
+	functions *hashedslice.Slice[schemav1.InMemoryFunction]
+	locations *hashedslice.Slice[schemav1.InMemoryLocation]
 }
 
 func NewSymbolMerger() *SymbolMerger {
 	m := &SymbolMerger{}
-	m.strings = newHashedSlice(func(a, b string) bool { return a == b })
-	m.mappings = newHashedSlice(func(a, b schemav1.InMemoryMapping) bool {
+	m.strings = hashedslice.New(func(a, b string) bool { return a == b })
+	m.mappings = hashedslice.New(func(a, b schemav1.InMemoryMapping) bool {
 		return a.MemoryStart == b.MemoryStart &&
 			a.MemoryLimit == b.MemoryLimit &&
 			a.FileOffset == b.FileOffset &&
@@ -179,13 +138,13 @@ func NewSymbolMerger() *SymbolMerger {
 			a.HasLineNumbers == b.HasLineNumbers &&
 			a.HasInlineFrames == b.HasInlineFrames
 	})
-	m.functions = newHashedSlice(func(a, b schemav1.InMemoryFunction) bool {
+	m.functions = hashedslice.New(func(a, b schemav1.InMemoryFunction) bool {
 		return a.Name == b.Name &&
 			a.SystemName == b.SystemName &&
 			a.Filename == b.Filename &&
 			a.StartLine == b.StartLine
 	})
-	m.locations = newHashedSlice(func(a, b schemav1.InMemoryLocation) bool {
+	m.locations = hashedslice.New(func(a, b schemav1.InMemoryLocation) bool {
 		if a.Address != b.Address ||
 			a.MappingId != b.MappingId ||
 			a.IsFolded != b.IsFolded ||
@@ -202,10 +161,10 @@ func NewSymbolMerger() *SymbolMerger {
 	})
 
 	// make sure the first string is the empty string
-	m.strings.add(hashZero, "")
-	m.mappings.add(hashZero, schemav1.InMemoryMapping{})
-	m.locations.add(hashZero, schemav1.InMemoryLocation{})
-	m.functions.add(hashZero, schemav1.InMemoryFunction{})
+	m.strings.Add(hashZero, "")
+	m.mappings.Add(hashZero, schemav1.InMemoryMapping{})
+	m.locations.Add(hashZero, schemav1.InMemoryLocation{})
+	m.functions.Add(hashZero, schemav1.InMemoryFunction{})
 
 	return m
 }
@@ -357,7 +316,7 @@ func (sm *SymbolMerger) addSymbols(symbols *Symbols, locationIDs []int32) (func(
 
 	// add the strings to the merger
 	stringIDs := rm.stringIDs()
-	sm.strings.grow(len(stringIDs))
+	sm.strings.Grow(len(stringIDs))
 	h := xxhash.New()
 	for _, sID := range stringIDs {
 		s := symbols.Strings[sID]
@@ -366,13 +325,13 @@ func (sm *SymbolMerger) addSymbols(symbols *Symbols, locationIDs []int32) (func(
 		if err != nil {
 			return nil, err
 		}
-		rm.strings[sID] = sm.strings.add(h.Sum64(), s)
+		rm.strings[sID] = sm.strings.Add(h.Sum64(), s)
 	}
 
 	// add the functions to the merger
 	var f schemav1.InMemoryFunction
 	functionIDs := rm.functionIDs()
-	sm.functions.grow(len(functionIDs))
+	sm.functions.Grow(len(functionIDs))
 	buf := make([]byte, 8)
 	for _, fID := range functionIDs {
 		if int(fID) >= len(symbols.Functions) {
@@ -389,13 +348,13 @@ func (sm *SymbolMerger) addSymbols(symbols *Symbols, locationIDs []int32) (func(
 		if err := sm.hashFunction(h, &f, buf); err != nil {
 			return nil, err
 		}
-		rm.functions[fID] = sm.functions.add(h.Sum64(), f)
+		rm.functions[fID] = sm.functions.Add(h.Sum64(), f)
 	}
 
 	// add the mappings to the merger
 	var mp schemav1.InMemoryMapping
 	mappingIDs := rm.mappingIDs()
-	sm.mappings.grow(len(mappingIDs))
+	sm.mappings.Grow(len(mappingIDs))
 	for _, mID := range mappingIDs {
 		if int(mID) >= len(symbols.Mappings) {
 			// ID 0 is the "unset" sentinel — remap to 0 and skip when there are no mappings.
@@ -411,7 +370,7 @@ func (sm *SymbolMerger) addSymbols(symbols *Symbols, locationIDs []int32) (func(
 		if err := sm.hashMapping(h, &mp, buf); err != nil {
 			return nil, err
 		}
-		rm.mappings[mID] = sm.mappings.add(h.Sum64(), mp)
+		rm.mappings[mID] = sm.mappings.Add(h.Sum64(), mp)
 	}
 
 	// add the locations to the merger
@@ -424,7 +383,7 @@ func (sm *SymbolMerger) addSymbols(symbols *Symbols, locationIDs []int32) (func(
 		if err := sm.hashLocation(h, &loc, buf); err != nil {
 			return nil, err
 		}
-		locationRemap[lID] = sm.locations.add(h.Sum64(), loc)
+		locationRemap[lID] = sm.locations.Add(h.Sum64(), loc)
 	}
 
 	// Return a remap function
@@ -447,28 +406,28 @@ func (sm *SymbolMerger) Add(ts *queryv1.TreeSymbols) (func(model.LocationRefName
 
 	// add the strings to the merger
 	for idx, s := range ts.Strings {
-		sm.strings.grow(len(ts.Strings))
-		rm.strings[int32(idx)] = sm.strings.add(ts.StringHashes[idx], s)
+		sm.strings.Grow(len(ts.Strings))
+		rm.strings[int32(idx)] = sm.strings.Add(ts.StringHashes[idx], s)
 	}
 
 	// add the functions to the merger
 	{
 		var f schemav1.InMemoryFunction
-		sm.functions.grow(len(ts.Functions))
+		sm.functions.Grow(len(ts.Functions))
 		for idx, orig := range ts.Functions {
 			f.StartLine = uint32(orig.StartLine)
 			f.Name = uint32(orig.Name)
 			f.SystemName = uint32(orig.SystemName)
 			f.Filename = uint32(orig.Filename)
 			rm.updateFunction(&f)
-			rm.functions[int32(idx)] = sm.functions.add(ts.FunctionHashes[idx], f)
+			rm.functions[int32(idx)] = sm.functions.Add(ts.FunctionHashes[idx], f)
 		}
 	}
 
 	// add the mappings to the merger
 	{
 		var m schemav1.InMemoryMapping
-		sm.mappings.grow(len(ts.Mappings))
+		sm.mappings.Grow(len(ts.Mappings))
 		for idx, orig := range ts.Mappings {
 			m.MemoryStart = orig.MemoryStart
 			m.MemoryLimit = orig.MemoryLimit
@@ -480,13 +439,13 @@ func (sm *SymbolMerger) Add(ts *queryv1.TreeSymbols) (func(model.LocationRefName
 			m.HasLineNumbers = orig.HasLineNumbers
 			m.HasInlineFrames = orig.HasInlineFrames
 			rm.updateMapping(&m)
-			rm.mappings[int32(idx)] = sm.mappings.add(ts.MappingHashes[idx], m)
+			rm.mappings[int32(idx)] = sm.mappings.Add(ts.MappingHashes[idx], m)
 		}
 	}
 
 	// add the locations to the merger
 	var loc schemav1.InMemoryLocation
-	sm.locations.grow(len(ts.Locations))
+	sm.locations.Grow(len(ts.Locations))
 	locationRemap := make(map[int32]int32, len(ts.Locations))
 	for idx, orig := range ts.Locations {
 		loc.Address = orig.Address
@@ -500,7 +459,7 @@ func (sm *SymbolMerger) Add(ts *queryv1.TreeSymbols) (func(model.LocationRefName
 			}
 		}
 		rm.updateLocation(&loc)
-		locationRemap[int32(idx)] = sm.locations.add(ts.LocationHashes[idx], loc)
+		locationRemap[int32(idx)] = sm.locations.Add(ts.LocationHashes[idx], loc)
 	}
 
 	// Return a remap function
@@ -518,7 +477,7 @@ func (sm *SymbolMerger) ResultBuilder() *symbolResultBuilder {
 	return &symbolResultBuilder{
 		merger:          sm,
 		locationsLookup: map[int32]int32{0: 0},
-		locationsRef:    make([]int32, 1, sm.locations.len()),
+		locationsRef:    make([]int32, 1, sm.locations.Len()),
 	}
 }
 
@@ -558,7 +517,7 @@ func (m *symbolResultBuilder) Build(r *queryv1.TreeSymbols) {
 		r = &queryv1.TreeSymbols{}
 	}
 
-	rm.resolveLocationIDs(m.locationsRef, m.merger.locations.sl, m.merger.mappings.sl, m.merger.functions.sl)
+	rm.resolveLocationIDs(m.locationsRef, m.merger.locations.Values, m.merger.mappings.Values, m.merger.functions.Values)
 
 	// add the strings to the result
 	{
@@ -566,8 +525,8 @@ func (m *symbolResultBuilder) Build(r *queryv1.TreeSymbols) {
 		r.Strings = make([]string, len(stringIDs))
 		r.StringHashes = make([]uint64, len(stringIDs))
 		for idx, sID := range stringIDs {
-			r.Strings[idx] = m.merger.strings.sl[sID]
-			r.StringHashes[idx] = m.merger.strings.hashes[sID]
+			r.Strings[idx] = m.merger.strings.Values[sID]
+			r.StringHashes[idx] = m.merger.strings.Hashes[sID]
 			rm.strings[sID] = int32(idx)
 		}
 	}
@@ -579,7 +538,7 @@ func (m *symbolResultBuilder) Build(r *queryv1.TreeSymbols) {
 		r.Functions = make([]*profilev1.Function, len(functionIDs))
 		r.FunctionHashes = make([]uint64, len(functionIDs))
 		for idx, fID := range functionIDs {
-			orig := m.merger.functions.sl[fID]
+			orig := m.merger.functions.Values[fID]
 			rm.updateFunction(&orig)
 			functions[idx].Id = uint64(idx)
 			functions[idx].Name = int64(orig.Name)
@@ -587,7 +546,7 @@ func (m *symbolResultBuilder) Build(r *queryv1.TreeSymbols) {
 			functions[idx].Filename = int64(orig.Filename)
 			functions[idx].StartLine = int64(orig.StartLine)
 			r.Functions[idx] = &functions[idx]
-			r.FunctionHashes[idx] = m.merger.functions.hashes[fID]
+			r.FunctionHashes[idx] = m.merger.functions.Hashes[fID]
 			rm.functions[fID] = int32(idx)
 		}
 	}
@@ -599,7 +558,7 @@ func (m *symbolResultBuilder) Build(r *queryv1.TreeSymbols) {
 		r.Mappings = make([]*profilev1.Mapping, len(mappingIDs))
 		r.MappingHashes = make([]uint64, len(mappingIDs))
 		for idx, mID := range mappingIDs {
-			orig := m.merger.mappings.sl[mID]
+			orig := m.merger.mappings.Values[mID]
 			rm.updateMapping(&orig)
 			mappings[idx].Id = uint64(idx)
 			mappings[idx].MemoryStart = orig.MemoryStart
@@ -612,7 +571,7 @@ func (m *symbolResultBuilder) Build(r *queryv1.TreeSymbols) {
 			mappings[idx].HasLineNumbers = orig.HasLineNumbers
 			mappings[idx].HasInlineFrames = orig.HasInlineFrames
 			r.Mappings[idx] = &mappings[idx]
-			r.MappingHashes[idx] = m.merger.mappings.hashes[mID]
+			r.MappingHashes[idx] = m.merger.mappings.Hashes[mID]
 			rm.mappings[mID] = int32(idx)
 		}
 	}
@@ -623,7 +582,7 @@ func (m *symbolResultBuilder) Build(r *queryv1.TreeSymbols) {
 		r.Locations = make([]*profilev1.Location, len(m.locationsRef))
 		r.LocationHashes = make([]uint64, len(m.locationsRef))
 		for idx, lID := range m.locationsRef {
-			orig := m.merger.locations.sl[lID]
+			orig := m.merger.locations.Values[lID]
 			rm.updateLocation(&orig)
 			locations[idx].Id = uint64(idx)
 			locations[idx].Address = orig.Address
@@ -637,7 +596,7 @@ func (m *symbolResultBuilder) Build(r *queryv1.TreeSymbols) {
 				}
 			}
 			r.Locations[idx] = &locations[idx]
-			r.LocationHashes[idx] = m.merger.locations.hashes[lID]
+			r.LocationHashes[idx] = m.merger.locations.Hashes[lID]
 		}
 	}
 

--- a/pkg/phlaredb/symdb/symbol_merger_test.go
+++ b/pkg/phlaredb/symdb/symbol_merger_test.go
@@ -358,9 +358,9 @@ func TestSymbolMerger_HashCollision(t *testing.T) {
 	const sameHash = uint64(0xdeadbeefcafebabe)
 
 	// Add "foo" – placed at index 1 (index 0 is the sentinel empty string).
-	idxFoo := sm.strings.add(sameHash, "foo")
+	idxFoo := sm.strings.Add(sameHash, "foo")
 	// Add "bar" with the same hash – linear probing must resolve the collision.
-	idxBar := sm.strings.add(sameHash, "bar")
+	idxBar := sm.strings.Add(sameHash, "bar")
 
 	// Both values must get distinct indices.
 	require.NotEqual(t, idxFoo, idxBar)
@@ -368,16 +368,16 @@ func TestSymbolMerger_HashCollision(t *testing.T) {
 	require.Equal(t, int32(2), idxBar)
 
 	// Slice contains sentinel + the two colliding values.
-	require.Equal(t, []string{"", "foo", "bar"}, sm.strings.sl)
+	require.Equal(t, []string{"", "foo", "bar"}, sm.strings.Values)
 
 	// The original hash (not the probe offset) is stored for both entries.
-	require.Equal(t, sameHash, sm.strings.hashes[idxFoo])
-	require.Equal(t, sameHash, sm.strings.hashes[idxBar])
+	require.Equal(t, sameHash, sm.strings.Hashes[idxFoo])
+	require.Equal(t, sameHash, sm.strings.Hashes[idxBar])
 
 	// Re-adding "foo" or "bar" with the same hash must return the original index (deduplication).
-	idxFooAgain := sm.strings.add(sameHash, "foo")
+	idxFooAgain := sm.strings.Add(sameHash, "foo")
 	require.Equal(t, idxFoo, idxFooAgain)
-	idxBarAgain := sm.strings.add(sameHash, "bar")
+	idxBarAgain := sm.strings.Add(sameHash, "bar")
 	require.Equal(t, idxBar, idxBarAgain)
 }
 

--- a/pkg/util/hashedslice/hashedslice.go
+++ b/pkg/util/hashedslice/hashedslice.go
@@ -1,0 +1,63 @@
+// Package hashedslice provides a content-addressed, append-only slice:
+// adding a value equal to one added before returns the existing index
+// instead of appending, so a value's index is stable for the life of the
+// slice.
+package hashedslice
+
+import "slices"
+
+// New returns an empty Slice that uses equal to confirm matches when two
+// values share a hash.
+func New[A any](equal func(A, A) bool) *Slice[A] {
+	return &Slice[A]{
+		m:     make(map[uint64]int),
+		equal: equal,
+	}
+}
+
+// Slice is a content-addressed, append-only slice. Callers supply each
+// value's hash; collisions are resolved by probing successive hash slots
+// and confirming with the equality function, so hash quality affects
+// performance, not correctness. Not safe for concurrent use.
+type Slice[A any] struct {
+	m     map[uint64]int
+	equal func(A, A) bool
+
+	// Values holds the distinct values in insertion order; indices returned
+	// by Add point into it. Hashes is parallel to Values and records each
+	// value's original hash. Both are exported for read access and must not
+	// be modified.
+	Values []A
+	Hashes []uint64
+}
+
+// Len returns the number of distinct values added.
+func (h *Slice[A]) Len() int {
+	return len(h.Values)
+}
+
+// Grow ensures capacity for size additional values.
+func (h *Slice[A]) Grow(size int) {
+	h.Values = slices.Grow(h.Values, size)
+	h.Hashes = slices.Grow(h.Hashes, size)
+}
+
+// Add returns the index of v, appending it if no equal value was added
+// before. hash must be deterministic for v: equal values must supply equal
+// hashes.
+func (h *Slice[A]) Add(hash uint64, v A) int32 {
+	for probeHash := hash; ; probeHash++ {
+		idx, found := h.m[probeHash]
+		if !found {
+			idx = len(h.Values)
+			h.m[probeHash] = idx
+			h.Values = append(h.Values, v)
+			h.Hashes = append(h.Hashes, hash) // store original hash, not probe offset
+			return int32(idx)
+		}
+		if h.equal(h.Values[idx], v) {
+			return int32(idx)
+		}
+		// hash collision: probe next slot
+	}
+}

--- a/pkg/util/hashedslice/hashedslice_test.go
+++ b/pkg/util/hashedslice/hashedslice_test.go
@@ -1,0 +1,64 @@
+package hashedslice_test
+
+import (
+	"testing"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/pyroscope/v2/pkg/util/hashedslice"
+)
+
+func stringEq(a, b string) bool { return a == b }
+
+func add(h *hashedslice.Slice[string], s string) int32 {
+	return h.Add(xxhash.Sum64String(s), s)
+}
+
+func TestAddDedupsEqualValues(t *testing.T) {
+	h := hashedslice.New(stringEq)
+	require.Equal(t, 0, h.Len())
+
+	a := add(h, "a")
+	b := add(h, "b")
+	require.Equal(t, a, add(h, "a"))
+	require.Equal(t, b, add(h, "b"))
+	require.NotEqual(t, a, b)
+
+	require.Equal(t, 2, h.Len())
+	require.Equal(t, []string{"a", "b"}, h.Values)
+	require.Equal(t, "a", h.Values[a])
+	require.Equal(t, "b", h.Values[b])
+	require.Equal(t, []uint64{xxhash.Sum64String("a"), xxhash.Sum64String("b")}, h.Hashes)
+}
+
+// TestAddResolvesHashCollisions forces distinct values onto the same hash:
+// they must still get distinct indices, repeated adds must keep returning
+// them, and Hashes must record the original hash for both, not the probed
+// slot.
+func TestAddResolvesHashCollisions(t *testing.T) {
+	h := hashedslice.New(stringEq)
+	const hash = uint64(42)
+
+	a := h.Add(hash, "a")
+	b := h.Add(hash, "b")
+	c := h.Add(hash, "c")
+	require.NotEqual(t, a, b)
+	require.NotEqual(t, b, c)
+
+	require.Equal(t, a, h.Add(hash, "a"))
+	require.Equal(t, b, h.Add(hash, "b"))
+	require.Equal(t, c, h.Add(hash, "c"))
+
+	require.Equal(t, []string{"a", "b", "c"}, h.Values)
+	require.Equal(t, []uint64{hash, hash, hash}, h.Hashes)
+}
+
+func TestGrowPreservesContent(t *testing.T) {
+	h := hashedslice.New(stringEq)
+	a := add(h, "a")
+	h.Grow(1024)
+	require.Equal(t, a, add(h, "a"))
+	require.Equal(t, []string{"a"}, h.Values)
+	require.Equal(t, 1, h.Len())
+}


### PR DESCRIPTION
## Part of a series: symbol-aware tree references (3 of 8)

Full context and series overview: #5317 (PR 1). Compact map:

1. symbolizer: expose address-level `Resolve` API (#5317)
2. proto: `SymbolRefTable` + tree query/report fields (#5318)
3. **`model/symbolref`: intern table + merge rebasing ← this PR**
4. `model/symbolref`: job grouping + tree rebuild
5. symdb + querybackend: produce and aggregate symbol-ref trees
6. frontend: orchestration behind a default-off per-tenant flag — nothing activates before this
7. integration tests + docs (#5335)
8. symdb: compaction preserves line-less locations (#5337) — stacked at the bottom of the series, merges first

Tracking issue: grafana/pyroscope-squad#487. Based on #5318's branch; the diff here is only the
new package.

## What

`pkg/model/symbolref`: the intern table that pairs a `model.LocationRefNameTree` with the
`queryv1.SymbolRefTable` side message from #5318, so tree nodes can reference either resolved
frame names or unresolved `{build ID, address}` locations in one integer reference space.

- `Table` — content-addressed interning (`InternName`, `InternUnresolved`), safe for concurrent
  producers; structured as a lock-free core wrapped by a uniform locking boundary, so lock
  discipline is auditable at a glance and no function carries an unenforceable "must hold lock"
  precondition.
- `Table.Add` — merges another table's wire form and returns a remap function compatible with
  `TreeMerger.MergeTreeBytes(..., WithTreeMergeFormatNodeNames(remap))`, the same rebasing pattern
  the existing FullSymbols path uses. The `-1` truncation sentinel passes through unchanged.
- `ResultBuilder` — marshal-time compaction (`KeepRef`) and wire encoding (`Build`): only refs
  reachable in the marshaled tree are emitted; unresolved entries are sorted by
  `(build ID, address)` so merge output is deterministic and downstream grouping into
  per-build-ID jobs is a single scan. Built from a point-in-time snapshot taken under the table's
  lock.

Job grouping and the final tree rebuild (expanding resolved frames back into a plain tree) land
in the next PR; nothing consumes this package yet.

## Design notes

- **Reference 0 is reserved** (`InternName`'s first real call returns 1): any tree that
  round-trips the tree unmarshal path surfaces a synthetic virtual-root frame carrying the zero
  ref — existing consumers already special-case it — so a real name must never land on ref 0.
- **Merge determinism is semantic, not byte-identical**: per-stack values and the content-sorted
  unresolved wire fields are independent of partial arrival order; the name-table order is not.
  Final rendered output is unaffected (the eventual rebuild re-sorts structurally).

## Testing

Table-driven unit tests covering intern idempotency, remap round-trips, merge determinism under
permuted arrival order (all 3! orderings), wire-ordering, sentinel passthrough, empty/only-resolved
tables, and plain-tree absorption — 95.9% statement coverage under `-race`. Benchmarks for
intern+merge throughput at three cardinalities (100 / 10k / 1M addresses) and marshal-time
compaction of a 100k-node table, with throughput/size reported via custom metrics.

