### PR TITLE
feat(read-path): produce and aggregate symbol-ref trees (model, symdb, query backend)

### DIFF
--- a/pkg/model/symbolref/bench_test.go
+++ b/pkg/model/symbolref/bench_test.go
@@ -1,13 +1,15 @@
 package symbolref_test
 
-// Benchmarks below cover Table's intern/merge throughput and
-// ResultBuilder's marshal-time compaction. Rebuild's own memory/throughput
-// benchmark, and a wire-size-vs-literal-encoding benchmark, are deferred
-// until Rebuild is implemented.
+// Benchmarks below cover Table's intern/merge throughput, ResultBuilder's
+// marshal-time compaction, Rebuild's throughput on a deferred-truncation-
+// shaped tree, and the interned wire encoding's size relative to the
+// design's literal (repeated build-ID string per reference) encoding.
 
 import (
 	"fmt"
 	"testing"
+
+	"google.golang.org/protobuf/proto"
 
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
 	"github.com/grafana/pyroscope/v2/pkg/model"
@@ -102,4 +104,86 @@ func BenchmarkResultBuilderBuild(b *testing.B) {
 	}
 
 	b.ReportMetric(float64(numNodes), "input_size")
+}
+
+// BenchmarkRebuild is the deferred-truncation guardrail baseline: it
+// rebuilds a large tree whose table has never been truncated (the worst
+// case a query plan carrying unresolved locations through every merge
+// allows), against a resolve stub with a realistic hit/fallback mix (1 in
+// 10 addresses fails to resolve).
+func BenchmarkRebuild(b *testing.B) {
+	const (
+		numNodes      = 1_000_000
+		numBuildIDs   = 10
+		fallbackEvery = 10
+	)
+	table := symbolref.NewTable()
+	tree := buildBenchTree(table, numNodes, numBuildIDs, 0)
+	rb := table.ResultBuilder()
+	treeBytes := tree.Bytes(0, rb.KeepRef)
+	pb := new(queryv1.SymbolRefTable)
+	rb.Build(pb)
+
+	resolve := func(buildID string, addr uint64) []symbolref.Frame {
+		if addr%fallbackEvery == 0 {
+			return nil
+		}
+		return []symbolref.Frame{{Name: "resolved_" + buildID}}
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := symbolref.Rebuild(treeBytes, pb, resolve, 0); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ReportMetric(float64(numNodes), "input_size")
+}
+
+// BenchmarkWireSize reports the interned SymbolRefTable wire encoding's size
+// against the design's literal (repeated build-ID string + address per
+// reference, undeduplicated) encoding, for an eBPF-shaped fixture: 5 build
+// IDs, 50,000 addresses each, with realistic reuse of the same physical
+// address across several different stacks. It runs once (no b.Loop) and
+// reports a size ratio rather than a timing.
+func BenchmarkWireSize(b *testing.B) {
+	const (
+		numBuildIDs        = 5
+		addressesPerID     = 50_000
+		referencesPerEntry = 4 // realistic reuse: each address seen under several stacks
+	)
+
+	table := symbolref.NewTable()
+	buildIDLen := 0
+	for bi := range numBuildIDs {
+		buildID := fmt.Sprintf("%040x", bi) // GNU build-ID-shaped: 40 hex chars
+		binaryName := fmt.Sprintf("binary-%d", bi)
+		buildIDLen = len(buildID)
+		for a := range addressesPerID {
+			table.InternUnresolved(buildID, binaryName, uint64(a))
+		}
+	}
+
+	rb := table.ResultBuilder()
+	pb := new(queryv1.SymbolRefTable)
+	rb.Build(pb)
+
+	internedBytes, err := proto.Marshal(pb)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	entryCount := numBuildIDs * addressesPerID
+	referenceCount := entryCount * referencesPerEntry
+
+	// Reference computation of the design's literal encoding: a build ID
+	// string and an 8-byte address repeated once per tree reference,
+	// undeduplicated.
+	literalBytes := (buildIDLen + 8) * referenceCount
+
+	b.ReportMetric(float64(entryCount), "input_size")
+	b.ReportMetric(float64(len(internedBytes))/float64(entryCount), "interned_bytes_per_ref")
+	b.ReportMetric(float64(literalBytes)/float64(referenceCount), "literal_bytes_per_ref")
+	b.ReportMetric(float64(literalBytes)/float64(len(internedBytes)), "size_ratio")
 }

--- a/pkg/model/symbolref/doc.go
+++ b/pkg/model/symbolref/doc.go
@@ -13,8 +13,8 @@
 // partitioning (resolved vs. unresolved vs. the truncation "other"
 // sentinel), merge-time ref rebasing, marshal-time compaction and
 // ordering, deferred-truncation bookkeeping, grouping unresolved
-// references into per-build-ID resolution jobs, and rebuilding/truncating
-// the final resolved tree.
+// references by binary for resolution, and rebuilding/truncating the final
+// resolved tree.
 //
 // Does NOT own: the generic tree node/marshal format (pkg/model's Tree,
 // reused unchanged), building per-dataset trees from block data

--- a/pkg/model/symbolref/fallback.go
+++ b/pkg/model/symbolref/fallback.go
@@ -1,0 +1,13 @@
+package symbolref
+
+import "fmt"
+
+// FallbackSymbolName renders the display name for an address that could not
+// be resolved to a function name: "binary!0xaddr", or "unknown!0xaddr" when
+// the binary name is empty.
+func FallbackSymbolName(binaryName string, addr uint64) string {
+	if binaryName == "" {
+		binaryName = "unknown"
+	}
+	return fmt.Sprintf("%s!0x%x", binaryName, addr)
+}

--- a/pkg/model/symbolref/rebuild.go
+++ b/pkg/model/symbolref/rebuild.go
@@ -1,0 +1,141 @@
+package symbolref
+
+import (
+	"fmt"
+	"slices"
+
+	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+	"github.com/grafana/pyroscope/v2/pkg/model"
+)
+
+// Frame is one resolved stack frame; deliberately minimal, with no lidia
+// dependency.
+type Frame struct {
+	Name string
+}
+
+// resolveKey memoizes Rebuild's resolve calls by (build ID index, address)
+// within a single call, so a repeated address is resolved once.
+type resolveKey struct {
+	buildID uint32
+	addr    uint64
+}
+
+// Rebuild expands every model.LocationRefName ref in treeBytes (a
+// model.LocationRefNameTree marshal paired with pb) into resolved
+// model.FunctionNames, rebuilds a plain tree from the expanded stacks, and
+// truncates exactly once, via a single tree.Bytes(maxNodes, nil) call after
+// every stack has been expanded and reinserted.
+//
+// resolve returning nil or an empty slice for a given (buildID, addr) means
+// "could not resolve"; Rebuild then synthesizes exactly one fallback frame
+// named fmt.Sprintf("%s!0x%x", binaryName, addr), substituting "unknown" for
+// an empty binaryName — matching the pprof detour's legacy fallback
+// rendering byte for byte. A resolved chain's frame order is copied through
+// from resolve unchanged, expanding one address into that many tree levels.
+// Because every stack is reinserted from scratch, two refs that expand to
+// the same name at the same position merge structurally, with no separate
+// dedup pass.
+//
+// Returns an error only for malformed input: an unmarshalable treeBytes, a
+// structurally inconsistent pb, or a tree ref outside pb's valid range.
+func Rebuild(
+	treeBytes []byte,
+	pb *queryv1.SymbolRefTable,
+	resolve func(buildID string, addr uint64) []Frame,
+	maxNodes int64,
+) ([]byte, error) {
+	if err := validateSymbolRefTable(pb); err != nil {
+		return nil, err
+	}
+
+	src, err := model.UnmarshalTree[model.LocationRefName, model.LocationRefNameI](treeBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	names := pb.GetNames()
+	buildIDs := pb.GetBuildIds()
+	binaryNames := pb.GetBinaryNames()
+	unresolvedBuildID := pb.GetUnresolvedBuildId()
+	unresolvedAddress := pb.GetUnresolvedAddress()
+	numUnresolved := len(unresolvedAddress)
+
+	cache := make(map[resolveKey][]model.FunctionName)
+
+	expand := func(ref model.LocationRefName) ([]model.FunctionName, error) {
+		switch {
+		case ref == model.OtherLocationRef:
+			return []model.FunctionName{model.OtherFunctionName}, nil
+		case ref < 0:
+			return nil, fmt.Errorf("symbolref: ref %d out of range", ref)
+		case int(ref) < len(names):
+			return []model.FunctionName{model.FunctionName(names[ref])}, nil
+		}
+
+		i := int(ref) - len(names)
+		if i >= numUnresolved {
+			return nil, fmt.Errorf("symbolref: ref %d out of range (len(names)=%d, len(unresolved)=%d)", ref, len(names), numUnresolved)
+		}
+
+		bi := unresolvedBuildID[i]
+		addr := unresolvedAddress[i]
+		key := resolveKey{buildID: bi, addr: addr}
+		if frames, ok := cache[key]; ok {
+			return frames, nil
+		}
+
+		frames := expandOne(resolve(buildIDs[bi], addr), buildIDBinaryName(binaryNames, bi), addr)
+		cache[key] = frames
+		return frames, nil
+	}
+
+	dst := new(model.FunctionNameTree)
+	expanded := make([]model.FunctionName, 0, 64)
+	var rebuildErr error
+	src.IterateStacks(func(_ model.LocationRefName, self int64, stack []model.LocationRefName) {
+		if rebuildErr != nil {
+			return
+		}
+		slices.Reverse(stack)
+		expanded = expanded[:0]
+		for _, ref := range stack {
+			frames, err := expand(ref)
+			if err != nil {
+				rebuildErr = err
+				return
+			}
+			expanded = append(expanded, frames...)
+		}
+		dst.InsertStack(self, expanded...)
+	})
+	if rebuildErr != nil {
+		return nil, rebuildErr
+	}
+
+	return dst.Bytes(maxNodes, nil), nil
+}
+
+// expandOne converts a resolve() result into the frame chain for one
+// unresolved location, synthesizing the fallback frame when resolution
+// failed.
+func expandOne(resolved []Frame, binaryName string, addr uint64) []model.FunctionName {
+	if len(resolved) == 0 {
+		if binaryName == "" {
+			binaryName = "unknown"
+		}
+		return []model.FunctionName{model.FunctionName(fmt.Sprintf("%s!0x%x", binaryName, addr))}
+	}
+	frames := make([]model.FunctionName, len(resolved))
+	for i, f := range resolved {
+		frames[i] = model.FunctionName(f.Name)
+	}
+	return frames
+}
+
+func buildIDBinaryName(binaryNames []string, bi uint32) string {
+	if int(bi) < len(binaryNames) {
+		return binaryNames[bi]
+	}
+	return ""
+}

--- a/pkg/model/symbolref/rebuild.go
+++ b/pkg/model/symbolref/rebuild.go
@@ -31,8 +31,10 @@ type resolveKey struct {
 // "could not resolve"; Rebuild then synthesizes exactly one fallback frame
 // named fmt.Sprintf("%s!0x%x", binaryName, addr), substituting "unknown" for
 // an empty binaryName — matching the pprof detour's legacy fallback
-// rendering byte for byte. A resolved chain's frame order is copied through
-// from resolve unchanged, expanding one address into that many tree levels.
+// rendering byte for byte. A resolved chain must be root-first — outermost
+// caller at index 0, innermost frame last, the reverse of lidia's and pprof
+// Line order — and is spliced into the rebuilt stack unchanged, expanding
+// one address into that many tree levels.
 // Because every stack is reinserted from scratch, two refs that expand to
 // the same name at the same position merge structurally, with no separate
 // dedup pass.

--- a/pkg/model/symbolref/rebuild.go
+++ b/pkg/model/symbolref/rebuild.go
@@ -29,9 +29,7 @@ type resolveKey struct {
 //
 // resolve returning nil or an empty slice for a given (buildID, addr) means
 // "could not resolve"; Rebuild then synthesizes exactly one fallback frame
-// named fmt.Sprintf("%s!0x%x", binaryName, addr), substituting "unknown" for
-// an empty binaryName — matching the pprof detour's legacy fallback
-// rendering byte for byte. A resolved chain must be root-first — outermost
+// named by FallbackSymbolName. A resolved chain must be root-first — outermost
 // caller at index 0, innermost frame last, the reverse of lidia's and pprof
 // Line order — and is spliced into the rebuilt stack unchanged, expanding
 // one address into that many tree levels.
@@ -63,7 +61,7 @@ func Rebuild(
 	unresolvedAddress := pb.GetUnresolvedAddress()
 	numUnresolved := len(unresolvedAddress)
 
-	cache := make(map[resolveKey][]model.FunctionName)
+	cache := make(map[resolveKey][]model.FunctionName, numUnresolved)
 
 	expand := func(ref model.LocationRefName) ([]model.FunctionName, error) {
 		switch {
@@ -123,10 +121,7 @@ func Rebuild(
 // failed.
 func expandOne(resolved []Frame, binaryName string, addr uint64) []model.FunctionName {
 	if len(resolved) == 0 {
-		if binaryName == "" {
-			binaryName = "unknown"
-		}
-		return []model.FunctionName{model.FunctionName(fmt.Sprintf("%s!0x%x", binaryName, addr))}
+		return []model.FunctionName{model.FunctionName(FallbackSymbolName(binaryName, addr))}
 	}
 	frames := make([]model.FunctionName, len(resolved))
 	for i, f := range resolved {

--- a/pkg/model/symbolref/rebuild_test.go
+++ b/pkg/model/symbolref/rebuild_test.go
@@ -1,0 +1,339 @@
+package symbolref_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+	"github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/model/symbolref"
+)
+
+// functionStacks walks every stack in tree and sums self values keyed by
+// the root-to-leaf sequence of names joined with "/".
+func functionStacks(t *testing.T, tree *model.FunctionNameTree) map[string]int64 {
+	t.Helper()
+	out := make(map[string]int64)
+	tree.IterateStacks(func(_ model.FunctionName, self int64, stack []model.FunctionName) {
+		slices.Reverse(stack)
+		names := make([]string, len(stack))
+		for i, n := range stack {
+			names[i] = string(n)
+		}
+		out[strings.Join(names, "/")] += self
+	})
+	return out
+}
+
+// TestRebuildInlineChainExpansionOrder verifies one unresolved ref resolving
+// to multiple inlined frames expands into that many tree levels, in exactly
+// the order resolve returned them.
+func TestRebuildInlineChainExpansionOrder(t *testing.T) {
+	table := symbolref.NewTable()
+	loc := table.InternUnresolved("build1", "bin1", 0x1000)
+
+	tree := new(model.LocationRefNameTree)
+	tree.InsertStack(5, loc)
+
+	rb := table.ResultBuilder()
+	treeBytes := tree.Bytes(0, rb.KeepRef)
+	pb := new(queryv1.SymbolRefTable)
+	rb.Build(pb)
+
+	resolve := func(buildID string, addr uint64) []symbolref.Frame {
+		require.Equal(t, "build1", buildID)
+		require.Equal(t, uint64(0x1000), addr)
+		return []symbolref.Frame{{Name: "outer"}, {Name: "inlined_middle"}, {Name: "inner"}}
+	}
+
+	out, err := symbolref.Rebuild(treeBytes, pb, resolve, 0)
+	require.NoError(t, err)
+
+	got, err := model.UnmarshalTree[model.FunctionName, model.FunctionNameI](out)
+	require.NoError(t, err)
+
+	stacks := functionStacks(t, got)
+	require.Equal(t, int64(5), stacks["outer/inlined_middle/inner"])
+}
+
+// TestRebuildDuplicateNodeMerge verifies two different unresolved addresses
+// that resolve to the same function name, at the same tree position, merge
+// into one node with combined weight.
+func TestRebuildDuplicateNodeMerge(t *testing.T) {
+	table := symbolref.NewTable()
+	parent := table.InternName("parent")
+	loc1 := table.InternUnresolved("build1", "bin1", 0x1000)
+	loc2 := table.InternUnresolved("build1", "bin1", 0x2000)
+
+	tree := new(model.LocationRefNameTree)
+	tree.InsertStack(3, parent, loc1)
+	tree.InsertStack(4, parent, loc2)
+
+	rb := table.ResultBuilder()
+	treeBytes := tree.Bytes(0, rb.KeepRef)
+	pb := new(queryv1.SymbolRefTable)
+	rb.Build(pb)
+
+	resolve := func(buildID string, addr uint64) []symbolref.Frame {
+		return []symbolref.Frame{{Name: "malloc"}}
+	}
+
+	out, err := symbolref.Rebuild(treeBytes, pb, resolve, 0)
+	require.NoError(t, err)
+
+	got, err := model.UnmarshalTree[model.FunctionName, model.FunctionNameI](out)
+	require.NoError(t, err)
+
+	stacks := functionStacks(t, got)
+	require.Len(t, stacks, 1)
+	require.Equal(t, int64(7), stacks["parent/malloc"])
+}
+
+// TestRebuildFallbackRendering verifies an unresolved ref whose resolve
+// callback returns nil renders exactly the same fallback string
+// createFallbackSymbol produces (pkg/symbolizer/symbolizer.go), including
+// the empty-binaryName substitution to "unknown".
+func TestRebuildFallbackRendering(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		binaryName string
+		want       string
+	}{
+		{"with binary name", "myapp", "myapp!0x1a2b"},
+		{"empty binary name", "", "unknown!0x1a2b"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			table := symbolref.NewTable()
+			loc := table.InternUnresolved("deadbeef", tc.binaryName, 0x1a2b)
+
+			tree := new(model.LocationRefNameTree)
+			tree.InsertStack(1, loc)
+
+			rb := table.ResultBuilder()
+			treeBytes := tree.Bytes(0, rb.KeepRef)
+			pb := new(queryv1.SymbolRefTable)
+			rb.Build(pb)
+
+			resolve := func(buildID string, addr uint64) []symbolref.Frame { return nil }
+
+			out, err := symbolref.Rebuild(treeBytes, pb, resolve, 0)
+			require.NoError(t, err)
+
+			got, err := model.UnmarshalTree[model.FunctionName, model.FunctionNameI](out)
+			require.NoError(t, err)
+
+			stacks := functionStacks(t, got)
+			require.Equal(t, int64(1), stacks[tc.want])
+		})
+	}
+}
+
+// TestRebuildTruncationOnce verifies applying maxNodes truncation only once,
+// after resolution, retains a node that per-partial (pre-resolution)
+// truncation would have dropped.
+func TestRebuildTruncationOnce(t *testing.T) {
+	const maxNodes = 2
+
+	buildPartial1 := func() (*symbolref.Table, *model.LocationRefNameTree) {
+		table := symbolref.NewTable()
+		big1a := table.InternName("big1a")
+		big1b := table.InternName("big1b")
+		addrA := table.InternUnresolved("buildX", "binX", 0xA)
+		tree := new(model.LocationRefNameTree)
+		tree.InsertStack(10, big1a)
+		tree.InsertStack(9, big1b)
+		tree.InsertStack(6, addrA)
+		return table, tree
+	}
+	buildPartial2 := func() (*symbolref.Table, *model.LocationRefNameTree) {
+		table := symbolref.NewTable()
+		big2a := table.InternName("big2a")
+		big2b := table.InternName("big2b")
+		addrB := table.InternUnresolved("buildX", "binX", 0xB)
+		tree := new(model.LocationRefNameTree)
+		tree.InsertStack(11, big2a)
+		tree.InsertStack(8, big2b)
+		tree.InsertStack(7, addrB)
+		return table, tree
+	}
+
+	resolve := func(buildID string, addr uint64) []symbolref.Frame {
+		return []symbolref.Frame{{Name: "shared_symbol"}}
+	}
+
+	// rebuildMerged marshals each partial at partialTreeMaxNodes, merges
+	// them, and rebuilds at finalMaxNodes — the only difference between the
+	// deferred-truncation path and the pre-truncated baseline below is
+	// partialTreeMaxNodes.
+	rebuildMerged := func(t *testing.T, partialTreeMaxNodes int64) map[string]int64 {
+		table1, tree1 := buildPartial1()
+		table2, tree2 := buildPartial2()
+
+		rb1 := table1.ResultBuilder()
+		treeBytes1 := tree1.Bytes(partialTreeMaxNodes, rb1.KeepRef)
+		pb1 := new(queryv1.SymbolRefTable)
+		rb1.Build(pb1)
+
+		rb2 := table2.ResultBuilder()
+		treeBytes2 := tree2.Bytes(partialTreeMaxNodes, rb2.KeepRef)
+		pb2 := new(queryv1.SymbolRefTable)
+		rb2.Build(pb2)
+
+		dst := symbolref.NewTable()
+		merger := model.NewTreeMerger[model.LocationRefName, model.LocationRefNameI]()
+		remap1, err := dst.Add(pb1)
+		require.NoError(t, err)
+		require.NoError(t, merger.MergeTreeBytes(treeBytes1, model.WithTreeMergeFormatNodeNames(remap1)))
+		remap2, err := dst.Add(pb2)
+		require.NoError(t, err)
+		require.NoError(t, merger.MergeTreeBytes(treeBytes2, model.WithTreeMergeFormatNodeNames(remap2)))
+
+		finalRB := dst.ResultBuilder()
+		mergedTreeBytes := merger.Tree().Bytes(0, finalRB.KeepRef)
+		mergedPB := new(queryv1.SymbolRefTable)
+		finalRB.Build(mergedPB)
+
+		out, err := symbolref.Rebuild(mergedTreeBytes, mergedPB, resolve, maxNodes)
+		require.NoError(t, err)
+		got, err := model.UnmarshalTree[model.FunctionName, model.FunctionNameI](out)
+		require.NoError(t, err)
+		return functionStacks(t, got)
+	}
+
+	// Deferred-truncation path: both partials marshal untruncated (since
+	// HasUnresolved() is true for both, real truncation would be unsound),
+	// merged untruncated, resolved, and truncated exactly once at the end.
+	deferredStacks := rebuildMerged(t, 0)
+	require.Equal(t, int64(13), deferredStacks["shared_symbol"],
+		"combined weight from both partials should survive maxNodes=%d", maxNodes)
+
+	// Pre-truncated baseline: each partial truncated individually at
+	// maxNodes before merging — deliberately unsound, not part of the
+	// package's API, kept here only to demonstrate what deferred truncation
+	// avoids.
+	baselineStacks := rebuildMerged(t, maxNodes)
+	require.NotContains(t, baselineStacks, "shared_symbol")
+}
+
+// TestRebuildOtherNodePreservation verifies a partial's own pre-existing
+// truncation "other" node survives merge and Rebuild unchanged, and that
+// additional truncation mass Rebuild's own final maxNodes pass produces is
+// accounted for alongside it, not in place of it.
+func TestRebuildOtherNodePreservation(t *testing.T) {
+	const (
+		partialMaxNodes = 2
+		finalMaxNodes   = 2
+	)
+
+	// Partial A: a plain FunctionNameTree, pre-truncated normally (it has no
+	// unresolved entries, so ordinary truncation is sound), producing a
+	// nonzero pre-existing "other" mass.
+	plainTree := new(model.FunctionNameTree)
+	plainTree.InsertStack(10, model.FunctionName("keep1"))
+	plainTree.InsertStack(9, model.FunctionName("keep2"))
+	plainTree.InsertStack(6, model.FunctionName("small_dropped"))
+	plainTreeBytes := plainTree.Bytes(partialMaxNodes, nil)
+
+	dst := symbolref.NewTable()
+	merger := model.NewTreeMerger[model.LocationRefName, model.LocationRefNameI]()
+	merger.MergeTree(absorbPlainTree(t, dst, plainTreeBytes))
+
+	// Partial B: a genuine unresolved partial, plus a large resolved node
+	// so the merged tree has enough nodes for a small final maxNodes to
+	// force additional truncation.
+	tableB := symbolref.NewTable()
+	keep3 := tableB.InternName("keep3")
+	loc := tableB.InternUnresolved("buildX", "binX", 0x1)
+	treeB := new(model.LocationRefNameTree)
+	treeB.InsertStack(20, keep3)
+	treeB.InsertStack(2, loc)
+	rbB := tableB.ResultBuilder()
+	treeBytesB := treeB.Bytes(0, rbB.KeepRef)
+	pbB := new(queryv1.SymbolRefTable)
+	rbB.Build(pbB)
+
+	remapB, err := dst.Add(pbB)
+	require.NoError(t, err)
+	require.NoError(t, merger.MergeTreeBytes(treeBytesB, model.WithTreeMergeFormatNodeNames(remapB)))
+
+	finalRB := dst.ResultBuilder()
+	mergedTreeBytes := merger.Tree().Bytes(0, finalRB.KeepRef)
+	mergedPB := new(queryv1.SymbolRefTable)
+	finalRB.Build(mergedPB)
+
+	resolve := func(buildID string, addr uint64) []symbolref.Frame {
+		return []symbolref.Frame{{Name: "resolved_small"}}
+	}
+
+	out, err := symbolref.Rebuild(mergedTreeBytes, mergedPB, resolve, finalMaxNodes)
+	require.NoError(t, err)
+
+	got, err := model.UnmarshalTree[model.FunctionName, model.FunctionNameI](out)
+	require.NoError(t, err)
+
+	stacks := functionStacks(t, got)
+	require.GreaterOrEqual(t, stacks["other"], int64(6),
+		"other mass must include at least the 6 pre-existing in partial A")
+}
+
+// TestRebuildMalformedInput verifies Rebuild returns an error (never panics)
+// for structurally malformed input.
+func TestRebuildMalformedInput(t *testing.T) {
+	t.Run("unmarshalable tree bytes", func(t *testing.T) {
+		// An overlong varint (more than 10 continuation-marked bytes):
+		// the only malformed encoding pkg/model/og/util/varint.Uvarint
+		// reports as an error rather than silently treating as truncated.
+		overlongVarint := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01}
+		_, err := symbolref.Rebuild(overlongVarint, new(queryv1.SymbolRefTable), nil, 0)
+		require.Error(t, err)
+	})
+
+	t.Run("mismatched pb parallel slices", func(t *testing.T) {
+		table := symbolref.NewTable()
+		loc := table.InternUnresolved("build1", "bin1", 0x1000)
+		tree := new(model.LocationRefNameTree)
+		tree.InsertStack(1, loc)
+		rb := table.ResultBuilder()
+		treeBytes := tree.Bytes(0, rb.KeepRef)
+
+		badPB := &queryv1.SymbolRefTable{
+			BuildIds:          []string{"build1"},
+			BinaryNames:       []string{"bin1", "extra"},
+			UnresolvedBuildId: []uint32{0},
+			UnresolvedAddress: []uint64{0x1000},
+		}
+		_, err := symbolref.Rebuild(treeBytes, badPB, nil, 0)
+		require.Error(t, err)
+	})
+
+	t.Run("out-of-range unresolved_build_id", func(t *testing.T) {
+		table := symbolref.NewTable()
+		loc := table.InternUnresolved("build1", "bin1", 0x1000)
+		tree := new(model.LocationRefNameTree)
+		tree.InsertStack(1, loc)
+		rb := table.ResultBuilder()
+		treeBytes := tree.Bytes(0, rb.KeepRef)
+
+		badPB := &queryv1.SymbolRefTable{
+			BuildIds:          []string{"build1"},
+			BinaryNames:       []string{"bin1"},
+			UnresolvedBuildId: []uint32{5},
+			UnresolvedAddress: []uint64{0x1000},
+		}
+		_, err := symbolref.Rebuild(treeBytes, badPB, nil, 0)
+		require.Error(t, err)
+	})
+
+	t.Run("tree ref beyond pb's range", func(t *testing.T) {
+		tree := new(model.LocationRefNameTree)
+		tree.InsertStack(1, model.LocationRefName(100))
+		identity := func(ref model.LocationRefName) model.LocationRefName { return ref }
+		treeBytes := tree.Bytes(0, identity)
+
+		_, err := symbolref.Rebuild(treeBytes, new(queryv1.SymbolRefTable), nil, 0)
+		require.Error(t, err)
+	})
+}

--- a/pkg/model/symbolref/symbolref_test.go
+++ b/pkg/model/symbolref/symbolref_test.go
@@ -1,9 +1,5 @@
 package symbolref_test
 
-// Jobs and Rebuild are not implemented in this package yet; tests exercising
-// them, and the parts of the tests below that would need them, are deferred
-// to a follow-up change.
-
 import (
 	"cmp"
 	"fmt"
@@ -86,6 +82,31 @@ func buildPartial(build func(*symbolref.Table) *model.LocationRefNameTree) testP
 	pb := new(queryv1.SymbolRefTable)
 	rb.Build(pb)
 	return testPartial{tree: treeBytes, pb: pb}
+}
+
+// absorbPlainTree unmarshals a plain FunctionNameTree and re-inserts every
+// stack into a LocationRefNameTree via dst.InternName. It maps
+// model.OtherFunctionName to model.OtherLocationRef directly rather than
+// through InternName, since both are the truncation sentinel in their
+// respective node-name spaces.
+func absorbPlainTree(t *testing.T, dst *symbolref.Table, plainTreeBytes []byte) *model.LocationRefNameTree {
+	t.Helper()
+	plain, err := model.UnmarshalTree[model.FunctionName, model.FunctionNameI](plainTreeBytes)
+	require.NoError(t, err)
+	absorbed := new(model.LocationRefNameTree)
+	plain.IterateStacks(func(_ model.FunctionName, self int64, stack []model.FunctionName) {
+		slices.Reverse(stack)
+		refs := make([]model.LocationRefName, len(stack))
+		for i, n := range stack {
+			if n == model.OtherFunctionName {
+				refs[i] = model.OtherLocationRef
+				continue
+			}
+			refs[i] = dst.InternName(string(n))
+		}
+		absorbed.InsertStack(self, refs...)
+	})
+	return absorbed
 }
 
 // TestInternIdempotencyAndDedup verifies InternName and InternUnresolved are
@@ -375,9 +396,8 @@ func TestNegativeRefPassthrough(t *testing.T) {
 	require.Equal(t, model.OtherLocationRef, remap(model.OtherLocationRef))
 }
 
-// TestEmptyTable verifies a fresh Table and its ResultBuilder behave safely
-// with nothing interned. Jobs and Rebuild are not implemented in this
-// package yet, so their behavior on an empty table is not covered here.
+// TestEmptyTable verifies a fresh Table, its ResultBuilder,
+// UnresolvedBinaries, and Rebuild all behave safely with nothing interned.
 func TestEmptyTable(t *testing.T) {
 	table := symbolref.NewTable()
 	require.False(t, table.HasUnresolved())
@@ -397,6 +417,13 @@ func TestEmptyTable(t *testing.T) {
 	require.Empty(t, pb.GetBinaryNames())
 	require.Empty(t, pb.GetUnresolvedBuildId())
 	require.Empty(t, pb.GetUnresolvedAddress())
+
+	require.Empty(t, symbolref.UnresolvedBinaries(pb))
+
+	emptyTreeBytes := new(model.LocationRefNameTree).Bytes(0, nil)
+	rebuilt, err := symbolref.Rebuild(emptyTreeBytes, pb, func(string, uint64) []symbolref.Frame { return nil }, 0)
+	require.NoError(t, err)
+	require.Empty(t, rebuilt)
 }
 
 // TestOnlyResolvedTable verifies a table built purely from InternName calls
@@ -491,10 +518,9 @@ func TestAddRemapIsTotal(t *testing.T) {
 
 // TestPlainFunctionNameAbsorption verifies a plain FunctionName-tree partial
 // (as an old backend, or a fully-symbolized dataset, would produce) can be
-// absorbed into the symbol-ref space via InternName and merged alongside a
-// genuine unresolved partial without sample loss. The Rebuild-dependent
-// assertion (that the absorbed samples also survive a final rebuild) is
-// deferred: Rebuild is not implemented in this package yet.
+// absorbed into the symbol-ref space via InternName, merged alongside a
+// genuine unresolved partial, resolved, and rebuilt — with no sample loss
+// or misattribution across the FunctionName/LocationRefName shape boundary.
 func TestPlainFunctionNameAbsorption(t *testing.T) {
 	plainTree := new(model.FunctionNameTree)
 	plainTree.InsertStack(7, model.FunctionName("main"), model.FunctionName("plainFn"))
@@ -512,21 +538,7 @@ func TestPlainFunctionNameAbsorption(t *testing.T) {
 
 	dst := symbolref.NewTable()
 	merger := model.NewTreeMerger[model.LocationRefName, model.LocationRefNameI]()
-
-	// Unmarshal the plain partial and re-insert every stack into a
-	// LocationRefNameTree via InternName.
-	plain, err := model.UnmarshalTree[model.FunctionName, model.FunctionNameI](plainTreeBytes)
-	require.NoError(t, err)
-	absorbed := new(model.LocationRefNameTree)
-	plain.IterateStacks(func(_ model.FunctionName, self int64, stack []model.FunctionName) {
-		slices.Reverse(stack)
-		refs := make([]model.LocationRefName, len(stack))
-		for i, n := range stack {
-			refs[i] = dst.InternName(string(n))
-		}
-		absorbed.InsertStack(self, refs...)
-	})
-	merger.MergeTree(absorbed)
+	merger.MergeTree(absorbPlainTree(t, dst, plainTreeBytes))
 
 	remap, err := dst.Add(refPB)
 	require.NoError(t, err)
@@ -535,12 +547,27 @@ func TestPlainFunctionNameAbsorption(t *testing.T) {
 	require.True(t, dst.HasUnresolved())
 
 	rb := dst.ResultBuilder()
-	_, mergedWireTree := marshalWire(t, merger.Tree(), rb)
+	mergedTreeBytes, mergedWireTree := marshalWire(t, merger.Tree(), rb)
 	mergedPB := new(queryv1.SymbolRefTable)
 	rb.Build(mergedPB)
 
 	stacks := stacksByIdentity(t, mergedWireTree, mergedPB)
 	require.Equal(t, int64(7), stacks["name:main/name:plainFn"], "partial A's stack must survive absorption with its original self value")
+
+	resolve := func(buildID string, addr uint64) []symbolref.Frame {
+		require.Equal(t, "buildB", buildID)
+		require.Equal(t, uint64(0x9000), addr)
+		return []symbolref.Frame{{Name: "resolved_b"}}
+	}
+	rebuiltBytes, err := symbolref.Rebuild(mergedTreeBytes, mergedPB, resolve, 0)
+	require.NoError(t, err)
+
+	rebuiltTree, err := model.UnmarshalTree[model.FunctionName, model.FunctionNameI](rebuiltBytes)
+	require.NoError(t, err)
+
+	rebuiltStacks := functionStacks(t, rebuiltTree)
+	require.Equal(t, int64(7), rebuiltStacks["main/plainFn"], "partial A's stack must survive the final rebuild")
+	require.Equal(t, int64(4), rebuiltStacks["main/resolved_b"], "partial B's stack must resolve correctly in the final rebuild")
 }
 
 // Wire refs must decode to the right SymbolRefTable rows regardless of

--- a/pkg/model/symbolref/symbolref_test.go
+++ b/pkg/model/symbolref/symbolref_test.go
@@ -418,7 +418,9 @@ func TestEmptyTable(t *testing.T) {
 	require.Empty(t, pb.GetUnresolvedBuildId())
 	require.Empty(t, pb.GetUnresolvedAddress())
 
-	require.Empty(t, symbolref.UnresolvedBinaries(pb))
+	binaries, err := symbolref.UnresolvedBinaries(pb)
+	require.NoError(t, err)
+	require.Empty(t, binaries)
 
 	emptyTreeBytes := new(model.LocationRefNameTree).Bytes(0, nil)
 	rebuilt, err := symbolref.Rebuild(emptyTreeBytes, pb, func(string, uint64) []symbolref.Frame { return nil }, 0)

--- a/pkg/model/symbolref/table.go
+++ b/pkg/model/symbolref/table.go
@@ -324,6 +324,25 @@ func (rb *ResultBuilder) KeepRef(ref model.LocationRefName) model.LocationRefNam
 	}
 }
 
+// NameOf returns ref's display name from the snapshot: the interned name of
+// a resolved ref, or the FallbackSymbolName rendering of an unresolved
+// entry's (binary name, address). Refs the snapshot does not describe —
+// model.OtherLocationRef and out-of-range values — render as the empty
+// string; a caller that special-cases the truncation sentinel must do so
+// before calling. ref is Table's internal encoding, as with KeepRef.
+func (rb *ResultBuilder) NameOf(ref model.LocationRefName) string {
+	switch {
+	case ref >= 0 && int(ref) < rb.namesLen:
+		return rb.namesSl[ref]
+	case ref <= -2:
+		if idx := -2 - int(ref); idx < len(rb.unresolvedBin) {
+			b := rb.binaries[rb.unresolvedBin[idx]]
+			return FallbackSymbolName(b.name, rb.unresolvedAd[idx])
+		}
+	}
+	return ""
+}
+
 // Build writes pb.Names, pb.BuildIds, pb.BinaryNames, pb.UnresolvedBuildId
 // and pb.UnresolvedAddress from the snapshot and returns pb, allocating the
 // returned queryv1.SymbolRefTable when pb == nil. Every interned name is

--- a/pkg/model/symbolref/unresolved.go
+++ b/pkg/model/symbolref/unresolved.go
@@ -1,0 +1,105 @@
+package symbolref
+
+import (
+	"cmp"
+	"slices"
+
+	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+)
+
+// UnresolvedBinary is one binary's worth of unresolved addresses to resolve.
+type UnresolvedBinary struct {
+	BuildID    string
+	BinaryName string
+	Addresses  []uint64 // sorted ascending, deduplicated
+}
+
+// UnresolvedBinaries groups a table's unresolved references by build ID,
+// one entry per distinct binary referenced. ResultBuilder.Build already
+// sorts unresolved entries by (buildID, address), making contiguous-run
+// grouping a single forward pass; a table from a different producer may not
+// be grouped that way, so UnresolvedBinaries falls back to sorting first
+// when it detects that.
+func UnresolvedBinaries(pb *queryv1.SymbolRefTable) []UnresolvedBinary {
+	buildIdx := pb.GetUnresolvedBuildId()
+	addrs := pb.GetUnresolvedAddress()
+	if len(buildIdx) == 0 {
+		return nil
+	}
+
+	if !groupedByBuildID(buildIdx) {
+		buildIdx, addrs = sortByBuildIDAndAddress(buildIdx, addrs)
+	}
+
+	binaries := make([]UnresolvedBinary, 0, len(pb.GetBuildIds()))
+	start := 0
+	for i := 1; i <= len(buildIdx); i++ {
+		if i < len(buildIdx) && buildIdx[i] == buildIdx[start] {
+			continue
+		}
+		binaries = append(binaries, newUnresolvedBinary(pb, buildIdx[start], addrs[start:i]))
+		start = i
+	}
+	return binaries
+}
+
+// groupedByBuildID reports whether equal build ID indices in buildIdx always
+// occur in one contiguous run.
+func groupedByBuildID(buildIdx []uint32) bool {
+	seen := make(map[uint32]struct{}, len(buildIdx))
+	for i, bi := range buildIdx {
+		if i > 0 && buildIdx[i-1] == bi {
+			continue
+		}
+		if _, ok := seen[bi]; ok {
+			return false
+		}
+		seen[bi] = struct{}{}
+	}
+	return true
+}
+
+func sortByBuildIDAndAddress(buildIdx []uint32, addrs []uint64) ([]uint32, []uint64) {
+	type entry struct {
+		buildID uint32
+		addr    uint64
+	}
+	entries := make([]entry, len(buildIdx))
+	for i := range buildIdx {
+		entries[i] = entry{buildIdx[i], addrs[i]}
+	}
+	slices.SortFunc(entries, func(a, b entry) int {
+		return cmp.Or(cmp.Compare(a.buildID, b.buildID), cmp.Compare(a.addr, b.addr))
+	})
+
+	outBuildIdx := make([]uint32, len(entries))
+	outAddrs := make([]uint64, len(entries))
+	for i, e := range entries {
+		outBuildIdx[i] = e.buildID
+		outAddrs[i] = e.addr
+	}
+	return outBuildIdx, outAddrs
+}
+
+// newUnresolvedBinary builds one UnresolvedBinary from a contiguous run of
+// addresses sharing build ID index bi, sorting and deduplicating the
+// addresses regardless of the order they arrived in.
+func newUnresolvedBinary(pb *queryv1.SymbolRefTable, bi uint32, addrs []uint64) UnresolvedBinary {
+	sorted := slices.Clone(addrs)
+	slices.Sort(sorted)
+	sorted = slices.Compact(sorted)
+
+	var buildID, binaryName string
+	if int(bi) < len(pb.GetBuildIds()) {
+		buildID = pb.GetBuildIds()[bi]
+	}
+	if int(bi) < len(pb.GetBinaryNames()) {
+		binaryName = pb.GetBinaryNames()[bi]
+	}
+
+	return UnresolvedBinary{
+		BuildID:    buildID,
+		BinaryName: binaryName,
+		Addresses:  sorted,
+	}
+}

--- a/pkg/model/symbolref/unresolved.go
+++ b/pkg/model/symbolref/unresolved.go
@@ -14,17 +14,21 @@ type UnresolvedBinary struct {
 	Addresses  []uint64 // sorted ascending, deduplicated
 }
 
-// UnresolvedBinaries groups a table's unresolved references by build ID,
-// one entry per distinct binary referenced. ResultBuilder.Build already
-// sorts unresolved entries by (buildID, address), making contiguous-run
-// grouping a single forward pass; a table from a different producer may not
-// be grouped that way, so UnresolvedBinaries falls back to sorting first
-// when it detects that.
-func UnresolvedBinaries(pb *queryv1.SymbolRefTable) []UnresolvedBinary {
+// UnresolvedBinaries groups a table's unresolved references by binary row,
+// one entry per distinct (build ID, binary name) row referenced; err is
+// non-nil only for a structurally malformed pb. ResultBuilder.Build already
+// sorts unresolved entries by (build ID, binary name, address), making
+// contiguous-run grouping a single forward pass; a table from a different
+// producer may not be grouped that way, so UnresolvedBinaries falls back to
+// sorting first when it detects that.
+func UnresolvedBinaries(pb *queryv1.SymbolRefTable) ([]UnresolvedBinary, error) {
+	if err := validateSymbolRefTable(pb); err != nil {
+		return nil, err
+	}
 	buildIdx := pb.GetUnresolvedBuildId()
 	addrs := pb.GetUnresolvedAddress()
 	if len(buildIdx) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	if !groupedByBuildID(buildIdx) {
@@ -40,7 +44,7 @@ func UnresolvedBinaries(pb *queryv1.SymbolRefTable) []UnresolvedBinary {
 		binaries = append(binaries, newUnresolvedBinary(pb, buildIdx[start], addrs[start:i]))
 		start = i
 	}
-	return binaries
+	return binaries, nil
 }
 
 // groupedByBuildID reports whether equal build ID indices in buildIdx always
@@ -83,23 +87,17 @@ func sortByBuildIDAndAddress(buildIdx []uint32, addrs []uint64) ([]uint32, []uin
 
 // newUnresolvedBinary builds one UnresolvedBinary from a contiguous run of
 // addresses sharing build ID index bi, sorting and deduplicating the
-// addresses regardless of the order they arrived in.
+// addresses regardless of the order they arrived in. bi is in range and the
+// build_ids/binary_names slices are parallel: pb was validated before
+// grouping started.
 func newUnresolvedBinary(pb *queryv1.SymbolRefTable, bi uint32, addrs []uint64) UnresolvedBinary {
 	sorted := slices.Clone(addrs)
 	slices.Sort(sorted)
 	sorted = slices.Compact(sorted)
 
-	var buildID, binaryName string
-	if int(bi) < len(pb.GetBuildIds()) {
-		buildID = pb.GetBuildIds()[bi]
-	}
-	if int(bi) < len(pb.GetBinaryNames()) {
-		binaryName = pb.GetBinaryNames()[bi]
-	}
-
 	return UnresolvedBinary{
-		BuildID:    buildID,
-		BinaryName: binaryName,
+		BuildID:    pb.GetBuildIds()[bi],
+		BinaryName: pb.GetBinaryNames()[bi],
 		Addresses:  sorted,
 	}
 }

--- a/pkg/model/symbolref/unresolved_test.go
+++ b/pkg/model/symbolref/unresolved_test.go
@@ -1,0 +1,74 @@
+package symbolref_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+	"github.com/grafana/pyroscope/v2/pkg/model/symbolref"
+)
+
+// TestUnresolvedBinariesGrouping verifies UnresolvedBinaries groups
+// unresolved refs by build ID with sorted, deduplicated addresses and the
+// correct BinaryName, even when addresses were interned out of order or
+// repeated.
+func TestUnresolvedBinariesGrouping(t *testing.T) {
+	table := symbolref.NewTable()
+	table.InternUnresolved("b1", "bin-one", 0x300)
+	table.InternUnresolved("b1", "bin-one", 0x100)
+	table.InternUnresolved("b1", "bin-one", 0x300)
+	table.InternUnresolved("b2", "bin-two", 0x50)
+
+	rb := table.ResultBuilder()
+	built := new(queryv1.SymbolRefTable)
+	rb.Build(built)
+
+	binaries := symbolref.UnresolvedBinaries(built)
+	require.Len(t, binaries, 2)
+
+	byBuildID := make(map[string]symbolref.UnresolvedBinary, len(binaries))
+	for _, u := range binaries {
+		byBuildID[u.BuildID] = u
+	}
+
+	b1, ok := byBuildID["b1"]
+	require.True(t, ok)
+	require.Equal(t, []uint64{0x100, 0x300}, b1.Addresses)
+	require.Equal(t, "bin-one", b1.BinaryName)
+
+	b2, ok := byBuildID["b2"]
+	require.True(t, ok)
+	require.Equal(t, []uint64{0x50}, b2.Addresses)
+	require.Equal(t, "bin-two", b2.BinaryName)
+}
+
+// TestUnresolvedBinariesGroupingUnsorted verifies UnresolvedBinaries still
+// groups correctly when its input is not already sorted by
+// (buildID, address), as a table from a different producer might be.
+func TestUnresolvedBinariesGroupingUnsorted(t *testing.T) {
+	pb := &queryv1.SymbolRefTable{
+		BuildIds:          []string{"aaa", "bbb"},
+		BinaryNames:       []string{"bin-a", "bin-b"},
+		UnresolvedBuildId: []uint32{1, 0, 1, 0},
+		UnresolvedAddress: []uint64{0x20, 0x10, 0x10, 0x30},
+	}
+
+	binaries := symbolref.UnresolvedBinaries(pb)
+	require.Len(t, binaries, 2)
+
+	byBuildID := make(map[string]symbolref.UnresolvedBinary, len(binaries))
+	for _, u := range binaries {
+		byBuildID[u.BuildID] = u
+	}
+
+	require.Equal(t, []uint64{0x10, 0x30}, byBuildID["aaa"].Addresses)
+	require.Equal(t, []uint64{0x10, 0x20}, byBuildID["bbb"].Addresses)
+}
+
+// TestUnresolvedBinariesEmpty verifies UnresolvedBinaries returns an empty
+// slice for a table with no unresolved entries.
+func TestUnresolvedBinariesEmpty(t *testing.T) {
+	require.Empty(t, symbolref.UnresolvedBinaries(nil))
+	require.Empty(t, symbolref.UnresolvedBinaries(new(queryv1.SymbolRefTable)))
+}

--- a/pkg/model/symbolref/unresolved_test.go
+++ b/pkg/model/symbolref/unresolved_test.go
@@ -24,7 +24,8 @@ func TestUnresolvedBinariesGrouping(t *testing.T) {
 	built := new(queryv1.SymbolRefTable)
 	rb.Build(built)
 
-	binaries := symbolref.UnresolvedBinaries(built)
+	binaries, err := symbolref.UnresolvedBinaries(built)
+	require.NoError(t, err)
 	require.Len(t, binaries, 2)
 
 	byBuildID := make(map[string]symbolref.UnresolvedBinary, len(binaries))
@@ -54,7 +55,8 @@ func TestUnresolvedBinariesGroupingUnsorted(t *testing.T) {
 		UnresolvedAddress: []uint64{0x20, 0x10, 0x10, 0x30},
 	}
 
-	binaries := symbolref.UnresolvedBinaries(pb)
+	binaries, err := symbolref.UnresolvedBinaries(pb)
+	require.NoError(t, err)
 	require.Len(t, binaries, 2)
 
 	byBuildID := make(map[string]symbolref.UnresolvedBinary, len(binaries))
@@ -69,6 +71,46 @@ func TestUnresolvedBinariesGroupingUnsorted(t *testing.T) {
 // TestUnresolvedBinariesEmpty verifies UnresolvedBinaries returns an empty
 // slice for a table with no unresolved entries.
 func TestUnresolvedBinariesEmpty(t *testing.T) {
-	require.Empty(t, symbolref.UnresolvedBinaries(nil))
-	require.Empty(t, symbolref.UnresolvedBinaries(new(queryv1.SymbolRefTable)))
+	for name, pb := range map[string]*queryv1.SymbolRefTable{
+		"nil":   nil,
+		"empty": new(queryv1.SymbolRefTable),
+	} {
+		t.Run(name, func(t *testing.T) {
+			binaries, err := symbolref.UnresolvedBinaries(pb)
+			require.NoError(t, err)
+			require.Empty(t, binaries)
+		})
+	}
+}
+
+// TestUnresolvedBinariesRejectsMalformed verifies UnresolvedBinaries rejects
+// a structurally malformed table instead of grouping garbage.
+func TestUnresolvedBinariesRejectsMalformed(t *testing.T) {
+	t.Run("mismatched binary_names length", func(t *testing.T) {
+		_, err := symbolref.UnresolvedBinaries(&queryv1.SymbolRefTable{
+			BuildIds:    []string{"aaa"},
+			BinaryNames: []string{"bin-a", "extra"},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("build ID index out of range", func(t *testing.T) {
+		_, err := symbolref.UnresolvedBinaries(&queryv1.SymbolRefTable{
+			BuildIds:          []string{"aaa"},
+			BinaryNames:       []string{"bin-a"},
+			UnresolvedBuildId: []uint32{1},
+			UnresolvedAddress: []uint64{0x10},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("mismatched unresolved lengths", func(t *testing.T) {
+		_, err := symbolref.UnresolvedBinaries(&queryv1.SymbolRefTable{
+			BuildIds:          []string{"aaa"},
+			BinaryNames:       []string{"bin-a"},
+			UnresolvedBuildId: []uint32{0, 0},
+			UnresolvedAddress: []uint64{0x10},
+		})
+		require.Error(t, err)
+	})
 }

--- a/pkg/phlaredb/symdb/resolver.go
+++ b/pkg/phlaredb/symdb/resolver.go
@@ -322,10 +322,11 @@ func (r *Resolver) LocationRefNameTree() (*model.LocationRefNameTree, ResultBuil
 // entries must not be truncated before those entries are resolved, so,
 // unlike Tree/LocationRefNameTree, there is no maxNodes parameter.
 //
-// unresolvedCapExceeded counts locations that would have grown the number
-// of distinct unresolved entries past WithResolverSymbolRefCap; those
-// locations are rendered as an inline fallback name instead, so the call
-// always succeeds and never drops samples.
+// unresolvedCapExceeded counts location occurrences rendered as an inline
+// fallback name because the number of distinct unresolved entries reached
+// WithResolverSymbolRefCap — occurrences, not distinct locations, so a
+// recurring capped location counts every time (see unresolvedCap). The
+// call always succeeds and never drops samples.
 func (r *Resolver) SymbolRefTree() (tree *model.LocationRefNameTree, rb *symbolref.ResultBuilder, unresolvedCapExceeded int64, err error) {
 	span, ctx := tracing.StartSpanFromContext(r.ctx, "Resolver.SymbolRefTree")
 	defer span.Finish()

--- a/pkg/phlaredb/symdb/resolver.go
+++ b/pkg/phlaredb/symdb/resolver.go
@@ -13,6 +13,7 @@ import (
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	"github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/model/symbolref"
 	schemav1 "github.com/grafana/pyroscope/v2/pkg/phlaredb/schemas/v1"
 	"github.com/grafana/pyroscope/v2/pkg/pprof"
 	"github.com/grafana/pyroscope/v2/pkg/util"
@@ -39,6 +40,7 @@ type Resolver struct {
 	maxNodes        int64
 	sts             *typesv1.StackTraceSelector
 	sanitizeOnMerge bool
+	symbolRefCap    int
 }
 
 type ResolverOption func(*Resolver)
@@ -72,6 +74,16 @@ func WithResolverStackTraceSelector(sts *typesv1.StackTraceSelector) ResolverOpt
 func WithResolverSanitizeOnMerge(sanitizeOnMerge bool) ResolverOption {
 	return func(r *Resolver) {
 		r.sanitizeOnMerge = sanitizeOnMerge
+	}
+}
+
+// WithResolverSymbolRefCap bounds the number of distinct unresolved (build
+// ID, address) entries a single SymbolRefTree call interns; locations past
+// the cap render an inline fallback name instead (see unresolvedCap). Zero
+// (the default) means unlimited.
+func WithResolverSymbolRefCap(n int) ResolverOption {
+	return func(r *Resolver) {
+		r.symbolRefCap = n
 	}
 }
 
@@ -296,6 +308,43 @@ func (r *Resolver) LocationRefNameTree() (*model.LocationRefNameTree, ResultBuil
 	})
 	tree.Total()
 	return tree, sym.ResultBuilder(), err
+}
+
+// SymbolRefTree resolves the tree for all selected stack traces using a
+// symbolref.Table for node names: resolved frames are interned as names,
+// frames symdb cannot resolve locally are interned as (build ID, address)
+// pairs for deferred resolution (see Symbols.SymbolRefTree for the exact
+// per-location rules). The table is shared across every partition, so refs
+// are already in one namespace and need no merge-time remap, unlike
+// LocationRefNameTree's SymbolMerger/FormatNodeNames step.
+//
+// The tree is always built without truncation, since a tree with unresolved
+// entries must not be truncated before those entries are resolved, so,
+// unlike Tree/LocationRefNameTree, there is no maxNodes parameter.
+//
+// unresolvedCapExceeded counts locations that would have grown the number
+// of distinct unresolved entries past WithResolverSymbolRefCap; those
+// locations are rendered as an inline fallback name instead, so the call
+// always succeeds and never drops samples.
+func (r *Resolver) SymbolRefTree() (tree *model.LocationRefNameTree, rb *symbolref.ResultBuilder, unresolvedCapExceeded int64, err error) {
+	span, ctx := tracing.StartSpanFromContext(r.ctx, "Resolver.SymbolRefTree")
+	defer span.Finish()
+	table := symbolref.NewTable()
+	capper := newUnresolvedCap(r.symbolRefCap)
+	var lock sync.Mutex
+	tree = new(model.LocationRefNameTree)
+	err = r.withSymbols(ctx, func(symbols *Symbols, appender *SampleAppender) error {
+		resolved, err := symbols.SymbolRefTree(ctx, appender, SelectStackTraces(symbols, r.sts), table, capper)
+		if err != nil {
+			return err
+		}
+		lock.Lock()
+		tree.Merge(resolved)
+		lock.Unlock()
+		return nil
+	})
+	tree.Total()
+	return tree, table.ResultBuilder(), capper.exceededCount(), err
 }
 
 func (r *Resolver) Tree() (*model.FunctionNameTree, error) {

--- a/pkg/phlaredb/symdb/resolver.go
+++ b/pkg/phlaredb/symdb/resolver.go
@@ -77,10 +77,11 @@ func WithResolverSanitizeOnMerge(sanitizeOnMerge bool) ResolverOption {
 	}
 }
 
-// WithResolverSymbolRefCap bounds the number of distinct unresolved (build
-// ID, address) entries a single SymbolRefTree call interns; locations past
-// the cap render an inline fallback name instead (see unresolvedCap). Zero
-// (the default) means unlimited.
+// WithResolverSymbolRefCap bounds the number of distinct unresolved
+// locations a single SymbolRefTree call interns into its table — counted by
+// the table itself, on its own (build ID, binary name, address) identity; a
+// location past the limit fails the call with
+// ErrTooManyUnresolvedLocations. Zero (the default) means unlimited.
 func WithResolverSymbolRefCap(n int) ResolverOption {
 	return func(r *Resolver) {
 		r.symbolRefCap = n
@@ -322,20 +323,17 @@ func (r *Resolver) LocationRefNameTree() (*model.LocationRefNameTree, ResultBuil
 // entries must not be truncated before those entries are resolved, so,
 // unlike Tree/LocationRefNameTree, there is no maxNodes parameter.
 //
-// unresolvedCapExceeded counts location occurrences rendered as an inline
-// fallback name because the number of distinct unresolved entries reached
-// WithResolverSymbolRefCap — occurrences, not distinct locations, so a
-// recurring capped location counts every time (see unresolvedCap). The
-// call always succeeds and never drops samples.
-func (r *Resolver) SymbolRefTree() (tree *model.LocationRefNameTree, rb *symbolref.ResultBuilder, unresolvedCapExceeded int64, err error) {
+// The call fails with ErrTooManyUnresolvedLocations once the number of
+// distinct unresolved entries exceeds WithResolverSymbolRefCap; no partial
+// or mixed-representation result is ever returned.
+func (r *Resolver) SymbolRefTree() (tree *model.LocationRefNameTree, rb *symbolref.ResultBuilder, err error) {
 	span, ctx := tracing.StartSpanFromContext(r.ctx, "Resolver.SymbolRefTree")
 	defer span.Finish()
 	table := symbolref.NewTable()
-	capper := newUnresolvedCap(r.symbolRefCap)
 	var lock sync.Mutex
 	tree = new(model.LocationRefNameTree)
 	err = r.withSymbols(ctx, func(symbols *Symbols, appender *SampleAppender) error {
-		resolved, err := symbols.SymbolRefTree(ctx, appender, SelectStackTraces(symbols, r.sts), table, capper)
+		resolved, err := symbols.SymbolRefTree(ctx, appender, SelectStackTraces(symbols, r.sts), table, r.symbolRefCap)
 		if err != nil {
 			return err
 		}
@@ -345,7 +343,7 @@ func (r *Resolver) SymbolRefTree() (tree *model.LocationRefNameTree, rb *symbolr
 		return nil
 	})
 	tree.Total()
-	return tree, table.ResultBuilder(), capper.exceededCount(), err
+	return tree, table.ResultBuilder(), err
 }
 
 func (r *Resolver) Tree() (*model.FunctionNameTree, error) {

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree.go
@@ -1,0 +1,244 @@
+package symdb
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"sync"
+
+	"github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/model/symbolref"
+	schemav1 "github.com/grafana/pyroscope/v2/pkg/phlaredb/schemas/v1"
+)
+
+// SymbolRefTree resolves the tree for the samples in appender into a
+// model.LocationRefNameTree whose node names are refs into table.
+//
+// A location with lines is interned per line into table via InternName (one
+// intern per line, including inlined frames), exactly as addFunctionNames
+// does for the FunctionName tree.
+//
+// A line-less location needs symbolization: it is interned via
+// InternUnresolved, keyed on the (build ID, address) of its mapping. The
+// mapping is read by direct index into symbols.Mappings, exactly as
+// copyMappings (resolver_pprof.go) does — in this representation index 0
+// is a real mapping, not a "no mapping" sentinel, so it must not be
+// special-cased. A location whose mapping carries no build ID cannot be
+// symbolized (a genuine no-mapping kernel/JIT frame, or a binary with no
+// GNU build ID): it renders as the bare hex address via InternName,
+// matching the legacy path, which leaves such locations unsymbolized.
+//
+// capper bounds the number of distinct unresolved entries table accepts
+// for this call; locations past the cap render an inline fallback name via
+// InternName instead of InternUnresolved (see unresolvedCap).
+//
+// The tree is always built without truncation (maxNodes 0): a tree with
+// unresolved entries must not be truncated before those are resolved.
+func (r *Symbols) SymbolRefTree(
+	ctx context.Context,
+	appender *SampleAppender,
+	selection *SelectedStackTraces,
+	table *symbolref.Table,
+	capper *unresolvedCap,
+) (*model.LocationRefNameTree, error) {
+	if !selection.HasValidCallSite() {
+		return &model.LocationRefNameTree{}, nil
+	}
+	samples := appender.Samples()
+	b := newSymbolRefTreeBuilder(r, samples, selection, table, capper)
+	if err := r.Stacktraces.ResolveStacktraceLocations(ctx, b, samples.StacktraceIDs); err != nil {
+		return nil, err
+	}
+	return model.TreeFromStacktraceTree[model.LocationRefName, model.LocationRefNameI](b.tree, 0, b.lookup), nil
+}
+
+// unresolvedCap bounds the number of distinct (build ID, address) pairs a
+// single SymbolRefTree call interns as unresolved entries. Once the limit
+// is reached, further distinct pairs are rendered as an inline fallback
+// name instead of being interned, so a pathological input (e.g. a profile
+// referencing a huge number of distinct native addresses) can never make
+// the deferred-resolution work list unbounded, fail the query, or drop
+// samples. Safe for concurrent use.
+type unresolvedCap struct {
+	mu       sync.Mutex
+	max      int // <= 0 means unlimited.
+	seen     map[unresolvedCapKey]struct{}
+	exceeded int64
+}
+
+type unresolvedCapKey struct {
+	buildID string
+	addr    uint64
+}
+
+func newUnresolvedCap(max int) *unresolvedCap {
+	return &unresolvedCap{max: max, seen: make(map[unresolvedCapKey]struct{})}
+}
+
+// allow reports whether (buildID, addr) may be interned as an unresolved
+// entry: true if the cap is unlimited, the pair was already counted
+// before, or the cap has not been reached yet; false once the cap has been
+// reached for a pair not yet seen, incrementing the exceeded count.
+func (c *unresolvedCap) allow(buildID string, addr uint64) bool {
+	if c.max <= 0 {
+		return true
+	}
+	key := unresolvedCapKey{buildID, addr}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.seen[key]; ok {
+		return true
+	}
+	if len(c.seen) >= c.max {
+		c.exceeded++
+		return false
+	}
+	c.seen[key] = struct{}{}
+	return true
+}
+
+func (c *unresolvedCap) exceededCount() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.exceeded
+}
+
+// symbolRefTreeBuilder is a StacktraceInserter that interns every stack
+// frame directly into a shared symbolref.Table and accumulates the result
+// into an intermediate model.StacktraceTree.
+//
+// symbolref.Table refs can be negative (unresolved entries), but
+// model.StacktraceTree's Location field, and TreeFromStacktraceTree's
+// truncation-sentinel check in particular, treat any negative location as
+// the "other" truncation marker. slotOf/slots translate refs into a dense,
+// non-negative, per-builder "slot" space so the intermediate tree only
+// ever sees non-negative locations; lookup translates slots back into the
+// real (possibly negative) refs once the tree's final shape is known.
+type symbolRefTreeBuilder struct {
+	symbols *Symbols
+	samples *schemav1.Samples
+	table   *symbolref.Table
+	capper  *unresolvedCap
+	tree    *model.StacktraceTree
+	cur     int
+
+	refs  []int32 // per-stack ref buffer, as slots.
+	lines []int32 // per-stack string-table-index buffer; only used when funcNamesMatcher is set.
+
+	selection        *SelectedStackTraces
+	funcNamesMatcher func([]int32) bool
+
+	slotOf map[model.LocationRefName]int32
+	slots  []model.LocationRefName
+}
+
+func newSymbolRefTreeBuilder(
+	symbols *Symbols,
+	samples schemav1.Samples,
+	selection *SelectedStackTraces,
+	table *symbolref.Table,
+	capper *unresolvedCap,
+) *symbolRefTreeBuilder {
+	b := &symbolRefTreeBuilder{
+		symbols:   symbols,
+		samples:   &samples,
+		table:     table,
+		capper:    capper,
+		tree:      model.NewStacktraceTree(samples.Len() * 2),
+		selection: selection,
+		slotOf:    make(map[model.LocationRefName]int32),
+	}
+	if selection != nil && len(selection.callSite) > 0 {
+		b.funcNamesMatcher = b.funcNamesMatchSelection
+	}
+	return b
+}
+
+func (b *symbolRefTreeBuilder) InsertStacktrace(_ uint32, locations []int32) {
+	if b.funcNamesMatcher != nil {
+		b.lines = b.lines[:0]
+		for i := 0; i < len(locations); i++ {
+			b.lines = addFunctionNames(b.lines, locations[i], b.symbols)
+		}
+		if !b.funcNamesMatcher(b.lines) {
+			b.cur++
+			return
+		}
+	}
+	b.refs = b.refs[:0]
+	for i := 0; i < len(locations); i++ {
+		b.refs = b.appendLocationRefs(b.refs, locations[i])
+	}
+	b.tree.Insert(b.refs, int64(b.samples.Values[b.cur]))
+	b.cur++
+}
+
+// funcNamesMatchSelection mirrors treeSymbols.funcNamesMatchSelection
+// (resolver_tree.go): funcNames is leaf-first (addFunctionNames' order),
+// so the selector's call site (root-first) is checked against funcNames'
+// tail.
+func (b *symbolRefTreeBuilder) funcNamesMatchSelection(funcNames []int32) bool {
+	if len(funcNames) < int(b.selection.depth) {
+		return false
+	}
+	for i := 0; i < int(b.selection.depth); i++ {
+		if b.symbols.Strings[funcNames[len(funcNames)-1-i]] != b.selection.callSite[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// appendLocationRefs appends the slot(s) for locID's symbolref.Table ref(s)
+// to dst: see SymbolRefTree's doc comment for the per-location rules, and
+// symbolRefTreeBuilder's doc comment for why slots (not raw refs) are used
+// here.
+func (b *symbolRefTreeBuilder) appendLocationRefs(dst []int32, locID int32) []int32 {
+	loc := b.symbols.Locations[locID]
+	if len(loc.Line) > 0 {
+		for l := 0; l < len(loc.Line); l++ {
+			name := b.symbols.Strings[b.symbols.Functions[loc.Line[l].FunctionId].Name]
+			dst = append(dst, b.toSlot(b.table.InternName(name)))
+		}
+		return dst
+	}
+	var buildID, binaryName string
+	if int(loc.MappingId) < len(b.symbols.Mappings) {
+		mapping := b.symbols.Mappings[loc.MappingId]
+		buildID = b.symbols.Strings[mapping.BuildId]
+		binaryName = filepath.Base(b.symbols.Strings[mapping.Filename])
+	}
+	if buildID == "" {
+		hex := strconv.FormatInt(int64(loc.Address), 16)
+		return append(dst, b.toSlot(b.table.InternName(hex)))
+	}
+	if b.capper.allow(buildID, loc.Address) {
+		return append(dst, b.toSlot(b.table.InternUnresolved(buildID, binaryName, loc.Address)))
+	}
+	return append(dst, b.toSlot(b.table.InternName(fallbackSymbolName(binaryName, loc.Address))))
+}
+
+func (b *symbolRefTreeBuilder) toSlot(ref model.LocationRefName) int32 {
+	if slot, ok := b.slotOf[ref]; ok {
+		return slot
+	}
+	slot := int32(len(b.slots))
+	b.slotOf[ref] = slot
+	b.slots = append(b.slots, ref)
+	return slot
+}
+
+func (b *symbolRefTreeBuilder) lookup(slot int32) model.LocationRefName {
+	return b.slots[slot]
+}
+
+// fallbackSymbolName matches Symbolizer.createFallbackSymbol
+// (pkg/symbolizer/symbolizer.go) byte for byte.
+func fallbackSymbolName(binaryName string, addr uint64) string {
+	prefix := "unknown"
+	if binaryName != "" {
+		prefix = binaryName
+	}
+	return fmt.Sprintf("%s!0x%x", prefix, addr)
+}

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree.go
@@ -2,9 +2,9 @@ package symdb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
-	"sync"
 
 	"github.com/grafana/pyroscope/v2/pkg/model"
 	"github.com/grafana/pyroscope/v2/pkg/model/symbolref"
@@ -26,12 +26,17 @@ import (
 // special-cased. A location whose mapping carries no build ID cannot be
 // symbolized (a genuine no-mapping kernel/JIT frame, or a binary with no
 // GNU build ID): it is interned via InternName with the same fallback name
-// the legacy symbolizer gives unresolvable frames (binary!0xaddr, keeping
-// the binary-name context; see fallbackSymbolName).
+// every unresolvable frame in Pyroscope renders
+// (symbolref.FallbackSymbolName, keeping the binary-name context).
 //
-// capper bounds the number of distinct unresolved entries table accepts
-// for this call; locations past the cap render an inline fallback name via
-// InternName instead of InternUnresolved (see unresolvedCap).
+// maxUnresolved bounds the number of distinct unresolved entries table
+// accepts — counted by the table itself, across every call sharing it — so
+// a pathological input (e.g. a profile referencing a huge number of
+// distinct native addresses) can never make the deferred-resolution work
+// list unbounded. A location past the limit fails the call with
+// ErrTooManyUnresolvedLocations: rendering the remainder as inline fallback
+// names instead would keep growing the name table without bound and make
+// the result depend on arrival order. Zero or negative means unlimited.
 //
 // The tree is always built without truncation (maxNodes 0): a tree with
 // unresolved entries must not be truncated before those are resolved.
@@ -40,76 +45,26 @@ func (r *Symbols) SymbolRefTree(
 	appender *SampleAppender,
 	selection *SelectedStackTraces,
 	table *symbolref.Table,
-	capper *unresolvedCap,
+	maxUnresolved int,
 ) (*model.LocationRefNameTree, error) {
 	if !selection.HasValidCallSite() {
 		return &model.LocationRefNameTree{}, nil
 	}
 	samples := appender.Samples()
-	b := newSymbolRefTreeBuilder(r, samples, selection, table, capper)
+	b := newSymbolRefTreeBuilder(r, samples, selection, table, maxUnresolved)
 	if err := r.Stacktraces.ResolveStacktraceLocations(ctx, b, samples.StacktraceIDs); err != nil {
 		return nil, err
+	}
+	if b.err != nil {
+		return nil, b.err
 	}
 	return model.TreeFromStacktraceTree[model.LocationRefName, model.LocationRefNameI](b.tree, 0, b.lookup), nil
 }
 
-// unresolvedCap bounds the number of distinct (build ID, address) pairs a
-// single SymbolRefTree call interns as unresolved entries. Once the limit
-// is reached, further pairs are rendered as an inline fallback name
-// instead of being interned, so a pathological input (e.g. a profile
-// referencing a huge number of distinct native addresses) can never make
-// the deferred-resolution work list unbounded, fail the query, or drop
-// samples. Safe for concurrent use.
-//
-// exceeded counts each location occurrence rendered as a fallback name —
-// occurrences, not distinct pairs: pairs rejected by the cap are not
-// recorded (remembering them would grow memory without bound, which is
-// what the cap exists to prevent), so a recurring capped pair counts every
-// time it is seen.
-type unresolvedCap struct {
-	mu       sync.Mutex
-	max      int // <= 0 means unlimited.
-	seen     map[unresolvedCapKey]struct{}
-	exceeded int64
-}
-
-type unresolvedCapKey struct {
-	buildID string
-	addr    uint64
-}
-
-func newUnresolvedCap(max int) *unresolvedCap {
-	return &unresolvedCap{max: max, seen: make(map[unresolvedCapKey]struct{})}
-}
-
-// allow reports whether (buildID, addr) may be interned as an unresolved
-// entry: true if the cap is unlimited, the pair was interned before the
-// cap was reached, or the cap has not been reached yet; false for every
-// occurrence of any other pair once the cap has been reached, incrementing
-// exceeded each time.
-func (c *unresolvedCap) allow(buildID string, addr uint64) bool {
-	if c.max <= 0 {
-		return true
-	}
-	key := unresolvedCapKey{buildID, addr}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if _, ok := c.seen[key]; ok {
-		return true
-	}
-	if len(c.seen) >= c.max {
-		c.exceeded++
-		return false
-	}
-	c.seen[key] = struct{}{}
-	return true
-}
-
-func (c *unresolvedCap) exceededCount() int64 {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.exceeded
-}
+// ErrTooManyUnresolvedLocations fails a symbol-ref tree build whose number
+// of distinct unresolved locations exceeds the configured limit
+// (WithResolverSymbolRefCap).
+var ErrTooManyUnresolvedLocations = errors.New("too many unresolved locations in query")
 
 // symbolRefTreeBuilder is a StacktraceInserter that interns every stack
 // frame directly into a shared symbolref.Table and accumulates the result
@@ -123,12 +78,13 @@ func (c *unresolvedCap) exceededCount() int64 {
 // ever sees non-negative locations; lookup translates slots back into the
 // real (possibly negative) refs once the tree's final shape is known.
 type symbolRefTreeBuilder struct {
-	symbols *Symbols
-	samples *schemav1.Samples
-	table   *symbolref.Table
-	capper  *unresolvedCap
-	tree    *model.StacktraceTree
-	cur     int
+	symbols       *Symbols
+	samples       *schemav1.Samples
+	table         *symbolref.Table
+	maxUnresolved int
+	tree          *model.StacktraceTree
+	cur           int
+	err           error // first limit breach; set once, the whole call fails.
 
 	refs  []int32 // per-stack ref buffer, as slots.
 	lines []int32 // per-stack string-table-index buffer; only used when funcNamesMatcher is set.
@@ -145,16 +101,16 @@ func newSymbolRefTreeBuilder(
 	samples schemav1.Samples,
 	selection *SelectedStackTraces,
 	table *symbolref.Table,
-	capper *unresolvedCap,
+	maxUnresolved int,
 ) *symbolRefTreeBuilder {
 	b := &symbolRefTreeBuilder{
-		symbols:   symbols,
-		samples:   &samples,
-		table:     table,
-		capper:    capper,
-		tree:      model.NewStacktraceTree(samples.Len() * 2),
-		selection: selection,
-		slotOf:    make(map[model.LocationRefName]int32),
+		symbols:       symbols,
+		samples:       &samples,
+		table:         table,
+		maxUnresolved: maxUnresolved,
+		tree:          model.NewStacktraceTree(samples.Len() * 2),
+		selection:     selection,
+		slotOf:        make(map[model.LocationRefName]int32),
 	}
 	if selection != nil && len(selection.callSite) > 0 {
 		b.funcNamesMatcher = b.funcNamesMatchSelection
@@ -163,6 +119,10 @@ func newSymbolRefTreeBuilder(
 }
 
 func (b *symbolRefTreeBuilder) InsertStacktrace(_ uint32, locations []int32) {
+	if b.err != nil {
+		b.cur++
+		return
+	}
 	if b.funcNamesMatcher != nil {
 		// The call-site selection is matched against locally resolved
 		// function names only, mirroring the FunctionName tree path: a
@@ -182,6 +142,10 @@ func (b *symbolRefTreeBuilder) InsertStacktrace(_ uint32, locations []int32) {
 	b.refs = b.refs[:0]
 	for i := 0; i < len(locations); i++ {
 		b.refs = b.appendLocationRefs(b.refs, locations[i])
+	}
+	if b.err != nil {
+		b.cur++
+		return
 	}
 	b.tree.Insert(b.refs, int64(b.samples.Values[b.cur]))
 	b.cur++
@@ -223,12 +187,19 @@ func (b *symbolRefTreeBuilder) appendLocationRefs(dst []int32, locID int32) []in
 		binaryName = filepath.Base(b.symbols.Strings[mapping.Filename])
 	}
 	if buildID == "" {
-		return append(dst, b.toSlot(b.table.InternName(fallbackSymbolName(binaryName, loc.Address))))
+		return append(dst, b.toSlot(b.table.InternName(symbolref.FallbackSymbolName(binaryName, loc.Address))))
 	}
-	if b.capper.allow(buildID, loc.Address) {
-		return append(dst, b.toSlot(b.table.InternUnresolved(buildID, binaryName, loc.Address)))
+	// Intern first, check after: the limit bounds exactly what the shared
+	// table holds — its distinct (build ID, binary name, address) entries —
+	// so the accounting cannot drift from the identity the table dedups on.
+	// Transiently exceeding the limit by an in-flight intern is fine; the
+	// whole call fails either way.
+	ref := b.table.InternUnresolved(buildID, binaryName, loc.Address)
+	if b.maxUnresolved > 0 && b.table.UnresolvedCount() > b.maxUnresolved {
+		b.err = fmt.Errorf("%w (limit %d)", ErrTooManyUnresolvedLocations, b.maxUnresolved)
+		return dst
 	}
-	return append(dst, b.toSlot(b.table.InternName(fallbackSymbolName(binaryName, loc.Address))))
+	return append(dst, b.toSlot(ref))
 }
 
 func (b *symbolRefTreeBuilder) toSlot(ref model.LocationRefName) int32 {
@@ -243,14 +214,4 @@ func (b *symbolRefTreeBuilder) toSlot(ref model.LocationRefName) int32 {
 
 func (b *symbolRefTreeBuilder) lookup(slot int32) model.LocationRefName {
 	return b.slots[slot]
-}
-
-// fallbackSymbolName matches Symbolizer.createFallbackSymbol
-// (pkg/symbolizer/symbolizer.go) byte for byte.
-func fallbackSymbolName(binaryName string, addr uint64) string {
-	prefix := "unknown"
-	if binaryName != "" {
-		prefix = binaryName
-	}
-	return fmt.Sprintf("%s!0x%x", prefix, addr)
 }

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strconv"
 	"sync"
 
 	"github.com/grafana/pyroscope/v2/pkg/model"
@@ -26,8 +25,9 @@ import (
 // is a real mapping, not a "no mapping" sentinel, so it must not be
 // special-cased. A location whose mapping carries no build ID cannot be
 // symbolized (a genuine no-mapping kernel/JIT frame, or a binary with no
-// GNU build ID): it renders as the bare hex address via InternName,
-// matching the legacy path, which leaves such locations unsymbolized.
+// GNU build ID): it is interned via InternName with the same fallback name
+// the legacy symbolizer gives unresolvable frames (binary!0xaddr, keeping
+// the binary-name context; see fallbackSymbolName).
 //
 // capper bounds the number of distinct unresolved entries table accepts
 // for this call; locations past the cap render an inline fallback name via
@@ -217,8 +217,7 @@ func (b *symbolRefTreeBuilder) appendLocationRefs(dst []int32, locID int32) []in
 		binaryName = filepath.Base(b.symbols.Strings[mapping.Filename])
 	}
 	if buildID == "" {
-		hex := strconv.FormatInt(int64(loc.Address), 16)
-		return append(dst, b.toSlot(b.table.InternName(hex)))
+		return append(dst, b.toSlot(b.table.InternName(fallbackSymbolName(binaryName, loc.Address))))
 	}
 	if b.capper.allow(buildID, loc.Address) {
 		return append(dst, b.toSlot(b.table.InternUnresolved(buildID, binaryName, loc.Address)))

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree.go
@@ -55,11 +55,17 @@ func (r *Symbols) SymbolRefTree(
 
 // unresolvedCap bounds the number of distinct (build ID, address) pairs a
 // single SymbolRefTree call interns as unresolved entries. Once the limit
-// is reached, further distinct pairs are rendered as an inline fallback
-// name instead of being interned, so a pathological input (e.g. a profile
+// is reached, further pairs are rendered as an inline fallback name
+// instead of being interned, so a pathological input (e.g. a profile
 // referencing a huge number of distinct native addresses) can never make
 // the deferred-resolution work list unbounded, fail the query, or drop
 // samples. Safe for concurrent use.
+//
+// exceeded counts each location occurrence rendered as a fallback name —
+// occurrences, not distinct pairs: pairs rejected by the cap are not
+// recorded (remembering them would grow memory without bound, which is
+// what the cap exists to prevent), so a recurring capped pair counts every
+// time it is seen.
 type unresolvedCap struct {
 	mu       sync.Mutex
 	max      int // <= 0 means unlimited.
@@ -77,9 +83,10 @@ func newUnresolvedCap(max int) *unresolvedCap {
 }
 
 // allow reports whether (buildID, addr) may be interned as an unresolved
-// entry: true if the cap is unlimited, the pair was already counted
-// before, or the cap has not been reached yet; false once the cap has been
-// reached for a pair not yet seen, incrementing the exceeded count.
+// entry: true if the cap is unlimited, the pair was interned before the
+// cap was reached, or the cap has not been reached yet; false for every
+// occurrence of any other pair once the cap has been reached, incrementing
+// exceeded each time.
 func (c *unresolvedCap) allow(buildID string, addr uint64) bool {
 	if c.max <= 0 {
 		return true

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree.go
@@ -164,6 +164,12 @@ func newSymbolRefTreeBuilder(
 
 func (b *symbolRefTreeBuilder) InsertStacktrace(_ uint32, locations []int32) {
 	if b.funcNamesMatcher != nil {
+		// The call-site selection is matched against locally resolved
+		// function names only, mirroring the FunctionName tree path: a
+		// line-less (unsymbolized) location contributes no name here, so a
+		// stack whose match depends on such a frame is not selected.
+		// Lifting that requires propagating every stack that contains an
+		// unsymbolized location and filtering only after symbolization.
 		b.lines = b.lines[:0]
 		for i := 0; i < len(locations); i++ {
 			b.lines = addFunctionNames(b.lines, locations[i], b.symbols)

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
@@ -142,7 +142,9 @@ func TestSymbols_SymbolRefTree_FirstMappingResolves(t *testing.T) {
 	assert.Equal(t, "bidA", unresolved[0].BuildID)
 	assert.Equal(t, "libA.so", unresolved[0].BinaryName)
 	assert.Equal(t, []uint64{0x1234}, unresolved[0].Addresses)
-	assert.Empty(t, pb.Names, "nothing should render as a bare hex name")
+	// Build always writes the reserved ref-0 placeholder, so a snapshot
+	// with no real names is [""], not empty.
+	assert.Equal(t, []string{""}, pb.Names, "nothing should render as a bare hex name")
 }
 
 // TestSymbols_SymbolRefTree_NoBuildIDRendersHex covers a line-less location

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
@@ -228,9 +228,8 @@ func TestResolver_SymbolRefTree_MultiPartitionRefConsistency(t *testing.T) {
 	r.AddSamples(0, indexed0[0].Samples)
 	r.AddSamples(1, indexed1[0].Samples)
 
-	tree, rb, exceeded, err := r.SymbolRefTree()
+	tree, rb, err := r.SymbolRefTree()
 	require.NoError(t, err)
-	assert.Equal(t, int64(0), exceeded)
 	assert.Equal(t, int64(42), tree.Total())
 
 	stacks, selves := collectStacks(tree)
@@ -264,13 +263,12 @@ func TestResolver_SymbolRefTree_MultiPartitionRefConsistency(t *testing.T) {
 	assert.Equal(t, []uint64{0x9000}, unresolved[0].Addresses)
 }
 
-// TestResolver_SymbolRefTree_UnresolvedCapExceeded verifies the cap-overflow
-// guardrail: once WithResolverSymbolRefCap's limit is reached, further
-// distinct unresolved locations render as an inline fallback name instead
-// of growing the table, no error is returned, and no sample is lost.
-func TestResolver_SymbolRefTree_UnresolvedCapExceeded(t *testing.T) {
+// TestResolver_SymbolRefTree_UnresolvedCap verifies the cap guardrail: a
+// query whose distinct unresolved locations exceed WithResolverSymbolRefCap
+// fails with ErrTooManyUnresolvedLocations instead of returning a partial
+// or mixed-representation result, while a query at the cap succeeds.
+func TestResolver_SymbolRefTree_UnresolvedCap(t *testing.T) {
 	const distinctAddresses = 5
-	const refCap = 2
 
 	locs := make([]*profilev1.Location, 0, distinctAddresses)
 	samples := make([]*profilev1.Sample, 0, distinctAddresses)
@@ -294,25 +292,24 @@ func TestResolver_SymbolRefTree_UnresolvedCapExceeded(t *testing.T) {
 
 	s := newMemSuite(t, nil)
 	indexed := s.db.WriteProfileSymbols(0, p)
-	r := NewResolver(context.Background(), s.db, WithResolverSymbolRefCap(refCap))
-	defer r.Release()
-	r.AddSamples(0, indexed[0].Samples)
 
-	tree, rb, exceeded, err := r.SymbolRefTree()
-	require.NoError(t, err)
-	assert.Equal(t, int64(distinctAddresses-refCap), exceeded)
-	assert.Equal(t, wantTotal, tree.Total(), "no sample is dropped once the cap is exceeded")
-
-	stacks, _ := collectStacks(tree)
-	for _, s := range stacks {
-		require.Len(t, s, 1)
-		rb.KeepRef(s[0])
+	newResolver := func(refCap int) *Resolver {
+		r := NewResolver(context.Background(), s.db, WithResolverSymbolRefCap(refCap))
+		t.Cleanup(r.Release)
+		r.AddSamples(0, indexed[0].Samples)
+		return r
 	}
-	pb := &queryv1.SymbolRefTable{}
-	rb.Build(pb)
-	unresolved := symbolref.UnresolvedBinaries(pb)
-	require.Len(t, unresolved, 1)
-	assert.Len(t, unresolved[0].Addresses, refCap, "only the first refCap distinct addresses are actually interned as unresolved")
+
+	t.Run("at the cap the query succeeds", func(t *testing.T) {
+		tree, _, err := newResolver(distinctAddresses).SymbolRefTree()
+		require.NoError(t, err)
+		assert.Equal(t, wantTotal, tree.Total())
+	})
+
+	t.Run("past the cap the query fails", func(t *testing.T) {
+		_, _, err := newResolver(distinctAddresses - 1).SymbolRefTree()
+		require.ErrorIs(t, err, ErrTooManyUnresolvedLocations)
+	})
 }
 
 // TestSymbols_SymbolRefTree_StackTraceSelector verifies call-site selection
@@ -375,14 +372,13 @@ func TestSymbols_SymbolRefTree_UnresolvableStacktrace(t *testing.T) {
 	assert.Equal(t, int64(0), tree.Total())
 }
 
-// The exceeded count is occurrences, not distinct pairs: capped pairs are
-// not recorded (that would grow memory without bound), so each recurrence
-// counts.
-func TestUnresolvedCap_ExceededCountsOccurrences(t *testing.T) {
+// A pair interned before the cap filled stays allowed; any new pair past
+// the cap is rejected, and rejected pairs are not recorded (that would
+// grow memory without bound).
+func TestUnresolvedCap_Allow(t *testing.T) {
 	c := newUnresolvedCap(1)
 	assert.True(t, c.allow("bid", 0x1))
 	assert.True(t, c.allow("bid", 0x1), "an interned pair stays allowed after the cap fills")
 	assert.False(t, c.allow("bid", 0x2))
 	assert.False(t, c.allow("bid", 0x2))
-	assert.Equal(t, int64(2), c.exceededCount())
 }

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
@@ -67,7 +67,7 @@ func TestSymbols_SymbolRefTree_LinedAndUnresolved(t *testing.T) {
 	symbols, appender := symbolsForProfile(t, p)
 	table := symbolref.NewTable()
 
-	tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, nil), table, newUnresolvedCap(0))
+	tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, nil), table, 0)
 	require.NoError(t, err)
 	assert.Equal(t, int64(42), tree.Total())
 
@@ -88,7 +88,8 @@ func TestSymbols_SymbolRefTree_LinedAndUnresolved(t *testing.T) {
 	assert.Equal(t, ".!0xdeadbeef", pb.Names[kernelIdx],
 		`legacy-parity fallback; "." is filepath.Base of the filename-less mapping the no-mapping frame indexes`)
 
-	unresolved := symbolref.UnresolvedBinaries(pb)
+	unresolved, err := symbolref.UnresolvedBinaries(pb)
+	require.NoError(t, err)
 	require.Len(t, unresolved, 1)
 	assert.Equal(t, "bidB", unresolved[0].BuildID)
 	assert.Equal(t, "libB.so", unresolved[0].BinaryName)
@@ -126,7 +127,7 @@ func TestSymbols_SymbolRefTree_FirstMappingResolves(t *testing.T) {
 	symbols, appender := symbolsForProfile(t, p)
 	table := symbolref.NewTable()
 
-	tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, nil), table, newUnresolvedCap(0))
+	tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, nil), table, 0)
 	require.NoError(t, err)
 
 	rb := table.ResultBuilder()
@@ -137,7 +138,8 @@ func TestSymbols_SymbolRefTree_FirstMappingResolves(t *testing.T) {
 	pb := &queryv1.SymbolRefTable{}
 	rb.Build(pb)
 
-	unresolved := symbolref.UnresolvedBinaries(pb)
+	unresolved, err := symbolref.UnresolvedBinaries(pb)
+	require.NoError(t, err)
 	require.Len(t, unresolved, 1, "a line-less location on the first mapping must be symbolizable, not bare hex")
 	assert.Equal(t, "bidA", unresolved[0].BuildID)
 	assert.Equal(t, "libA.so", unresolved[0].BinaryName)
@@ -172,7 +174,7 @@ func TestSymbols_SymbolRefTree_NoBuildIDRendersFallback(t *testing.T) {
 	symbols, appender := symbolsForProfile(t, p)
 	table := symbolref.NewTable()
 
-	tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, nil), table, newUnresolvedCap(0))
+	tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, nil), table, 0)
 	require.NoError(t, err)
 
 	rb := table.ResultBuilder()
@@ -184,7 +186,9 @@ func TestSymbols_SymbolRefTree_NoBuildIDRendersFallback(t *testing.T) {
 	pb := &queryv1.SymbolRefTable{}
 	rb.Build(pb)
 
-	assert.Empty(t, symbolref.UnresolvedBinaries(pb), "a mapping with no build ID is not symbolizable")
+	binaries, err := symbolref.UnresolvedBinaries(pb)
+	require.NoError(t, err)
+	assert.Empty(t, binaries, "a mapping with no build ID is not symbolizable")
 	assert.Contains(t, pb.Names, "goldpinger!0xdeadbeef", "keeps the binary-name context, like the legacy fallback")
 	assert.Contains(t, pb.Names, ".!0x1111",
 		`empty filename: "." is filepath.Base(""), byte-for-byte with the legacy fallback derivation`)
@@ -257,7 +261,8 @@ func TestResolver_SymbolRefTree_MultiPartitionRefConsistency(t *testing.T) {
 	rb.KeepRef(unresolvedRef)
 	rb.Build(pb)
 	assert.Equal(t, "main", pb.Names[mainIdx])
-	unresolved := symbolref.UnresolvedBinaries(pb)
+	unresolved, err := symbolref.UnresolvedBinaries(pb)
+	require.NoError(t, err)
 	require.Len(t, unresolved, 1)
 	assert.Equal(t, "bid-shared", unresolved[0].BuildID)
 	assert.Equal(t, []uint64{0x9000}, unresolved[0].Addresses)
@@ -340,7 +345,7 @@ func TestSymbols_SymbolRefTree_StackTraceSelector(t *testing.T) {
 	t.Run("matching selector keeps only the selected subtree", func(t *testing.T) {
 		sts := &typesv1.StackTraceSelector{CallSite: []*typesv1.Location{{Name: "main"}}}
 		table := symbolref.NewTable()
-		tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, sts), table, newUnresolvedCap(0))
+		tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, sts), table, 0)
 		require.NoError(t, err)
 		assert.Equal(t, int64(5), tree.Total())
 	})
@@ -348,7 +353,7 @@ func TestSymbols_SymbolRefTree_StackTraceSelector(t *testing.T) {
 	t.Run("non-matching selector yields an empty tree without error", func(t *testing.T) {
 		sts := &typesv1.StackTraceSelector{CallSite: []*typesv1.Location{{Name: "no-such-function"}}}
 		table := symbolref.NewTable()
-		tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, sts), table, newUnresolvedCap(0))
+		tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, sts), table, 0)
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), tree.Total())
 	})
@@ -367,18 +372,69 @@ func TestSymbols_SymbolRefTree_UnresolvableStacktrace(t *testing.T) {
 	}
 	symbols, appender := symbolsForProfile(t, p)
 	table := symbolref.NewTable()
-	tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, nil), table, newUnresolvedCap(0))
+	tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, nil), table, 0)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), tree.Total())
 }
 
-// A pair interned before the cap filled stays allowed; any new pair past
-// the cap is rejected, and rejected pairs are not recorded (that would
-// grow memory without bound).
-func TestUnresolvedCap_Allow(t *testing.T) {
-	c := newUnresolvedCap(1)
-	assert.True(t, c.allow("bid", 0x1))
-	assert.True(t, c.allow("bid", 0x1), "an interned pair stays allowed after the cap fills")
-	assert.False(t, c.allow("bid", 0x2))
-	assert.False(t, c.allow("bid", 0x2))
+// TestSymbols_SymbolRefTree_UnresolvedLimit exercises the fail-fast limit
+// through the real build path: two distinct unresolved locations breach a
+// limit of 1 and the whole call fails; the same input passes at 2. A
+// repeated location dedups in the table, so it never counts twice.
+func TestSymbols_SymbolRefTree_UnresolvedLimit(t *testing.T) {
+	// A fresh profile per ingest: WriteProfileSymbols rewrites the
+	// profile's location IDs in place.
+	profile := func() *profilev1.Profile {
+		return &profilev1.Profile{
+			StringTable: []string{"", "libA.so", "bidA"},
+			Mapping: []*profilev1.Mapping{
+				{Id: 1, Filename: 1, BuildId: 2},
+			},
+			Location: []*profilev1.Location{
+				{Id: 1, MappingId: 1, Address: 0x1000},
+				{Id: 2, MappingId: 1, Address: 0x2000},
+			},
+			Sample: []*profilev1.Sample{
+				{LocationId: []uint64{2, 1}, Value: []int64{1}},
+				{LocationId: []uint64{1}, Value: []int64{1}},
+			},
+			SampleType: []*profilev1.ValueType{{Type: 0, Unit: 0}},
+		}
+	}
+
+	symbols, appender := symbolsForProfile(t, profile())
+	_, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, nil), symbolref.NewTable(), 1)
+	require.ErrorIs(t, err, ErrTooManyUnresolvedLocations)
+
+	symbols, appender = symbolsForProfile(t, profile())
+	tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, nil), symbolref.NewTable(), 2)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), tree.Total())
+}
+
+// The limit counts what the shared table holds, on the table's own identity
+// — (build ID, binary name, address) — so one build ID mapped under two
+// different file names yields two countable entries for the same address,
+// exactly as the table stores them.
+func TestSymbols_SymbolRefTree_UnresolvedLimitCountsBinaryName(t *testing.T) {
+	p := &profilev1.Profile{
+		StringTable: []string{"", "libA.so", "bidA", "libA-renamed.so"},
+		Mapping: []*profilev1.Mapping{
+			{Id: 1, Filename: 1, BuildId: 2},
+			{Id: 2, Filename: 3, BuildId: 2},
+		},
+		Location: []*profilev1.Location{
+			{Id: 1, MappingId: 1, Address: 0x1000},
+			{Id: 2, MappingId: 2, Address: 0x1000},
+		},
+		Sample: []*profilev1.Sample{
+			{LocationId: []uint64{2, 1}, Value: []int64{1}},
+		},
+		SampleType: []*profilev1.ValueType{{Type: 0, Unit: 0}},
+	}
+	symbols, appender := symbolsForProfile(t, p)
+	table := symbolref.NewTable()
+	_, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, nil), table, 1)
+	require.ErrorIs(t, err, ErrTooManyUnresolvedLocations)
+	assert.Equal(t, 2, table.UnresolvedCount())
 }

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
@@ -1,0 +1,366 @@
+package symdb
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	"github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/model/symbolref"
+)
+
+// symbolsForProfile writes p to a fresh in-memory partition 0 and returns
+// its Symbols and an appender loaded with every resulting sample.
+func symbolsForProfile(t *testing.T, p *profilev1.Profile) (*Symbols, *SampleAppender) {
+	t.Helper()
+	s := newMemSuite(t, nil)
+	const partition = 0
+	indexed := s.db.WriteProfileSymbols(partition, p)
+	pr, err := s.db.Partition(context.Background(), partition)
+	require.NoError(t, err)
+	appender := NewSampleAppender()
+	for _, ip := range indexed {
+		appender.AppendMany(ip.Samples.StacktraceIDs, ip.Samples.Values)
+	}
+	return pr.Symbols(), appender
+}
+
+// collectStacks captures every (leaf-first stack, self) pair IterateStacks
+// visits, cloning the stack slice since IterateStacks reuses its buffer.
+func collectStacks(tree *model.LocationRefNameTree) (stacks [][]model.LocationRefName, selves []int64) {
+	tree.IterateStacks(func(_ model.LocationRefName, self int64, stack []model.LocationRefName) {
+		stacks = append(stacks, append([]model.LocationRefName{}, stack...))
+		selves = append(selves, self)
+	})
+	return stacks, selves
+}
+
+// TestSymbols_SymbolRefTree_LinedAndUnresolved covers a stack that mixes a
+// lined (resolved) frame, an unresolved line-less frame with a real,
+// unambiguous mapping, and a genuine no-mapping (kernel/JIT) frame.
+func TestSymbols_SymbolRefTree_LinedAndUnresolved(t *testing.T) {
+	p := &profilev1.Profile{
+		StringTable: []string{"", "main", "libB.so", "bidB"},
+		Mapping: []*profilev1.Mapping{
+			{Id: 1}, // occupies symdb index 0; unused by any line-less location.
+			{Id: 2, Filename: 2, BuildId: 3},
+		},
+		Function: []*profilev1.Function{
+			{Id: 1, Name: 1},
+		},
+		Location: []*profilev1.Location{
+			{Id: 1, MappingId: 1, Line: []*profilev1.Line{{FunctionId: 1}}}, // main, lined
+			{Id: 2, MappingId: 2, Address: 0x2000},                          // unresolved, real mapping
+			{Id: 3, MappingId: 0, Address: 0xdeadbeef},                      // kernel/JIT, no mapping
+		},
+		Sample: []*profilev1.Sample{
+			// leaf-first: kernel/JIT frame, then the unresolved lib frame, then main at the root.
+			{LocationId: []uint64{3, 2, 1}, Value: []int64{42}},
+		},
+		SampleType: []*profilev1.ValueType{{Type: 0, Unit: 0}},
+	}
+	symbols, appender := symbolsForProfile(t, p)
+	table := symbolref.NewTable()
+
+	tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, nil), table, newUnresolvedCap(0))
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), tree.Total())
+
+	stacks, selves := collectStacks(tree)
+	require.Len(t, stacks, 1)
+	require.Len(t, stacks[0], 3)
+	assert.Equal(t, int64(42), selves[0])
+	kernelRef, unresolvedRef, mainRef := stacks[0][0], stacks[0][1], stacks[0][2]
+
+	rb := table.ResultBuilder()
+	mainIdx := rb.KeepRef(mainRef)
+	kernelIdx := rb.KeepRef(kernelRef)
+	rb.KeepRef(unresolvedRef)
+	pb := &queryv1.SymbolRefTable{}
+	rb.Build(pb)
+
+	assert.Equal(t, "main", pb.Names[mainIdx])
+	assert.Equal(t, strconv.FormatInt(0xdeadbeef, 16), pb.Names[kernelIdx])
+
+	unresolved := symbolref.UnresolvedBinaries(pb)
+	require.Len(t, unresolved, 1)
+	assert.Equal(t, "bidB", unresolved[0].BuildID)
+	assert.Equal(t, "libB.so", unresolved[0].BinaryName)
+	assert.Equal(t, []uint64{0x2000}, unresolved[0].Addresses)
+}
+
+// TestSymbols_SymbolRefTree_FirstMappingResolves covers the case the old
+// MappingId==0 special-case silently broke: a line-less location on the
+// partition's first mapping (symdb index 0, a real mapping with a build ID)
+// must reach InternUnresolved and be symbolizable, not render as bare hex.
+// This is the common single-mapping native-profile shape.
+//
+// It also documents the residual limitation of gating on the build ID: a
+// genuine no-mapping (kernel/JIT) location shares symdb index 0 with the
+// first real mapping, so it is attributed to that mapping's build ID and
+// falls back at resolve time (wrong binary name) rather than staying bare
+// hex. Fully disambiguating the two would need a write-side change to
+// reserve index 0; this read-side fix trades a rare, gracefully-degrading
+// misattribution for correct symbolization of the common case. See
+// SymbolRefTree's doc comment.
+func TestSymbols_SymbolRefTree_FirstMappingResolves(t *testing.T) {
+	p := &profilev1.Profile{
+		StringTable: []string{"", "libA.so", "bidA"},
+		Mapping: []*profilev1.Mapping{
+			{Id: 1, Filename: 1, BuildId: 2}, // symdb index 0: a real, resolvable mapping.
+		},
+		Location: []*profilev1.Location{
+			{Id: 1, MappingId: 1, Address: 0x1234}, // line-less, on the first mapping (index 0).
+		},
+		Sample: []*profilev1.Sample{
+			{LocationId: []uint64{1}, Value: []int64{1}},
+		},
+		SampleType: []*profilev1.ValueType{{Type: 0, Unit: 0}},
+	}
+	symbols, appender := symbolsForProfile(t, p)
+	table := symbolref.NewTable()
+
+	tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, nil), table, newUnresolvedCap(0))
+	require.NoError(t, err)
+
+	rb := table.ResultBuilder()
+	stacks, _ := collectStacks(tree)
+	require.Len(t, stacks, 1)
+	require.Len(t, stacks[0], 1)
+	rb.KeepRef(stacks[0][0])
+	pb := &queryv1.SymbolRefTable{}
+	rb.Build(pb)
+
+	unresolved := symbolref.UnresolvedBinaries(pb)
+	require.Len(t, unresolved, 1, "a line-less location on the first mapping must be symbolizable, not bare hex")
+	assert.Equal(t, "bidA", unresolved[0].BuildID)
+	assert.Equal(t, "libA.so", unresolved[0].BinaryName)
+	assert.Equal(t, []uint64{0x1234}, unresolved[0].Addresses)
+	assert.Empty(t, pb.Names, "nothing should render as a bare hex name")
+}
+
+// TestSymbols_SymbolRefTree_NoBuildIDRendersHex covers a line-less location
+// whose mapping carries no build ID (a binary with no GNU build ID, or a
+// genuine no-mapping frame indexing a build-ID-less mapping): it cannot be
+// symbolized and renders as the bare hex address via InternName, matching
+// the legacy path, which leaves such locations unsymbolized.
+func TestSymbols_SymbolRefTree_NoBuildIDRendersHex(t *testing.T) {
+	p := &profilev1.Profile{
+		StringTable: []string{""},
+		Mapping: []*profilev1.Mapping{
+			{Id: 1}, // symdb index 0: no filename, no build ID.
+		},
+		Location: []*profilev1.Location{
+			{Id: 1, MappingId: 1, Address: 0xdeadbeef},
+		},
+		Sample: []*profilev1.Sample{
+			{LocationId: []uint64{1}, Value: []int64{1}},
+		},
+		SampleType: []*profilev1.ValueType{{Type: 0, Unit: 0}},
+	}
+	symbols, appender := symbolsForProfile(t, p)
+	table := symbolref.NewTable()
+
+	tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, nil), table, newUnresolvedCap(0))
+	require.NoError(t, err)
+
+	rb := table.ResultBuilder()
+	stacks, _ := collectStacks(tree)
+	require.Len(t, stacks, 1)
+	require.Len(t, stacks[0], 1)
+	rb.KeepRef(stacks[0][0])
+	pb := &queryv1.SymbolRefTable{}
+	rb.Build(pb)
+
+	assert.Empty(t, symbolref.UnresolvedBinaries(pb), "a mapping with no build ID is not symbolizable")
+	assert.Contains(t, pb.Names, strconv.FormatInt(0xdeadbeef, 16), "renders as the bare hex address")
+}
+
+// TestResolver_SymbolRefTree_MultiPartitionRefConsistency verifies that the
+// same resolved name and the same unresolved (build ID, address) pair,
+// interned from two different partitions, land on the same symbolref.Table
+// ref and merge into a single tree node rather than two siblings.
+func TestResolver_SymbolRefTree_MultiPartitionRefConsistency(t *testing.T) {
+	newPartitionProfile := func(mainValue, unresolvedValue int64) *profilev1.Profile {
+		return &profilev1.Profile{
+			StringTable: []string{"", "main", "libshared.so", "bid-shared"},
+			Mapping: []*profilev1.Mapping{
+				{Id: 1}, // dummy, occupies symdb index 0.
+				{Id: 2, Filename: 2, BuildId: 3},
+			},
+			Function: []*profilev1.Function{
+				{Id: 1, Name: 1},
+			},
+			Location: []*profilev1.Location{
+				{Id: 1, MappingId: 1, Line: []*profilev1.Line{{FunctionId: 1}}},
+				{Id: 2, MappingId: 2, Address: 0x9000},
+			},
+			Sample: []*profilev1.Sample{
+				{LocationId: []uint64{1}, Value: []int64{mainValue}},
+				{LocationId: []uint64{2}, Value: []int64{unresolvedValue}},
+			},
+			SampleType: []*profilev1.ValueType{{Type: 0, Unit: 0}},
+		}
+	}
+
+	s := newMemSuite(t, nil)
+	indexed0 := s.db.WriteProfileSymbols(0, newPartitionProfile(10, 5))
+	indexed1 := s.db.WriteProfileSymbols(1, newPartitionProfile(20, 7))
+
+	r := NewResolver(context.Background(), s.db)
+	defer r.Release()
+	r.AddSamples(0, indexed0[0].Samples)
+	r.AddSamples(1, indexed1[0].Samples)
+
+	tree, rb, exceeded, err := r.SymbolRefTree()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), exceeded)
+	assert.Equal(t, int64(42), tree.Total())
+
+	stacks, selves := collectStacks(tree)
+	require.Len(t, stacks, 2, "same-content frames from both partitions must coalesce into one node each, not one per partition")
+
+	total := make(map[model.LocationRefName]int64, 2)
+	for i, s := range stacks {
+		require.Len(t, s, 1)
+		total[s[0]] += selves[i]
+	}
+	var mainSelf, unresolvedSelf int64
+	var mainRef, unresolvedRef model.LocationRefName
+	for ref, v := range total {
+		if ref >= 0 {
+			mainSelf, mainRef = v, ref
+		} else {
+			unresolvedSelf, unresolvedRef = v, ref
+		}
+	}
+	assert.Equal(t, int64(30), mainSelf)
+	assert.Equal(t, int64(12), unresolvedSelf)
+
+	pb := &queryv1.SymbolRefTable{}
+	mainIdx := rb.KeepRef(mainRef)
+	rb.KeepRef(unresolvedRef)
+	rb.Build(pb)
+	assert.Equal(t, "main", pb.Names[mainIdx])
+	unresolved := symbolref.UnresolvedBinaries(pb)
+	require.Len(t, unresolved, 1)
+	assert.Equal(t, "bid-shared", unresolved[0].BuildID)
+	assert.Equal(t, []uint64{0x9000}, unresolved[0].Addresses)
+}
+
+// TestResolver_SymbolRefTree_UnresolvedCapExceeded verifies the cap-overflow
+// guardrail: once WithResolverSymbolRefCap's limit is reached, further
+// distinct unresolved locations render as an inline fallback name instead
+// of growing the table, no error is returned, and no sample is lost.
+func TestResolver_SymbolRefTree_UnresolvedCapExceeded(t *testing.T) {
+	const distinctAddresses = 5
+	const refCap = 2
+
+	locs := make([]*profilev1.Location, 0, distinctAddresses)
+	samples := make([]*profilev1.Sample, 0, distinctAddresses)
+	var wantTotal int64
+	for i := 0; i < distinctAddresses; i++ {
+		addr := uint64(0x1000 * (i + 1))
+		locs = append(locs, &profilev1.Location{Id: uint64(i + 1), MappingId: 2, Address: addr})
+		samples = append(samples, &profilev1.Sample{LocationId: []uint64{uint64(i + 1)}, Value: []int64{int64(i + 1)}})
+		wantTotal += int64(i + 1)
+	}
+	p := &profilev1.Profile{
+		StringTable: []string{"", "libshared.so", "bid-shared"},
+		Mapping: []*profilev1.Mapping{
+			{Id: 1}, // dummy, occupies symdb index 0.
+			{Id: 2, Filename: 1, BuildId: 2},
+		},
+		Location:   locs,
+		Sample:     samples,
+		SampleType: []*profilev1.ValueType{{Type: 0, Unit: 0}},
+	}
+
+	s := newMemSuite(t, nil)
+	indexed := s.db.WriteProfileSymbols(0, p)
+	r := NewResolver(context.Background(), s.db, WithResolverSymbolRefCap(refCap))
+	defer r.Release()
+	r.AddSamples(0, indexed[0].Samples)
+
+	tree, rb, exceeded, err := r.SymbolRefTree()
+	require.NoError(t, err)
+	assert.Equal(t, int64(distinctAddresses-refCap), exceeded)
+	assert.Equal(t, wantTotal, tree.Total(), "no sample is dropped once the cap is exceeded")
+
+	stacks, _ := collectStacks(tree)
+	for _, s := range stacks {
+		require.Len(t, s, 1)
+		rb.KeepRef(s[0])
+	}
+	pb := &queryv1.SymbolRefTable{}
+	rb.Build(pb)
+	unresolved := symbolref.UnresolvedBinaries(pb)
+	require.Len(t, unresolved, 1)
+	assert.Len(t, unresolved[0].Addresses, refCap, "only the first refCap distinct addresses are actually interned as unresolved")
+}
+
+// TestSymbols_SymbolRefTree_StackTraceSelector verifies call-site selection
+// is respected: SymbolRefTree must not silently ignore a
+// StackTraceSelector configured on the Resolver it shares state with.
+func TestSymbols_SymbolRefTree_StackTraceSelector(t *testing.T) {
+	p := &profilev1.Profile{
+		StringTable: []string{"", "main", "helper", "other"},
+		Mapping:     []*profilev1.Mapping{{Id: 1}},
+		Function: []*profilev1.Function{
+			{Id: 1, Name: 1},
+			{Id: 2, Name: 2},
+			{Id: 3, Name: 3},
+		},
+		Location: []*profilev1.Location{
+			{Id: 1, MappingId: 1, Line: []*profilev1.Line{{FunctionId: 1}}},
+			{Id: 2, MappingId: 1, Line: []*profilev1.Line{{FunctionId: 2}}},
+			{Id: 3, MappingId: 1, Line: []*profilev1.Line{{FunctionId: 3}}},
+		},
+		Sample: []*profilev1.Sample{
+			{LocationId: []uint64{2, 1}, Value: []int64{5}}, // main -> helper
+			{LocationId: []uint64{3}, Value: []int64{7}},    // other, unrelated root
+		},
+		SampleType: []*profilev1.ValueType{{Type: 0, Unit: 0}},
+	}
+	symbols, appender := symbolsForProfile(t, p)
+
+	t.Run("matching selector keeps only the selected subtree", func(t *testing.T) {
+		sts := &typesv1.StackTraceSelector{CallSite: []*typesv1.Location{{Name: "main"}}}
+		table := symbolref.NewTable()
+		tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, sts), table, newUnresolvedCap(0))
+		require.NoError(t, err)
+		assert.Equal(t, int64(5), tree.Total())
+	})
+
+	t.Run("non-matching selector yields an empty tree without error", func(t *testing.T) {
+		sts := &typesv1.StackTraceSelector{CallSite: []*typesv1.Location{{Name: "no-such-function"}}}
+		table := symbolref.NewTable()
+		tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, sts), table, newUnresolvedCap(0))
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), tree.Total())
+	})
+}
+
+// TestSymbols_SymbolRefTree_UnresolvableStacktrace covers
+// StacktraceResolver's documented contract that an unresolvable stacktrace
+// resolves to zero locations: SymbolRefTree must return an empty tree, not
+// panic or error.
+func TestSymbols_SymbolRefTree_UnresolvableStacktrace(t *testing.T) {
+	p := &profilev1.Profile{
+		StringTable: []string{""},
+		Mapping:     []*profilev1.Mapping{{Id: 1}},
+		Sample:      []*profilev1.Sample{{LocationId: nil, Value: []int64{1}}},
+		SampleType:  []*profilev1.ValueType{{Type: 0, Unit: 0}},
+	}
+	symbols, appender := symbolsForProfile(t, p)
+	table := symbolref.NewTable()
+	tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, nil), table, newUnresolvedCap(0))
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), tree.Total())
+}

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
@@ -364,3 +364,15 @@ func TestSymbols_SymbolRefTree_UnresolvableStacktrace(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), tree.Total())
 }
+
+// The exceeded count is occurrences, not distinct pairs: capped pairs are
+// not recorded (that would grow memory without bound), so each recurrence
+// counts.
+func TestUnresolvedCap_ExceededCountsOccurrences(t *testing.T) {
+	c := newUnresolvedCap(1)
+	assert.True(t, c.allow("bid", 0x1))
+	assert.True(t, c.allow("bid", 0x1), "an interned pair stays allowed after the cap fills")
+	assert.False(t, c.allow("bid", 0x2))
+	assert.False(t, c.allow("bid", 0x2))
+	assert.Equal(t, int64(2), c.exceededCount())
+}

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
@@ -2,7 +2,6 @@ package symdb
 
 import (
 	"context"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -86,7 +85,8 @@ func TestSymbols_SymbolRefTree_LinedAndUnresolved(t *testing.T) {
 	rb.Build(pb)
 
 	assert.Equal(t, "main", pb.Names[mainIdx])
-	assert.Equal(t, strconv.FormatInt(0xdeadbeef, 16), pb.Names[kernelIdx])
+	assert.Equal(t, ".!0xdeadbeef", pb.Names[kernelIdx],
+		`legacy-parity fallback; "." is filepath.Base of the filename-less mapping the no-mapping frame indexes`)
 
 	unresolved := symbolref.UnresolvedBinaries(pb)
 	require.Len(t, unresolved, 1)
@@ -147,22 +147,25 @@ func TestSymbols_SymbolRefTree_FirstMappingResolves(t *testing.T) {
 	assert.Equal(t, []string{""}, pb.Names, "nothing should render as a bare hex name")
 }
 
-// TestSymbols_SymbolRefTree_NoBuildIDRendersHex covers a line-less location
-// whose mapping carries no build ID (a binary with no GNU build ID, or a
-// genuine no-mapping frame indexing a build-ID-less mapping): it cannot be
-// symbolized and renders as the bare hex address via InternName, matching
-// the legacy path, which leaves such locations unsymbolized.
-func TestSymbols_SymbolRefTree_NoBuildIDRendersHex(t *testing.T) {
+// TestSymbols_SymbolRefTree_NoBuildIDRendersFallback covers line-less
+// locations whose mapping carries no build ID (a binary with no GNU build
+// ID, or a genuine no-mapping frame indexing a build-ID-less mapping): they
+// cannot be symbolized, are not interned as unresolved, and render the same
+// fallback name the legacy symbolizer gives unresolvable frames — keeping
+// the binary-name context when the mapping has a filename.
+func TestSymbols_SymbolRefTree_NoBuildIDRendersFallback(t *testing.T) {
 	p := &profilev1.Profile{
-		StringTable: []string{""},
+		StringTable: []string{"", "/usr/bin/goldpinger"},
 		Mapping: []*profilev1.Mapping{
-			{Id: 1}, // symdb index 0: no filename, no build ID.
+			{Id: 1, Filename: 1}, // filename, no build ID: e.g. a Go binary without a GNU build ID.
+			{Id: 2},              // neither filename nor build ID.
 		},
 		Location: []*profilev1.Location{
 			{Id: 1, MappingId: 1, Address: 0xdeadbeef},
+			{Id: 2, MappingId: 2, Address: 0x1111},
 		},
 		Sample: []*profilev1.Sample{
-			{LocationId: []uint64{1}, Value: []int64{1}},
+			{LocationId: []uint64{2, 1}, Value: []int64{1}},
 		},
 		SampleType: []*profilev1.ValueType{{Type: 0, Unit: 0}},
 	}
@@ -175,13 +178,18 @@ func TestSymbols_SymbolRefTree_NoBuildIDRendersHex(t *testing.T) {
 	rb := table.ResultBuilder()
 	stacks, _ := collectStacks(tree)
 	require.Len(t, stacks, 1)
-	require.Len(t, stacks[0], 1)
+	require.Len(t, stacks[0], 2)
 	rb.KeepRef(stacks[0][0])
+	rb.KeepRef(stacks[0][1])
 	pb := &queryv1.SymbolRefTable{}
 	rb.Build(pb)
 
 	assert.Empty(t, symbolref.UnresolvedBinaries(pb), "a mapping with no build ID is not symbolizable")
-	assert.Contains(t, pb.Names, strconv.FormatInt(0xdeadbeef, 16), "renders as the bare hex address")
+	assert.Contains(t, pb.Names, "goldpinger!0xdeadbeef", "keeps the binary-name context, like the legacy fallback")
+	assert.Contains(t, pb.Names, ".!0x1111",
+		`empty filename: "." is filepath.Base(""), byte-for-byte with the legacy fallback derivation`)
+	assert.NotContains(t, pb.Names, "deadbeef", "no bare-hex names")
+	assert.NotContains(t, pb.Names, "1111", "no bare-hex names")
 }
 
 // TestResolver_SymbolRefTree_MultiPartitionRefConsistency verifies that the

--- a/pkg/querybackend/query_tree.go
+++ b/pkg/querybackend/query_tree.go
@@ -196,7 +196,7 @@ func queryTree(q *queryContext, query *queryv1.Query) (*queryv1.Report, error) {
 	// for: keep the existing FunctionName path unconditionally, same as a
 	// non-symbol-ref query.
 	if mode == queryv1.SymbolMode_SYMBOL_MODE_REFS && datasetUnsymbolized(q.obj.Metadata(), q.ds.Metadata()) {
-		return queryTreeSymbolRefs(q, query, resolver)
+		return queryTreeSymbolRefs(query, resolver)
 	}
 
 	tree, err := resolver.Tree()
@@ -219,7 +219,7 @@ func queryTree(q *queryContext, query *queryv1.Query) (*queryv1.Report, error) {
 // the selected samples actually resolved to an unresolved location, the
 // dataset falls back to the plain FunctionName path, since there is
 // nothing left to defer.
-func queryTreeSymbolRefs(q *queryContext, query *queryv1.Query, resolver *symdb.Resolver) (*queryv1.Report, error) {
+func queryTreeSymbolRefs(query *queryv1.Query, resolver *symdb.Resolver) (*queryv1.Report, error) {
 	tree, rb, err := resolver.SymbolRefTree()
 	if err != nil {
 		return nil, err
@@ -310,6 +310,8 @@ func (a *treeAggregator) aggregate(report *queryv1.Report) error {
 			// A partial from a dataset that took the plain FunctionName
 			// path (native or degenerate, see queryTree): absorb it into
 			// the shared ref space instead of merging it as a plain tree.
+			// Absorption interns resolved names only, so it cannot grow
+			// the unresolved count.
 			absorbed, err := absorbPlainTree(a.symbolRefTable, r.Tree)
 			if err != nil {
 				return err
@@ -319,6 +321,9 @@ func (a *treeAggregator) aggregate(report *queryv1.Report) error {
 		}
 		remap, err := a.symbolRefTable.Add(r.SymbolRefs)
 		if err != nil {
+			return err
+		}
+		if err := a.checkUnresolvedLimit(); err != nil {
 			return err
 		}
 		return a.symbolRefTree.MergeTreeBytes(r.Tree, model.WithTreeMergeFormatNodeNames(remap))
@@ -346,6 +351,21 @@ func (a *treeAggregator) aggregate(report *queryv1.Report) error {
 		})
 		return a.tree.MergeTreeBytes(r.Tree)
 	}
+}
+
+// checkUnresolvedLimit fails the query once the merged table's distinct
+// unresolved locations exceed the query's limit: aggregation memory is
+// bounded by the same per-tenant knob that bounds each dataset's build
+// (see symdb.WithResolverSymbolRefCap).
+func (a *treeAggregator) checkUnresolvedLimit() error {
+	limit := a.query.GetMaxUnresolvedLocations()
+	if limit <= 0 {
+		return nil
+	}
+	if n := a.symbolRefTable.UnresolvedCount(); int64(n) > limit {
+		return fmt.Errorf("%w (limit %d)", symdb.ErrTooManyUnresolvedLocations, limit)
+	}
+	return nil
 }
 
 func (a *treeAggregator) build() *queryv1.Report {
@@ -417,53 +437,25 @@ func absorbPlainTree(dst *symbolref.Table, plainTreeBytes []byte) (*model.Locati
 	return absorbed, nil
 }
 
-// stackToInsert is a root-first stack of table refs, paired with its self
-// value, collected from a tree so an intermediate ResultBuilder pass can
-// run before it is known how any given ref renders as a name.
-type stackToInsert struct {
-	self  int64
-	stack []model.LocationRefName
-}
-
-// locationRefTreeToFunctionNameTree converts tree into a FunctionNameTree,
-// resolving every ref through rb. The caller must ensure rb's table has no
-// unresolved entries reachable from tree: any such ref renders as the
-// empty string, since there is no name to fall back to. rb may already
-// have observed refs from an earlier KeepRef/Build pass (e.g. a prior
-// marshal of the same tree): KeepRef is idempotent, so this only adds to
-// rb's state, never invalidates it.
+// locationRefTreeToFunctionNameTree converts tree into a FunctionNameTree
+// in a single pass, resolving every ref to its display name through
+// rb.NameOf. The caller must ensure rb's table has no unresolved entries
+// reachable from tree; a violating ref still renders — as its
+// binary!0xaddr fallback — rather than dropping the frame.
 func locationRefTreeToFunctionNameTree(tree *model.LocationRefNameTree, rb *symbolref.ResultBuilder) *model.FunctionNameTree {
-	var stacks []stackToInsert
-	tree.IterateStacks(func(_ model.LocationRefName, self int64, stack []model.LocationRefName) {
-		cp := append([]model.LocationRefName(nil), stack...)
-		slices.Reverse(cp)
-		stacks = append(stacks, stackToInsert{self: self, stack: cp})
-	})
-
-	kept := make([][]model.LocationRefName, len(stacks))
-	for i, e := range stacks {
-		k := make([]model.LocationRefName, len(e.stack))
-		for j, ref := range e.stack {
-			k[j] = rb.KeepRef(ref)
-		}
-		kept[i] = k
-	}
-	pb := new(queryv1.SymbolRefTable)
-	rb.Build(pb)
-
 	out := new(model.FunctionNameTree)
-	for i, e := range stacks {
-		names := make([]model.FunctionName, len(e.stack))
-		for j, ref := range e.stack {
-			if ref == model.OtherLocationRef {
-				names[j] = model.OtherFunctionName
-				continue
-			}
-			if idx := kept[i][j]; idx >= 0 && int(idx) < len(pb.Names) {
-				names[j] = model.FunctionName(pb.Names[idx])
+	var names []model.FunctionName
+	tree.IterateStacks(func(_ model.LocationRefName, self int64, stack []model.LocationRefName) {
+		names = names[:0]
+		// stack is leaf-first; InsertStack wants root-first.
+		for i := len(stack) - 1; i >= 0; i-- {
+			if stack[i] == model.OtherLocationRef {
+				names = append(names, model.OtherFunctionName)
+			} else {
+				names = append(names, model.FunctionName(rb.NameOf(stack[i])))
 			}
 		}
-		out.InsertStack(e.self, names...)
-	}
+		out.InsertStack(self, names...)
+	})
 	return out
 }

--- a/pkg/querybackend/query_tree.go
+++ b/pkg/querybackend/query_tree.go
@@ -2,6 +2,7 @@ package querybackend
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 
@@ -9,9 +10,12 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
 	"github.com/grafana/pyroscope/v2/pkg/block"
+	"github.com/grafana/pyroscope/v2/pkg/block/metadata"
 	"github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/model/symbolref"
 	parquetquery "github.com/grafana/pyroscope/v2/pkg/phlaredb/query"
 	v1 "github.com/grafana/pyroscope/v2/pkg/phlaredb/schemas/v1"
 	"github.com/grafana/pyroscope/v2/pkg/phlaredb/symdb"
@@ -47,10 +51,9 @@ func treeSymbolMode(t *queryv1.TreeQuery) (queryv1.SymbolMode, error) {
 	switch mode {
 	case queryv1.SymbolMode_SYMBOL_MODE_UNSPECIFIED:
 		return queryv1.SymbolMode_SYMBOL_MODE_NAME, nil
-	case queryv1.SymbolMode_SYMBOL_MODE_NAME, queryv1.SymbolMode_SYMBOL_MODE_FULL:
+	case queryv1.SymbolMode_SYMBOL_MODE_NAME, queryv1.SymbolMode_SYMBOL_MODE_FULL, queryv1.SymbolMode_SYMBOL_MODE_REFS:
 		return mode, nil
 	default:
-		// SYMBOL_MODE_REFS is schema-defined but not implemented here yet.
 		return 0, fmt.Errorf("unsupported symbol_mode %s", mode)
 	}
 }
@@ -128,6 +131,9 @@ func queryTree(q *queryContext, query *queryv1.Query) (*queryv1.Report, error) {
 	if query.Tree.StackTraceSelector != nil {
 		resolverOptions = append(resolverOptions, symdb.WithResolverStackTraceSelector(query.Tree.StackTraceSelector))
 	}
+	if mode == queryv1.SymbolMode_SYMBOL_MODE_REFS {
+		resolverOptions = append(resolverOptions, symdb.WithResolverSymbolRefCap(int(query.Tree.GetMaxUnresolvedLocations())))
+	}
 
 	profiles := parquetquery.NewRepeatedRowIterator(q.ctx, entries, q.ds.Profiles().RowGroups(), indices...)
 	defer runutil.CloseWithErrCapture(&err, profiles, "failed to close profile stream")
@@ -186,6 +192,13 @@ func queryTree(q *queryContext, query *queryv1.Query) (*queryv1.Report, error) {
 		return resp, nil
 	}
 
+	// A dataset not labeled unsymbolized has nothing to defer resolution
+	// for: keep the existing FunctionName path unconditionally, same as a
+	// non-symbol-ref query.
+	if mode == queryv1.SymbolMode_SYMBOL_MODE_REFS && datasetUnsymbolized(q.obj.Metadata(), q.ds.Metadata()) {
+		return queryTreeSymbolRefs(q, query, resolver)
+	}
+
 	tree, err := resolver.Tree()
 	if err != nil {
 		return nil, err
@@ -200,6 +213,69 @@ func queryTree(q *queryContext, query *queryv1.Query) (*queryv1.Report, error) {
 	return resp, nil
 }
 
+// queryTreeSymbolRefs builds the report for a dataset labeled unsymbolized:
+// the resolver defers resolution of frames it cannot symbolize locally into
+// a SymbolRefTable instead of dropping or approximating them. If none of
+// the selected samples actually resolved to an unresolved location, the
+// dataset falls back to the plain FunctionName path, since there is
+// nothing left to defer.
+func queryTreeSymbolRefs(q *queryContext, query *queryv1.Query, resolver *symdb.Resolver) (*queryv1.Report, error) {
+	tree, rb, err := resolver.SymbolRefTree()
+	if err != nil {
+		return nil, err
+	}
+
+	// tree.Bytes must run before rb.Build: Build only reports the refs
+	// KeepRef (invoked from Bytes as it marshals) has observed as reachable.
+	treeBytes := tree.Bytes(0, rb.KeepRef)
+	symbolRefs := new(queryv1.SymbolRefTable)
+	rb.Build(symbolRefs)
+
+	if len(symbolRefs.UnresolvedBuildId) == 0 {
+		// Labeled unsymbolized, but nothing the query selected actually
+		// resolved to an unresolved location (e.g. rollout skew, or a
+		// selector that only matched already-resolved stacks): convert back
+		// to a plain, truncatable FunctionName report via the same rb,
+		// rather than re-resolving the stack traces from scratch.
+		plain := locationRefTreeToFunctionNameTree(tree, rb)
+		return &queryv1.Report{
+			Tree: &queryv1.TreeReport{
+				Query: query.Tree.CloneVT(),
+				Tree:  plain.Bytes(query.Tree.GetMaxNodes(), nil),
+			},
+		}, nil
+	}
+
+	return &queryv1.Report{
+		Tree: &queryv1.TreeReport{
+			Query:      query.Tree.CloneVT(),
+			Tree:       treeBytes,
+			SymbolRefs: symbolRefs,
+		},
+	}, nil
+}
+
+// datasetUnsymbolized reports whether any of the dataset's label sets
+// carries __unsymbolized__="true". A compacted dataset accumulates the
+// label sets of all its sources, so every set must be checked, not just
+// the first.
+func datasetUnsymbolized(md *metastorev1.BlockMeta, ds *metastorev1.Dataset) bool {
+	pairs := metadata.LabelPairs(ds.Labels)
+	for pairs.Next() {
+		p := pairs.At()
+		for k := 0; k+1 < len(p); k += 2 {
+			n, v := p[k], p[k+1]
+			if n < 0 || int(n) >= len(md.StringTable) || v < 0 || int(v) >= len(md.StringTable) {
+				continue
+			}
+			if md.StringTable[n] == metadata.LabelNameUnsymbolized && md.StringTable[v] == "true" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 type treeAggregator struct {
 	init  sync.Once
 	mode  queryv1.SymbolMode
@@ -209,6 +285,9 @@ type treeAggregator struct {
 	lrTree       *model.TreeMerger[model.LocationRefName, model.LocationRefNameI]
 	symbolLock   sync.Mutex
 	symbolMerger *symdb.SymbolMerger
+
+	symbolRefTable *symbolref.Table
+	symbolRefTree  *model.TreeMerger[model.LocationRefName, model.LocationRefNameI]
 }
 
 func newTreeAggregator(*queryv1.InvokeRequest) aggregator { return new(treeAggregator) }
@@ -219,7 +298,32 @@ func (a *treeAggregator) aggregate(report *queryv1.Report) error {
 	if err != nil {
 		return err
 	}
-	if mode == queryv1.SymbolMode_SYMBOL_MODE_FULL {
+	switch mode {
+	case queryv1.SymbolMode_SYMBOL_MODE_REFS:
+		a.init.Do(func() {
+			a.mode = mode
+			a.symbolRefTable = symbolref.NewTable()
+			a.symbolRefTree = model.NewTreeMerger[model.LocationRefName, model.LocationRefNameI]()
+			a.query = r.Query.CloneVT()
+		})
+		if r.SymbolRefs == nil {
+			// A partial from a dataset that took the plain FunctionName
+			// path (native or degenerate, see queryTree): absorb it into
+			// the shared ref space instead of merging it as a plain tree.
+			absorbed, err := absorbPlainTree(a.symbolRefTable, r.Tree)
+			if err != nil {
+				return err
+			}
+			a.symbolRefTree.MergeTree(absorbed)
+			return nil
+		}
+		remap, err := a.symbolRefTable.Add(r.SymbolRefs)
+		if err != nil {
+			return err
+		}
+		return a.symbolRefTree.MergeTreeBytes(r.Tree, model.WithTreeMergeFormatNodeNames(remap))
+
+	case queryv1.SymbolMode_SYMBOL_MODE_FULL:
 		a.init.Do(func() {
 			a.mode = mode
 			a.lrTree = model.NewTreeMerger[model.LocationRefName, model.LocationRefNameI]()
@@ -233,14 +337,15 @@ func (a *treeAggregator) aggregate(report *queryv1.Report) error {
 			return err
 		}
 		return a.lrTree.MergeTreeBytes(r.Tree, model.WithTreeMergeFormatNodeNames(adder))
-	}
 
-	a.init.Do(func() {
-		a.mode = mode
-		a.tree = model.NewTreeMerger[model.FunctionName, model.FunctionNameI]()
-		a.query = r.Query.CloneVT()
-	})
-	return a.tree.MergeTreeBytes(r.Tree)
+	default:
+		a.init.Do(func() {
+			a.mode = mode
+			a.tree = model.NewTreeMerger[model.FunctionName, model.FunctionNameI]()
+			a.query = r.Query.CloneVT()
+		})
+		return a.tree.MergeTreeBytes(r.Tree)
+	}
 }
 
 func (a *treeAggregator) build() *queryv1.Report {
@@ -250,14 +355,115 @@ func (a *treeAggregator) build() *queryv1.Report {
 		},
 	}
 
-	if a.mode == queryv1.SymbolMode_SYMBOL_MODE_FULL {
+	switch a.mode {
+	case queryv1.SymbolMode_SYMBOL_MODE_REFS:
+		if !a.symbolRefTable.HasUnresolved() {
+			// Every partial absorbed cleanly (native datasets, or degenerate
+			// ones): there is nothing left to defer, so collapse back to a
+			// plain, truncatable FunctionName report instead of forcing the
+			// SymbolRefTable format on a query that never needed it. This
+			// keeps a symbol-ref query over an otherwise fully-symbolized
+			// tenant no more expensive than a plain one, and matches
+			// queryTree's own degenerate case (see queryTreeSymbolRefs).
+			plain := locationRefTreeToFunctionNameTree(a.symbolRefTree.Tree(), a.symbolRefTable.ResultBuilder())
+			result.Tree.Tree = plain.Bytes(a.query.GetMaxNodes(), nil)
+			return result
+		}
+		// A tree with unresolved entries must not be truncated before those
+		// are resolved: truncation is deferred to a later symbolref.Rebuild
+		// call, once resolution has happened.
+		rb := a.symbolRefTable.ResultBuilder()
+		result.Tree.Tree = a.symbolRefTree.Tree().Bytes(0, rb.KeepRef)
+		result.Tree.SymbolRefs = new(queryv1.SymbolRefTable)
+		rb.Build(result.Tree.SymbolRefs)
+		return result
+
+	case queryv1.SymbolMode_SYMBOL_MODE_FULL:
 		builder := a.symbolMerger.ResultBuilder()
 		result.Tree.Tree = a.lrTree.Tree().Bytes(a.query.GetMaxNodes(), builder.KeepSymbol)
 		result.Tree.Symbols = new(queryv1.TreeSymbols)
 		builder.Build(result.Tree.Symbols)
 		return result
-	}
 
-	result.Tree.Tree = a.tree.Tree().Bytes(a.query.GetMaxNodes(), nil)
-	return result
+	default:
+		result.Tree.Tree = a.tree.Tree().Bytes(a.query.GetMaxNodes(), nil)
+		return result
+	}
+}
+
+// absorbPlainTree unmarshals a plain FunctionNameTree and re-inserts every
+// stack into a LocationRefNameTree via dst.InternName. It maps
+// model.OtherFunctionName to model.OtherLocationRef directly rather than
+// through InternName, since both are the truncation sentinel in their
+// respective node-name spaces.
+func absorbPlainTree(dst *symbolref.Table, plainTreeBytes []byte) (*model.LocationRefNameTree, error) {
+	plain, err := model.UnmarshalTree[model.FunctionName, model.FunctionNameI](plainTreeBytes)
+	if err != nil {
+		return nil, err
+	}
+	absorbed := new(model.LocationRefNameTree)
+	plain.IterateStacks(func(_ model.FunctionName, self int64, stack []model.FunctionName) {
+		slices.Reverse(stack)
+		refs := make([]model.LocationRefName, len(stack))
+		for i, n := range stack {
+			if n == model.OtherFunctionName {
+				refs[i] = model.OtherLocationRef
+				continue
+			}
+			refs[i] = dst.InternName(string(n))
+		}
+		absorbed.InsertStack(self, refs...)
+	})
+	return absorbed, nil
+}
+
+// stackToInsert is a root-first stack of table refs, paired with its self
+// value, collected from a tree so an intermediate ResultBuilder pass can
+// run before it is known how any given ref renders as a name.
+type stackToInsert struct {
+	self  int64
+	stack []model.LocationRefName
+}
+
+// locationRefTreeToFunctionNameTree converts tree into a FunctionNameTree,
+// resolving every ref through rb. The caller must ensure rb's table has no
+// unresolved entries reachable from tree: any such ref renders as the
+// empty string, since there is no name to fall back to. rb may already
+// have observed refs from an earlier KeepRef/Build pass (e.g. a prior
+// marshal of the same tree): KeepRef is idempotent, so this only adds to
+// rb's state, never invalidates it.
+func locationRefTreeToFunctionNameTree(tree *model.LocationRefNameTree, rb *symbolref.ResultBuilder) *model.FunctionNameTree {
+	var stacks []stackToInsert
+	tree.IterateStacks(func(_ model.LocationRefName, self int64, stack []model.LocationRefName) {
+		cp := append([]model.LocationRefName(nil), stack...)
+		slices.Reverse(cp)
+		stacks = append(stacks, stackToInsert{self: self, stack: cp})
+	})
+
+	kept := make([][]model.LocationRefName, len(stacks))
+	for i, e := range stacks {
+		k := make([]model.LocationRefName, len(e.stack))
+		for j, ref := range e.stack {
+			k[j] = rb.KeepRef(ref)
+		}
+		kept[i] = k
+	}
+	pb := new(queryv1.SymbolRefTable)
+	rb.Build(pb)
+
+	out := new(model.FunctionNameTree)
+	for i, e := range stacks {
+		names := make([]model.FunctionName, len(e.stack))
+		for j, ref := range e.stack {
+			if ref == model.OtherLocationRef {
+				names[j] = model.OtherFunctionName
+				continue
+			}
+			if idx := kept[i][j]; idx >= 0 && int(idx) < len(pb.Names) {
+				names[j] = model.FunctionName(pb.Names[idx])
+			}
+		}
+		out.InsertStack(e.self, names...)
+	}
+	return out
 }

--- a/pkg/querybackend/query_tree_symbolref_test.go
+++ b/pkg/querybackend/query_tree_symbolref_test.go
@@ -1,0 +1,231 @@
+package querybackend
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+	"github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/model/symbolref"
+)
+
+// TestDatasetUnsymbolized covers datasetUnsymbolized's label-pair scanning,
+// including a compacted dataset that carries more than one label set.
+func TestDatasetUnsymbolized(t *testing.T) {
+	// index: 0="" 1="__unsymbolized__" 2="true" 3="other_label" 4="other_value"
+	md := &metastorev1.BlockMeta{
+		StringTable: []string{"", "__unsymbolized__", "true", "other_label", "other_value"},
+	}
+	tests := []struct {
+		name   string
+		labels []int32
+		want   bool
+	}{
+		{name: "no labels", labels: nil, want: false},
+		{name: "unrelated label only", labels: []int32{1, 3, 4}, want: false},
+		{name: "unsymbolized=true", labels: []int32{1, 1, 2}, want: true},
+		{
+			name:   "unsymbolized=true among other label sets (compacted dataset)",
+			labels: []int32{1, 3, 4, 1, 1, 2},
+			want:   true,
+		},
+		{
+			name:   "unsymbolized label name present but value is not true",
+			labels: []int32{1, 1, 3},
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds := &metastorev1.Dataset{Labels: tt.labels}
+			assert.Equal(t, tt.want, datasetUnsymbolized(md, ds))
+		})
+	}
+}
+
+// plainReport builds a symbol_refs-mode partial report that took the plain
+// FunctionName path (native dataset, or a degenerate labeled one): no
+// SymbolRefs, Tree bytes are a marshaled FunctionNameTree.
+func plainReport(maxNodes int64, stacks map[string]int64) *queryv1.Report {
+	tree := new(model.FunctionNameTree)
+	for stack, self := range stacks {
+		tree.InsertStack(self, model.FunctionName(stack))
+	}
+	return &queryv1.Report{
+		Tree: &queryv1.TreeReport{
+			Query: &queryv1.TreeQuery{SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_REFS, MaxNodes: maxNodes},
+			Tree:  tree.Bytes(0, nil),
+		},
+	}
+}
+
+// refReport builds a symbol_refs-mode partial report with a genuine
+// unresolved entry: a single-frame stack referencing (buildID, addr).
+func refReport(maxNodes int64, self int64, buildID, binaryName string, addr uint64) *queryv1.Report {
+	table := symbolref.NewTable()
+	ref := table.InternUnresolved(buildID, binaryName, addr)
+	tree := new(model.LocationRefNameTree)
+	tree.InsertStack(self, ref)
+	rb := table.ResultBuilder()
+	treeBytes := tree.Bytes(0, rb.KeepRef)
+	pb := new(queryv1.SymbolRefTable)
+	rb.Build(pb)
+	return &queryv1.Report{
+		Tree: &queryv1.TreeReport{
+			Query:      &queryv1.TreeQuery{SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_REFS, MaxNodes: maxNodes},
+			Tree:       treeBytes,
+			SymbolRefs: pb,
+		},
+	}
+}
+
+// aggregate runs every report through a fresh treeAggregator and returns
+// the built TreeReport.
+func aggregate(t *testing.T, reports ...*queryv1.Report) *queryv1.TreeReport {
+	t.Helper()
+	a := newTreeAggregator(&queryv1.InvokeRequest{}).(*treeAggregator)
+	for _, r := range reports {
+		require.NoError(t, a.aggregate(r))
+	}
+	return a.build().Tree
+}
+
+// buildSymbolRefs aggregates reports and unmarshals the result as a
+// LocationRefNameTree, asserting a SymbolRefTable is attached (i.e. the
+// merge still has something unresolved; see TestTreeAggregator_SymbolRefs_
+// AllPlain and _OtherPreservation for the opposite, collapsed-to-plain
+// case). Every tree here has gone through a real marshal (build always
+// calls Tree.Bytes), which always keeps ref 0 as a side effect of
+// marshaling the format's virtual root node: pb.Names[0] is therefore
+// always "", the reserved sentinel (see symbolref.NewTable's doc comment),
+// on top of whatever real names the test cares about.
+func buildSymbolRefs(t *testing.T, reports ...*queryv1.Report) (*queryv1.SymbolRefTable, *model.LocationRefNameTree) {
+	t.Helper()
+	report := aggregate(t, reports...)
+	require.NotNil(t, report.SymbolRefs)
+	require.NotEmpty(t, report.SymbolRefs.Names)
+	assert.Equal(t, "", report.SymbolRefs.Names[0], "index 0 is always the reserved sentinel")
+	tree, err := model.UnmarshalTree[model.LocationRefName, model.LocationRefNameI](report.Tree)
+	require.NoError(t, err)
+	return report.SymbolRefs, tree
+}
+
+// realNames returns pb.Names with the reserved index-0 sentinel dropped.
+func realNames(pb *queryv1.SymbolRefTable) []string {
+	return pb.Names[1:]
+}
+
+// namesByRef resolves a leaf's own ref (the name IterateStacks passes to
+// its callback) to its SymbolRefTable name, using placeholders for the
+// truncation sentinel and unresolved entries.
+func namesByRef(pb *queryv1.SymbolRefTable, ref model.LocationRefName) string {
+	switch {
+	case ref == model.OtherLocationRef:
+		return "<other>"
+	case ref >= 0 && int(ref) < len(pb.Names):
+		return pb.Names[ref]
+	default:
+		return "<unresolved>"
+	}
+}
+
+// TestTreeAggregator_SymbolRefs_AllPlain covers every partial taking the
+// plain FunctionName path: the merged table has nothing unresolved, so
+// build() collapses back to a plain, truncatable FunctionName report
+// instead of forcing the SymbolRefTable format on it.
+func TestTreeAggregator_SymbolRefs_AllPlain(t *testing.T) {
+	report := aggregate(t, plainReport(2, map[string]int64{
+		"f1": 50, "f2": 40, "f3": 30, "f4": 20, "f5": 10,
+	}))
+	require.Nil(t, report.SymbolRefs, "nothing unresolved: must not force the SymbolRefTable format")
+
+	tree, err := model.UnmarshalTree[model.FunctionName, model.FunctionNameI](report.Tree)
+	require.NoError(t, err)
+
+	var otherTotal, total int64
+	var distinctNames int
+	tree.IterateStacks(func(name model.FunctionName, self int64, _ []model.FunctionName) {
+		total += self
+		if name == model.OtherFunctionName {
+			otherTotal += self
+		} else {
+			distinctNames++
+		}
+	})
+	assert.Equal(t, int64(150), total, "total sample value must be preserved across truncation")
+	assert.LessOrEqual(t, distinctNames, 2, "maxNodes=2 must truncate for real once nothing is unresolved")
+	assert.Greater(t, otherTotal, int64(0), "the truncated nodes must be folded into the other bucket")
+}
+
+// TestTreeAggregator_SymbolRefs_AllRef covers every partial carrying a
+// genuine unresolved entry: build() must not truncate, regardless of
+// MaxNodes, since doing so would be unsound before resolution.
+func TestTreeAggregator_SymbolRefs_AllRef(t *testing.T) {
+	pb, tree := buildSymbolRefs(t,
+		refReport(2, 50, "buildA", "binA", 0x1000),
+		refReport(2, 40, "buildB", "binB", 0x2000),
+		refReport(2, 30, "buildC", "binC", 0x3000),
+	)
+
+	require.Len(t, pb.UnresolvedBuildId, 3, "maxNodes must not drop unresolved entries")
+	assert.Equal(t, int64(120), tree.Total())
+
+	var sawOther bool
+	tree.IterateStacks(func(name model.LocationRefName, _ int64, _ []model.LocationRefName) {
+		if name == model.OtherLocationRef {
+			sawOther = true
+		}
+	})
+	assert.False(t, sawOther, "a tree with unresolved entries must not be truncated")
+}
+
+// TestTreeAggregator_SymbolRefs_Mixed covers a query that spans datasets in
+// different states (rollout skew): some partials plain (native or
+// degenerate), some carrying genuine unresolved entries. Every partial's
+// value must be preserved in the merged tree, and truncation must stay
+// disabled because at least one unresolved entry survives.
+func TestTreeAggregator_SymbolRefs_Mixed(t *testing.T) {
+	pb, tree := buildSymbolRefs(t,
+		plainReport(1, map[string]int64{"main": 7}),
+		refReport(1, 4, "buildB", "binB", 0x9000),
+	)
+
+	require.Len(t, pb.UnresolvedBuildId, 1)
+	assert.Equal(t, []string{"main"}, realNames(pb))
+	assert.Equal(t, int64(11), tree.Total())
+
+	totals := make(map[string]int64)
+	tree.IterateStacks(func(name model.LocationRefName, self int64, _ []model.LocationRefName) {
+		totals[namesByRef(pb, name)] += self
+	})
+	assert.Equal(t, int64(7), totals["main"], "the plain partial's stack must survive absorption with its original value")
+	assert.Equal(t, int64(4), totals["<unresolved>"], "the ref partial's stack must survive the merge with its original value")
+}
+
+// TestTreeAggregator_SymbolRefs_OtherPreservation covers a plain partial
+// that already carries the truncation sentinel (model.OtherFunctionName,
+// "other"): absorption must map it to model.OtherLocationRef, and, since
+// nothing else in this merge is unresolved, build()'s conversion back to
+// FunctionName format must map OtherLocationRef back to OtherFunctionName,
+// never through an ordinary resolvable name.
+func TestTreeAggregator_SymbolRefs_OtherPreservation(t *testing.T) {
+	report := aggregate(t, plainReport(0, map[string]int64{
+		"main":                          5,
+		string(model.OtherFunctionName): 3,
+	}))
+	require.Nil(t, report.SymbolRefs)
+
+	tree, err := model.UnmarshalTree[model.FunctionName, model.FunctionNameI](report.Tree)
+	require.NoError(t, err)
+
+	var otherSelf int64
+	tree.IterateStacks(func(name model.FunctionName, self int64, _ []model.FunctionName) {
+		if name == model.OtherFunctionName {
+			otherSelf = self
+		}
+	})
+	assert.Equal(t, int64(3), otherSelf, "the sentinel's value must round-trip through OtherLocationRef and back")
+}

--- a/pkg/querybackend/query_tree_symbolref_test.go
+++ b/pkg/querybackend/query_tree_symbolref_test.go
@@ -10,6 +10,7 @@ import (
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
 	"github.com/grafana/pyroscope/v2/pkg/model"
 	"github.com/grafana/pyroscope/v2/pkg/model/symbolref"
+	"github.com/grafana/pyroscope/v2/pkg/phlaredb/symdb"
 )
 
 // TestDatasetUnsymbolized covers datasetUnsymbolized's label-pair scanning,
@@ -228,4 +229,35 @@ func TestTreeAggregator_SymbolRefs_OtherPreservation(t *testing.T) {
 		}
 	})
 	assert.Equal(t, int64(3), otherSelf, "the sentinel's value must round-trip through OtherLocationRef and back")
+}
+
+// TestTreeAggregator_SymbolRefs_UnresolvedLimit verifies the merged table's
+// distinct unresolved locations are bounded by the query's
+// max_unresolved_locations: aggregation fails once the limit is crossed,
+// while a merge exactly at the limit succeeds.
+func TestTreeAggregator_SymbolRefs_UnresolvedLimit(t *testing.T) {
+	reports := func(limit int64) []*queryv1.Report {
+		rs := []*queryv1.Report{
+			refReport(0, 1, "build-a", "bin-a", 0x100),
+			refReport(0, 2, "build-b", "bin-b", 0x200),
+		}
+		for _, r := range rs {
+			r.Tree.Query.MaxUnresolvedLocations = limit
+		}
+		return rs
+	}
+
+	t.Run("at the limit", func(t *testing.T) {
+		a := newTreeAggregator(&queryv1.InvokeRequest{}).(*treeAggregator)
+		for _, r := range reports(2) {
+			require.NoError(t, a.aggregate(r))
+		}
+	})
+
+	t.Run("past the limit", func(t *testing.T) {
+		a := newTreeAggregator(&queryv1.InvokeRequest{}).(*treeAggregator)
+		rs := reports(1)
+		require.NoError(t, a.aggregate(rs[0]))
+		require.ErrorIs(t, a.aggregate(rs[1]), symdb.ErrTooManyUnresolvedLocations)
+	})
 }

--- a/pkg/querybackend/query_tree_test.go
+++ b/pkg/querybackend/query_tree_test.go
@@ -195,6 +195,7 @@ func TestTreeSymbolMode(t *testing.T) {
 		{name: "unset defaults to name", query: &queryv1.TreeQuery{}, want: queryv1.SymbolMode_SYMBOL_MODE_NAME},
 		{name: "name", query: &queryv1.TreeQuery{SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_NAME}, want: queryv1.SymbolMode_SYMBOL_MODE_NAME},
 		{name: "full", query: &queryv1.TreeQuery{SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_FULL}, want: queryv1.SymbolMode_SYMBOL_MODE_FULL},
+		{name: "refs", query: &queryv1.TreeQuery{SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_REFS}, want: queryv1.SymbolMode_SYMBOL_MODE_REFS},
 		{
 			name:  "deprecated full_symbols maps to full",
 			query: &queryv1.TreeQuery{FullSymbols: true}, //nolint:staticcheck // exercises the deprecated bridge
@@ -204,11 +205,6 @@ func TestTreeSymbolMode(t *testing.T) {
 			name:    "full_symbols combined with symbol_mode is rejected",
 			query:   &queryv1.TreeQuery{FullSymbols: true, SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_FULL}, //nolint:staticcheck // exercises the deprecated bridge
 			wantErr: "must not be combined",
-		},
-		{
-			name:    "refs is not implemented yet",
-			query:   &queryv1.TreeQuery{SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_REFS},
-			wantErr: "unsupported symbol_mode",
 		},
 		{
 			name:    "unknown mode is rejected",
@@ -226,4 +222,55 @@ func TestTreeSymbolMode(t *testing.T) {
 			require.Equal(t, tc.want, mode)
 		})
 	}
+}
+
+// Test_QueryTree_SymbolModeConflict verifies that a query combining the
+// deprecated full_symbols bool with an explicit symbol_mode is rejected end
+// to end, rather than silently preferring one and dropping the other.
+func (s *testSuite) Test_QueryTree_SymbolModeConflict() {
+	_, err := s.reader.Invoke(s.ctx, &queryv1.InvokeRequest{
+		EndTime:       time.Now().UnixMilli(),
+		LabelSelector: "{}",
+		QueryPlan:     s.plan,
+		Query: []*queryv1.Query{{
+			QueryType: queryv1.QueryType_QUERY_TREE,
+			Tree:      &queryv1.TreeQuery{FullSymbols: true, SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_REFS}, //nolint:staticcheck // exercises the deprecated bridge
+		}},
+		Tenant: s.tenant,
+	})
+	s.Require().Error(err)
+	s.Assert().Contains(err.Error(), "full_symbols must not be combined with symbol_mode")
+}
+
+// Test_QueryTree_SymbolRefs_NativeDatasetKeepsPlainPath verifies that a
+// SYMBOL_MODE_REFS query against a dataset not labeled unsymbolized (every
+// dataset in the test fixtures) keeps today's FunctionName path exactly:
+// no SymbolRefTable is attached, and the tree matches a names-only query
+// byte for byte in structure (same totals, no TREE->PPROF detour).
+func (s *testSuite) Test_QueryTree_SymbolRefs_NativeDatasetKeepsPlainPath() {
+	invoke := func(mode queryv1.SymbolMode) *queryv1.TreeReport {
+		resp, err := s.reader.Invoke(s.ctx, &queryv1.InvokeRequest{
+			EndTime:       time.Now().UnixMilli(),
+			LabelSelector: "{}",
+			QueryPlan:     s.plan,
+			Query: []*queryv1.Query{{
+				QueryType: queryv1.QueryType_QUERY_TREE,
+				Tree:      &queryv1.TreeQuery{MaxNodes: 16, SymbolMode: mode},
+			}},
+			Tenant: s.tenant,
+		})
+		s.Require().NoError(err)
+		s.Require().Len(resp.Reports, 1)
+		return resp.Reports[0].Tree
+	}
+
+	plain := invoke(queryv1.SymbolMode_SYMBOL_MODE_NAME)
+	symbolRefs := invoke(queryv1.SymbolMode_SYMBOL_MODE_REFS)
+	s.Assert().Nil(symbolRefs.SymbolRefs, "a native dataset must not attach a SymbolRefTable")
+
+	plainTree, err := phlaremodel.UnmarshalTree[phlaremodel.FunctionName, phlaremodel.FunctionNameI](plain.Tree)
+	s.Require().NoError(err)
+	symbolRefsTree, err := phlaremodel.UnmarshalTree[phlaremodel.FunctionName, phlaremodel.FunctionNameI](symbolRefs.Tree)
+	s.Require().NoError(err)
+	s.Assert().Equal(plainTree.String(), symbolRefsTree.String())
 }

--- a/pkg/symbolizer/symbolizer.go
+++ b/pkg/symbolizer/symbolizer.go
@@ -23,6 +23,7 @@ import (
 	googlev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 	"github.com/grafana/pyroscope/lidia"
 	"github.com/grafana/pyroscope/v2/pkg/debuginfo"
+	"github.com/grafana/pyroscope/v2/pkg/model/symbolref"
 	"github.com/grafana/pyroscope/v2/pkg/objstore"
 )
 
@@ -570,13 +571,8 @@ func (s *Symbolizer) processELFData(data []byte, maxSize int64) (lidiaData []byt
 }
 
 func (s *Symbolizer) createFallbackSymbol(binaryName string, address uint64) []lidia.SourceInfoFrame {
-	prefix := "unknown"
-	if binaryName != "" {
-		prefix = binaryName
-	}
-
 	return []lidia.SourceInfoFrame{{
-		FunctionName: fmt.Sprintf("%s!0x%x", prefix, address),
+		FunctionName: symbolref.FallbackSymbolName(binaryName, address),
 		LineNumber:   0,
 	}}
 }


### PR DESCRIPTION
## Part of a series: symbol-aware tree references (4 of 6)

Full context and series overview: #5317 (PR 1). Compact map:

1. symbolizer: expose address-level `Resolve` API (#5317) — merged
2. proto: `SymbolRefTable` + `SymbolMode` tree query fields (#5318) — merged
3. `model/symbolref`: intern table + merge rebasing (#5321) — merged
4. **backend half: `model/symbolref` grouping + rebuild, symdb resolver, querybackend aggregation ← this PR**
5. frontend: orchestration behind a default-off per-tenant flag — nothing activates before this (#5334)
6. integration tests + docs (#5335)

Tracking issue: grafana/pyroscope-squad#487.

> **Note:** this PR consolidates what were previously three PRs (#5322, #5332, #5333) after
> feedback that the stack was too fine-grained to review. Commits remain separated per
> component for commit-by-commit review; earlier review discussion lives on the closed PRs.

## What

Everything the read path needs to *produce* symbol-ref trees, bottom to top. Nothing is
reachable until the frontend PR (#5334) wires it up behind the per-tenant flag.

**`pkg/model/symbolref` consumer half** (`unresolved.go`, `rebuild.go`):

- **`UnresolvedBinaries`** groups a table's unresolved references by build ID — one
  `UnresolvedBinary{BuildID, BinaryName, Addresses}` per distinct binary, addresses sorted and
  deduplicated, binary name carried for fallback rendering. Input is validated (paired-slice
  lengths, build-ID index range) before grouping; a single forward scan when the input follows
  the wire contract's ordering, with a defensive sort otherwise.
- **`Rebuild`** expands a merged reference tree back into a plain `FunctionName` tree:
  references resolve through a caller-supplied callback (memoized per distinct location within
  a call); multi-frame inline chains expand into that many tree levels (root-first); unresolved
  locations render the legacy `binary!0xaddr` fallback. Truncation happens exactly once, after
  every stack is expanded.

**symdb resolver output** (`Resolver.SymbolRefTree`):

A new output shape alongside `Tree`/`LocationRefNameTree`/`Pprof`. Locations with line info
contribute resolved frame names; line-less locations contribute unresolved
`{build ID, address}` references, carrying the mapping's binary name. A line-less location
without a build ID cannot be symbolized and renders the legacy `binary!0xaddr` fallback
inline. Trees build untruncated — truncation is deferred until after symbolization, since a
truncated-away unresolved node might merge with a kept one once resolved.

**querybackend production and aggregation**:

- **Per-dataset gating.** When a tree query requests `SYMBOL_MODE_REFS`, a dataset labeled
  `__unsymbolized__` at ingest builds a symbol-ref tree; an unlabeled, already-symbolized
  dataset keeps today's exact `FunctionName` path. The label is read from dataset metadata at
  query-execution time, so queryless queries routed through the tenant-wide index work too.
- **Content-driven collapse.** A labeled dataset (or a fully merged result) whose selected
  samples produced no unresolved locations converts back to a plain, truncatable tree — only
  data that actually needs symbolization pays the deferred-truncation cost.
- **Mixed-shape aggregation.** The aggregator merges partials of both shapes into one result:
  symbol-ref partials rebase their references through a shared table; plain partials are
  absorbed by interning their names, with the truncation "other" sentinel mapped explicitly.

No pprof detour is taken on any of these paths, so every tree-query selector (span, trace,
profile-ID, stack-trace) flows through unchanged.

## Bounding memory: the unresolved-locations limit

Deferred truncation must not mean unbounded memory. The query carries
`max_unresolved_locations` (stamped by the frontend from the per-tenant
`symbolizer.max-unresolved-locations` override, default 1,000,000; 0 disables), and the
backend enforces it **fail-fast at both levels**: each dataset's tree build stops at the cap
(`WithResolverSymbolRefCap`), and the aggregator re-checks the merged table after every
partial it absorbs. A query over the limit fails with `too many unresolved locations in
query` rather than degrading — a partial fallback rendering would keep growing the result
anyway and make output depend on merge order.

## Notes

- Call-site (`StackTraceSelector`) selection matches locally resolved names only, mirroring
  the `FunctionName` path: a stack whose match depends on a not-yet-symbolized frame is not
  selected. Called out in code; lifting it requires filtering after symbolization.
- The ingest rewrite assigns a partition's first mapping index 0 — the same value used for
  "no mapping" — so kernel/JIT frames and a line-less location on the first mapping are not
  always distinguishable. Documented and pinned by a test.

## Testing

`go test -race` green across `pkg/model/symbolref`, `pkg/phlaredb/symdb`, `pkg/querybackend`.
Coverage includes: grouping/rebuild round-trips with inline chains and malformed-input
validation; mixed lined/line-less fixtures; `MappingId==0` rendering; multi-partition
reference consistency; cap-overflow fail-fast at build and at merge; the dataset gate; the
aggregator across all-plain / all-ref / mixed / "other"-preservation; and a native-dataset
plain-path test on the real block fixture. `golangci-lint` clean; whole-repo build clean.
