### PR TITLE
feat(symdb): add symbol-ref tree resolver output

### DIFF
--- a/pkg/phlaredb/symdb/resolver.go
+++ b/pkg/phlaredb/symdb/resolver.go
@@ -78,9 +78,9 @@ func WithResolverSanitizeOnMerge(sanitizeOnMerge bool) ResolverOption {
 }
 
 // WithResolverSymbolRefCap bounds the number of distinct unresolved (build
-// ID, address) entries a single SymbolRefTree call interns; locations past
-// the cap render an inline fallback name instead (see unresolvedCap). Zero
-// (the default) means unlimited.
+// ID, address) entries a single SymbolRefTree call interns; a location
+// past the cap fails the call with ErrTooManyUnresolvedLocations (see
+// unresolvedCap). Zero (the default) means unlimited.
 func WithResolverSymbolRefCap(n int) ResolverOption {
 	return func(r *Resolver) {
 		r.symbolRefCap = n
@@ -322,12 +322,10 @@ func (r *Resolver) LocationRefNameTree() (*model.LocationRefNameTree, ResultBuil
 // entries must not be truncated before those entries are resolved, so,
 // unlike Tree/LocationRefNameTree, there is no maxNodes parameter.
 //
-// unresolvedCapExceeded counts location occurrences rendered as an inline
-// fallback name because the number of distinct unresolved entries reached
-// WithResolverSymbolRefCap — occurrences, not distinct locations, so a
-// recurring capped location counts every time (see unresolvedCap). The
-// call always succeeds and never drops samples.
-func (r *Resolver) SymbolRefTree() (tree *model.LocationRefNameTree, rb *symbolref.ResultBuilder, unresolvedCapExceeded int64, err error) {
+// The call fails with ErrTooManyUnresolvedLocations once the number of
+// distinct unresolved entries exceeds WithResolverSymbolRefCap; no partial
+// or mixed-representation result is ever returned.
+func (r *Resolver) SymbolRefTree() (tree *model.LocationRefNameTree, rb *symbolref.ResultBuilder, err error) {
 	span, ctx := tracing.StartSpanFromContext(r.ctx, "Resolver.SymbolRefTree")
 	defer span.Finish()
 	table := symbolref.NewTable()
@@ -345,7 +343,7 @@ func (r *Resolver) SymbolRefTree() (tree *model.LocationRefNameTree, rb *symbolr
 		return nil
 	})
 	tree.Total()
-	return tree, table.ResultBuilder(), capper.exceededCount(), err
+	return tree, table.ResultBuilder(), err
 }
 
 func (r *Resolver) Tree() (*model.FunctionNameTree, error) {

--- a/pkg/phlaredb/symdb/resolver.go
+++ b/pkg/phlaredb/symdb/resolver.go
@@ -322,10 +322,11 @@ func (r *Resolver) LocationRefNameTree() (*model.LocationRefNameTree, ResultBuil
 // entries must not be truncated before those entries are resolved, so,
 // unlike Tree/LocationRefNameTree, there is no maxNodes parameter.
 //
-// unresolvedCapExceeded counts locations that would have grown the number
-// of distinct unresolved entries past WithResolverSymbolRefCap; those
-// locations are rendered as an inline fallback name instead, so the call
-// always succeeds and never drops samples.
+// unresolvedCapExceeded counts location occurrences rendered as an inline
+// fallback name because the number of distinct unresolved entries reached
+// WithResolverSymbolRefCap — occurrences, not distinct locations, so a
+// recurring capped location counts every time (see unresolvedCap). The
+// call always succeeds and never drops samples.
 func (r *Resolver) SymbolRefTree() (tree *model.LocationRefNameTree, rb *symbolref.ResultBuilder, unresolvedCapExceeded int64, err error) {
 	span, ctx := tracing.StartSpanFromContext(r.ctx, "Resolver.SymbolRefTree")
 	defer span.Finish()

--- a/pkg/phlaredb/symdb/resolver.go
+++ b/pkg/phlaredb/symdb/resolver.go
@@ -13,6 +13,7 @@ import (
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	"github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/model/symbolref"
 	schemav1 "github.com/grafana/pyroscope/v2/pkg/phlaredb/schemas/v1"
 	"github.com/grafana/pyroscope/v2/pkg/pprof"
 	"github.com/grafana/pyroscope/v2/pkg/util"
@@ -39,6 +40,7 @@ type Resolver struct {
 	maxNodes        int64
 	sts             *typesv1.StackTraceSelector
 	sanitizeOnMerge bool
+	symbolRefCap    int
 }
 
 type ResolverOption func(*Resolver)
@@ -72,6 +74,16 @@ func WithResolverStackTraceSelector(sts *typesv1.StackTraceSelector) ResolverOpt
 func WithResolverSanitizeOnMerge(sanitizeOnMerge bool) ResolverOption {
 	return func(r *Resolver) {
 		r.sanitizeOnMerge = sanitizeOnMerge
+	}
+}
+
+// WithResolverSymbolRefCap bounds the number of distinct unresolved (build
+// ID, address) entries a single SymbolRefTree call interns; locations past
+// the cap render an inline fallback name instead (see unresolvedCap). Zero
+// (the default) means unlimited.
+func WithResolverSymbolRefCap(n int) ResolverOption {
+	return func(r *Resolver) {
+		r.symbolRefCap = n
 	}
 }
 
@@ -296,6 +308,43 @@ func (r *Resolver) LocationRefNameTree() (*model.LocationRefNameTree, ResultBuil
 	})
 	tree.Total()
 	return tree, sym.ResultBuilder(), err
+}
+
+// SymbolRefTree resolves the tree for all selected stack traces using a
+// symbolref.Table for node names: resolved frames are interned as names,
+// frames symdb cannot resolve locally are interned as (build ID, address)
+// pairs for deferred resolution (see Symbols.SymbolRefTree for the exact
+// per-location rules). The table is shared across every partition, so refs
+// are already in one namespace and need no merge-time remap, unlike
+// LocationRefNameTree's SymbolMerger/FormatNodeNames step.
+//
+// The tree is always built without truncation, since a tree with unresolved
+// entries must not be truncated before those entries are resolved, so,
+// unlike Tree/LocationRefNameTree, there is no maxNodes parameter.
+//
+// unresolvedCapExceeded counts locations that would have grown the number
+// of distinct unresolved entries past WithResolverSymbolRefCap; those
+// locations are rendered as an inline fallback name instead, so the call
+// always succeeds and never drops samples.
+func (r *Resolver) SymbolRefTree() (tree *model.LocationRefNameTree, rb *symbolref.ResultBuilder, unresolvedCapExceeded int64, err error) {
+	span, ctx := tracing.StartSpanFromContext(r.ctx, "Resolver.SymbolRefTree")
+	defer span.Finish()
+	table := symbolref.NewTable()
+	capper := newUnresolvedCap(r.symbolRefCap)
+	var lock sync.Mutex
+	tree = new(model.LocationRefNameTree)
+	err = r.withSymbols(ctx, func(symbols *Symbols, appender *SampleAppender) error {
+		resolved, err := symbols.SymbolRefTree(ctx, appender, SelectStackTraces(symbols, r.sts), table, capper)
+		if err != nil {
+			return err
+		}
+		lock.Lock()
+		tree.Merge(resolved)
+		lock.Unlock()
+		return nil
+	})
+	tree.Total()
+	return tree, table.ResultBuilder(), capper.exceededCount(), err
 }
 
 func (r *Resolver) Tree() (*model.FunctionNameTree, error) {

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree.go
@@ -1,0 +1,244 @@
+package symdb
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"sync"
+
+	"github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/model/symbolref"
+	schemav1 "github.com/grafana/pyroscope/v2/pkg/phlaredb/schemas/v1"
+)
+
+// SymbolRefTree resolves the tree for the samples in appender into a
+// model.LocationRefNameTree whose node names are refs into table.
+//
+// A location with lines is interned per line into table via InternName (one
+// intern per line, including inlined frames), exactly as addFunctionNames
+// does for the FunctionName tree.
+//
+// A line-less location needs symbolization: it is interned via
+// InternUnresolved, keyed on the (build ID, address) of its mapping. The
+// mapping is read by direct index into symbols.Mappings, exactly as
+// copyMappings (resolver_pprof.go) does — in this representation index 0
+// is a real mapping, not a "no mapping" sentinel, so it must not be
+// special-cased. A location whose mapping carries no build ID cannot be
+// symbolized (a genuine no-mapping kernel/JIT frame, or a binary with no
+// GNU build ID): it renders as the bare hex address via InternName,
+// matching the legacy path, which leaves such locations unsymbolized.
+//
+// capper bounds the number of distinct unresolved entries table accepts
+// for this call; locations past the cap render an inline fallback name via
+// InternName instead of InternUnresolved (see unresolvedCap).
+//
+// The tree is always built without truncation (maxNodes 0): a tree with
+// unresolved entries must not be truncated before those are resolved.
+func (r *Symbols) SymbolRefTree(
+	ctx context.Context,
+	appender *SampleAppender,
+	selection *SelectedStackTraces,
+	table *symbolref.Table,
+	capper *unresolvedCap,
+) (*model.LocationRefNameTree, error) {
+	if !selection.HasValidCallSite() {
+		return &model.LocationRefNameTree{}, nil
+	}
+	samples := appender.Samples()
+	b := newSymbolRefTreeBuilder(r, samples, selection, table, capper)
+	if err := r.Stacktraces.ResolveStacktraceLocations(ctx, b, samples.StacktraceIDs); err != nil {
+		return nil, err
+	}
+	return model.TreeFromStacktraceTree[model.LocationRefName, model.LocationRefNameI](b.tree, 0, b.lookup), nil
+}
+
+// unresolvedCap bounds the number of distinct (build ID, address) pairs a
+// single SymbolRefTree call interns as unresolved entries. Once the limit
+// is reached, further distinct pairs are rendered as an inline fallback
+// name instead of being interned, so a pathological input (e.g. a profile
+// referencing a huge number of distinct native addresses) can never make
+// the deferred-resolution work list unbounded, fail the query, or drop
+// samples. Safe for concurrent use.
+type unresolvedCap struct {
+	mu       sync.Mutex
+	max      int // <= 0 means unlimited.
+	seen     map[unresolvedCapKey]struct{}
+	exceeded int64
+}
+
+type unresolvedCapKey struct {
+	buildID string
+	addr    uint64
+}
+
+func newUnresolvedCap(max int) *unresolvedCap {
+	return &unresolvedCap{max: max, seen: make(map[unresolvedCapKey]struct{})}
+}
+
+// allow reports whether (buildID, addr) may be interned as an unresolved
+// entry: true if the cap is unlimited, the pair was already counted
+// before, or the cap has not been reached yet; false once the cap has been
+// reached for a pair not yet seen, incrementing the exceeded count.
+func (c *unresolvedCap) allow(buildID string, addr uint64) bool {
+	if c.max <= 0 {
+		return true
+	}
+	key := unresolvedCapKey{buildID, addr}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.seen[key]; ok {
+		return true
+	}
+	if len(c.seen) >= c.max {
+		c.exceeded++
+		return false
+	}
+	c.seen[key] = struct{}{}
+	return true
+}
+
+func (c *unresolvedCap) exceededCount() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.exceeded
+}
+
+// symbolRefTreeBuilder is a StacktraceInserter that interns every stack
+// frame directly into a shared symbolref.Table and accumulates the result
+// into an intermediate model.StacktraceTree.
+//
+// symbolref.Table refs can be negative (unresolved entries), but
+// model.StacktraceTree's Location field, and TreeFromStacktraceTree's
+// truncation-sentinel check in particular, treat any negative location as
+// the "other" truncation marker. slotOf/slots translate refs into a dense,
+// non-negative, per-builder "slot" space so the intermediate tree only
+// ever sees non-negative locations; lookup translates slots back into the
+// real (possibly negative) refs once the tree's final shape is known.
+type symbolRefTreeBuilder struct {
+	symbols *Symbols
+	samples *schemav1.Samples
+	table   *symbolref.Table
+	capper  *unresolvedCap
+	tree    *model.StacktraceTree
+	cur     int
+
+	refs  []int32 // per-stack ref buffer, as slots.
+	lines []int32 // per-stack string-table-index buffer; only used when funcNamesMatcher is set.
+
+	selection        *SelectedStackTraces
+	funcNamesMatcher func([]int32) bool
+
+	slotOf map[model.LocationRefName]int32
+	slots  []model.LocationRefName
+}
+
+func newSymbolRefTreeBuilder(
+	symbols *Symbols,
+	samples schemav1.Samples,
+	selection *SelectedStackTraces,
+	table *symbolref.Table,
+	capper *unresolvedCap,
+) *symbolRefTreeBuilder {
+	b := &symbolRefTreeBuilder{
+		symbols:   symbols,
+		samples:   &samples,
+		table:     table,
+		capper:    capper,
+		tree:      model.NewStacktraceTree(samples.Len() * 2),
+		selection: selection,
+		slotOf:    make(map[model.LocationRefName]int32),
+	}
+	if selection != nil && len(selection.callSite) > 0 {
+		b.funcNamesMatcher = b.funcNamesMatchSelection
+	}
+	return b
+}
+
+func (b *symbolRefTreeBuilder) InsertStacktrace(_ uint32, locations []int32) {
+	if b.funcNamesMatcher != nil {
+		b.lines = b.lines[:0]
+		for i := 0; i < len(locations); i++ {
+			b.lines = addFunctionNames(b.lines, locations[i], b.symbols)
+		}
+		if !b.funcNamesMatcher(b.lines) {
+			b.cur++
+			return
+		}
+	}
+	b.refs = b.refs[:0]
+	for i := 0; i < len(locations); i++ {
+		b.refs = b.appendLocationRefs(b.refs, locations[i])
+	}
+	b.tree.Insert(b.refs, int64(b.samples.Values[b.cur]))
+	b.cur++
+}
+
+// funcNamesMatchSelection mirrors treeSymbols.funcNamesMatchSelection
+// (resolver_tree.go): funcNames is leaf-first (addFunctionNames' order),
+// so the selector's call site (root-first) is checked against funcNames'
+// tail.
+func (b *symbolRefTreeBuilder) funcNamesMatchSelection(funcNames []int32) bool {
+	if len(funcNames) < int(b.selection.depth) {
+		return false
+	}
+	for i := 0; i < int(b.selection.depth); i++ {
+		if b.symbols.Strings[funcNames[len(funcNames)-1-i]] != b.selection.callSite[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// appendLocationRefs appends the slot(s) for locID's symbolref.Table ref(s)
+// to dst: see SymbolRefTree's doc comment for the per-location rules, and
+// symbolRefTreeBuilder's doc comment for why slots (not raw refs) are used
+// here.
+func (b *symbolRefTreeBuilder) appendLocationRefs(dst []int32, locID int32) []int32 {
+	loc := b.symbols.Locations[locID]
+	if len(loc.Line) > 0 {
+		for l := 0; l < len(loc.Line); l++ {
+			name := b.symbols.Strings[b.symbols.Functions[loc.Line[l].FunctionId].Name]
+			dst = append(dst, b.toSlot(b.table.InternName(name)))
+		}
+		return dst
+	}
+	var buildID, binaryName string
+	if int(loc.MappingId) < len(b.symbols.Mappings) {
+		mapping := b.symbols.Mappings[loc.MappingId]
+		buildID = b.symbols.Strings[mapping.BuildId]
+		binaryName = filepath.Base(b.symbols.Strings[mapping.Filename])
+	}
+	if buildID == "" {
+		hex := strconv.FormatInt(int64(loc.Address), 16)
+		return append(dst, b.toSlot(b.table.InternName(hex)))
+	}
+	if b.capper.allow(buildID, loc.Address) {
+		return append(dst, b.toSlot(b.table.InternUnresolved(buildID, binaryName, loc.Address)))
+	}
+	return append(dst, b.toSlot(b.table.InternName(fallbackSymbolName(binaryName, loc.Address))))
+}
+
+func (b *symbolRefTreeBuilder) toSlot(ref model.LocationRefName) int32 {
+	if slot, ok := b.slotOf[ref]; ok {
+		return slot
+	}
+	slot := int32(len(b.slots))
+	b.slotOf[ref] = slot
+	b.slots = append(b.slots, ref)
+	return slot
+}
+
+func (b *symbolRefTreeBuilder) lookup(slot int32) model.LocationRefName {
+	return b.slots[slot]
+}
+
+// fallbackSymbolName matches Symbolizer.createFallbackSymbol
+// (pkg/symbolizer/symbolizer.go) byte for byte.
+func fallbackSymbolName(binaryName string, addr uint64) string {
+	prefix := "unknown"
+	if binaryName != "" {
+		prefix = binaryName
+	}
+	return fmt.Sprintf("%s!0x%x", prefix, addr)
+}

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strconv"
 	"sync"
 
 	"github.com/grafana/pyroscope/v2/pkg/model"
@@ -26,8 +25,9 @@ import (
 // is a real mapping, not a "no mapping" sentinel, so it must not be
 // special-cased. A location whose mapping carries no build ID cannot be
 // symbolized (a genuine no-mapping kernel/JIT frame, or a binary with no
-// GNU build ID): it renders as the bare hex address via InternName,
-// matching the legacy path, which leaves such locations unsymbolized.
+// GNU build ID): it is interned via InternName with the same fallback name
+// the legacy symbolizer gives unresolvable frames (binary!0xaddr, keeping
+// the binary-name context; see fallbackSymbolName).
 //
 // capper bounds the number of distinct unresolved entries table accepts
 // for this call; locations past the cap render an inline fallback name via
@@ -217,8 +217,7 @@ func (b *symbolRefTreeBuilder) appendLocationRefs(dst []int32, locID int32) []in
 		binaryName = filepath.Base(b.symbols.Strings[mapping.Filename])
 	}
 	if buildID == "" {
-		hex := strconv.FormatInt(int64(loc.Address), 16)
-		return append(dst, b.toSlot(b.table.InternName(hex)))
+		return append(dst, b.toSlot(b.table.InternName(fallbackSymbolName(binaryName, loc.Address))))
 	}
 	if b.capper.allow(buildID, loc.Address) {
 		return append(dst, b.toSlot(b.table.InternUnresolved(buildID, binaryName, loc.Address)))

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree.go
@@ -55,11 +55,17 @@ func (r *Symbols) SymbolRefTree(
 
 // unresolvedCap bounds the number of distinct (build ID, address) pairs a
 // single SymbolRefTree call interns as unresolved entries. Once the limit
-// is reached, further distinct pairs are rendered as an inline fallback
-// name instead of being interned, so a pathological input (e.g. a profile
+// is reached, further pairs are rendered as an inline fallback name
+// instead of being interned, so a pathological input (e.g. a profile
 // referencing a huge number of distinct native addresses) can never make
 // the deferred-resolution work list unbounded, fail the query, or drop
 // samples. Safe for concurrent use.
+//
+// exceeded counts each location occurrence rendered as a fallback name —
+// occurrences, not distinct pairs: pairs rejected by the cap are not
+// recorded (remembering them would grow memory without bound, which is
+// what the cap exists to prevent), so a recurring capped pair counts every
+// time it is seen.
 type unresolvedCap struct {
 	mu       sync.Mutex
 	max      int // <= 0 means unlimited.
@@ -77,9 +83,10 @@ func newUnresolvedCap(max int) *unresolvedCap {
 }
 
 // allow reports whether (buildID, addr) may be interned as an unresolved
-// entry: true if the cap is unlimited, the pair was already counted
-// before, or the cap has not been reached yet; false once the cap has been
-// reached for a pair not yet seen, incrementing the exceeded count.
+// entry: true if the cap is unlimited, the pair was interned before the
+// cap was reached, or the cap has not been reached yet; false for every
+// occurrence of any other pair once the cap has been reached, incrementing
+// exceeded each time.
 func (c *unresolvedCap) allow(buildID string, addr uint64) bool {
 	if c.max <= 0 {
 		return true

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree.go
@@ -2,6 +2,7 @@ package symdb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sync"
@@ -30,8 +31,8 @@ import (
 // the binary-name context; see fallbackSymbolName).
 //
 // capper bounds the number of distinct unresolved entries table accepts
-// for this call; locations past the cap render an inline fallback name via
-// InternName instead of InternUnresolved (see unresolvedCap).
+// for this call; a location past the cap fails the call with
+// ErrTooManyUnresolvedLocations (see unresolvedCap).
 //
 // The tree is always built without truncation (maxNodes 0): a tree with
 // unresolved entries must not be truncated before those are resolved.
@@ -50,27 +51,29 @@ func (r *Symbols) SymbolRefTree(
 	if err := r.Stacktraces.ResolveStacktraceLocations(ctx, b, samples.StacktraceIDs); err != nil {
 		return nil, err
 	}
+	if b.err != nil {
+		return nil, b.err
+	}
 	return model.TreeFromStacktraceTree[model.LocationRefName, model.LocationRefNameI](b.tree, 0, b.lookup), nil
 }
 
+// ErrTooManyUnresolvedLocations fails a symbol-ref tree build whose number
+// of distinct unresolved (build ID, address) locations exceeds the
+// configured cap (WithResolverSymbolRefCap).
+var ErrTooManyUnresolvedLocations = errors.New("too many unresolved locations in query")
+
 // unresolvedCap bounds the number of distinct (build ID, address) pairs a
-// single SymbolRefTree call interns as unresolved entries. Once the limit
-// is reached, further pairs are rendered as an inline fallback name
-// instead of being interned, so a pathological input (e.g. a profile
-// referencing a huge number of distinct native addresses) can never make
-// the deferred-resolution work list unbounded, fail the query, or drop
-// samples. Safe for concurrent use.
-//
-// exceeded counts each location occurrence rendered as a fallback name —
-// occurrences, not distinct pairs: pairs rejected by the cap are not
-// recorded (remembering them would grow memory without bound, which is
-// what the cap exists to prevent), so a recurring capped pair counts every
-// time it is seen.
+// single SymbolRefTree call interns as unresolved entries, so a
+// pathological input (e.g. a profile referencing a huge number of distinct
+// native addresses) can never make the deferred-resolution work list
+// unbounded. Exceeding the cap fails the call: rendering the remainder as
+// inline fallback names instead would keep growing the name table without
+// bound and make the result depend on arrival order. Safe for concurrent
+// use.
 type unresolvedCap struct {
-	mu       sync.Mutex
-	max      int // <= 0 means unlimited.
-	seen     map[unresolvedCapKey]struct{}
-	exceeded int64
+	mu   sync.Mutex
+	max  int // <= 0 means unlimited.
+	seen map[unresolvedCapKey]struct{}
 }
 
 type unresolvedCapKey struct {
@@ -84,9 +87,10 @@ func newUnresolvedCap(max int) *unresolvedCap {
 
 // allow reports whether (buildID, addr) may be interned as an unresolved
 // entry: true if the cap is unlimited, the pair was interned before the
-// cap was reached, or the cap has not been reached yet; false for every
-// occurrence of any other pair once the cap has been reached, incrementing
-// exceeded each time.
+// cap was reached, or the cap has not been reached yet; false for any
+// other pair once the cap has been reached. Rejected pairs are not
+// recorded: remembering them would grow memory without bound, which is
+// what the cap exists to prevent.
 func (c *unresolvedCap) allow(buildID string, addr uint64) bool {
 	if c.max <= 0 {
 		return true
@@ -98,17 +102,10 @@ func (c *unresolvedCap) allow(buildID string, addr uint64) bool {
 		return true
 	}
 	if len(c.seen) >= c.max {
-		c.exceeded++
 		return false
 	}
 	c.seen[key] = struct{}{}
 	return true
-}
-
-func (c *unresolvedCap) exceededCount() int64 {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.exceeded
 }
 
 // symbolRefTreeBuilder is a StacktraceInserter that interns every stack
@@ -129,6 +126,7 @@ type symbolRefTreeBuilder struct {
 	capper  *unresolvedCap
 	tree    *model.StacktraceTree
 	cur     int
+	err     error // first cap breach; set once, the whole call fails.
 
 	refs  []int32 // per-stack ref buffer, as slots.
 	lines []int32 // per-stack string-table-index buffer; only used when funcNamesMatcher is set.
@@ -163,6 +161,10 @@ func newSymbolRefTreeBuilder(
 }
 
 func (b *symbolRefTreeBuilder) InsertStacktrace(_ uint32, locations []int32) {
+	if b.err != nil {
+		b.cur++
+		return
+	}
 	if b.funcNamesMatcher != nil {
 		// The call-site selection is matched against locally resolved
 		// function names only, mirroring the FunctionName tree path: a
@@ -182,6 +184,10 @@ func (b *symbolRefTreeBuilder) InsertStacktrace(_ uint32, locations []int32) {
 	b.refs = b.refs[:0]
 	for i := 0; i < len(locations); i++ {
 		b.refs = b.appendLocationRefs(b.refs, locations[i])
+	}
+	if b.err != nil {
+		b.cur++
+		return
 	}
 	b.tree.Insert(b.refs, int64(b.samples.Values[b.cur]))
 	b.cur++
@@ -225,10 +231,11 @@ func (b *symbolRefTreeBuilder) appendLocationRefs(dst []int32, locID int32) []in
 	if buildID == "" {
 		return append(dst, b.toSlot(b.table.InternName(fallbackSymbolName(binaryName, loc.Address))))
 	}
-	if b.capper.allow(buildID, loc.Address) {
-		return append(dst, b.toSlot(b.table.InternUnresolved(buildID, binaryName, loc.Address)))
+	if !b.capper.allow(buildID, loc.Address) {
+		b.err = fmt.Errorf("%w (limit %d)", ErrTooManyUnresolvedLocations, b.capper.max)
+		return dst
 	}
-	return append(dst, b.toSlot(b.table.InternName(fallbackSymbolName(binaryName, loc.Address))))
+	return append(dst, b.toSlot(b.table.InternUnresolved(buildID, binaryName, loc.Address)))
 }
 
 func (b *symbolRefTreeBuilder) toSlot(ref model.LocationRefName) int32 {

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree.go
@@ -164,6 +164,12 @@ func newSymbolRefTreeBuilder(
 
 func (b *symbolRefTreeBuilder) InsertStacktrace(_ uint32, locations []int32) {
 	if b.funcNamesMatcher != nil {
+		// The call-site selection is matched against locally resolved
+		// function names only, mirroring the FunctionName tree path: a
+		// line-less (unsymbolized) location contributes no name here, so a
+		// stack whose match depends on such a frame is not selected.
+		// Lifting that requires propagating every stack that contains an
+		// unsymbolized location and filtering only after symbolization.
 		b.lines = b.lines[:0]
 		for i := 0; i < len(locations); i++ {
 			b.lines = addFunctionNames(b.lines, locations[i], b.symbols)

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
@@ -142,7 +142,9 @@ func TestSymbols_SymbolRefTree_FirstMappingResolves(t *testing.T) {
 	assert.Equal(t, "bidA", unresolved[0].BuildID)
 	assert.Equal(t, "libA.so", unresolved[0].BinaryName)
 	assert.Equal(t, []uint64{0x1234}, unresolved[0].Addresses)
-	assert.Empty(t, pb.Names, "nothing should render as a bare hex name")
+	// Build always writes the reserved ref-0 placeholder, so a snapshot
+	// with no real names is [""], not empty.
+	assert.Equal(t, []string{""}, pb.Names, "nothing should render as a bare hex name")
 }
 
 // TestSymbols_SymbolRefTree_NoBuildIDRendersHex covers a line-less location

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
@@ -228,9 +228,8 @@ func TestResolver_SymbolRefTree_MultiPartitionRefConsistency(t *testing.T) {
 	r.AddSamples(0, indexed0[0].Samples)
 	r.AddSamples(1, indexed1[0].Samples)
 
-	tree, rb, exceeded, err := r.SymbolRefTree()
+	tree, rb, err := r.SymbolRefTree()
 	require.NoError(t, err)
-	assert.Equal(t, int64(0), exceeded)
 	assert.Equal(t, int64(42), tree.Total())
 
 	stacks, selves := collectStacks(tree)
@@ -264,13 +263,12 @@ func TestResolver_SymbolRefTree_MultiPartitionRefConsistency(t *testing.T) {
 	assert.Equal(t, []uint64{0x9000}, unresolved[0].Addresses)
 }
 
-// TestResolver_SymbolRefTree_UnresolvedCapExceeded verifies the cap-overflow
-// guardrail: once WithResolverSymbolRefCap's limit is reached, further
-// distinct unresolved locations render as an inline fallback name instead
-// of growing the table, no error is returned, and no sample is lost.
-func TestResolver_SymbolRefTree_UnresolvedCapExceeded(t *testing.T) {
+// TestResolver_SymbolRefTree_UnresolvedCap verifies the cap guardrail: a
+// query whose distinct unresolved locations exceed WithResolverSymbolRefCap
+// fails with ErrTooManyUnresolvedLocations instead of returning a partial
+// or mixed-representation result, while a query at the cap succeeds.
+func TestResolver_SymbolRefTree_UnresolvedCap(t *testing.T) {
 	const distinctAddresses = 5
-	const refCap = 2
 
 	locs := make([]*profilev1.Location, 0, distinctAddresses)
 	samples := make([]*profilev1.Sample, 0, distinctAddresses)
@@ -294,25 +292,24 @@ func TestResolver_SymbolRefTree_UnresolvedCapExceeded(t *testing.T) {
 
 	s := newMemSuite(t, nil)
 	indexed := s.db.WriteProfileSymbols(0, p)
-	r := NewResolver(context.Background(), s.db, WithResolverSymbolRefCap(refCap))
-	defer r.Release()
-	r.AddSamples(0, indexed[0].Samples)
 
-	tree, rb, exceeded, err := r.SymbolRefTree()
-	require.NoError(t, err)
-	assert.Equal(t, int64(distinctAddresses-refCap), exceeded)
-	assert.Equal(t, wantTotal, tree.Total(), "no sample is dropped once the cap is exceeded")
-
-	stacks, _ := collectStacks(tree)
-	for _, s := range stacks {
-		require.Len(t, s, 1)
-		rb.KeepRef(s[0])
+	newResolver := func(refCap int) *Resolver {
+		r := NewResolver(context.Background(), s.db, WithResolverSymbolRefCap(refCap))
+		t.Cleanup(r.Release)
+		r.AddSamples(0, indexed[0].Samples)
+		return r
 	}
-	pb := &queryv1.SymbolRefTable{}
-	rb.Build(pb)
-	unresolved := symbolref.UnresolvedBinaries(pb)
-	require.Len(t, unresolved, 1)
-	assert.Len(t, unresolved[0].Addresses, refCap, "only the first refCap distinct addresses are actually interned as unresolved")
+
+	t.Run("at the cap the query succeeds", func(t *testing.T) {
+		tree, _, err := newResolver(distinctAddresses).SymbolRefTree()
+		require.NoError(t, err)
+		assert.Equal(t, wantTotal, tree.Total())
+	})
+
+	t.Run("past the cap the query fails", func(t *testing.T) {
+		_, _, err := newResolver(distinctAddresses - 1).SymbolRefTree()
+		require.ErrorIs(t, err, ErrTooManyUnresolvedLocations)
+	})
 }
 
 // TestSymbols_SymbolRefTree_StackTraceSelector verifies call-site selection
@@ -375,14 +372,13 @@ func TestSymbols_SymbolRefTree_UnresolvableStacktrace(t *testing.T) {
 	assert.Equal(t, int64(0), tree.Total())
 }
 
-// The exceeded count is occurrences, not distinct pairs: capped pairs are
-// not recorded (that would grow memory without bound), so each recurrence
-// counts.
-func TestUnresolvedCap_ExceededCountsOccurrences(t *testing.T) {
+// A pair interned before the cap filled stays allowed; any new pair past
+// the cap is rejected, and rejected pairs are not recorded (that would
+// grow memory without bound).
+func TestUnresolvedCap_Allow(t *testing.T) {
 	c := newUnresolvedCap(1)
 	assert.True(t, c.allow("bid", 0x1))
 	assert.True(t, c.allow("bid", 0x1), "an interned pair stays allowed after the cap fills")
 	assert.False(t, c.allow("bid", 0x2))
 	assert.False(t, c.allow("bid", 0x2))
-	assert.Equal(t, int64(2), c.exceededCount())
 }

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
@@ -88,7 +88,8 @@ func TestSymbols_SymbolRefTree_LinedAndUnresolved(t *testing.T) {
 	assert.Equal(t, ".!0xdeadbeef", pb.Names[kernelIdx],
 		`legacy-parity fallback; "." is filepath.Base of the filename-less mapping the no-mapping frame indexes`)
 
-	unresolved := symbolref.UnresolvedBinaries(pb)
+	unresolved, err := symbolref.UnresolvedBinaries(pb)
+	require.NoError(t, err)
 	require.Len(t, unresolved, 1)
 	assert.Equal(t, "bidB", unresolved[0].BuildID)
 	assert.Equal(t, "libB.so", unresolved[0].BinaryName)
@@ -137,7 +138,8 @@ func TestSymbols_SymbolRefTree_FirstMappingResolves(t *testing.T) {
 	pb := &queryv1.SymbolRefTable{}
 	rb.Build(pb)
 
-	unresolved := symbolref.UnresolvedBinaries(pb)
+	unresolved, err := symbolref.UnresolvedBinaries(pb)
+	require.NoError(t, err)
 	require.Len(t, unresolved, 1, "a line-less location on the first mapping must be symbolizable, not bare hex")
 	assert.Equal(t, "bidA", unresolved[0].BuildID)
 	assert.Equal(t, "libA.so", unresolved[0].BinaryName)
@@ -184,7 +186,9 @@ func TestSymbols_SymbolRefTree_NoBuildIDRendersFallback(t *testing.T) {
 	pb := &queryv1.SymbolRefTable{}
 	rb.Build(pb)
 
-	assert.Empty(t, symbolref.UnresolvedBinaries(pb), "a mapping with no build ID is not symbolizable")
+	binaries, err := symbolref.UnresolvedBinaries(pb)
+	require.NoError(t, err)
+	assert.Empty(t, binaries, "a mapping with no build ID is not symbolizable")
 	assert.Contains(t, pb.Names, "goldpinger!0xdeadbeef", "keeps the binary-name context, like the legacy fallback")
 	assert.Contains(t, pb.Names, ".!0x1111",
 		`empty filename: "." is filepath.Base(""), byte-for-byte with the legacy fallback derivation`)
@@ -257,7 +261,8 @@ func TestResolver_SymbolRefTree_MultiPartitionRefConsistency(t *testing.T) {
 	rb.KeepRef(unresolvedRef)
 	rb.Build(pb)
 	assert.Equal(t, "main", pb.Names[mainIdx])
-	unresolved := symbolref.UnresolvedBinaries(pb)
+	unresolved, err := symbolref.UnresolvedBinaries(pb)
+	require.NoError(t, err)
 	require.Len(t, unresolved, 1)
 	assert.Equal(t, "bid-shared", unresolved[0].BuildID)
 	assert.Equal(t, []uint64{0x9000}, unresolved[0].Addresses)

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
@@ -1,0 +1,366 @@
+package symdb
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	"github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/model/symbolref"
+)
+
+// symbolsForProfile writes p to a fresh in-memory partition 0 and returns
+// its Symbols and an appender loaded with every resulting sample.
+func symbolsForProfile(t *testing.T, p *profilev1.Profile) (*Symbols, *SampleAppender) {
+	t.Helper()
+	s := newMemSuite(t, nil)
+	const partition = 0
+	indexed := s.db.WriteProfileSymbols(partition, p)
+	pr, err := s.db.Partition(context.Background(), partition)
+	require.NoError(t, err)
+	appender := NewSampleAppender()
+	for _, ip := range indexed {
+		appender.AppendMany(ip.Samples.StacktraceIDs, ip.Samples.Values)
+	}
+	return pr.Symbols(), appender
+}
+
+// collectStacks captures every (leaf-first stack, self) pair IterateStacks
+// visits, cloning the stack slice since IterateStacks reuses its buffer.
+func collectStacks(tree *model.LocationRefNameTree) (stacks [][]model.LocationRefName, selves []int64) {
+	tree.IterateStacks(func(_ model.LocationRefName, self int64, stack []model.LocationRefName) {
+		stacks = append(stacks, append([]model.LocationRefName{}, stack...))
+		selves = append(selves, self)
+	})
+	return stacks, selves
+}
+
+// TestSymbols_SymbolRefTree_LinedAndUnresolved covers a stack that mixes a
+// lined (resolved) frame, an unresolved line-less frame with a real,
+// unambiguous mapping, and a genuine no-mapping (kernel/JIT) frame.
+func TestSymbols_SymbolRefTree_LinedAndUnresolved(t *testing.T) {
+	p := &profilev1.Profile{
+		StringTable: []string{"", "main", "libB.so", "bidB"},
+		Mapping: []*profilev1.Mapping{
+			{Id: 1}, // occupies symdb index 0; unused by any line-less location.
+			{Id: 2, Filename: 2, BuildId: 3},
+		},
+		Function: []*profilev1.Function{
+			{Id: 1, Name: 1},
+		},
+		Location: []*profilev1.Location{
+			{Id: 1, MappingId: 1, Line: []*profilev1.Line{{FunctionId: 1}}}, // main, lined
+			{Id: 2, MappingId: 2, Address: 0x2000},                          // unresolved, real mapping
+			{Id: 3, MappingId: 0, Address: 0xdeadbeef},                      // kernel/JIT, no mapping
+		},
+		Sample: []*profilev1.Sample{
+			// leaf-first: kernel/JIT frame, then the unresolved lib frame, then main at the root.
+			{LocationId: []uint64{3, 2, 1}, Value: []int64{42}},
+		},
+		SampleType: []*profilev1.ValueType{{Type: 0, Unit: 0}},
+	}
+	symbols, appender := symbolsForProfile(t, p)
+	table := symbolref.NewTable()
+
+	tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, nil), table, newUnresolvedCap(0))
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), tree.Total())
+
+	stacks, selves := collectStacks(tree)
+	require.Len(t, stacks, 1)
+	require.Len(t, stacks[0], 3)
+	assert.Equal(t, int64(42), selves[0])
+	kernelRef, unresolvedRef, mainRef := stacks[0][0], stacks[0][1], stacks[0][2]
+
+	rb := table.ResultBuilder()
+	mainIdx := rb.KeepRef(mainRef)
+	kernelIdx := rb.KeepRef(kernelRef)
+	rb.KeepRef(unresolvedRef)
+	pb := &queryv1.SymbolRefTable{}
+	rb.Build(pb)
+
+	assert.Equal(t, "main", pb.Names[mainIdx])
+	assert.Equal(t, strconv.FormatInt(0xdeadbeef, 16), pb.Names[kernelIdx])
+
+	unresolved := symbolref.UnresolvedBinaries(pb)
+	require.Len(t, unresolved, 1)
+	assert.Equal(t, "bidB", unresolved[0].BuildID)
+	assert.Equal(t, "libB.so", unresolved[0].BinaryName)
+	assert.Equal(t, []uint64{0x2000}, unresolved[0].Addresses)
+}
+
+// TestSymbols_SymbolRefTree_FirstMappingResolves covers the case the old
+// MappingId==0 special-case silently broke: a line-less location on the
+// partition's first mapping (symdb index 0, a real mapping with a build ID)
+// must reach InternUnresolved and be symbolizable, not render as bare hex.
+// This is the common single-mapping native-profile shape.
+//
+// It also documents the residual limitation of gating on the build ID: a
+// genuine no-mapping (kernel/JIT) location shares symdb index 0 with the
+// first real mapping, so it is attributed to that mapping's build ID and
+// falls back at resolve time (wrong binary name) rather than staying bare
+// hex. Fully disambiguating the two would need a write-side change to
+// reserve index 0; this read-side fix trades a rare, gracefully-degrading
+// misattribution for correct symbolization of the common case. See
+// SymbolRefTree's doc comment.
+func TestSymbols_SymbolRefTree_FirstMappingResolves(t *testing.T) {
+	p := &profilev1.Profile{
+		StringTable: []string{"", "libA.so", "bidA"},
+		Mapping: []*profilev1.Mapping{
+			{Id: 1, Filename: 1, BuildId: 2}, // symdb index 0: a real, resolvable mapping.
+		},
+		Location: []*profilev1.Location{
+			{Id: 1, MappingId: 1, Address: 0x1234}, // line-less, on the first mapping (index 0).
+		},
+		Sample: []*profilev1.Sample{
+			{LocationId: []uint64{1}, Value: []int64{1}},
+		},
+		SampleType: []*profilev1.ValueType{{Type: 0, Unit: 0}},
+	}
+	symbols, appender := symbolsForProfile(t, p)
+	table := symbolref.NewTable()
+
+	tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, nil), table, newUnresolvedCap(0))
+	require.NoError(t, err)
+
+	rb := table.ResultBuilder()
+	stacks, _ := collectStacks(tree)
+	require.Len(t, stacks, 1)
+	require.Len(t, stacks[0], 1)
+	rb.KeepRef(stacks[0][0])
+	pb := &queryv1.SymbolRefTable{}
+	rb.Build(pb)
+
+	unresolved := symbolref.UnresolvedBinaries(pb)
+	require.Len(t, unresolved, 1, "a line-less location on the first mapping must be symbolizable, not bare hex")
+	assert.Equal(t, "bidA", unresolved[0].BuildID)
+	assert.Equal(t, "libA.so", unresolved[0].BinaryName)
+	assert.Equal(t, []uint64{0x1234}, unresolved[0].Addresses)
+	assert.Empty(t, pb.Names, "nothing should render as a bare hex name")
+}
+
+// TestSymbols_SymbolRefTree_NoBuildIDRendersHex covers a line-less location
+// whose mapping carries no build ID (a binary with no GNU build ID, or a
+// genuine no-mapping frame indexing a build-ID-less mapping): it cannot be
+// symbolized and renders as the bare hex address via InternName, matching
+// the legacy path, which leaves such locations unsymbolized.
+func TestSymbols_SymbolRefTree_NoBuildIDRendersHex(t *testing.T) {
+	p := &profilev1.Profile{
+		StringTable: []string{""},
+		Mapping: []*profilev1.Mapping{
+			{Id: 1}, // symdb index 0: no filename, no build ID.
+		},
+		Location: []*profilev1.Location{
+			{Id: 1, MappingId: 1, Address: 0xdeadbeef},
+		},
+		Sample: []*profilev1.Sample{
+			{LocationId: []uint64{1}, Value: []int64{1}},
+		},
+		SampleType: []*profilev1.ValueType{{Type: 0, Unit: 0}},
+	}
+	symbols, appender := symbolsForProfile(t, p)
+	table := symbolref.NewTable()
+
+	tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, nil), table, newUnresolvedCap(0))
+	require.NoError(t, err)
+
+	rb := table.ResultBuilder()
+	stacks, _ := collectStacks(tree)
+	require.Len(t, stacks, 1)
+	require.Len(t, stacks[0], 1)
+	rb.KeepRef(stacks[0][0])
+	pb := &queryv1.SymbolRefTable{}
+	rb.Build(pb)
+
+	assert.Empty(t, symbolref.UnresolvedBinaries(pb), "a mapping with no build ID is not symbolizable")
+	assert.Contains(t, pb.Names, strconv.FormatInt(0xdeadbeef, 16), "renders as the bare hex address")
+}
+
+// TestResolver_SymbolRefTree_MultiPartitionRefConsistency verifies that the
+// same resolved name and the same unresolved (build ID, address) pair,
+// interned from two different partitions, land on the same symbolref.Table
+// ref and merge into a single tree node rather than two siblings.
+func TestResolver_SymbolRefTree_MultiPartitionRefConsistency(t *testing.T) {
+	newPartitionProfile := func(mainValue, unresolvedValue int64) *profilev1.Profile {
+		return &profilev1.Profile{
+			StringTable: []string{"", "main", "libshared.so", "bid-shared"},
+			Mapping: []*profilev1.Mapping{
+				{Id: 1}, // dummy, occupies symdb index 0.
+				{Id: 2, Filename: 2, BuildId: 3},
+			},
+			Function: []*profilev1.Function{
+				{Id: 1, Name: 1},
+			},
+			Location: []*profilev1.Location{
+				{Id: 1, MappingId: 1, Line: []*profilev1.Line{{FunctionId: 1}}},
+				{Id: 2, MappingId: 2, Address: 0x9000},
+			},
+			Sample: []*profilev1.Sample{
+				{LocationId: []uint64{1}, Value: []int64{mainValue}},
+				{LocationId: []uint64{2}, Value: []int64{unresolvedValue}},
+			},
+			SampleType: []*profilev1.ValueType{{Type: 0, Unit: 0}},
+		}
+	}
+
+	s := newMemSuite(t, nil)
+	indexed0 := s.db.WriteProfileSymbols(0, newPartitionProfile(10, 5))
+	indexed1 := s.db.WriteProfileSymbols(1, newPartitionProfile(20, 7))
+
+	r := NewResolver(context.Background(), s.db)
+	defer r.Release()
+	r.AddSamples(0, indexed0[0].Samples)
+	r.AddSamples(1, indexed1[0].Samples)
+
+	tree, rb, exceeded, err := r.SymbolRefTree()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), exceeded)
+	assert.Equal(t, int64(42), tree.Total())
+
+	stacks, selves := collectStacks(tree)
+	require.Len(t, stacks, 2, "same-content frames from both partitions must coalesce into one node each, not one per partition")
+
+	total := make(map[model.LocationRefName]int64, 2)
+	for i, s := range stacks {
+		require.Len(t, s, 1)
+		total[s[0]] += selves[i]
+	}
+	var mainSelf, unresolvedSelf int64
+	var mainRef, unresolvedRef model.LocationRefName
+	for ref, v := range total {
+		if ref >= 0 {
+			mainSelf, mainRef = v, ref
+		} else {
+			unresolvedSelf, unresolvedRef = v, ref
+		}
+	}
+	assert.Equal(t, int64(30), mainSelf)
+	assert.Equal(t, int64(12), unresolvedSelf)
+
+	pb := &queryv1.SymbolRefTable{}
+	mainIdx := rb.KeepRef(mainRef)
+	rb.KeepRef(unresolvedRef)
+	rb.Build(pb)
+	assert.Equal(t, "main", pb.Names[mainIdx])
+	unresolved := symbolref.UnresolvedBinaries(pb)
+	require.Len(t, unresolved, 1)
+	assert.Equal(t, "bid-shared", unresolved[0].BuildID)
+	assert.Equal(t, []uint64{0x9000}, unresolved[0].Addresses)
+}
+
+// TestResolver_SymbolRefTree_UnresolvedCapExceeded verifies the cap-overflow
+// guardrail: once WithResolverSymbolRefCap's limit is reached, further
+// distinct unresolved locations render as an inline fallback name instead
+// of growing the table, no error is returned, and no sample is lost.
+func TestResolver_SymbolRefTree_UnresolvedCapExceeded(t *testing.T) {
+	const distinctAddresses = 5
+	const refCap = 2
+
+	locs := make([]*profilev1.Location, 0, distinctAddresses)
+	samples := make([]*profilev1.Sample, 0, distinctAddresses)
+	var wantTotal int64
+	for i := 0; i < distinctAddresses; i++ {
+		addr := uint64(0x1000 * (i + 1))
+		locs = append(locs, &profilev1.Location{Id: uint64(i + 1), MappingId: 2, Address: addr})
+		samples = append(samples, &profilev1.Sample{LocationId: []uint64{uint64(i + 1)}, Value: []int64{int64(i + 1)}})
+		wantTotal += int64(i + 1)
+	}
+	p := &profilev1.Profile{
+		StringTable: []string{"", "libshared.so", "bid-shared"},
+		Mapping: []*profilev1.Mapping{
+			{Id: 1}, // dummy, occupies symdb index 0.
+			{Id: 2, Filename: 1, BuildId: 2},
+		},
+		Location:   locs,
+		Sample:     samples,
+		SampleType: []*profilev1.ValueType{{Type: 0, Unit: 0}},
+	}
+
+	s := newMemSuite(t, nil)
+	indexed := s.db.WriteProfileSymbols(0, p)
+	r := NewResolver(context.Background(), s.db, WithResolverSymbolRefCap(refCap))
+	defer r.Release()
+	r.AddSamples(0, indexed[0].Samples)
+
+	tree, rb, exceeded, err := r.SymbolRefTree()
+	require.NoError(t, err)
+	assert.Equal(t, int64(distinctAddresses-refCap), exceeded)
+	assert.Equal(t, wantTotal, tree.Total(), "no sample is dropped once the cap is exceeded")
+
+	stacks, _ := collectStacks(tree)
+	for _, s := range stacks {
+		require.Len(t, s, 1)
+		rb.KeepRef(s[0])
+	}
+	pb := &queryv1.SymbolRefTable{}
+	rb.Build(pb)
+	unresolved := symbolref.UnresolvedBinaries(pb)
+	require.Len(t, unresolved, 1)
+	assert.Len(t, unresolved[0].Addresses, refCap, "only the first refCap distinct addresses are actually interned as unresolved")
+}
+
+// TestSymbols_SymbolRefTree_StackTraceSelector verifies call-site selection
+// is respected: SymbolRefTree must not silently ignore a
+// StackTraceSelector configured on the Resolver it shares state with.
+func TestSymbols_SymbolRefTree_StackTraceSelector(t *testing.T) {
+	p := &profilev1.Profile{
+		StringTable: []string{"", "main", "helper", "other"},
+		Mapping:     []*profilev1.Mapping{{Id: 1}},
+		Function: []*profilev1.Function{
+			{Id: 1, Name: 1},
+			{Id: 2, Name: 2},
+			{Id: 3, Name: 3},
+		},
+		Location: []*profilev1.Location{
+			{Id: 1, MappingId: 1, Line: []*profilev1.Line{{FunctionId: 1}}},
+			{Id: 2, MappingId: 1, Line: []*profilev1.Line{{FunctionId: 2}}},
+			{Id: 3, MappingId: 1, Line: []*profilev1.Line{{FunctionId: 3}}},
+		},
+		Sample: []*profilev1.Sample{
+			{LocationId: []uint64{2, 1}, Value: []int64{5}}, // main -> helper
+			{LocationId: []uint64{3}, Value: []int64{7}},    // other, unrelated root
+		},
+		SampleType: []*profilev1.ValueType{{Type: 0, Unit: 0}},
+	}
+	symbols, appender := symbolsForProfile(t, p)
+
+	t.Run("matching selector keeps only the selected subtree", func(t *testing.T) {
+		sts := &typesv1.StackTraceSelector{CallSite: []*typesv1.Location{{Name: "main"}}}
+		table := symbolref.NewTable()
+		tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, sts), table, newUnresolvedCap(0))
+		require.NoError(t, err)
+		assert.Equal(t, int64(5), tree.Total())
+	})
+
+	t.Run("non-matching selector yields an empty tree without error", func(t *testing.T) {
+		sts := &typesv1.StackTraceSelector{CallSite: []*typesv1.Location{{Name: "no-such-function"}}}
+		table := symbolref.NewTable()
+		tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, sts), table, newUnresolvedCap(0))
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), tree.Total())
+	})
+}
+
+// TestSymbols_SymbolRefTree_UnresolvableStacktrace covers
+// StacktraceResolver's documented contract that an unresolvable stacktrace
+// resolves to zero locations: SymbolRefTree must return an empty tree, not
+// panic or error.
+func TestSymbols_SymbolRefTree_UnresolvableStacktrace(t *testing.T) {
+	p := &profilev1.Profile{
+		StringTable: []string{""},
+		Mapping:     []*profilev1.Mapping{{Id: 1}},
+		Sample:      []*profilev1.Sample{{LocationId: nil, Value: []int64{1}}},
+		SampleType:  []*profilev1.ValueType{{Type: 0, Unit: 0}},
+	}
+	symbols, appender := symbolsForProfile(t, p)
+	table := symbolref.NewTable()
+	tree, err := symbols.SymbolRefTree(context.Background(), appender, SelectStackTraces(symbols, nil), table, newUnresolvedCap(0))
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), tree.Total())
+}

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
@@ -364,3 +364,15 @@ func TestSymbols_SymbolRefTree_UnresolvableStacktrace(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), tree.Total())
 }
+
+// The exceeded count is occurrences, not distinct pairs: capped pairs are
+// not recorded (that would grow memory without bound), so each recurrence
+// counts.
+func TestUnresolvedCap_ExceededCountsOccurrences(t *testing.T) {
+	c := newUnresolvedCap(1)
+	assert.True(t, c.allow("bid", 0x1))
+	assert.True(t, c.allow("bid", 0x1), "an interned pair stays allowed after the cap fills")
+	assert.False(t, c.allow("bid", 0x2))
+	assert.False(t, c.allow("bid", 0x2))
+	assert.Equal(t, int64(2), c.exceededCount())
+}

--- a/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
+++ b/pkg/phlaredb/symdb/resolver_symbolref_tree_test.go
@@ -2,7 +2,6 @@ package symdb
 
 import (
 	"context"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -86,7 +85,8 @@ func TestSymbols_SymbolRefTree_LinedAndUnresolved(t *testing.T) {
 	rb.Build(pb)
 
 	assert.Equal(t, "main", pb.Names[mainIdx])
-	assert.Equal(t, strconv.FormatInt(0xdeadbeef, 16), pb.Names[kernelIdx])
+	assert.Equal(t, ".!0xdeadbeef", pb.Names[kernelIdx],
+		`legacy-parity fallback; "." is filepath.Base of the filename-less mapping the no-mapping frame indexes`)
 
 	unresolved := symbolref.UnresolvedBinaries(pb)
 	require.Len(t, unresolved, 1)
@@ -147,22 +147,25 @@ func TestSymbols_SymbolRefTree_FirstMappingResolves(t *testing.T) {
 	assert.Equal(t, []string{""}, pb.Names, "nothing should render as a bare hex name")
 }
 
-// TestSymbols_SymbolRefTree_NoBuildIDRendersHex covers a line-less location
-// whose mapping carries no build ID (a binary with no GNU build ID, or a
-// genuine no-mapping frame indexing a build-ID-less mapping): it cannot be
-// symbolized and renders as the bare hex address via InternName, matching
-// the legacy path, which leaves such locations unsymbolized.
-func TestSymbols_SymbolRefTree_NoBuildIDRendersHex(t *testing.T) {
+// TestSymbols_SymbolRefTree_NoBuildIDRendersFallback covers line-less
+// locations whose mapping carries no build ID (a binary with no GNU build
+// ID, or a genuine no-mapping frame indexing a build-ID-less mapping): they
+// cannot be symbolized, are not interned as unresolved, and render the same
+// fallback name the legacy symbolizer gives unresolvable frames — keeping
+// the binary-name context when the mapping has a filename.
+func TestSymbols_SymbolRefTree_NoBuildIDRendersFallback(t *testing.T) {
 	p := &profilev1.Profile{
-		StringTable: []string{""},
+		StringTable: []string{"", "/usr/bin/goldpinger"},
 		Mapping: []*profilev1.Mapping{
-			{Id: 1}, // symdb index 0: no filename, no build ID.
+			{Id: 1, Filename: 1}, // filename, no build ID: e.g. a Go binary without a GNU build ID.
+			{Id: 2},              // neither filename nor build ID.
 		},
 		Location: []*profilev1.Location{
 			{Id: 1, MappingId: 1, Address: 0xdeadbeef},
+			{Id: 2, MappingId: 2, Address: 0x1111},
 		},
 		Sample: []*profilev1.Sample{
-			{LocationId: []uint64{1}, Value: []int64{1}},
+			{LocationId: []uint64{2, 1}, Value: []int64{1}},
 		},
 		SampleType: []*profilev1.ValueType{{Type: 0, Unit: 0}},
 	}
@@ -175,13 +178,18 @@ func TestSymbols_SymbolRefTree_NoBuildIDRendersHex(t *testing.T) {
 	rb := table.ResultBuilder()
 	stacks, _ := collectStacks(tree)
 	require.Len(t, stacks, 1)
-	require.Len(t, stacks[0], 1)
+	require.Len(t, stacks[0], 2)
 	rb.KeepRef(stacks[0][0])
+	rb.KeepRef(stacks[0][1])
 	pb := &queryv1.SymbolRefTable{}
 	rb.Build(pb)
 
 	assert.Empty(t, symbolref.UnresolvedBinaries(pb), "a mapping with no build ID is not symbolizable")
-	assert.Contains(t, pb.Names, strconv.FormatInt(0xdeadbeef, 16), "renders as the bare hex address")
+	assert.Contains(t, pb.Names, "goldpinger!0xdeadbeef", "keeps the binary-name context, like the legacy fallback")
+	assert.Contains(t, pb.Names, ".!0x1111",
+		`empty filename: "." is filepath.Base(""), byte-for-byte with the legacy fallback derivation`)
+	assert.NotContains(t, pb.Names, "deadbeef", "no bare-hex names")
+	assert.NotContains(t, pb.Names, "1111", "no bare-hex names")
 }
 
 // TestResolver_SymbolRefTree_MultiPartitionRefConsistency verifies that the


### PR DESCRIPTION
## Part of a series: symbol-aware tree references (5a of 8)

Full context and series overview: #5317 (PR 1). Compact map:

1. symbolizer: expose address-level `Resolve` API (#5317)
2. proto: `SymbolRefTable` + tree query/report fields (#5318)
3. `model/symbolref`: intern table + merge rebasing (#5321)
4. `model/symbolref`: unresolved-binary grouping + tree rebuild (#5322)
5. **symdb: symbol-ref tree resolver output ← this PR** · querybackend: query mode + aggregation (next)
6. frontend: orchestration behind a default-off per-tenant flag — nothing activates before this
7. integration tests + docs (#5335)
8. symdb: compaction preserves line-less locations (#5337) — stacked at the bottom of the series, merges first

Tracking issue: grafana/pyroscope-squad#487. Based on #5322's branch; the diff here is only the new symdb output path.

## What

Adds `Resolver.SymbolRefTree`, a new output shape alongside the resolver's existing `Tree`/`LocationRefNameTree`/`Pprof` methods. It builds a location-reference tree paired with a `symbolref` table: locations with line info contribute resolved frame names; line-less locations contribute unresolved `{build ID, address}` references, carrying the mapping's binary name so unresolved frames can render the existing `binary!0xaddr` fallback.

Trees build **untruncated** — the method takes no node limit, because truncation is deferred until after symbolization (a truncated-away unresolved node might merge with another into a kept node once resolved). To bound memory under that deferral, an optional cap limits distinct unresolved references; on overflow the remainder renders fallback names inline, which restores truncatability without failing the query or dropping samples.

Nothing calls `SymbolRefTree` yet — the query backend consumes it in the next PR.

## Notes

- Line-less locations without a mapping render as bare hex addresses, matching the existing pprof-path rendering.
- The ingest rewrite assigns a partition's first mapping index 0 — the same value used for "no mapping" — so kernel/JIT frames and a line-less location on the first mapping are not always distinguishable. The behavior is documented and pinned by a test rather than silently assumed.

## Testing

`go test ./pkg/phlaredb/symdb/... -race` green; new tests cover mixed lined/line-less fixtures, the `MappingId==0` rendering, multi-partition reference consistency, and cap-overflow semantics (no error, exact values, fallback rendering, truncation re-armed). `golangci-lint` clean; whole-repo build clean.

