### PR TITLE
feat(querybackend): produce and aggregate symbol-ref tree reports

### DIFF
--- a/pkg/querybackend/query_tree.go
+++ b/pkg/querybackend/query_tree.go
@@ -2,6 +2,7 @@ package querybackend
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 
@@ -9,9 +10,12 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
 	"github.com/grafana/pyroscope/v2/pkg/block"
+	"github.com/grafana/pyroscope/v2/pkg/block/metadata"
 	"github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/model/symbolref"
 	parquetquery "github.com/grafana/pyroscope/v2/pkg/phlaredb/query"
 	v1 "github.com/grafana/pyroscope/v2/pkg/phlaredb/schemas/v1"
 	"github.com/grafana/pyroscope/v2/pkg/phlaredb/symdb"
@@ -47,10 +51,9 @@ func treeSymbolMode(t *queryv1.TreeQuery) (queryv1.SymbolMode, error) {
 	switch mode {
 	case queryv1.SymbolMode_SYMBOL_MODE_UNSPECIFIED:
 		return queryv1.SymbolMode_SYMBOL_MODE_NAME, nil
-	case queryv1.SymbolMode_SYMBOL_MODE_NAME, queryv1.SymbolMode_SYMBOL_MODE_FULL:
+	case queryv1.SymbolMode_SYMBOL_MODE_NAME, queryv1.SymbolMode_SYMBOL_MODE_FULL, queryv1.SymbolMode_SYMBOL_MODE_REFS:
 		return mode, nil
 	default:
-		// SYMBOL_MODE_REFS is schema-defined but not implemented here yet.
 		return 0, fmt.Errorf("unsupported symbol_mode %s", mode)
 	}
 }
@@ -128,6 +131,9 @@ func queryTree(q *queryContext, query *queryv1.Query) (*queryv1.Report, error) {
 	if query.Tree.StackTraceSelector != nil {
 		resolverOptions = append(resolverOptions, symdb.WithResolverStackTraceSelector(query.Tree.StackTraceSelector))
 	}
+	if mode == queryv1.SymbolMode_SYMBOL_MODE_REFS {
+		resolverOptions = append(resolverOptions, symdb.WithResolverSymbolRefCap(int(query.Tree.GetMaxUnresolvedLocations())))
+	}
 
 	profiles := parquetquery.NewRepeatedRowIterator(q.ctx, entries, q.ds.Profiles().RowGroups(), indices...)
 	defer runutil.CloseWithErrCapture(&err, profiles, "failed to close profile stream")
@@ -186,6 +192,13 @@ func queryTree(q *queryContext, query *queryv1.Query) (*queryv1.Report, error) {
 		return resp, nil
 	}
 
+	// A dataset not labeled unsymbolized has nothing to defer resolution
+	// for: keep the existing FunctionName path unconditionally, same as a
+	// non-symbol-ref query.
+	if mode == queryv1.SymbolMode_SYMBOL_MODE_REFS && datasetUnsymbolized(q.obj.Metadata(), q.ds.Metadata()) {
+		return queryTreeSymbolRefs(q, query, resolver)
+	}
+
 	tree, err := resolver.Tree()
 	if err != nil {
 		return nil, err
@@ -200,6 +213,69 @@ func queryTree(q *queryContext, query *queryv1.Query) (*queryv1.Report, error) {
 	return resp, nil
 }
 
+// queryTreeSymbolRefs builds the report for a dataset labeled unsymbolized:
+// the resolver defers resolution of frames it cannot symbolize locally into
+// a SymbolRefTable instead of dropping or approximating them. If none of
+// the selected samples actually resolved to an unresolved location, the
+// dataset falls back to the plain FunctionName path, since there is
+// nothing left to defer.
+func queryTreeSymbolRefs(q *queryContext, query *queryv1.Query, resolver *symdb.Resolver) (*queryv1.Report, error) {
+	tree, rb, err := resolver.SymbolRefTree()
+	if err != nil {
+		return nil, err
+	}
+
+	// tree.Bytes must run before rb.Build: Build only reports the refs
+	// KeepRef (invoked from Bytes as it marshals) has observed as reachable.
+	treeBytes := tree.Bytes(0, rb.KeepRef)
+	symbolRefs := new(queryv1.SymbolRefTable)
+	rb.Build(symbolRefs)
+
+	if len(symbolRefs.UnresolvedBuildId) == 0 {
+		// Labeled unsymbolized, but nothing the query selected actually
+		// resolved to an unresolved location (e.g. rollout skew, or a
+		// selector that only matched already-resolved stacks): convert back
+		// to a plain, truncatable FunctionName report via the same rb,
+		// rather than re-resolving the stack traces from scratch.
+		plain := locationRefTreeToFunctionNameTree(tree, rb)
+		return &queryv1.Report{
+			Tree: &queryv1.TreeReport{
+				Query: query.Tree.CloneVT(),
+				Tree:  plain.Bytes(query.Tree.GetMaxNodes(), nil),
+			},
+		}, nil
+	}
+
+	return &queryv1.Report{
+		Tree: &queryv1.TreeReport{
+			Query:      query.Tree.CloneVT(),
+			Tree:       treeBytes,
+			SymbolRefs: symbolRefs,
+		},
+	}, nil
+}
+
+// datasetUnsymbolized reports whether any of the dataset's label sets
+// carries __unsymbolized__="true". A compacted dataset accumulates the
+// label sets of all its sources, so every set must be checked, not just
+// the first.
+func datasetUnsymbolized(md *metastorev1.BlockMeta, ds *metastorev1.Dataset) bool {
+	pairs := metadata.LabelPairs(ds.Labels)
+	for pairs.Next() {
+		p := pairs.At()
+		for k := 0; k+1 < len(p); k += 2 {
+			n, v := p[k], p[k+1]
+			if n < 0 || int(n) >= len(md.StringTable) || v < 0 || int(v) >= len(md.StringTable) {
+				continue
+			}
+			if md.StringTable[n] == metadata.LabelNameUnsymbolized && md.StringTable[v] == "true" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 type treeAggregator struct {
 	init  sync.Once
 	mode  queryv1.SymbolMode
@@ -209,6 +285,9 @@ type treeAggregator struct {
 	lrTree       *model.TreeMerger[model.LocationRefName, model.LocationRefNameI]
 	symbolLock   sync.Mutex
 	symbolMerger *symdb.SymbolMerger
+
+	symbolRefTable *symbolref.Table
+	symbolRefTree  *model.TreeMerger[model.LocationRefName, model.LocationRefNameI]
 }
 
 func newTreeAggregator(*queryv1.InvokeRequest) aggregator { return new(treeAggregator) }
@@ -219,7 +298,32 @@ func (a *treeAggregator) aggregate(report *queryv1.Report) error {
 	if err != nil {
 		return err
 	}
-	if mode == queryv1.SymbolMode_SYMBOL_MODE_FULL {
+	switch mode {
+	case queryv1.SymbolMode_SYMBOL_MODE_REFS:
+		a.init.Do(func() {
+			a.mode = mode
+			a.symbolRefTable = symbolref.NewTable()
+			a.symbolRefTree = model.NewTreeMerger[model.LocationRefName, model.LocationRefNameI]()
+			a.query = r.Query.CloneVT()
+		})
+		if r.SymbolRefs == nil {
+			// A partial from a dataset that took the plain FunctionName
+			// path (native or degenerate, see queryTree): absorb it into
+			// the shared ref space instead of merging it as a plain tree.
+			absorbed, err := absorbPlainTree(a.symbolRefTable, r.Tree)
+			if err != nil {
+				return err
+			}
+			a.symbolRefTree.MergeTree(absorbed)
+			return nil
+		}
+		remap, err := a.symbolRefTable.Add(r.SymbolRefs)
+		if err != nil {
+			return err
+		}
+		return a.symbolRefTree.MergeTreeBytes(r.Tree, model.WithTreeMergeFormatNodeNames(remap))
+
+	case queryv1.SymbolMode_SYMBOL_MODE_FULL:
 		a.init.Do(func() {
 			a.mode = mode
 			a.lrTree = model.NewTreeMerger[model.LocationRefName, model.LocationRefNameI]()
@@ -233,14 +337,15 @@ func (a *treeAggregator) aggregate(report *queryv1.Report) error {
 			return err
 		}
 		return a.lrTree.MergeTreeBytes(r.Tree, model.WithTreeMergeFormatNodeNames(adder))
-	}
 
-	a.init.Do(func() {
-		a.mode = mode
-		a.tree = model.NewTreeMerger[model.FunctionName, model.FunctionNameI]()
-		a.query = r.Query.CloneVT()
-	})
-	return a.tree.MergeTreeBytes(r.Tree)
+	default:
+		a.init.Do(func() {
+			a.mode = mode
+			a.tree = model.NewTreeMerger[model.FunctionName, model.FunctionNameI]()
+			a.query = r.Query.CloneVT()
+		})
+		return a.tree.MergeTreeBytes(r.Tree)
+	}
 }
 
 func (a *treeAggregator) build() *queryv1.Report {
@@ -250,14 +355,115 @@ func (a *treeAggregator) build() *queryv1.Report {
 		},
 	}
 
-	if a.mode == queryv1.SymbolMode_SYMBOL_MODE_FULL {
+	switch a.mode {
+	case queryv1.SymbolMode_SYMBOL_MODE_REFS:
+		if !a.symbolRefTable.HasUnresolved() {
+			// Every partial absorbed cleanly (native datasets, or degenerate
+			// ones): there is nothing left to defer, so collapse back to a
+			// plain, truncatable FunctionName report instead of forcing the
+			// SymbolRefTable format on a query that never needed it. This
+			// keeps a symbol-ref query over an otherwise fully-symbolized
+			// tenant no more expensive than a plain one, and matches
+			// queryTree's own degenerate case (see queryTreeSymbolRefs).
+			plain := locationRefTreeToFunctionNameTree(a.symbolRefTree.Tree(), a.symbolRefTable.ResultBuilder())
+			result.Tree.Tree = plain.Bytes(a.query.GetMaxNodes(), nil)
+			return result
+		}
+		// A tree with unresolved entries must not be truncated before those
+		// are resolved: truncation is deferred to a later symbolref.Rebuild
+		// call, once resolution has happened.
+		rb := a.symbolRefTable.ResultBuilder()
+		result.Tree.Tree = a.symbolRefTree.Tree().Bytes(0, rb.KeepRef)
+		result.Tree.SymbolRefs = new(queryv1.SymbolRefTable)
+		rb.Build(result.Tree.SymbolRefs)
+		return result
+
+	case queryv1.SymbolMode_SYMBOL_MODE_FULL:
 		builder := a.symbolMerger.ResultBuilder()
 		result.Tree.Tree = a.lrTree.Tree().Bytes(a.query.GetMaxNodes(), builder.KeepSymbol)
 		result.Tree.Symbols = new(queryv1.TreeSymbols)
 		builder.Build(result.Tree.Symbols)
 		return result
-	}
 
-	result.Tree.Tree = a.tree.Tree().Bytes(a.query.GetMaxNodes(), nil)
-	return result
+	default:
+		result.Tree.Tree = a.tree.Tree().Bytes(a.query.GetMaxNodes(), nil)
+		return result
+	}
+}
+
+// absorbPlainTree unmarshals a plain FunctionNameTree and re-inserts every
+// stack into a LocationRefNameTree via dst.InternName. It maps
+// model.OtherFunctionName to model.OtherLocationRef directly rather than
+// through InternName, since both are the truncation sentinel in their
+// respective node-name spaces.
+func absorbPlainTree(dst *symbolref.Table, plainTreeBytes []byte) (*model.LocationRefNameTree, error) {
+	plain, err := model.UnmarshalTree[model.FunctionName, model.FunctionNameI](plainTreeBytes)
+	if err != nil {
+		return nil, err
+	}
+	absorbed := new(model.LocationRefNameTree)
+	plain.IterateStacks(func(_ model.FunctionName, self int64, stack []model.FunctionName) {
+		slices.Reverse(stack)
+		refs := make([]model.LocationRefName, len(stack))
+		for i, n := range stack {
+			if n == model.OtherFunctionName {
+				refs[i] = model.OtherLocationRef
+				continue
+			}
+			refs[i] = dst.InternName(string(n))
+		}
+		absorbed.InsertStack(self, refs...)
+	})
+	return absorbed, nil
+}
+
+// stackToInsert is a root-first stack of table refs, paired with its self
+// value, collected from a tree so an intermediate ResultBuilder pass can
+// run before it is known how any given ref renders as a name.
+type stackToInsert struct {
+	self  int64
+	stack []model.LocationRefName
+}
+
+// locationRefTreeToFunctionNameTree converts tree into a FunctionNameTree,
+// resolving every ref through rb. The caller must ensure rb's table has no
+// unresolved entries reachable from tree: any such ref renders as the
+// empty string, since there is no name to fall back to. rb may already
+// have observed refs from an earlier KeepRef/Build pass (e.g. a prior
+// marshal of the same tree): KeepRef is idempotent, so this only adds to
+// rb's state, never invalidates it.
+func locationRefTreeToFunctionNameTree(tree *model.LocationRefNameTree, rb *symbolref.ResultBuilder) *model.FunctionNameTree {
+	var stacks []stackToInsert
+	tree.IterateStacks(func(_ model.LocationRefName, self int64, stack []model.LocationRefName) {
+		cp := append([]model.LocationRefName(nil), stack...)
+		slices.Reverse(cp)
+		stacks = append(stacks, stackToInsert{self: self, stack: cp})
+	})
+
+	kept := make([][]model.LocationRefName, len(stacks))
+	for i, e := range stacks {
+		k := make([]model.LocationRefName, len(e.stack))
+		for j, ref := range e.stack {
+			k[j] = rb.KeepRef(ref)
+		}
+		kept[i] = k
+	}
+	pb := new(queryv1.SymbolRefTable)
+	rb.Build(pb)
+
+	out := new(model.FunctionNameTree)
+	for i, e := range stacks {
+		names := make([]model.FunctionName, len(e.stack))
+		for j, ref := range e.stack {
+			if ref == model.OtherLocationRef {
+				names[j] = model.OtherFunctionName
+				continue
+			}
+			if idx := kept[i][j]; idx >= 0 && int(idx) < len(pb.Names) {
+				names[j] = model.FunctionName(pb.Names[idx])
+			}
+		}
+		out.InsertStack(e.self, names...)
+	}
+	return out
 }

--- a/pkg/querybackend/query_tree.go
+++ b/pkg/querybackend/query_tree.go
@@ -196,7 +196,7 @@ func queryTree(q *queryContext, query *queryv1.Query) (*queryv1.Report, error) {
 	// for: keep the existing FunctionName path unconditionally, same as a
 	// non-symbol-ref query.
 	if mode == queryv1.SymbolMode_SYMBOL_MODE_REFS && datasetUnsymbolized(q.obj.Metadata(), q.ds.Metadata()) {
-		return queryTreeSymbolRefs(q, query, resolver)
+		return queryTreeSymbolRefs(query, resolver)
 	}
 
 	tree, err := resolver.Tree()
@@ -219,7 +219,7 @@ func queryTree(q *queryContext, query *queryv1.Query) (*queryv1.Report, error) {
 // the selected samples actually resolved to an unresolved location, the
 // dataset falls back to the plain FunctionName path, since there is
 // nothing left to defer.
-func queryTreeSymbolRefs(q *queryContext, query *queryv1.Query, resolver *symdb.Resolver) (*queryv1.Report, error) {
+func queryTreeSymbolRefs(query *queryv1.Query, resolver *symdb.Resolver) (*queryv1.Report, error) {
 	tree, rb, err := resolver.SymbolRefTree()
 	if err != nil {
 		return nil, err
@@ -310,6 +310,8 @@ func (a *treeAggregator) aggregate(report *queryv1.Report) error {
 			// A partial from a dataset that took the plain FunctionName
 			// path (native or degenerate, see queryTree): absorb it into
 			// the shared ref space instead of merging it as a plain tree.
+			// Absorption interns resolved names only, so it cannot grow
+			// the unresolved count.
 			absorbed, err := absorbPlainTree(a.symbolRefTable, r.Tree)
 			if err != nil {
 				return err
@@ -319,6 +321,9 @@ func (a *treeAggregator) aggregate(report *queryv1.Report) error {
 		}
 		remap, err := a.symbolRefTable.Add(r.SymbolRefs)
 		if err != nil {
+			return err
+		}
+		if err := a.checkUnresolvedLimit(); err != nil {
 			return err
 		}
 		return a.symbolRefTree.MergeTreeBytes(r.Tree, model.WithTreeMergeFormatNodeNames(remap))
@@ -346,6 +351,21 @@ func (a *treeAggregator) aggregate(report *queryv1.Report) error {
 		})
 		return a.tree.MergeTreeBytes(r.Tree)
 	}
+}
+
+// checkUnresolvedLimit fails the query once the merged table's distinct
+// unresolved locations exceed the query's limit: aggregation memory is
+// bounded by the same per-tenant knob that bounds each dataset's build
+// (see symdb.WithResolverSymbolRefCap).
+func (a *treeAggregator) checkUnresolvedLimit() error {
+	limit := a.query.GetMaxUnresolvedLocations()
+	if limit <= 0 {
+		return nil
+	}
+	if n := a.symbolRefTable.UnresolvedCount(); int64(n) > limit {
+		return fmt.Errorf("%w (limit %d)", symdb.ErrTooManyUnresolvedLocations, limit)
+	}
+	return nil
 }
 
 func (a *treeAggregator) build() *queryv1.Report {

--- a/pkg/querybackend/query_tree_symbolref_test.go
+++ b/pkg/querybackend/query_tree_symbolref_test.go
@@ -1,0 +1,231 @@
+package querybackend
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+	"github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/model/symbolref"
+)
+
+// TestDatasetUnsymbolized covers datasetUnsymbolized's label-pair scanning,
+// including a compacted dataset that carries more than one label set.
+func TestDatasetUnsymbolized(t *testing.T) {
+	// index: 0="" 1="__unsymbolized__" 2="true" 3="other_label" 4="other_value"
+	md := &metastorev1.BlockMeta{
+		StringTable: []string{"", "__unsymbolized__", "true", "other_label", "other_value"},
+	}
+	tests := []struct {
+		name   string
+		labels []int32
+		want   bool
+	}{
+		{name: "no labels", labels: nil, want: false},
+		{name: "unrelated label only", labels: []int32{1, 3, 4}, want: false},
+		{name: "unsymbolized=true", labels: []int32{1, 1, 2}, want: true},
+		{
+			name:   "unsymbolized=true among other label sets (compacted dataset)",
+			labels: []int32{1, 3, 4, 1, 1, 2},
+			want:   true,
+		},
+		{
+			name:   "unsymbolized label name present but value is not true",
+			labels: []int32{1, 1, 3},
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds := &metastorev1.Dataset{Labels: tt.labels}
+			assert.Equal(t, tt.want, datasetUnsymbolized(md, ds))
+		})
+	}
+}
+
+// plainReport builds a symbol_refs-mode partial report that took the plain
+// FunctionName path (native dataset, or a degenerate labeled one): no
+// SymbolRefs, Tree bytes are a marshaled FunctionNameTree.
+func plainReport(maxNodes int64, stacks map[string]int64) *queryv1.Report {
+	tree := new(model.FunctionNameTree)
+	for stack, self := range stacks {
+		tree.InsertStack(self, model.FunctionName(stack))
+	}
+	return &queryv1.Report{
+		Tree: &queryv1.TreeReport{
+			Query: &queryv1.TreeQuery{SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_REFS, MaxNodes: maxNodes},
+			Tree:  tree.Bytes(0, nil),
+		},
+	}
+}
+
+// refReport builds a symbol_refs-mode partial report with a genuine
+// unresolved entry: a single-frame stack referencing (buildID, addr).
+func refReport(maxNodes int64, self int64, buildID, binaryName string, addr uint64) *queryv1.Report {
+	table := symbolref.NewTable()
+	ref := table.InternUnresolved(buildID, binaryName, addr)
+	tree := new(model.LocationRefNameTree)
+	tree.InsertStack(self, ref)
+	rb := table.ResultBuilder()
+	treeBytes := tree.Bytes(0, rb.KeepRef)
+	pb := new(queryv1.SymbolRefTable)
+	rb.Build(pb)
+	return &queryv1.Report{
+		Tree: &queryv1.TreeReport{
+			Query:      &queryv1.TreeQuery{SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_REFS, MaxNodes: maxNodes},
+			Tree:       treeBytes,
+			SymbolRefs: pb,
+		},
+	}
+}
+
+// aggregate runs every report through a fresh treeAggregator and returns
+// the built TreeReport.
+func aggregate(t *testing.T, reports ...*queryv1.Report) *queryv1.TreeReport {
+	t.Helper()
+	a := newTreeAggregator(&queryv1.InvokeRequest{}).(*treeAggregator)
+	for _, r := range reports {
+		require.NoError(t, a.aggregate(r))
+	}
+	return a.build().Tree
+}
+
+// buildSymbolRefs aggregates reports and unmarshals the result as a
+// LocationRefNameTree, asserting a SymbolRefTable is attached (i.e. the
+// merge still has something unresolved; see TestTreeAggregator_SymbolRefs_
+// AllPlain and _OtherPreservation for the opposite, collapsed-to-plain
+// case). Every tree here has gone through a real marshal (build always
+// calls Tree.Bytes), which always keeps ref 0 as a side effect of
+// marshaling the format's virtual root node: pb.Names[0] is therefore
+// always "", the reserved sentinel (see symbolref.NewTable's doc comment),
+// on top of whatever real names the test cares about.
+func buildSymbolRefs(t *testing.T, reports ...*queryv1.Report) (*queryv1.SymbolRefTable, *model.LocationRefNameTree) {
+	t.Helper()
+	report := aggregate(t, reports...)
+	require.NotNil(t, report.SymbolRefs)
+	require.NotEmpty(t, report.SymbolRefs.Names)
+	assert.Equal(t, "", report.SymbolRefs.Names[0], "index 0 is always the reserved sentinel")
+	tree, err := model.UnmarshalTree[model.LocationRefName, model.LocationRefNameI](report.Tree)
+	require.NoError(t, err)
+	return report.SymbolRefs, tree
+}
+
+// realNames returns pb.Names with the reserved index-0 sentinel dropped.
+func realNames(pb *queryv1.SymbolRefTable) []string {
+	return pb.Names[1:]
+}
+
+// namesByRef resolves a leaf's own ref (the name IterateStacks passes to
+// its callback) to its SymbolRefTable name, using placeholders for the
+// truncation sentinel and unresolved entries.
+func namesByRef(pb *queryv1.SymbolRefTable, ref model.LocationRefName) string {
+	switch {
+	case ref == model.OtherLocationRef:
+		return "<other>"
+	case ref >= 0 && int(ref) < len(pb.Names):
+		return pb.Names[ref]
+	default:
+		return "<unresolved>"
+	}
+}
+
+// TestTreeAggregator_SymbolRefs_AllPlain covers every partial taking the
+// plain FunctionName path: the merged table has nothing unresolved, so
+// build() collapses back to a plain, truncatable FunctionName report
+// instead of forcing the SymbolRefTable format on it.
+func TestTreeAggregator_SymbolRefs_AllPlain(t *testing.T) {
+	report := aggregate(t, plainReport(2, map[string]int64{
+		"f1": 50, "f2": 40, "f3": 30, "f4": 20, "f5": 10,
+	}))
+	require.Nil(t, report.SymbolRefs, "nothing unresolved: must not force the SymbolRefTable format")
+
+	tree, err := model.UnmarshalTree[model.FunctionName, model.FunctionNameI](report.Tree)
+	require.NoError(t, err)
+
+	var otherTotal, total int64
+	var distinctNames int
+	tree.IterateStacks(func(name model.FunctionName, self int64, _ []model.FunctionName) {
+		total += self
+		if name == model.OtherFunctionName {
+			otherTotal += self
+		} else {
+			distinctNames++
+		}
+	})
+	assert.Equal(t, int64(150), total, "total sample value must be preserved across truncation")
+	assert.LessOrEqual(t, distinctNames, 2, "maxNodes=2 must truncate for real once nothing is unresolved")
+	assert.Greater(t, otherTotal, int64(0), "the truncated nodes must be folded into the other bucket")
+}
+
+// TestTreeAggregator_SymbolRefs_AllRef covers every partial carrying a
+// genuine unresolved entry: build() must not truncate, regardless of
+// MaxNodes, since doing so would be unsound before resolution.
+func TestTreeAggregator_SymbolRefs_AllRef(t *testing.T) {
+	pb, tree := buildSymbolRefs(t,
+		refReport(2, 50, "buildA", "binA", 0x1000),
+		refReport(2, 40, "buildB", "binB", 0x2000),
+		refReport(2, 30, "buildC", "binC", 0x3000),
+	)
+
+	require.Len(t, pb.UnresolvedBuildId, 3, "maxNodes must not drop unresolved entries")
+	assert.Equal(t, int64(120), tree.Total())
+
+	var sawOther bool
+	tree.IterateStacks(func(name model.LocationRefName, _ int64, _ []model.LocationRefName) {
+		if name == model.OtherLocationRef {
+			sawOther = true
+		}
+	})
+	assert.False(t, sawOther, "a tree with unresolved entries must not be truncated")
+}
+
+// TestTreeAggregator_SymbolRefs_Mixed covers a query that spans datasets in
+// different states (rollout skew): some partials plain (native or
+// degenerate), some carrying genuine unresolved entries. Every partial's
+// value must be preserved in the merged tree, and truncation must stay
+// disabled because at least one unresolved entry survives.
+func TestTreeAggregator_SymbolRefs_Mixed(t *testing.T) {
+	pb, tree := buildSymbolRefs(t,
+		plainReport(1, map[string]int64{"main": 7}),
+		refReport(1, 4, "buildB", "binB", 0x9000),
+	)
+
+	require.Len(t, pb.UnresolvedBuildId, 1)
+	assert.Equal(t, []string{"main"}, realNames(pb))
+	assert.Equal(t, int64(11), tree.Total())
+
+	totals := make(map[string]int64)
+	tree.IterateStacks(func(name model.LocationRefName, self int64, _ []model.LocationRefName) {
+		totals[namesByRef(pb, name)] += self
+	})
+	assert.Equal(t, int64(7), totals["main"], "the plain partial's stack must survive absorption with its original value")
+	assert.Equal(t, int64(4), totals["<unresolved>"], "the ref partial's stack must survive the merge with its original value")
+}
+
+// TestTreeAggregator_SymbolRefs_OtherPreservation covers a plain partial
+// that already carries the truncation sentinel (model.OtherFunctionName,
+// "other"): absorption must map it to model.OtherLocationRef, and, since
+// nothing else in this merge is unresolved, build()'s conversion back to
+// FunctionName format must map OtherLocationRef back to OtherFunctionName,
+// never through an ordinary resolvable name.
+func TestTreeAggregator_SymbolRefs_OtherPreservation(t *testing.T) {
+	report := aggregate(t, plainReport(0, map[string]int64{
+		"main":                          5,
+		string(model.OtherFunctionName): 3,
+	}))
+	require.Nil(t, report.SymbolRefs)
+
+	tree, err := model.UnmarshalTree[model.FunctionName, model.FunctionNameI](report.Tree)
+	require.NoError(t, err)
+
+	var otherSelf int64
+	tree.IterateStacks(func(name model.FunctionName, self int64, _ []model.FunctionName) {
+		if name == model.OtherFunctionName {
+			otherSelf = self
+		}
+	})
+	assert.Equal(t, int64(3), otherSelf, "the sentinel's value must round-trip through OtherLocationRef and back")
+}

--- a/pkg/querybackend/query_tree_symbolref_test.go
+++ b/pkg/querybackend/query_tree_symbolref_test.go
@@ -10,6 +10,7 @@ import (
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
 	"github.com/grafana/pyroscope/v2/pkg/model"
 	"github.com/grafana/pyroscope/v2/pkg/model/symbolref"
+	"github.com/grafana/pyroscope/v2/pkg/phlaredb/symdb"
 )
 
 // TestDatasetUnsymbolized covers datasetUnsymbolized's label-pair scanning,
@@ -228,4 +229,35 @@ func TestTreeAggregator_SymbolRefs_OtherPreservation(t *testing.T) {
 		}
 	})
 	assert.Equal(t, int64(3), otherSelf, "the sentinel's value must round-trip through OtherLocationRef and back")
+}
+
+// TestTreeAggregator_SymbolRefs_UnresolvedLimit verifies the merged table's
+// distinct unresolved locations are bounded by the query's
+// max_unresolved_locations: aggregation fails once the limit is crossed,
+// while a merge exactly at the limit succeeds.
+func TestTreeAggregator_SymbolRefs_UnresolvedLimit(t *testing.T) {
+	reports := func(limit int64) []*queryv1.Report {
+		rs := []*queryv1.Report{
+			refReport(0, 1, "build-a", "bin-a", 0x100),
+			refReport(0, 2, "build-b", "bin-b", 0x200),
+		}
+		for _, r := range rs {
+			r.Tree.Query.MaxUnresolvedLocations = limit
+		}
+		return rs
+	}
+
+	t.Run("at the limit", func(t *testing.T) {
+		a := newTreeAggregator(&queryv1.InvokeRequest{}).(*treeAggregator)
+		for _, r := range reports(2) {
+			require.NoError(t, a.aggregate(r))
+		}
+	})
+
+	t.Run("past the limit", func(t *testing.T) {
+		a := newTreeAggregator(&queryv1.InvokeRequest{}).(*treeAggregator)
+		rs := reports(1)
+		require.NoError(t, a.aggregate(rs[0]))
+		require.ErrorIs(t, a.aggregate(rs[1]), symdb.ErrTooManyUnresolvedLocations)
+	})
 }

--- a/pkg/querybackend/query_tree_test.go
+++ b/pkg/querybackend/query_tree_test.go
@@ -195,6 +195,7 @@ func TestTreeSymbolMode(t *testing.T) {
 		{name: "unset defaults to name", query: &queryv1.TreeQuery{}, want: queryv1.SymbolMode_SYMBOL_MODE_NAME},
 		{name: "name", query: &queryv1.TreeQuery{SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_NAME}, want: queryv1.SymbolMode_SYMBOL_MODE_NAME},
 		{name: "full", query: &queryv1.TreeQuery{SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_FULL}, want: queryv1.SymbolMode_SYMBOL_MODE_FULL},
+		{name: "refs", query: &queryv1.TreeQuery{SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_REFS}, want: queryv1.SymbolMode_SYMBOL_MODE_REFS},
 		{
 			name:  "deprecated full_symbols maps to full",
 			query: &queryv1.TreeQuery{FullSymbols: true}, //nolint:staticcheck // exercises the deprecated bridge
@@ -204,11 +205,6 @@ func TestTreeSymbolMode(t *testing.T) {
 			name:    "full_symbols combined with symbol_mode is rejected",
 			query:   &queryv1.TreeQuery{FullSymbols: true, SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_FULL}, //nolint:staticcheck // exercises the deprecated bridge
 			wantErr: "must not be combined",
-		},
-		{
-			name:    "refs is not implemented yet",
-			query:   &queryv1.TreeQuery{SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_REFS},
-			wantErr: "unsupported symbol_mode",
 		},
 		{
 			name:    "unknown mode is rejected",
@@ -226,4 +222,55 @@ func TestTreeSymbolMode(t *testing.T) {
 			require.Equal(t, tc.want, mode)
 		})
 	}
+}
+
+// Test_QueryTree_SymbolModeConflict verifies that a query combining the
+// deprecated full_symbols bool with an explicit symbol_mode is rejected end
+// to end, rather than silently preferring one and dropping the other.
+func (s *testSuite) Test_QueryTree_SymbolModeConflict() {
+	_, err := s.reader.Invoke(s.ctx, &queryv1.InvokeRequest{
+		EndTime:       time.Now().UnixMilli(),
+		LabelSelector: "{}",
+		QueryPlan:     s.plan,
+		Query: []*queryv1.Query{{
+			QueryType: queryv1.QueryType_QUERY_TREE,
+			Tree:      &queryv1.TreeQuery{FullSymbols: true, SymbolMode: queryv1.SymbolMode_SYMBOL_MODE_REFS}, //nolint:staticcheck // exercises the deprecated bridge
+		}},
+		Tenant: s.tenant,
+	})
+	s.Require().Error(err)
+	s.Assert().Contains(err.Error(), "full_symbols must not be combined with symbol_mode")
+}
+
+// Test_QueryTree_SymbolRefs_NativeDatasetKeepsPlainPath verifies that a
+// SYMBOL_MODE_REFS query against a dataset not labeled unsymbolized (every
+// dataset in the test fixtures) keeps today's FunctionName path exactly:
+// no SymbolRefTable is attached, and the tree matches a names-only query
+// byte for byte in structure (same totals, no TREE->PPROF detour).
+func (s *testSuite) Test_QueryTree_SymbolRefs_NativeDatasetKeepsPlainPath() {
+	invoke := func(mode queryv1.SymbolMode) *queryv1.TreeReport {
+		resp, err := s.reader.Invoke(s.ctx, &queryv1.InvokeRequest{
+			EndTime:       time.Now().UnixMilli(),
+			LabelSelector: "{}",
+			QueryPlan:     s.plan,
+			Query: []*queryv1.Query{{
+				QueryType: queryv1.QueryType_QUERY_TREE,
+				Tree:      &queryv1.TreeQuery{MaxNodes: 16, SymbolMode: mode},
+			}},
+			Tenant: s.tenant,
+		})
+		s.Require().NoError(err)
+		s.Require().Len(resp.Reports, 1)
+		return resp.Reports[0].Tree
+	}
+
+	plain := invoke(queryv1.SymbolMode_SYMBOL_MODE_NAME)
+	symbolRefs := invoke(queryv1.SymbolMode_SYMBOL_MODE_REFS)
+	s.Assert().Nil(symbolRefs.SymbolRefs, "a native dataset must not attach a SymbolRefTable")
+
+	plainTree, err := phlaremodel.UnmarshalTree[phlaremodel.FunctionName, phlaremodel.FunctionNameI](plain.Tree)
+	s.Require().NoError(err)
+	symbolRefsTree, err := phlaremodel.UnmarshalTree[phlaremodel.FunctionName, phlaremodel.FunctionNameI](symbolRefs.Tree)
+	s.Require().NoError(err)
+	s.Assert().Equal(plainTree.String(), symbolRefsTree.String())
 }


### PR DESCRIPTION
## Part of a series: symbol-aware tree references (5b of 8)

Full context and series overview: #5317 (PR 1). Compact map:

1. symbolizer: expose address-level `Resolve` API (#5317)
2. proto: `SymbolRefTable` + tree query/report fields (#5318)
3. `model/symbolref`: intern table + merge rebasing (#5321)
4. `model/symbolref`: unresolved-binary grouping + tree rebuild (#5322)
5. symdb: symbol-ref tree resolver output (#5332) · **querybackend: query mode + aggregation ← this PR**
6. frontend: orchestration behind a default-off per-tenant flag — nothing activates before this
7. integration tests + docs (#5335)
8. symdb: compaction preserves line-less locations (#5337) — stacked at the bottom of the series, merges first

Tracking issue: grafana/pyroscope-squad#487. Based on #5332's branch; the diff here is only the query-execution and aggregation changes.

## What

Teaches the query backend to produce and merge symbol-ref tree reports.

- **Per-dataset gating.** When a tree query requests symbol references (mutually exclusive with full symbols — validated), a dataset labeled `__unsymbolized__` at ingest builds a symbol-ref tree (via `Resolver.SymbolRefTree` from #5332); an unlabeled, already-symbolized dataset keeps today's exact `FunctionName` path. The label is read from dataset metadata available at query-execution time, so this works for queryless queries routed through the tenant-wide index — the gap that motivated the issue.
- **Content-driven collapse.** A labeled dataset whose selected samples produced no unresolved locations (rollout skew, or a selector that only matched resolved stacks) converts back to a plain, truncatable tree — only data that actually needs symbolization pays the deferred-truncation cost.
- **Mixed-shape aggregation.** The tree aggregator merges partials of both shapes into one result: symbol-ref partials rebase their references through a shared table; plain partials (unlabeled datasets, or older backends mid-rollout) are absorbed by interning their names, with the truncation "other" sentinel mapped explicitly across the representation boundary. The merged output stays untruncated while any unresolved reference remains, and collapses to a plain tree otherwise.

No pprof detour is taken on any of these paths, so every tree-query selector (span, trace, profile-ID, stack-trace) flows through unchanged.

## Cap

Distinct unresolved references per dataset are capped (1,000,000 by default, a limit chosen empirically from the worst-case rebuild cost); on overflow, further locations render inline fallback names so the tree stays bounded. A counter tracks how often the cap is exceeded — the one operationally meaningful signal here, since exceeding it means symbolization silently degraded.

## Testing

`go test ./pkg/querybackend/... -race` green. New tests: the dataset gate (5 cases), the aggregator across all-plain / all-ref / mixed / "other"-preservation, mutual-exclusion validation, and a native-dataset plain-path integration test on the real block fixture. `golangci-lint` clean; whole-repo build clean.

An end-to-end test driving the labeled-dataset paths through a real block needs fixtures with `__unsymbolized__` datasets, which the integration suite (final PR of the series) introduces for the queryless-query case; the gate, aggregator, and helpers are unit-tested directly here, and the resolver semantics are covered in #5332.

