### PR TITLE
feat(frontend): resolve symbol-ref trees after the final merge

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -1619,6 +1619,10 @@ Usage of ./pyroscope:
     	[experimental] Enable symbolization for tenants by default.
   -symbolizer.max-debuginfod-concurrency int
     	Maximum number of concurrent symbolization requests to debuginfod server. (default 10)
+  -symbolizer.resolve-timeout duration
+    	Maximum time the query frontend waits to resolve a single binary's unresolved addresses for a symbol-ref tree query, before falling back to binary!0xaddr frames for that binary. (default 20s)
+  -symbolizer.symbol-ref-trees-enabled
+    	[experimental] Enable symbol-aware tree references: tree queries are executed natively and symbolized by the frontend after the final merge, instead of being rewritten to pprof. Requires a symbolizer to be configured.
   -target comma-separated-list-of-strings
     	Comma-separated list of Pyroscope modules to load. The alias 'all' can be used in the list to load a number of core modules and will enable single-binary mode.  (default all)
   -tenant-settings.recording-rules.enabled

--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -1619,6 +1619,8 @@ Usage of ./pyroscope:
     	[experimental] Enable symbolization for tenants by default.
   -symbolizer.max-debuginfod-concurrency int
     	Maximum number of concurrent symbolization requests to debuginfod server. (default 10)
+  -symbolizer.max-unresolved-locations int
+    	[experimental] Maximum number of distinct unresolved locations a symbol-ref tree query may carry through the read path before symbolization; a query exceeding the limit fails. 0 disables the limit. (default 1000000)
   -symbolizer.resolve-timeout duration
     	Maximum time the query frontend waits to resolve a single binary's unresolved addresses for a symbol-ref tree query, before falling back to binary!0xaddr frames for that binary. (default 20s)
   -symbolizer.symbol-ref-trees-enabled

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -121,6 +121,8 @@ type Limits interface {
 	SymbolizerEnabled(string) bool
 	QuerySanitizeOnMerge(string) bool
 	QueryTreeEnabled(string) bool
+	SymbolRefTreesEnabled(string) bool
+	SymbolizerResolveTimeout(string) time.Duration
 	validation.FlameGraphLimits
 }
 

--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -123,6 +123,7 @@ type Limits interface {
 	QueryTreeEnabled(string) bool
 	SymbolRefTreesEnabled(string) bool
 	SymbolizerResolveTimeout(string) time.Duration
+	SymbolizerMaxUnresolvedLocations(string) int
 	validation.FlameGraphLimits
 }
 

--- a/pkg/frontend/readpath/queryfrontend/query_frontend.go
+++ b/pkg/frontend/readpath/queryfrontend/query_frontend.go
@@ -23,6 +23,7 @@ import (
 	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
 	"github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect"
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+	"github.com/grafana/pyroscope/lidia"
 	"github.com/grafana/pyroscope/v2/pkg/block"
 	"github.com/grafana/pyroscope/v2/pkg/block/metadata"
 	"github.com/grafana/pyroscope/v2/pkg/frontend"
@@ -40,6 +41,10 @@ type QueryBackend interface {
 
 type Symbolizer interface {
 	SymbolizePprof(ctx context.Context, profile *googlev1.Profile) error
+	Resolve(ctx context.Context, buildID, binaryName string, addrs []uint64) ([][]lidia.SourceInfoFrame, error)
+	// ResolveConcurrency is the maximum number of concurrent Resolve calls
+	// the symbolizer allows.
+	ResolveConcurrency() int
 }
 
 // DiagnosticsStore provides the ability to store query diagnostics.
@@ -65,6 +70,8 @@ type QueryFrontend struct {
 type queryFrontendMetrics struct {
 	fetchedBytesTotal       *prometheus.CounterVec
 	estimationAccuracyRatio prometheus.Histogram
+
+	symbolRefLocationsTotal *prometheus.CounterVec
 }
 
 func newQueryFrontendMetrics(reg prometheus.Registerer) *queryFrontendMetrics {
@@ -99,9 +106,22 @@ func newQueryFrontendMetrics(reg prometheus.Registerer) *queryFrontendMetrics {
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: time.Hour,
 		}),
+		symbolRefLocationsTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "pyroscope",
+				Subsystem: "query_frontend",
+				Name:      "symbol_ref_locations_total",
+				Help:      "Total number of unresolved symbol-ref locations processed by the query frontend, by outcome (resolved, a symbolizer miss, or a per-binary resolve timeout).",
+			},
+			[]string{"result"},
+		),
 	}
 	if reg != nil {
-		reg.MustRegister(m.fetchedBytesTotal, m.estimationAccuracyRatio)
+		reg.MustRegister(
+			m.fetchedBytesTotal,
+			m.estimationAccuracyRatio,
+			m.symbolRefLocationsTotal,
+		)
 	}
 	return m
 }

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_span_profile_test.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_span_profile_test.go
@@ -100,7 +100,7 @@ func TestSelectMergeSpanProfile_Symbolization(t *testing.T) {
 			},
 			setupMocks: func(l *mockfrontend.MockLimits, s *mockqueryfrontend.MockSymbolizer) {
 				l.On("SymbolizerEnabled", "tenant2").Return(false)
-				l.On("SymbolRefTreesEnabled", "tenant2").Return(false)
+				l.On("SymbolRefTreesEnabled", "tenant2").Return(false).Maybe() // short-circuited when symbolization is off
 				l.On("QuerySanitizeOnMerge", "tenant2").Return(false)
 			},
 			// No symbolizer wrapping: backend receives QUERY_TREE with SpanSelector intact.

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_span_profile_test.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_span_profile_test.go
@@ -68,6 +68,7 @@ func TestSelectMergeSpanProfile_Symbolization(t *testing.T) {
 			},
 			setupMocks: func(l *mockfrontend.MockLimits, s *mockqueryfrontend.MockSymbolizer) {
 				l.On("SymbolizerEnabled", "tenant1").Return(true)
+				l.On("SymbolRefTreesEnabled", "tenant1").Return(false)
 				l.On("QuerySanitizeOnMerge", "tenant1").Return(false)
 				s.On("SymbolizePprof", mock.Anything, mock.Anything).
 					Run(func(args mock.Arguments) {
@@ -99,6 +100,7 @@ func TestSelectMergeSpanProfile_Symbolization(t *testing.T) {
 			},
 			setupMocks: func(l *mockfrontend.MockLimits, s *mockqueryfrontend.MockSymbolizer) {
 				l.On("SymbolizerEnabled", "tenant2").Return(false)
+				l.On("SymbolRefTreesEnabled", "tenant2").Return(false)
 				l.On("QuerySanitizeOnMerge", "tenant2").Return(false)
 			},
 			// No symbolizer wrapping: backend receives QUERY_TREE with SpanSelector intact.
@@ -122,6 +124,7 @@ func TestSelectMergeSpanProfile_Symbolization(t *testing.T) {
 			},
 			setupMocks: func(l *mockfrontend.MockLimits, s *mockqueryfrontend.MockSymbolizer) {
 				l.On("SymbolizerEnabled", "tenant3").Return(true)
+				l.On("SymbolRefTreesEnabled", "tenant3").Return(false)
 				l.On("QuerySanitizeOnMerge", "tenant3").Return(false)
 			},
 			// No symbolizer wrapping: backend receives QUERY_TREE with SpanSelector intact.

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces.go
@@ -128,6 +128,16 @@ func (q *QueryFrontend) selectMergeStacktracesTree(
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	useSymbolRefs := q.useSymbolRefTrees(tenantIDs)
+	treeQuery := &queryv1.TreeQuery{
+		MaxNodes:           maxNodes,
+		StackTraceSelector: c.Msg.StackTraceSelector,
+		ProfileIdSelector:  c.Msg.ProfileIdSelector,
+		TraceIdSelector:    c.Msg.TraceIdSelector,
+		SpanSelector:       c.Msg.SpanSelector,
+	}
+	if useSymbolRefs {
+		q.symbolRefTreeQuery(treeQuery, tenantIDs)
+	}
 	report, err := q.querySingle(ctx,
 		&queryv1.QueryRequest{
 			StartTime:     c.Msg.Start,
@@ -135,14 +145,7 @@ func (q *QueryFrontend) selectMergeStacktracesTree(
 			LabelSelector: labelSelector,
 			Query: []*queryv1.Query{{
 				QueryType: queryv1.QueryType_QUERY_TREE,
-				Tree: &queryv1.TreeQuery{
-					MaxNodes:           maxNodes,
-					StackTraceSelector: c.Msg.StackTraceSelector,
-					ProfileIdSelector:  c.Msg.ProfileIdSelector,
-					TraceIdSelector:    c.Msg.TraceIdSelector,
-					SpanSelector:       c.Msg.SpanSelector,
-					SymbolRefs:         useSymbolRefs,
-				},
+				Tree:      treeQuery,
 			}},
 		},
 		func(ctx context.Context, upstream QueryBackend, blocks []*metastorev1.BlockMeta) QueryBackend {

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces.go
@@ -127,6 +127,7 @@ func (q *QueryFrontend) selectMergeStacktracesTree(
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
+	useSymbolRefs := q.useSymbolRefTrees(tenantIDs)
 	report, err := q.querySingle(ctx,
 		&queryv1.QueryRequest{
 			StartTime:     c.Msg.Start,
@@ -140,10 +141,14 @@ func (q *QueryFrontend) selectMergeStacktracesTree(
 					ProfileIdSelector:  c.Msg.ProfileIdSelector,
 					TraceIdSelector:    c.Msg.TraceIdSelector,
 					SpanSelector:       c.Msg.SpanSelector,
+					SymbolRefs:         useSymbolRefs,
 				},
 			}},
 		},
 		func(ctx context.Context, upstream QueryBackend, blocks []*metastorev1.BlockMeta) QueryBackend {
+			if useSymbolRefs {
+				return upstream
+			}
 			shouldSymbolize := q.shouldSymbolize(ctx, tenantIDs, blocks)
 			if !shouldSymbolize {
 				return upstream
@@ -159,6 +164,9 @@ func (q *QueryFrontend) selectMergeStacktracesTree(
 	}
 	if report == nil {
 		return nil, nil
+	}
+	if err := q.resolveSymbolRefs(ctx, tenantIDs, report, maxNodes); err != nil {
+		return nil, err
 	}
 	return report.Tree.Tree, nil
 }

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces_test.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces_test.go
@@ -199,6 +199,7 @@ func TestSelectMergeStacktrace_Symbolization(t *testing.T) {
 			},
 			setupMocks: func(l *mockfrontend.MockLimits, s *mockqueryfrontend.MockSymbolizer) {
 				l.On("SymbolizerEnabled", "tenant1").Return(true)
+				l.On("SymbolRefTreesEnabled", "tenant1").Return(false)
 				l.On("QuerySanitizeOnMerge", "tenant1").Return(false)
 				s.On("SymbolizePprof", mock.Anything, mock.Anything).
 					Run(func(args mock.Arguments) {
@@ -223,6 +224,7 @@ func TestSelectMergeStacktrace_Symbolization(t *testing.T) {
 			},
 			setupMocks: func(l *mockfrontend.MockLimits, s *mockqueryfrontend.MockSymbolizer) {
 				l.On("SymbolizerEnabled", "tenant2").Return(false)
+				l.On("SymbolRefTreesEnabled", "tenant2").Return(false)
 				l.On("QuerySanitizeOnMerge", "tenant2").Return(false)
 			},
 		},
@@ -240,6 +242,7 @@ func TestSelectMergeStacktrace_Symbolization(t *testing.T) {
 			},
 			setupMocks: func(l *mockfrontend.MockLimits, s *mockqueryfrontend.MockSymbolizer) {
 				l.On("SymbolizerEnabled", "tenant3").Return(true)
+				l.On("SymbolRefTreesEnabled", "tenant3").Return(false)
 				l.On("QuerySanitizeOnMerge", "tenant3").Return(false)
 			},
 		},

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces_test.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces_test.go
@@ -224,7 +224,7 @@ func TestSelectMergeStacktrace_Symbolization(t *testing.T) {
 			},
 			setupMocks: func(l *mockfrontend.MockLimits, s *mockqueryfrontend.MockSymbolizer) {
 				l.On("SymbolizerEnabled", "tenant2").Return(false)
-				l.On("SymbolRefTreesEnabled", "tenant2").Return(false)
+				l.On("SymbolRefTreesEnabled", "tenant2").Return(false).Maybe() // short-circuited when symbolization is off
 				l.On("QuerySanitizeOnMerge", "tenant2").Return(false)
 			},
 		},

--- a/pkg/frontend/readpath/queryfrontend/symbol_ref_resolve.go
+++ b/pkg/frontend/readpath/queryfrontend/symbol_ref_resolve.go
@@ -39,7 +39,10 @@ func (q *QueryFrontend) resolveSymbolRefs(ctx context.Context, tenantIDs []strin
 	if pb == nil {
 		return nil
 	}
-	binaries := symbolref.UnresolvedBinaries(pb)
+	binaries, err := symbolref.UnresolvedBinaries(pb)
+	if err != nil {
+		return err
+	}
 	if len(binaries) == 0 {
 		return nil
 	}

--- a/pkg/frontend/readpath/queryfrontend/symbol_ref_resolve.go
+++ b/pkg/frontend/readpath/queryfrontend/symbol_ref_resolve.go
@@ -151,9 +151,12 @@ func (q *QueryFrontend) buildLookup(results []binaryResolution) symbolRefLookup 
 				missed++
 				continue
 			}
+			// lidia returns frames innermost-first (pprof Line order);
+			// Rebuild splices chains in root-first order, outermost caller
+			// first. Reverse at this boundary.
 			out := make([]symbolref.Frame, len(frames))
 			for j, f := range frames {
-				out[j] = symbolref.Frame{Name: f.FunctionName}
+				out[len(frames)-1-j] = symbolref.Frame{Name: f.FunctionName}
 			}
 			lookup[symbolRefAddr{r.binary.BuildID, addr}] = out
 			resolved++

--- a/pkg/frontend/readpath/queryfrontend/symbol_ref_resolve.go
+++ b/pkg/frontend/readpath/queryfrontend/symbol_ref_resolve.go
@@ -1,0 +1,166 @@
+package queryfrontend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/grafana/dskit/tracing"
+	"golang.org/x/sync/errgroup"
+
+	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+	"github.com/grafana/pyroscope/lidia"
+	"github.com/grafana/pyroscope/v2/pkg/model/symbolref"
+	validationutil "github.com/grafana/pyroscope/v2/pkg/util/validation"
+)
+
+const (
+	symbolRefLocationResolved = "resolved"
+	symbolRefLocationMiss     = "miss"
+	symbolRefLocationTimeout  = "timeout"
+
+	defaultResolveTimeout = 20 * time.Second
+	// minResolveConcurrency is a last-resort floor, not a default: the real
+	// default lives in pkg/symbolizer.Symbolizer.ResolveConcurrency. This
+	// only guards against a Symbolizer implementation that returns a
+	// non-positive value, which would otherwise block errgroup.SetLimit
+	// forever.
+	minResolveConcurrency = 1
+)
+
+// resolveSymbolRefs replaces a symbol-ref tree report's tree bytes with a
+// plain FunctionName tree, resolving every unresolved {buildID, address}
+// reference through the symbolizer. It is a no-op when the report carries no
+// symbol-ref table, or the table has nothing unresolved: today's plain tree
+// bytes are returned untouched either way.
+func (q *QueryFrontend) resolveSymbolRefs(ctx context.Context, tenantIDs []string, report *queryv1.Report, maxNodes int64) error {
+	pb := report.GetTree().GetSymbolRefs()
+	if pb == nil {
+		return nil
+	}
+	binaries := symbolref.UnresolvedBinaries(pb)
+	if len(binaries) == 0 {
+		return nil
+	}
+
+	span, ctx := tracing.StartSpanFromContext(ctx, "QueryFrontend.resolveSymbolRefs")
+	defer span.Finish()
+	span.SetTag("binaries", len(binaries))
+	span.SetTag("unresolved_references", len(pb.GetUnresolvedAddress()))
+
+	lookup, err := q.resolveBinaries(ctx, tenantIDs, binaries)
+	if err != nil {
+		return err
+	}
+
+	rebuilt, err := symbolref.Rebuild(report.Tree.Tree, pb, lookup.resolve, maxNodes)
+	if err != nil {
+		return fmt.Errorf("rebuild symbol-ref tree: %w", err)
+	}
+	report.Tree.Tree = rebuilt
+	report.Tree.SymbolRefs = nil
+	return nil
+}
+
+// symbolRefLookup maps a resolved (buildID, address) location to its frame
+// chain; an absent entry means the location has no resolution and Rebuild
+// renders the binary!0xaddr fallback for it.
+type symbolRefLookup map[symbolRefAddr][]symbolref.Frame
+
+type symbolRefAddr struct {
+	buildID string
+	addr    uint64
+}
+
+func (l symbolRefLookup) resolve(buildID string, addr uint64) []symbolref.Frame {
+	return l[symbolRefAddr{buildID, addr}]
+}
+
+// binaryResolution is the outcome of resolving one UnresolvedBinary.
+type binaryResolution struct {
+	binary symbolref.UnresolvedBinary
+	// frames is aligned to binary.Addresses; nil when timedOut is true.
+	frames [][]lidia.SourceInfoFrame
+	// timedOut is true when the binary's own resolve timebox expired while
+	// the parent request context was still live: every address is a miss.
+	timedOut bool
+}
+
+// resolveBinaries resolves every UnresolvedBinary concurrently, bounded by
+// the symbolizer's own configured concurrency (the same bound
+// SymbolizePprof's debuginfod fetches use) and timeboxed per binary by the
+// tenants' resolve-timeout limit.
+//
+// Resolve errors only when its context is done. A binary whose own timebox
+// expires while ctx (the request context) is still live is recorded as a
+// miss for all of its addresses rather than failing the request, since the
+// timeout only bounds that one binary's resolution cost; if ctx itself is
+// done (canceled, or its own deadline reached), the error is propagated and
+// the request fails, matching how SymbolizePprof errors are treated at these
+// call sites today.
+func (q *QueryFrontend) resolveBinaries(ctx context.Context, tenantIDs []string, binaries []symbolref.UnresolvedBinary) (symbolRefLookup, error) {
+	timeout := validationutil.SmallestPositiveNonZeroDurationPerTenant(tenantIDs, q.limits.SymbolizerResolveTimeout)
+	if timeout <= 0 {
+		timeout = defaultResolveTimeout
+	}
+	concurrency := q.symbolizer.ResolveConcurrency()
+	if concurrency < 1 {
+		concurrency = minResolveConcurrency
+	}
+
+	results := make([]binaryResolution, len(binaries))
+	var g errgroup.Group
+	g.SetLimit(concurrency)
+	for i, binary := range binaries {
+		g.Go(func() error {
+			binCtx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			frames, err := q.symbolizer.Resolve(binCtx, binary.BuildID, binary.BinaryName, binary.Addresses)
+			if err != nil {
+				if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+					results[i] = binaryResolution{binary: binary, timedOut: true}
+					return nil
+				}
+				return fmt.Errorf("resolve build id %s: %w", binary.BuildID, err)
+			}
+			results[i] = binaryResolution{binary: binary, frames: frames}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	return q.buildLookup(results), nil
+}
+
+// buildLookup flattens per-binary resolutions into a single lookup table and
+// records the resolved/miss/timeout location counts.
+func (q *QueryFrontend) buildLookup(results []binaryResolution) symbolRefLookup {
+	lookup := make(symbolRefLookup)
+	var resolved, missed, timedOut int
+	for _, r := range results {
+		for i, addr := range r.binary.Addresses {
+			if r.timedOut {
+				timedOut++
+				continue
+			}
+			frames := r.frames[i]
+			if len(frames) == 0 {
+				missed++
+				continue
+			}
+			out := make([]symbolref.Frame, len(frames))
+			for j, f := range frames {
+				out[j] = symbolref.Frame{Name: f.FunctionName}
+			}
+			lookup[symbolRefAddr{r.binary.BuildID, addr}] = out
+			resolved++
+		}
+	}
+	q.metrics.symbolRefLocationsTotal.WithLabelValues(symbolRefLocationResolved).Add(float64(resolved))
+	q.metrics.symbolRefLocationsTotal.WithLabelValues(symbolRefLocationMiss).Add(float64(missed))
+	q.metrics.symbolRefLocationsTotal.WithLabelValues(symbolRefLocationTimeout).Add(float64(timedOut))
+	return lookup
+}

--- a/pkg/frontend/readpath/queryfrontend/symbol_ref_resolve_test.go
+++ b/pkg/frontend/readpath/queryfrontend/symbol_ref_resolve_test.go
@@ -238,6 +238,27 @@ func TestSelectMergeStacktracesTree_SymbolRefResolution(t *testing.T) {
 	mockSymbolizer.AssertExpectations(t)
 }
 
+// TestBuildLookup_ReversesLidiaFrameOrder verifies the lookup reverses each
+// resolved chain from lidia's innermost-first order (pprof Line order) to
+// the root-first order Rebuild splices in: without the reversal, inlined
+// frames render with parent and child flipped relative to the legacy pprof
+// path (see TestRebuildInlineChainExpansionOrder for the Rebuild-side
+// contract).
+func TestBuildLookup_ReversesLidiaFrameOrder(t *testing.T) {
+	qf := NewQueryFrontend(log.NewNopLogger(), nil, nil, nil, nil, nil, nil, nil)
+	lookup := qf.buildLookup([]binaryResolution{{
+		binary: symbolref.UnresolvedBinary{BuildID: "build-a", BinaryName: "libfoo.so", Addresses: []uint64{0x100}},
+		frames: [][]lidia.SourceInfoFrame{{
+			{FunctionName: "inner"},
+			{FunctionName: "inlined_middle"},
+			{FunctionName: "outer"},
+		}},
+	}})
+	require.Equal(t,
+		[]symbolref.Frame{{Name: "outer"}, {Name: "inlined_middle"}, {Name: "inner"}},
+		lookup.resolve("build-a", 0x100))
+}
+
 // TestResolveSymbolRefs_NoSymbolRefTable verifies a report without a
 // symbol-ref table (an old backend, or a fully-symbolized dataset) passes
 // through completely unchanged: no symbolizer call, tree bytes untouched.

--- a/pkg/frontend/readpath/queryfrontend/symbol_ref_resolve_test.go
+++ b/pkg/frontend/readpath/queryfrontend/symbol_ref_resolve_test.go
@@ -1,0 +1,419 @@
+package queryfrontend
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+	"github.com/grafana/pyroscope/lidia"
+	phlaremodel "github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/model/symbolref"
+	"github.com/grafana/pyroscope/v2/pkg/tenant"
+	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockfrontend"
+	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockmetastorev1"
+	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockqueryfrontend"
+)
+
+// buildSymbolRefFixture returns a symbol-ref tree/table pair rooted at a
+// resolved frame ("known_func") with two unresolved locations on build
+// "build-a" (0x100 and 0x200, deliberately out of address order) and one on
+// build "build-b" (0x300).
+func buildSymbolRefFixture(t *testing.T) ([]byte, *queryv1.SymbolRefTable) {
+	t.Helper()
+	table := symbolref.NewTable()
+	known := table.InternName("known_func")
+	locHit := table.InternUnresolved("build-a", "libfoo.so", 0x100)
+	locMiss := table.InternUnresolved("build-a", "libfoo.so", 0x200)
+	locOther := table.InternUnresolved("build-b", "libbar.so", 0x300)
+
+	tree := new(phlaremodel.LocationRefNameTree)
+	tree.InsertStack(1, known)
+	tree.InsertStack(2, known, locHit)
+	tree.InsertStack(3, known, locMiss)
+	tree.InsertStack(4, known, locOther)
+
+	rb := table.ResultBuilder()
+	treeBytes := tree.Bytes(0, rb.KeepRef)
+	pb := new(queryv1.SymbolRefTable)
+	rb.Build(pb)
+	return treeBytes, pb
+}
+
+func flameNames(t *testing.T, treeBytes []byte) []string {
+	t.Helper()
+	tr, err := phlaremodel.UnmarshalTree[phlaremodel.FunctionName, phlaremodel.FunctionNameI](treeBytes)
+	require.NoError(t, err)
+	return phlaremodel.NewFlameGraph(tr, -1).Names
+}
+
+func TestUseSymbolRefTrees(t *testing.T) {
+	tests := []struct {
+		name          string
+		noSymbolizer  bool
+		tenants       []string
+		enabledPerTID map[string]bool
+		want          bool
+	}{
+		{
+			name:         "no symbolizer configured",
+			noSymbolizer: true,
+			tenants:      []string{"tenant-a"},
+			want:         false,
+		},
+		{
+			name:          "single tenant enabled",
+			tenants:       []string{"tenant-a"},
+			enabledPerTID: map[string]bool{"tenant-a": true},
+			want:          true,
+		},
+		{
+			name:          "single tenant disabled",
+			tenants:       []string{"tenant-a"},
+			enabledPerTID: map[string]bool{"tenant-a": false},
+			want:          false,
+		},
+		{
+			name:          "all tenants enabled",
+			tenants:       []string{"tenant-a", "tenant-b"},
+			enabledPerTID: map[string]bool{"tenant-a": true, "tenant-b": true},
+			want:          true,
+		},
+		{
+			name:          "one of several tenants disabled",
+			tenants:       []string{"tenant-a", "tenant-b"},
+			enabledPerTID: map[string]bool{"tenant-a": true, "tenant-b": false},
+			want:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockLimits := mockfrontend.NewMockLimits(t)
+			for _, tid := range tt.tenants {
+				mockLimits.On("SymbolRefTreesEnabled", tid).Return(tt.enabledPerTID[tid]).Maybe()
+			}
+
+			var sym Symbolizer
+			if !tt.noSymbolizer {
+				sym = mockqueryfrontend.NewMockSymbolizer(t)
+			}
+
+			qf := &QueryFrontend{limits: mockLimits, symbolizer: sym}
+			require.Equal(t, tt.want, qf.useSymbolRefTrees(tt.tenants))
+		})
+	}
+}
+
+// TestSelectMergeStacktracesTree_SymbolRefFlagOn verifies that once the
+// per-tenant flag is enabled, the request sets TreeQuery.SymbolRefs and is
+// sent as-is (no backendTreeSymbolizer wrapping, no QUERY_TREE -> QUERY_PPROF
+// rewrite), even when block metadata reports unsymbolized profiles -- the
+// exact condition that would trigger the legacy detour with the flag off.
+func TestSelectMergeStacktracesTree_SymbolRefFlagOn(t *testing.T) {
+	mockLimits := mockfrontend.NewMockLimits(t)
+	mockLimits.On("MaxQueryLookback", "tenant1").Return(time.Duration(0))
+	mockLimits.On("MaxQueryLength", "tenant1").Return(time.Duration(0))
+	mockLimits.On("MaxFlameGraphNodesDefault", "tenant1").Return(0)
+	mockLimits.On("QuerySanitizeOnMerge", "tenant1").Return(false)
+	mockLimits.On("SymbolRefTreesEnabled", "tenant1").Return(true)
+
+	mockSymbolizer := mockqueryfrontend.NewMockSymbolizer(t)
+
+	plainTree := new(phlaremodel.FunctionNameTree)
+	plainTree.InsertStack(1, phlaremodel.FunctionName("some_func"))
+
+	mockQueryBackend := mockqueryfrontend.NewMockQueryBackend(t)
+	mockQueryBackend.On("Invoke", mock.Anything, mock.MatchedBy(func(req *queryv1.InvokeRequest) bool {
+		require.Len(t, req.Query, 1)
+		require.Equal(t, queryv1.QueryType_QUERY_TREE, req.Query[0].QueryType)
+		require.True(t, req.Query[0].Tree.GetSymbolRefs())
+		return true
+	})).Return(&queryv1.InvokeResponse{
+		Reports: []*queryv1.Report{{
+			ReportType: queryv1.ReportType_REPORT_TREE,
+			Tree:       &queryv1.TreeReport{Tree: plainTree.Bytes(0, nil)},
+		}},
+	}, nil).Once()
+
+	mockMetadataClient := new(mockmetastorev1.MockMetadataQueryServiceClient)
+	mockMetadataClient.On("QueryMetadata", mock.Anything, mock.Anything).Return(&metastorev1.QueryMetadataResponse{
+		Blocks: []*metastorev1.BlockMeta{{
+			Id:          "block_id",
+			Datasets:    []*metastorev1.Dataset{{Labels: []int32{1, 1, 2}}},
+			StringTable: []string{"", "__unsymbolized__", "true"},
+		}},
+	}, nil).Once()
+
+	qf := NewQueryFrontend(log.NewNopLogger(), mockLimits, mockMetadataClient, nil, mockQueryBackend, mockSymbolizer, nil, nil)
+
+	ctx := tenant.InjectTenantID(context.Background(), "tenant1")
+	start, end := smpValidTimeRange()
+	resp, err := qf.SelectMergeStacktraces(ctx, connect.NewRequest(&querierv1.SelectMergeStacktracesRequest{
+		ProfileTypeID: smpProfileType,
+		LabelSelector: `{service_name="test-service"}`,
+		Start:         start,
+		End:           end,
+	}))
+
+	require.NoError(t, err)
+	require.Contains(t, resp.Msg.GetFlamegraph().GetNames(), "some_func")
+	mockQueryBackend.AssertExpectations(t)
+	// mockSymbolizer.Resolve must not be called: the response carried no
+	// SymbolRefs table (nothing to resolve).
+}
+
+// TestSelectMergeStacktracesTree_SymbolRefResolution verifies that a
+// response with unresolved symbol-ref locations is resolved through the
+// symbolizer, grouped once per distinct build ID with sorted, deduped
+// addresses, and rebuilt into a plain tree carrying both resolved names and
+// the binary!0xaddr fallback for an address the symbolizer misses.
+func TestSelectMergeStacktracesTree_SymbolRefResolution(t *testing.T) {
+	treeBytes, pb := buildSymbolRefFixture(t)
+
+	mockLimits := mockfrontend.NewMockLimits(t)
+	mockLimits.On("MaxQueryLookback", "tenant1").Return(time.Duration(0))
+	mockLimits.On("MaxQueryLength", "tenant1").Return(time.Duration(0))
+	mockLimits.On("MaxFlameGraphNodesDefault", "tenant1").Return(0)
+	mockLimits.On("QuerySanitizeOnMerge", "tenant1").Return(false)
+	mockLimits.On("SymbolRefTreesEnabled", "tenant1").Return(true)
+	mockLimits.On("SymbolizerResolveTimeout", "tenant1").Return(time.Second)
+
+	mockSymbolizer := mockqueryfrontend.NewMockSymbolizer(t)
+	mockSymbolizer.On("ResolveConcurrency").Return(4)
+	mockSymbolizer.On("Resolve", mock.Anything, "build-a", "libfoo.so", []uint64{0x100, 0x200}).
+		Return([][]lidia.SourceInfoFrame{
+			{{FunctionName: "resolved_a"}}, // 0x100 hits
+			nil,                            // 0x200 misses
+		}, nil).Once()
+	mockSymbolizer.On("Resolve", mock.Anything, "build-b", "libbar.so", []uint64{0x300}).
+		Return([][]lidia.SourceInfoFrame{{{FunctionName: "resolved_b"}}}, nil).Once()
+
+	mockQueryBackend := mockqueryfrontend.NewMockQueryBackend(t)
+	mockQueryBackend.On("Invoke", mock.Anything, mock.Anything).Return(&queryv1.InvokeResponse{
+		Reports: []*queryv1.Report{{
+			ReportType: queryv1.ReportType_REPORT_TREE,
+			Tree:       &queryv1.TreeReport{Tree: treeBytes, SymbolRefs: pb},
+		}},
+	}, nil).Once()
+
+	mockMetadataClient := new(mockmetastorev1.MockMetadataQueryServiceClient)
+	mockMetadataClient.On("QueryMetadata", mock.Anything, mock.Anything).Return(&metastorev1.QueryMetadataResponse{
+		Blocks: []*metastorev1.BlockMeta{{Id: "block_id"}},
+	}, nil).Once()
+
+	qf := NewQueryFrontend(log.NewNopLogger(), mockLimits, mockMetadataClient, nil, mockQueryBackend, mockSymbolizer, nil, nil)
+
+	before := testutil.ToFloat64(qf.metrics.symbolRefLocationsTotal.WithLabelValues(symbolRefLocationResolved))
+
+	ctx := tenant.InjectTenantID(context.Background(), "tenant1")
+	start, end := smpValidTimeRange()
+	resp, err := qf.SelectMergeStacktraces(ctx, connect.NewRequest(&querierv1.SelectMergeStacktracesRequest{
+		ProfileTypeID: smpProfileType,
+		LabelSelector: `{service_name="test-service"}`,
+		Start:         start,
+		End:           end,
+	}))
+	require.NoError(t, err)
+
+	names := resp.Msg.GetFlamegraph().GetNames()
+	require.Contains(t, names, "known_func")
+	require.Contains(t, names, "resolved_a")
+	require.Contains(t, names, "resolved_b")
+	require.Contains(t, names, "libfoo.so!0x200")
+
+	require.Equal(t, before+2, testutil.ToFloat64(qf.metrics.symbolRefLocationsTotal.WithLabelValues(symbolRefLocationResolved)))
+	require.Equal(t, float64(1), testutil.ToFloat64(qf.metrics.symbolRefLocationsTotal.WithLabelValues(symbolRefLocationMiss)))
+
+	mockQueryBackend.AssertExpectations(t)
+	mockSymbolizer.AssertExpectations(t)
+}
+
+// TestResolveSymbolRefs_NoSymbolRefTable verifies a report without a
+// symbol-ref table (an old backend, or a fully-symbolized dataset) passes
+// through completely unchanged: no symbolizer call, tree bytes untouched.
+func TestResolveSymbolRefs_NoSymbolRefTable(t *testing.T) {
+	qf := &QueryFrontend{metrics: newQueryFrontendMetrics(nil)}
+	report := &queryv1.Report{
+		ReportType: queryv1.ReportType_REPORT_TREE,
+		Tree:       &queryv1.TreeReport{Tree: []byte("plain-tree-bytes")},
+	}
+
+	err := qf.resolveSymbolRefs(context.Background(), []string{"tenant1"}, report, 0)
+	require.NoError(t, err)
+	require.Equal(t, []byte("plain-tree-bytes"), report.Tree.Tree)
+	require.Nil(t, report.Tree.SymbolRefs)
+}
+
+// TestResolveSymbolRefs_NoUnresolvedEntries verifies a symbol-ref table with
+// zero unresolved entries is left untouched (the degenerate case a
+// well-behaved backend collapses to a plain tree report on its own, per I4;
+// this only proves the frontend does not error or needlessly rebuild it).
+func TestResolveSymbolRefs_NoUnresolvedEntries(t *testing.T) {
+	qf := &QueryFrontend{metrics: newQueryFrontendMetrics(nil)}
+	report := &queryv1.Report{
+		ReportType: queryv1.ReportType_REPORT_TREE,
+		Tree: &queryv1.TreeReport{
+			Tree:       []byte("ref-space-tree-bytes"),
+			SymbolRefs: &queryv1.SymbolRefTable{Names: []string{"a", "b"}},
+		},
+	}
+
+	err := qf.resolveSymbolRefs(context.Background(), []string{"tenant1"}, report, 0)
+	require.NoError(t, err)
+	require.Equal(t, []byte("ref-space-tree-bytes"), report.Tree.Tree)
+	require.NotNil(t, report.Tree.SymbolRefs)
+}
+
+// TestResolveBinaries_PerBinaryTimeoutFallsBack verifies that a binary whose
+// own resolve timebox expires while the request context is still live is
+// recorded as a miss for its addresses, and the request succeeds.
+func TestResolveBinaries_PerBinaryTimeoutFallsBack(t *testing.T) {
+	treeBytes, pb := buildSymbolRefFixture(t)
+
+	mockLimits := mockfrontend.NewMockLimits(t)
+	mockLimits.On("SymbolizerResolveTimeout", "tenant1").Return(time.Millisecond)
+
+	mockSymbolizer := mockqueryfrontend.NewMockSymbolizer(t)
+	mockSymbolizer.On("ResolveConcurrency").Return(4)
+	mockSymbolizer.On("Resolve", mock.Anything, "build-a", "libfoo.so", []uint64{0x100, 0x200}).
+		Return(func(ctx context.Context, buildID, binaryName string, addrs []uint64) ([][]lidia.SourceInfoFrame, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}).Once()
+	mockSymbolizer.On("Resolve", mock.Anything, "build-b", "libbar.so", []uint64{0x300}).
+		Return([][]lidia.SourceInfoFrame{{{FunctionName: "resolved_b"}}}, nil).Once()
+
+	qf := &QueryFrontend{limits: mockLimits, symbolizer: mockSymbolizer, metrics: newQueryFrontendMetrics(nil)}
+	report := &queryv1.Report{
+		ReportType: queryv1.ReportType_REPORT_TREE,
+		Tree:       &queryv1.TreeReport{Tree: treeBytes, SymbolRefs: pb},
+	}
+
+	err := qf.resolveSymbolRefs(context.Background(), []string{"tenant1"}, report, 0)
+	require.NoError(t, err)
+
+	names := flameNames(t, report.Tree.Tree)
+	require.Contains(t, names, "resolved_b")
+	require.Contains(t, names, "libfoo.so!0x100")
+	require.Contains(t, names, "libfoo.so!0x200")
+	require.Equal(t, float64(2), testutil.ToFloat64(qf.metrics.symbolRefLocationsTotal.WithLabelValues(symbolRefLocationTimeout)))
+
+	mockSymbolizer.AssertExpectations(t)
+}
+
+// TestResolveBinaries_ParentContextCanceledFailsRequest verifies that when
+// the request context itself is canceled (not just a per-binary timebox),
+// the resolve error is propagated and the request fails.
+func TestResolveBinaries_ParentContextCanceledFailsRequest(t *testing.T) {
+	treeBytes, pb := buildSymbolRefFixture(t)
+
+	mockLimits := mockfrontend.NewMockLimits(t)
+	mockLimits.On("SymbolizerResolveTimeout", "tenant1").Return(time.Minute)
+
+	fetchStarted := make(chan struct{})
+	var once sync.Once
+	mockSymbolizer := mockqueryfrontend.NewMockSymbolizer(t)
+	mockSymbolizer.On("ResolveConcurrency").Return(4)
+	mockSymbolizer.On("Resolve", mock.Anything, "build-a", "libfoo.so", []uint64{0x100, 0x200}).
+		Return(func(ctx context.Context, buildID, binaryName string, addrs []uint64) ([][]lidia.SourceInfoFrame, error) {
+			once.Do(func() { close(fetchStarted) })
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}).Maybe()
+	mockSymbolizer.On("Resolve", mock.Anything, "build-b", "libbar.so", []uint64{0x300}).
+		Return(func(ctx context.Context, buildID, binaryName string, addrs []uint64) ([][]lidia.SourceInfoFrame, error) {
+			once.Do(func() { close(fetchStarted) })
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}).Maybe()
+
+	qf := &QueryFrontend{limits: mockLimits, symbolizer: mockSymbolizer, metrics: newQueryFrontendMetrics(nil)}
+	report := &queryv1.Report{
+		ReportType: queryv1.ReportType_REPORT_TREE,
+		Tree:       &queryv1.TreeReport{Tree: treeBytes, SymbolRefs: pb},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- qf.resolveSymbolRefs(ctx, []string{"tenant1"}, report, 0)
+	}()
+
+	<-fetchStarted
+	cancel()
+	err := <-errCh
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestResolveBinaries_ZeroResolveTimeoutFallsBackToSafeDefault verifies that
+// an all-tenants-zero resolve-timeout limit falls back to a safe positive
+// default rather than reproducing the "0 means unlimited/disabled"
+// convention used elsewhere: it must not hand Resolve an already-expired
+// context.
+func TestResolveBinaries_ZeroResolveTimeoutFallsBackToSafeDefault(t *testing.T) {
+	mockLimits := mockfrontend.NewMockLimits(t)
+	mockLimits.On("SymbolizerResolveTimeout", "tenant1").Return(time.Duration(0))
+
+	mockSymbolizer := mockqueryfrontend.NewMockSymbolizer(t)
+	mockSymbolizer.On("ResolveConcurrency").Return(4)
+	mockSymbolizer.On("Resolve", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(func(ctx context.Context, buildID, binaryName string, addrs []uint64) ([][]lidia.SourceInfoFrame, error) {
+			require.NoError(t, ctx.Err(), "SymbolizerResolveTimeout=0 must not produce an already-expired context")
+			return [][]lidia.SourceInfoFrame{{{FunctionName: "resolved"}}}, nil
+		}).Times(2)
+
+	qf := &QueryFrontend{limits: mockLimits, symbolizer: mockSymbolizer, metrics: newQueryFrontendMetrics(nil)}
+	binaries := []symbolref.UnresolvedBinary{
+		{BuildID: "build-a", BinaryName: "liba.so", Addresses: []uint64{0x1}},
+		{BuildID: "build-b", BinaryName: "libb.so", Addresses: []uint64{0x2}},
+	}
+
+	_, err := qf.resolveBinaries(context.Background(), []string{"tenant1"}, binaries)
+	require.NoError(t, err)
+}
+
+// TestResolveBinaries_NonPositiveResolveConcurrencyFallsBackToSafeFloor
+// verifies that a Symbolizer reporting a non-positive ResolveConcurrency
+// (a defensive case pkg/symbolizer's own normalization should already
+// prevent in production) falls back to a safe floor instead of blocking
+// errgroup.SetLimit forever.
+func TestResolveBinaries_NonPositiveResolveConcurrencyFallsBackToSafeFloor(t *testing.T) {
+	mockLimits := mockfrontend.NewMockLimits(t)
+	mockLimits.On("SymbolizerResolveTimeout", "tenant1").Return(time.Second)
+
+	mockSymbolizer := mockqueryfrontend.NewMockSymbolizer(t)
+	mockSymbolizer.On("ResolveConcurrency").Return(0)
+	mockSymbolizer.On("Resolve", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([][]lidia.SourceInfoFrame{{{FunctionName: "resolved"}}}, nil).Times(2)
+
+	qf := &QueryFrontend{limits: mockLimits, symbolizer: mockSymbolizer, metrics: newQueryFrontendMetrics(nil)}
+	binaries := []symbolref.UnresolvedBinary{
+		{BuildID: "build-a", BinaryName: "liba.so", Addresses: []uint64{0x1}},
+		{BuildID: "build-b", BinaryName: "libb.so", Addresses: []uint64{0x2}},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := qf.resolveBinaries(context.Background(), []string{"tenant1"}, binaries)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("resolveBinaries did not return: a non-positive ResolveConcurrency must fall back to a safe floor, not block forever")
+	}
+}

--- a/pkg/frontend/readpath/queryfrontend/symbol_ref_resolve_test.go
+++ b/pkg/frontend/readpath/queryfrontend/symbol_ref_resolve_test.go
@@ -58,11 +58,12 @@ func flameNames(t *testing.T, treeBytes []byte) []string {
 
 func TestUseSymbolRefTrees(t *testing.T) {
 	tests := []struct {
-		name          string
-		noSymbolizer  bool
-		tenants       []string
-		enabledPerTID map[string]bool
-		want          bool
+		name             string
+		noSymbolizer     bool
+		tenants          []string
+		enabledPerTID    map[string]bool
+		symbolizerPerTID map[string]bool // SymbolizerEnabled per tenant; defaults to true
+		want             bool
 	}{
 		{
 			name:         "no symbolizer configured",
@@ -94,12 +95,31 @@ func TestUseSymbolRefTrees(t *testing.T) {
 			enabledPerTID: map[string]bool{"tenant-a": true, "tenant-b": false},
 			want:          false,
 		},
+		{
+			name:             "flag on but symbolization disabled for the tenant",
+			tenants:          []string{"tenant-a"},
+			enabledPerTID:    map[string]bool{"tenant-a": true},
+			symbolizerPerTID: map[string]bool{"tenant-a": false},
+			want:             false,
+		},
+		{
+			name:             "symbolization disabled for one of several tenants",
+			tenants:          []string{"tenant-a", "tenant-b"},
+			enabledPerTID:    map[string]bool{"tenant-a": true, "tenant-b": true},
+			symbolizerPerTID: map[string]bool{"tenant-a": true, "tenant-b": false},
+			want:             false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockLimits := mockfrontend.NewMockLimits(t)
 			for _, tid := range tt.tenants {
+				symbolizerEnabled, ok := tt.symbolizerPerTID[tid]
+				if !ok {
+					symbolizerEnabled = true
+				}
+				mockLimits.On("SymbolizerEnabled", tid).Return(symbolizerEnabled).Maybe()
 				mockLimits.On("SymbolRefTreesEnabled", tid).Return(tt.enabledPerTID[tid]).Maybe()
 			}
 
@@ -125,6 +145,7 @@ func TestSelectMergeStacktracesTree_SymbolRefFlagOn(t *testing.T) {
 	mockLimits.On("MaxQueryLength", "tenant1").Return(time.Duration(0))
 	mockLimits.On("MaxFlameGraphNodesDefault", "tenant1").Return(0)
 	mockLimits.On("QuerySanitizeOnMerge", "tenant1").Return(false)
+	mockLimits.On("SymbolizerEnabled", "tenant1").Return(true)
 	mockLimits.On("SymbolRefTreesEnabled", "tenant1").Return(true)
 
 	mockSymbolizer := mockqueryfrontend.NewMockSymbolizer(t)
@@ -185,6 +206,7 @@ func TestSelectMergeStacktracesTree_SymbolRefResolution(t *testing.T) {
 	mockLimits.On("MaxQueryLength", "tenant1").Return(time.Duration(0))
 	mockLimits.On("MaxFlameGraphNodesDefault", "tenant1").Return(0)
 	mockLimits.On("QuerySanitizeOnMerge", "tenant1").Return(false)
+	mockLimits.On("SymbolizerEnabled", "tenant1").Return(true)
 	mockLimits.On("SymbolRefTreesEnabled", "tenant1").Return(true)
 	mockLimits.On("SymbolizerResolveTimeout", "tenant1").Return(time.Second)
 

--- a/pkg/frontend/readpath/queryfrontend/symbol_ref_resolve_test.go
+++ b/pkg/frontend/readpath/queryfrontend/symbol_ref_resolve_test.go
@@ -147,6 +147,7 @@ func TestSelectMergeStacktracesTree_SymbolRefFlagOn(t *testing.T) {
 	mockLimits.On("QuerySanitizeOnMerge", "tenant1").Return(false)
 	mockLimits.On("SymbolizerEnabled", "tenant1").Return(true)
 	mockLimits.On("SymbolRefTreesEnabled", "tenant1").Return(true)
+	mockLimits.On("SymbolizerMaxUnresolvedLocations", "tenant1").Return(1_000_000)
 
 	mockSymbolizer := mockqueryfrontend.NewMockSymbolizer(t)
 
@@ -157,7 +158,8 @@ func TestSelectMergeStacktracesTree_SymbolRefFlagOn(t *testing.T) {
 	mockQueryBackend.On("Invoke", mock.Anything, mock.MatchedBy(func(req *queryv1.InvokeRequest) bool {
 		require.Len(t, req.Query, 1)
 		require.Equal(t, queryv1.QueryType_QUERY_TREE, req.Query[0].QueryType)
-		require.True(t, req.Query[0].Tree.GetSymbolRefs())
+		require.Equal(t, queryv1.SymbolMode_SYMBOL_MODE_REFS, req.Query[0].Tree.GetSymbolMode())
+		require.Equal(t, int64(1_000_000), req.Query[0].Tree.GetMaxUnresolvedLocations())
 		return true
 	})).Return(&queryv1.InvokeResponse{
 		Reports: []*queryv1.Report{{
@@ -208,8 +210,8 @@ func TestSelectMergeStacktracesTree_SymbolRefResolution(t *testing.T) {
 	mockLimits.On("QuerySanitizeOnMerge", "tenant1").Return(false)
 	mockLimits.On("SymbolizerEnabled", "tenant1").Return(true)
 	mockLimits.On("SymbolRefTreesEnabled", "tenant1").Return(true)
+	mockLimits.On("SymbolizerMaxUnresolvedLocations", "tenant1").Return(1_000_000)
 	mockLimits.On("SymbolizerResolveTimeout", "tenant1").Return(time.Second)
-
 	mockSymbolizer := mockqueryfrontend.NewMockSymbolizer(t)
 	mockSymbolizer.On("ResolveConcurrency").Return(4)
 	mockSymbolizer.On("Resolve", mock.Anything, "build-a", "libfoo.so", []uint64{0x100, 0x200}).
@@ -325,7 +327,6 @@ func TestResolveBinaries_PerBinaryTimeoutFallsBack(t *testing.T) {
 
 	mockLimits := mockfrontend.NewMockLimits(t)
 	mockLimits.On("SymbolizerResolveTimeout", "tenant1").Return(time.Millisecond)
-
 	mockSymbolizer := mockqueryfrontend.NewMockSymbolizer(t)
 	mockSymbolizer.On("ResolveConcurrency").Return(4)
 	mockSymbolizer.On("Resolve", mock.Anything, "build-a", "libfoo.so", []uint64{0x100, 0x200}).
@@ -362,7 +363,6 @@ func TestResolveBinaries_ParentContextCanceledFailsRequest(t *testing.T) {
 
 	mockLimits := mockfrontend.NewMockLimits(t)
 	mockLimits.On("SymbolizerResolveTimeout", "tenant1").Return(time.Minute)
-
 	fetchStarted := make(chan struct{})
 	var once sync.Once
 	mockSymbolizer := mockqueryfrontend.NewMockSymbolizer(t)
@@ -435,7 +435,6 @@ func TestResolveBinaries_ZeroResolveTimeoutFallsBackToSafeDefault(t *testing.T) 
 func TestResolveBinaries_NonPositiveResolveConcurrencyFallsBackToSafeFloor(t *testing.T) {
 	mockLimits := mockfrontend.NewMockLimits(t)
 	mockLimits.On("SymbolizerResolveTimeout", "tenant1").Return(time.Second)
-
 	mockSymbolizer := mockqueryfrontend.NewMockSymbolizer(t)
 	mockSymbolizer.On("ResolveConcurrency").Return(0)
 	mockSymbolizer.On("Resolve", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -458,5 +457,33 @@ func TestResolveBinaries_NonPositiveResolveConcurrencyFallsBackToSafeFloor(t *te
 		require.NoError(t, err)
 	case <-time.After(5 * time.Second):
 		t.Fatal("resolveBinaries did not return: a non-positive ResolveConcurrency must fall back to a safe floor, not block forever")
+	}
+}
+
+// TestSymbolRefTreeQueryLimit verifies the limit carried on a symbol-ref
+// query: the largest limit across the request's tenants wins, and a tenant
+// with the limit disabled (0) makes the query unlimited.
+func TestSymbolRefTreeQueryLimit(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		limits map[string]int
+		want   int64
+	}{
+		{name: "single tenant", limits: map[string]int{"a": 300}, want: 300},
+		{name: "largest of two", limits: map[string]int{"a": 100, "b": 200}, want: 200},
+		{name: "disabled tenant makes it unlimited", limits: map[string]int{"a": 100, "b": 0}, want: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mockLimits := mockfrontend.NewMockLimits(t)
+			tenants := make([]string, 0, len(tc.limits))
+			for tenant, v := range tc.limits {
+				mockLimits.On("SymbolizerMaxUnresolvedLocations", tenant).Return(v).Maybe()
+				tenants = append(tenants, tenant)
+			}
+			tree := new(queryv1.TreeQuery)
+			(&QueryFrontend{limits: mockLimits}).symbolRefTreeQuery(tree, tenants)
+			require.Equal(t, queryv1.SymbolMode_SYMBOL_MODE_REFS, tree.SymbolMode)
+			require.Equal(t, tc.want, tree.MaxUnresolvedLocations)
+		})
 	}
 }

--- a/pkg/frontend/readpath/queryfrontend/symbolizer.go
+++ b/pkg/frontend/readpath/queryfrontend/symbolizer.go
@@ -148,13 +148,13 @@ func (q *QueryFrontend) shouldSymbolize(ctx context.Context, tenants []string, b
 // useSymbolRefTrees determines whether a tree query should request a
 // symbol-ref report (TreeQuery.SymbolRefs) instead of going through the
 // legacy pprof detour: a symbolizer must be configured, and every tenant on
-// the request must have the feature enabled.
+// the request must have both symbolization and the feature enabled.
 func (q *QueryFrontend) useSymbolRefTrees(tenants []string) bool {
 	if q.symbolizer == nil {
 		return false
 	}
 	for _, t := range tenants {
-		if !q.limits.SymbolRefTreesEnabled(t) {
+		if !q.limits.SymbolizerEnabled(t) || !q.limits.SymbolRefTreesEnabled(t) {
 			return false
 		}
 	}

--- a/pkg/frontend/readpath/queryfrontend/symbolizer.go
+++ b/pkg/frontend/readpath/queryfrontend/symbolizer.go
@@ -144,3 +144,19 @@ func (q *QueryFrontend) shouldSymbolize(ctx context.Context, tenants []string, b
 
 	return blocksWithUnsymbolized > 0
 }
+
+// useSymbolRefTrees determines whether a tree query should request a
+// symbol-ref report (TreeQuery.SymbolRefs) instead of going through the
+// legacy pprof detour: a symbolizer must be configured, and every tenant on
+// the request must have the feature enabled.
+func (q *QueryFrontend) useSymbolRefTrees(tenants []string) bool {
+	if q.symbolizer == nil {
+		return false
+	}
+	for _, t := range tenants {
+		if !q.limits.SymbolRefTreesEnabled(t) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/frontend/readpath/queryfrontend/symbolizer.go
+++ b/pkg/frontend/readpath/queryfrontend/symbolizer.go
@@ -146,9 +146,9 @@ func (q *QueryFrontend) shouldSymbolize(ctx context.Context, tenants []string, b
 }
 
 // useSymbolRefTrees determines whether a tree query should request a
-// symbol-ref report (TreeQuery.SymbolRefs) instead of going through the
-// legacy pprof detour: a symbolizer must be configured, and every tenant on
-// the request must have both symbolization and the feature enabled.
+// symbol-ref report (SYMBOL_MODE_REFS) instead of going through the legacy
+// pprof detour: a symbolizer must be configured, and every tenant on the
+// request must have both symbolization and the feature enabled.
 func (q *QueryFrontend) useSymbolRefTrees(tenants []string) bool {
 	if q.symbolizer == nil {
 		return false
@@ -159,4 +159,25 @@ func (q *QueryFrontend) useSymbolRefTrees(tenants []string) bool {
 		}
 	}
 	return true
+}
+
+// symbolRefTreeQuery marks tree as a symbol-ref query and carries the
+// per-tenant unresolved-locations limit on it, for the backend to enforce
+// while building and merging. A multi-tenant query takes the largest limit
+// across its tenants, and a tenant with the limit disabled (0) makes the
+// query unlimited.
+func (q *QueryFrontend) symbolRefTreeQuery(tree *queryv1.TreeQuery, tenants []string) {
+	tree.SymbolMode = queryv1.SymbolMode_SYMBOL_MODE_REFS
+	var largest int64
+	for _, t := range tenants {
+		v := int64(q.limits.SymbolizerMaxUnresolvedLocations(t))
+		if v <= 0 {
+			largest = 0
+			break
+		}
+		if v > largest {
+			largest = v
+		}
+	}
+	tree.MaxUnresolvedLocations = largest
 }

--- a/pkg/symbolizer/resolve_test.go
+++ b/pkg/symbolizer/resolve_test.go
@@ -158,6 +158,25 @@ func TestResolveContextCancellation(t *testing.T) {
 	})
 }
 
+func TestResolveConcurrency(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured int
+		want       int
+	}{
+		{"positive value passes through", 4, 4},
+		{"zero normalizes to default", 0, defaultMaxDebuginfodConcurrency},
+		{"negative normalizes to default", -1, defaultMaxDebuginfodConcurrency},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _, _ := newSymbolizerTest(t, nil)
+			s.cfg.MaxDebuginfodConcurrency = tt.configured
+			require.Equal(t, tt.want, s.ResolveConcurrency())
+		})
+	}
+}
+
 func TestResolveInvalidBuildID(t *testing.T) {
 	s, mockClient, mockBucket := newSymbolizerTest(t, nil)
 	ctx := tenant.InjectTenantID(context.Background(), "tenant")

--- a/pkg/symbolizer/symbolizer.go
+++ b/pkg/symbolizer/symbolizer.go
@@ -201,16 +201,27 @@ func (s *Symbolizer) SymbolizePprof(ctx context.Context, profile *googlev1.Profi
 	return nil
 }
 
+// defaultMaxDebuginfodConcurrency is used whenever Config.MaxDebuginfodConcurrency
+// is not positive, so every concurrency-bounded caller normalizes the same way.
+const defaultMaxDebuginfodConcurrency = 10
+
+// ResolveConcurrency returns the maximum number of concurrent Resolve calls
+// (or debuginfod fetches) this symbolizer allows, normalizing a non-positive
+// configured value to defaultMaxDebuginfodConcurrency.
+func (s *Symbolizer) ResolveConcurrency() int {
+	if s.cfg.MaxDebuginfodConcurrency <= 0 {
+		return defaultMaxDebuginfodConcurrency
+	}
+	return s.cfg.MaxDebuginfodConcurrency
+}
+
 // symbolizeMappingsConcurrently symbolizes multiple mappings concurrently with a concurrency limit.
 func (s *Symbolizer) symbolizeMappingsConcurrently(
 	ctx context.Context,
 	profile *googlev1.Profile,
 	locationsByMapping map[uint64][]*googlev1.Location,
 ) ([]symbolizedLocation, error) {
-	maxConcurrency := s.cfg.MaxDebuginfodConcurrency
-	if maxConcurrency <= 0 {
-		maxConcurrency = 10
-	}
+	maxConcurrency := s.ResolveConcurrency()
 
 	type mappingJob struct {
 		mappingID uint64

--- a/pkg/test/mocks/mockfrontend/mock_limits.go
+++ b/pkg/test/mocks/mockfrontend/mock_limits.go
@@ -481,6 +481,52 @@ func (_c *MockLimits_QueryTreeEnabled_Call) RunAndReturn(run func(string) bool) 
 	return _c
 }
 
+// SymbolRefTreesEnabled provides a mock function with given fields: _a0
+func (_m *MockLimits) SymbolRefTreesEnabled(_a0 string) bool {
+	ret := _m.Called(_a0)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SymbolRefTreesEnabled")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockLimits_SymbolRefTreesEnabled_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SymbolRefTreesEnabled'
+type MockLimits_SymbolRefTreesEnabled_Call struct {
+	*mock.Call
+}
+
+// SymbolRefTreesEnabled is a helper method to define mock.On call
+//   - _a0 string
+func (_e *MockLimits_Expecter) SymbolRefTreesEnabled(_a0 interface{}) *MockLimits_SymbolRefTreesEnabled_Call {
+	return &MockLimits_SymbolRefTreesEnabled_Call{Call: _e.mock.On("SymbolRefTreesEnabled", _a0)}
+}
+
+func (_c *MockLimits_SymbolRefTreesEnabled_Call) Run(run func(_a0 string)) *MockLimits_SymbolRefTreesEnabled_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockLimits_SymbolRefTreesEnabled_Call) Return(_a0 bool) *MockLimits_SymbolRefTreesEnabled_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockLimits_SymbolRefTreesEnabled_Call) RunAndReturn(run func(string) bool) *MockLimits_SymbolRefTreesEnabled_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SymbolizerEnabled provides a mock function with given fields: _a0
 func (_m *MockLimits) SymbolizerEnabled(_a0 string) bool {
 	ret := _m.Called(_a0)
@@ -523,6 +569,52 @@ func (_c *MockLimits_SymbolizerEnabled_Call) Return(_a0 bool) *MockLimits_Symbol
 }
 
 func (_c *MockLimits_SymbolizerEnabled_Call) RunAndReturn(run func(string) bool) *MockLimits_SymbolizerEnabled_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SymbolizerResolveTimeout provides a mock function with given fields: _a0
+func (_m *MockLimits) SymbolizerResolveTimeout(_a0 string) time.Duration {
+	ret := _m.Called(_a0)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SymbolizerResolveTimeout")
+	}
+
+	var r0 time.Duration
+	if rf, ok := ret.Get(0).(func(string) time.Duration); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+
+	return r0
+}
+
+// MockLimits_SymbolizerResolveTimeout_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SymbolizerResolveTimeout'
+type MockLimits_SymbolizerResolveTimeout_Call struct {
+	*mock.Call
+}
+
+// SymbolizerResolveTimeout is a helper method to define mock.On call
+//   - _a0 string
+func (_e *MockLimits_Expecter) SymbolizerResolveTimeout(_a0 interface{}) *MockLimits_SymbolizerResolveTimeout_Call {
+	return &MockLimits_SymbolizerResolveTimeout_Call{Call: _e.mock.On("SymbolizerResolveTimeout", _a0)}
+}
+
+func (_c *MockLimits_SymbolizerResolveTimeout_Call) Run(run func(_a0 string)) *MockLimits_SymbolizerResolveTimeout_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockLimits_SymbolizerResolveTimeout_Call) Return(_a0 time.Duration) *MockLimits_SymbolizerResolveTimeout_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockLimits_SymbolizerResolveTimeout_Call) RunAndReturn(run func(string) time.Duration) *MockLimits_SymbolizerResolveTimeout_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/test/mocks/mockfrontend/mock_limits.go
+++ b/pkg/test/mocks/mockfrontend/mock_limits.go
@@ -573,6 +573,52 @@ func (_c *MockLimits_SymbolizerEnabled_Call) RunAndReturn(run func(string) bool)
 	return _c
 }
 
+// SymbolizerMaxUnresolvedLocations provides a mock function with given fields: _a0
+func (_m *MockLimits) SymbolizerMaxUnresolvedLocations(_a0 string) int {
+	ret := _m.Called(_a0)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SymbolizerMaxUnresolvedLocations")
+	}
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(string) int); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	return r0
+}
+
+// MockLimits_SymbolizerMaxUnresolvedLocations_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SymbolizerMaxUnresolvedLocations'
+type MockLimits_SymbolizerMaxUnresolvedLocations_Call struct {
+	*mock.Call
+}
+
+// SymbolizerMaxUnresolvedLocations is a helper method to define mock.On call
+//   - _a0 string
+func (_e *MockLimits_Expecter) SymbolizerMaxUnresolvedLocations(_a0 interface{}) *MockLimits_SymbolizerMaxUnresolvedLocations_Call {
+	return &MockLimits_SymbolizerMaxUnresolvedLocations_Call{Call: _e.mock.On("SymbolizerMaxUnresolvedLocations", _a0)}
+}
+
+func (_c *MockLimits_SymbolizerMaxUnresolvedLocations_Call) Run(run func(_a0 string)) *MockLimits_SymbolizerMaxUnresolvedLocations_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockLimits_SymbolizerMaxUnresolvedLocations_Call) Return(_a0 int) *MockLimits_SymbolizerMaxUnresolvedLocations_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockLimits_SymbolizerMaxUnresolvedLocations_Call) RunAndReturn(run func(string) int) *MockLimits_SymbolizerMaxUnresolvedLocations_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SymbolizerResolveTimeout provides a mock function with given fields: _a0
 func (_m *MockLimits) SymbolizerResolveTimeout(_a0 string) time.Duration {
 	ret := _m.Called(_a0)

--- a/pkg/test/mocks/mockqueryfrontend/mock_symbolizer.go
+++ b/pkg/test/mocks/mockqueryfrontend/mock_symbolizer.go
@@ -6,6 +6,7 @@ import (
 	context "context"
 
 	googlev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	lidia "github.com/grafana/pyroscope/lidia"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -20,6 +21,112 @@ type MockSymbolizer_Expecter struct {
 
 func (_m *MockSymbolizer) EXPECT() *MockSymbolizer_Expecter {
 	return &MockSymbolizer_Expecter{mock: &_m.Mock}
+}
+
+// Resolve provides a mock function with given fields: ctx, buildID, binaryName, addrs
+func (_m *MockSymbolizer) Resolve(ctx context.Context, buildID string, binaryName string, addrs []uint64) ([][]lidia.SourceInfoFrame, error) {
+	ret := _m.Called(ctx, buildID, binaryName, addrs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Resolve")
+	}
+
+	var r0 [][]lidia.SourceInfoFrame
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, []uint64) ([][]lidia.SourceInfoFrame, error)); ok {
+		return rf(ctx, buildID, binaryName, addrs)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, []uint64) [][]lidia.SourceInfoFrame); ok {
+		r0 = rf(ctx, buildID, binaryName, addrs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([][]lidia.SourceInfoFrame)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, []uint64) error); ok {
+		r1 = rf(ctx, buildID, binaryName, addrs)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockSymbolizer_Resolve_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Resolve'
+type MockSymbolizer_Resolve_Call struct {
+	*mock.Call
+}
+
+// Resolve is a helper method to define mock.On call
+//   - ctx context.Context
+//   - buildID string
+//   - binaryName string
+//   - addrs []uint64
+func (_e *MockSymbolizer_Expecter) Resolve(ctx interface{}, buildID interface{}, binaryName interface{}, addrs interface{}) *MockSymbolizer_Resolve_Call {
+	return &MockSymbolizer_Resolve_Call{Call: _e.mock.On("Resolve", ctx, buildID, binaryName, addrs)}
+}
+
+func (_c *MockSymbolizer_Resolve_Call) Run(run func(ctx context.Context, buildID string, binaryName string, addrs []uint64)) *MockSymbolizer_Resolve_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].([]uint64))
+	})
+	return _c
+}
+
+func (_c *MockSymbolizer_Resolve_Call) Return(_a0 [][]lidia.SourceInfoFrame, _a1 error) *MockSymbolizer_Resolve_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockSymbolizer_Resolve_Call) RunAndReturn(run func(context.Context, string, string, []uint64) ([][]lidia.SourceInfoFrame, error)) *MockSymbolizer_Resolve_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ResolveConcurrency provides a mock function with no fields
+func (_m *MockSymbolizer) ResolveConcurrency() int {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ResolveConcurrency")
+	}
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func() int); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	return r0
+}
+
+// MockSymbolizer_ResolveConcurrency_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ResolveConcurrency'
+type MockSymbolizer_ResolveConcurrency_Call struct {
+	*mock.Call
+}
+
+// ResolveConcurrency is a helper method to define mock.On call
+func (_e *MockSymbolizer_Expecter) ResolveConcurrency() *MockSymbolizer_ResolveConcurrency_Call {
+	return &MockSymbolizer_ResolveConcurrency_Call{Call: _e.mock.On("ResolveConcurrency")}
+}
+
+func (_c *MockSymbolizer_ResolveConcurrency_Call) Run(run func()) *MockSymbolizer_ResolveConcurrency_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockSymbolizer_ResolveConcurrency_Call) Return(_a0 int) *MockSymbolizer_ResolveConcurrency_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockSymbolizer_ResolveConcurrency_Call) RunAndReturn(run func() int) *MockSymbolizer_ResolveConcurrency_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // SymbolizePprof provides a mock function with given fields: ctx, profile

--- a/pkg/validation/symbolizer.go
+++ b/pkg/validation/symbolizer.go
@@ -23,6 +23,11 @@ type Symbolizer struct {
 	// that exceeds this timebox falls back to binary!0xaddr frames for that
 	// query only.
 	ResolveTimeout time.Duration `yaml:"resolve_timeout" json:"resolve_timeout" category:"advanced"`
+
+	// MaxUnresolvedLocations bounds the distinct unresolved locations a
+	// single symbol-ref tree query may carry through the read path; a query
+	// exceeding it fails rather than degrading.
+	MaxUnresolvedLocations int `yaml:"max_unresolved_locations" json:"max_unresolved_locations" category:"experimental" doc:"hidden"`
 }
 
 func (s *Symbolizer) RegisterFlags(f *flag.FlagSet) {
@@ -30,6 +35,7 @@ func (s *Symbolizer) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&s.MaxSymbolSizeBytes, "valdation.symbolizer.max-symbol-size-bytes", 512*1024*1024, "Maximum size of a symbol in bytes. This an upper limits to both the compressed and uncompressed size. 0 to disable.")
 	f.BoolVar(&s.SymbolRefTreesEnabled, "symbolizer.symbol-ref-trees-enabled", false, "Enable symbol-aware tree references: tree queries are executed natively and symbolized by the frontend after the final merge, instead of being rewritten to pprof. Requires a symbolizer to be configured.")
 	f.DurationVar(&s.ResolveTimeout, "symbolizer.resolve-timeout", 20*time.Second, "Maximum time the query frontend waits to resolve a single binary's unresolved addresses for a symbol-ref tree query, before falling back to binary!0xaddr frames for that binary.")
+	f.IntVar(&s.MaxUnresolvedLocations, "symbolizer.max-unresolved-locations", 1_000_000, "Maximum number of distinct unresolved locations a symbol-ref tree query may carry through the read path before symbolization; a query exceeding the limit fails. 0 disables the limit.")
 }
 
 func (o *Overrides) SymbolizerEnabled(tenantID string) bool {
@@ -46,4 +52,8 @@ func (o *Overrides) SymbolRefTreesEnabled(tenantID string) bool {
 
 func (o *Overrides) SymbolizerResolveTimeout(tenantID string) time.Duration {
 	return o.getOverridesForTenant(tenantID).Symbolizer.ResolveTimeout
+}
+
+func (o *Overrides) SymbolizerMaxUnresolvedLocations(tenantID string) int {
+	return o.getOverridesForTenant(tenantID).Symbolizer.MaxUnresolvedLocations
 }

--- a/pkg/validation/symbolizer.go
+++ b/pkg/validation/symbolizer.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"flag"
+	"time"
 )
 
 type Symbolizer struct {
@@ -10,11 +11,25 @@ type Symbolizer struct {
 
 	// Maximum symbol size is checked against both the payload size and the decompressed size
 	MaxSymbolSizeBytes int `category:"advanced"`
+
+	// SymbolRefTreesEnabled makes tree queries carry unresolved symbol
+	// references through the native tree path instead of being rewritten to
+	// pprof for symbolization; the frontend resolves references itself after
+	// the final merge. Requires a symbolizer to be configured.
+	SymbolRefTreesEnabled bool `yaml:"symbol_ref_trees_enabled" json:"symbol_ref_trees_enabled" category:"experimental" doc:"hidden"`
+
+	// ResolveTimeout bounds how long the frontend waits to resolve a single
+	// binary's unresolved addresses for a symbol-ref tree query. A binary
+	// that exceeds this timebox falls back to binary!0xaddr frames for that
+	// query only.
+	ResolveTimeout time.Duration `yaml:"resolve_timeout" json:"resolve_timeout" category:"advanced"`
 }
 
 func (s *Symbolizer) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&s.Enabled, "symbolizer.enabled", false, "Enable symbolization for tenants by default.")
 	f.IntVar(&s.MaxSymbolSizeBytes, "valdation.symbolizer.max-symbol-size-bytes", 512*1024*1024, "Maximum size of a symbol in bytes. This an upper limits to both the compressed and uncompressed size. 0 to disable.")
+	f.BoolVar(&s.SymbolRefTreesEnabled, "symbolizer.symbol-ref-trees-enabled", false, "Enable symbol-aware tree references: tree queries are executed natively and symbolized by the frontend after the final merge, instead of being rewritten to pprof. Requires a symbolizer to be configured.")
+	f.DurationVar(&s.ResolveTimeout, "symbolizer.resolve-timeout", 20*time.Second, "Maximum time the query frontend waits to resolve a single binary's unresolved addresses for a symbol-ref tree query, before falling back to binary!0xaddr frames for that binary.")
 }
 
 func (o *Overrides) SymbolizerEnabled(tenantID string) bool {
@@ -23,4 +38,12 @@ func (o *Overrides) SymbolizerEnabled(tenantID string) bool {
 
 func (o *Overrides) SymbolizerMaxSymbolSizeBytes(tenantID string) int {
 	return o.getOverridesForTenant(tenantID).Symbolizer.MaxSymbolSizeBytes
+}
+
+func (o *Overrides) SymbolRefTreesEnabled(tenantID string) bool {
+	return o.getOverridesForTenant(tenantID).Symbolizer.SymbolRefTreesEnabled
+}
+
+func (o *Overrides) SymbolizerResolveTimeout(tenantID string) time.Duration {
+	return o.getOverridesForTenant(tenantID).Symbolizer.ResolveTimeout
 }

--- a/pkg/validation/symbolizer_test.go
+++ b/pkg/validation/symbolizer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,6 +22,17 @@ overrides:
     symbolizer:
       enabled: true
     ingestion_rate_mb: 100
+`
+
+const symbolRefTreesOverrideConfig = `
+overrides:
+  symbol-ref-trees-disabled:
+    symbolizer:
+      symbol_ref_trees_enabled: false
+  symbol-ref-trees-enabled:
+    symbolizer:
+      symbol_ref_trees_enabled: true
+      resolve_timeout: 5s
 `
 
 func Test_SymbolizerEnabled(t *testing.T) {
@@ -55,4 +67,27 @@ func Test_SymbolizerMockOverrides(t *testing.T) {
 
 	assert.False(t, overrides.SymbolizerEnabled("default-tenant"))
 	assert.True(t, overrides.SymbolizerEnabled("enabled-tenant"))
+}
+
+func Test_SymbolRefTreesEnabled(t *testing.T) {
+	rc, err := LoadRuntimeConfig(bytes.NewReader([]byte(symbolRefTreesOverrideConfig)))
+	require.NoError(t, err)
+
+	var defaultCfg Limits
+	fs := flag.NewFlagSet("test", flag.PanicOnError)
+	defaultCfg.RegisterFlags(fs)
+	defaultCfg.Symbolizer.RegisterFlags(fs)
+
+	err = fs.Parse([]string{})
+	require.NoError(t, err)
+
+	o, err := NewOverrides(defaultCfg, &wrappedRuntimeConfig{rc})
+	require.NoError(t, err)
+
+	assert.False(t, o.SymbolRefTreesEnabled("empty-overrides"))
+	assert.False(t, o.SymbolRefTreesEnabled("symbol-ref-trees-disabled"))
+	assert.True(t, o.SymbolRefTreesEnabled("symbol-ref-trees-enabled"))
+
+	assert.Equal(t, 20*time.Second, o.SymbolizerResolveTimeout("empty-overrides"))
+	assert.Equal(t, 5*time.Second, o.SymbolizerResolveTimeout("symbol-ref-trees-enabled"))
 }

--- a/pkg/validation/testutil.go
+++ b/pkg/validation/testutil.go
@@ -35,8 +35,10 @@ type MockLimits struct {
 
 	MaxQueriersPerTenantValue int
 
-	SymbolizerEnabledValue bool
-	QueryTreeEnabledValue  bool
+	SymbolizerEnabledValue        bool
+	QueryTreeEnabledValue         bool
+	SymbolRefTreesEnabledValue    bool
+	SymbolizerResolveTimeoutValue time.Duration
 
 	MaxAsyncQueryConcurrencyValue int
 
@@ -108,6 +110,11 @@ func (m MockLimits) RejectNewerThan(userID string) time.Duration {
 func (m MockLimits) SymbolizerEnabled(s string) bool       { return m.SymbolizerEnabledValue }
 func (m MockLimits) QueryTreeEnabled(s string) bool        { return m.QueryTreeEnabledValue }
 func (m MockLimits) MaxAsyncQueryConcurrency(s string) int { return m.MaxAsyncQueryConcurrencyValue }
+
+func (m MockLimits) SymbolRefTreesEnabled(s string) bool { return m.SymbolRefTreesEnabledValue }
+func (m MockLimits) SymbolizerResolveTimeout(s string) time.Duration {
+	return m.SymbolizerResolveTimeoutValue
+}
 
 func (m MockLimits) IngestionBodyLimitBytes(tenantID string) int64 {
 	return m.IngestionBodyLimitBytesValue

--- a/pkg/validation/testutil.go
+++ b/pkg/validation/testutil.go
@@ -35,10 +35,11 @@ type MockLimits struct {
 
 	MaxQueriersPerTenantValue int
 
-	SymbolizerEnabledValue        bool
-	QueryTreeEnabledValue         bool
-	SymbolRefTreesEnabledValue    bool
-	SymbolizerResolveTimeoutValue time.Duration
+	SymbolizerEnabledValue                bool
+	QueryTreeEnabledValue                 bool
+	SymbolRefTreesEnabledValue            bool
+	SymbolizerResolveTimeoutValue         time.Duration
+	SymbolizerMaxUnresolvedLocationsValue int
 
 	MaxAsyncQueryConcurrencyValue int
 
@@ -114,6 +115,10 @@ func (m MockLimits) MaxAsyncQueryConcurrency(s string) int { return m.MaxAsyncQu
 func (m MockLimits) SymbolRefTreesEnabled(s string) bool { return m.SymbolRefTreesEnabledValue }
 func (m MockLimits) SymbolizerResolveTimeout(s string) time.Duration {
 	return m.SymbolizerResolveTimeoutValue
+}
+
+func (m MockLimits) SymbolizerMaxUnresolvedLocations(s string) int {
+	return m.SymbolizerMaxUnresolvedLocationsValue
 }
 
 func (m MockLimits) IngestionBodyLimitBytes(tenantID string) int64 {


### PR DESCRIPTION
## Part of a series: symbol-aware tree references (6 of 8)

Full context and series overview: #5317 (PR 1). Compact map:

1. symbolizer: expose address-level `Resolve` API (#5317)
2. proto: `SymbolRefTable` + tree query/report fields (#5318)
3. `model/symbolref`: intern table + merge rebasing (#5321)
4. `model/symbolref`: unresolved-binary grouping + tree rebuild (#5322)
5. symdb: symbol-ref tree resolver output (#5332) · querybackend: query mode + aggregation (#5333)
6. **frontend: orchestration behind a default-off per-tenant flag ← this PR**
7. integration tests + docs (#5335)
8. symdb: compaction preserves line-less locations (#5337) — stacked at the bottom of the series, merges first

Tracking issue: grafana/pyroscope-squad#487. Based on #5333's branch.

## What

The activation PR. Behind a new per-tenant flag `symbolizer.symbol-ref-trees-enabled` (default **off**), tree and span-profile queries request symbol-ref tree reports instead of being rewritten through the pprof path when symbolization is needed. With the flag off, request construction and the legacy symbolization path are byte-identical to today — that's the rollback story.

When a merged report comes back with unresolved references, the frontend:
- groups them by binary (`symbolref.UnresolvedBinaries`),
- resolves each through the symbolizer's address-level API under bounded concurrency (the existing `max-debuginfod-concurrency`, shared with the pprof path) and a per-binary timeout (`symbolizer.resolve-timeout`, default 20s),
- rebuilds the final tree (`symbolref.Rebuild`), rendering the existing `binary!0xaddr` fallback for anything unresolved.

**Error semantics:** a per-binary timeout degrades that one binary to fallbacks and lets the query succeed; cancellation of the *request* context fails the query, matching how `SymbolizePprof` errors are already handled at these call sites.

## Observability

A single unsampled counter, `symbol_ref_locations_total{result=resolved|miss|timeout}`, drives the fallback-rate signal (an alert can't be built on sampled traces). The per-request detail — resolution timing, binary count, unresolved-reference count — lives on a `resolveSymbolRefs` tracing span instead of dedicated metrics.

## Testing

`go test ./pkg/frontend/... ./pkg/validation/... -race` green. Tests cover: flag off ⇒ byte-identical legacy behavior (existing `shouldSymbolize` tests untouched); flag on ⇒ symbol-ref request, no legacy wrapper; old-backend/degenerate responses pass through; per-buildID resolution with sorted/deduped addresses and fallback on miss; per-binary timeout ⇒ fallback + query succeeds; request-context cancellation ⇒ query fails; multi-tenant all-tenants gating. `golangci-lint` clean; whole-repo build clean.

