### PR TITLE
fix(symdb): preserve line-less locations when rewriting partitions without functions

### DIFF
--- a/pkg/phlaredb/symdb/rewriter.go
+++ b/pkg/phlaredb/symdb/rewriter.go
@@ -141,11 +141,14 @@ func (p *partitionRewriter) populateUnresolved(stacktraceIDs []uint32) error {
 		location := p.src.Locations[unresolvedLocs.At()]
 		location.MappingId = p.mappings.tryLookup(location.MappingId)
 		if len(p.src.Functions) == 0 {
+			// Line records cannot reference any function and are dropped,
+			// but the location itself must be kept: not-yet-symbolized
+			// native partitions consist entirely of line-less locations.
 			location.Line = nil
-			continue
-		}
-		for j, line := range location.Line {
-			location.Line[j].FunctionId = p.functions.tryLookup(line.FunctionId)
+		} else {
+			for j, line := range location.Line {
+				location.Line[j].FunctionId = p.functions.tryLookup(line.FunctionId)
+			}
 		}
 		unresolvedLocs.setValue(location)
 	}

--- a/pkg/phlaredb/symdb/rewriter_test.go
+++ b/pkg/phlaredb/symdb/rewriter_test.go
@@ -1,9 +1,14 @@
 package symdb
 
 import (
+	"context"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 )
 
 func Test_lookupTable(t *testing.T) {
@@ -97,4 +102,89 @@ func Test_lookupTable(t *testing.T) {
 
 	assert.Len(t, dst, 7)
 	assert.NotContains(t, dst, "seven")
+}
+
+// Location addresses must survive the rewrite: a partition with an empty
+// functions table — a native profile that has not been symbolized, where
+// every location is line-less — used to have all its locations rewritten
+// as zero values, permanently losing the addresses at compaction.
+func Test_Rewriter_location_addresses(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		profile     *profilev1.Profile
+		expected    []uint64
+	}{
+		{
+			description: "partition without functions",
+			profile:     linelessLocationsProfile(),
+			expected:    []uint64{0x1500, 0x3c5a},
+		},
+		{
+			description: "line-less location in a partition with functions",
+			profile:     mixedLocationsProfile(),
+			expected:    []uint64{0x3c5a},
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			src := newMemSuite(t, nil)
+			indexed := src.db.WriteProfileSymbols(0, tc.profile)
+			require.NotEmpty(t, indexed)
+
+			dst := NewSymDB(nil)
+			rw := NewRewriter(dst, src.db, nil)
+			for _, p := range indexed {
+				ids := slices.Clone(p.Samples.StacktraceIDs)
+				require.NoError(t, rw.Rewrite(0, ids))
+			}
+
+			pr, err := dst.Partition(context.Background(), 0)
+			require.NoError(t, err)
+			addresses := make([]uint64, 0, len(pr.Symbols().Locations))
+			for _, loc := range pr.Symbols().Locations {
+				addresses = append(addresses, loc.Address)
+			}
+			for _, addr := range tc.expected {
+				assert.Contains(t, addresses, addr)
+			}
+		})
+	}
+}
+
+func linelessLocationsProfile() *profilev1.Profile {
+	return &profilev1.Profile{
+		StringTable: []string{"", "libfoo.so", "build-id-f00"},
+		Mapping: []*profilev1.Mapping{
+			{Id: 1, MemoryLimit: 0x1000000, Filename: 1, BuildId: 2},
+		},
+		Location: []*profilev1.Location{
+			{Id: 1, MappingId: 1, Address: 0x1500},
+			{Id: 2, MappingId: 1, Address: 0x3c5a},
+		},
+		Sample: []*profilev1.Sample{
+			{LocationId: []uint64{1}, Value: []int64{100}},
+			{LocationId: []uint64{2}, Value: []int64{200}},
+			{LocationId: []uint64{1, 2}, Value: []int64{3}},
+		},
+		SampleType: []*profilev1.ValueType{{Type: 0, Unit: 0}},
+	}
+}
+
+func mixedLocationsProfile() *profilev1.Profile {
+	return &profilev1.Profile{
+		StringTable: []string{"", "libfoo.so", "build-id-f00", "main", "main.go"},
+		Mapping: []*profilev1.Mapping{
+			{Id: 1, MemoryLimit: 0x1000000, Filename: 1, BuildId: 2},
+		},
+		Function: []*profilev1.Function{
+			{Id: 1, Name: 3, Filename: 4},
+		},
+		Location: []*profilev1.Location{
+			{Id: 1, MappingId: 1, Line: []*profilev1.Line{{FunctionId: 1, Line: 5}}},
+			{Id: 2, MappingId: 1, Address: 0x3c5a},
+		},
+		Sample: []*profilev1.Sample{
+			{LocationId: []uint64{2, 1}, Value: []int64{77}},
+		},
+		SampleType: []*profilev1.ValueType{{Type: 0, Unit: 0}},
+	}
 }

--- a/pkg/test/integration/symbolization_test.go
+++ b/pkg/test/integration/symbolization_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 	pushv1 "github.com/grafana/pyroscope/api/gen/proto/go/push/v1"
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
@@ -68,7 +69,10 @@ func testSymbolizationFlow(t *testing.T, ctx context.Context, c *cluster.Cluster
 		name     string
 		profile  func(now time.Time) *profile.Profile
 		expected string
-		skip     bool
+		// Symbolized frames that must still be present after the pushed
+		// segment has been compacted; nil skips the post-compaction phase.
+		postCompactionSymbols map[string]uint64
+		skip                  bool
 	}{
 		{
 			name: "fully unsymbolized",
@@ -138,6 +142,7 @@ Locations
 Mappings
 1: 0x0/0x1000000/0x0 libfoo.so 2fa2055ef20fabc972d5751147e093275514b142 [FN]
 `,
+			postCompactionSymbols: map[string]uint64{"main": 0x1500, "atoll_b": 0x3c5a},
 		},
 		{
 			name: "partially symbolized",
@@ -279,7 +284,77 @@ Mappings
 				}
 				return true
 			}, 5*time.Second, 100*time.Millisecond)
+
+			if test.postCompactionSymbols == nil {
+				return
+			}
+			// The cluster compacts L0 blocks within seconds, and compaction
+			// deletes the source blocks: if the rewrite loses the addresses
+			// of line-less locations, the profile can never be symbolized
+			// again. The golden comparison above is order-sensitive and
+			// compaction may renumber locations, so past this point only the
+			// symbolized frames are asserted.
+			// Age-based batch flushing is evaluated only when another block
+			// arrives at the same compaction level, so keep pushing filler
+			// blocks — to a service the query below does not select — until
+			// the planner picks up the staged blocks.
+			require.Eventually(t, func() bool {
+				_, err := pusher.Push(ctx, connect.NewRequest(&pushv1.PushRequest{
+					Series: []*pushv1.RawProfileSeries{{
+						Labels: []*typesv1.LabelPair{
+							{Name: "service_name", Value: serviceName + "-compaction-filler"},
+							{Name: "__name__", Value: "process_cpu"},
+						},
+						Samples: []*pushv1.RawSample{{RawProfile: rawProfile}},
+					}},
+				}))
+				if err != nil {
+					t.Logf("Error pushing filler profile: %v", err)
+					return false
+				}
+				n, err := c.CompactionJobsFinished(ctx)
+				return err == nil && n >= 1
+			}, 30*time.Second, time.Second, "no L0 compaction observed")
+
+			queried := false
+			for deadline := time.Now().Add(8 * time.Second); time.Now().Before(deadline); time.Sleep(500 * time.Millisecond) {
+				resp, err := querier.SelectMergeProfile(ctx, q)
+				if err != nil {
+					t.Logf("Error querying profile: %v", err)
+					continue
+				}
+				requireSymbolizedFrames(t, resp.Msg, test.postCompactionSymbols)
+				queried = true
+			}
+			require.True(t, queried, "profile was not queryable after compaction")
 		})
 	}
 
+}
+
+// requireSymbolizedFrames asserts that the profile contains a symbolized
+// frame for every expected function name → address pair, and no fallback
+// (binary!0xaddr) frames.
+func requireSymbolizedFrames(t *testing.T, p *profilev1.Profile, symbols map[string]uint64) {
+	t.Helper()
+	names := make(map[uint64]string, len(p.Function))
+	for _, f := range p.Function {
+		names[f.Id] = p.StringTable[f.Name]
+	}
+	type frame struct {
+		name    string
+		address uint64
+	}
+	frames := make(map[frame]struct{})
+	for _, loc := range p.Location {
+		for _, line := range loc.Line {
+			name := names[line.FunctionId]
+			require.NotContains(t, name, "!0x", "unexpected fallback frame")
+			frames[frame{name: name, address: loc.Address}] = struct{}{}
+		}
+	}
+	for name, address := range symbols {
+		_, ok := frames[frame{name: name, address: address}]
+		require.True(t, ok, "missing symbolized frame %s@%#x (got: %v)", name, address, frames)
+	}
 }


### PR DESCRIPTION
## Part of a series: symbol-aware tree references (8 of 8)

Full context and series overview: #5317 (PR 1). Compact map:

1. symbolizer: expose address-level `Resolve` API (#5317)
2. proto: `SymbolRefTable` + tree fields (#5318)
3. `model/symbolref`: intern table + merge rebasing (#5321)
4. `model/symbolref`: grouping + rebuild (#5322)
5. symdb resolver output (#5332) · querybackend mode + aggregation (#5333)
6. frontend orchestration behind a default-off per-tenant flag (#5334)
7. integration tests + docs (#5335)
8. **symdb: compaction preserves line-less locations ← this PR — stacked at the bottom of the series, merges first**

Tracking issue: grafana/pyroscope-squad#487. Unlike the rest of the series this fixes pre-existing
shared code, so it is stacked first: the feature must not be enabled anywhere before it lands.

## What

`symdb.Rewriter.populateUnresolved` replaces every location of a partition whose functions table is
empty with a zero value: the guard added in #4051 drops the location's line records and then
`continue`s, skipping `unresolvedLocs.setValue(location)`. The location is never stored into the
lookup table, so the zero value `InMemoryLocation{}` is what gets written to the rewritten
partition — all locations of such a partition collapse into `{Address: 0, MappingId: 0}` (and dedup
into a single entry).

A partition without functions is not malformed: it is precisely a native profile that has not been
symbolized, where every location is line-less by definition. Both compactors (v1
`pkg/phlaredb/compact.go`, v2 `pkg/block/compaction.go`) rewrite symbols through this path, so the
first compaction permanently destroys the addresses of fully-unsymbolized datasets — source blocks
are deleted after compaction, making the loss unrecoverable. Read-time symbolization of compacted
data then renders `binary!0x0` fallback frames.

Partitions with at least one function are unaffected, which is why even partially-symbolized
profiles survive compaction — and why this went unnoticed: most agents symbolize locally before
pushing, so zero-function partitions are rare until server-side symbolization is in play.

## Fix

Keep dropping the line records (with no functions in the partition they cannot reference anything),
but store the location so its address and mapping reference survive the rewrite.

## Testing

- New `Test_Rewriter_location_addresses`: a zero-functions partition (fails without the fix — all
  locations collapse to one zero-valued entry) and a control partition with functions.
- The symbolization end-to-end test now runs past the first L0 compaction and asserts the
  symbolized frames survive, order-insensitively (compaction may renumber locations). Filler pushes
  drive the planner, since age-based batch flushing is only evaluated when another block arrives at
  the level. Without the rewriter fix it fails in seconds with `libfoo.so!0x0` fallback frames.
- Full `pkg/phlaredb/symdb` suite (incl. `-race`), v1 compaction tests (`pkg/phlaredb`), and v2
  `Test_CompactBlocks` (golden unchanged) pass.
