### PR TITLE
docs: add v2.1.1 release notes

### DIFF
--- a/docs/sources/release-notes/v2-1.md
+++ b/docs/sources/release-notes/v2-1.md
@@ -5,6 +5,11 @@ description: Release notes for Grafana Pyroscope 2.1
 weight: 670
 ---
 
+## Version 2.1.1 release notes
+
+### Security fixes
+* Update Go toolchain to 1.25.12, addressing CVE-2026-42505 and CVE-2026-39822 (security) ([#5338](https://github.com/grafana/pyroscope/pull/5338))
+
 ## Version 2.1.0 release notes
 
 The Pyroscope team is excited to present Grafana Pyroscope 2.1.0.


### PR DESCRIPTION
Release notes for the upcoming v2.1.1 patch release (Go toolchain 1.25.12, #5338).