### PR TITLE
docs: add v2.0.6 release notes

### DIFF
--- a/docs/sources/release-notes/v2-0.md
+++ b/docs/sources/release-notes/v2-0.md
@@ -5,6 +5,11 @@ description: Release notes for Grafana Pyroscope 2.0
 weight: 680
 ---
 
+## Version 2.0.6 release notes
+
+### Security fixes
+* Update Go toolchain to 1.25.12, addressing CVE-2026-42505 and CVE-2026-39822 (security) ([#5338](https://github.com/grafana/pyroscope/pull/5338))
+
 ## Version 2.0.5 release notes
 
 ### Security fixes


### PR DESCRIPTION
Release notes for the upcoming v2.0.6 patch release (Go toolchain 1.25.12, #5338).