### PR TITLE
[release/v2.0] docs: add v2.0.6 release notes

### DIFF
--- a/docs/sources/release-notes/v2-0.md
+++ b/docs/sources/release-notes/v2-0.md
@@ -5,6 +5,11 @@ description: Release notes for Grafana Pyroscope 2.0
 weight: 680
 ---
 
+## Version 2.0.6 release notes
+
+### Security fixes
+* Update Go toolchain to 1.25.12, addressing CVE-2026-42505 and CVE-2026-39822 (security) ([#5338](https://github.com/grafana/pyroscope/pull/5338))
+
 ## Version 2.0.5 release notes
 
 ### Security fixes


### PR DESCRIPTION
Backport 277dc2f8f4140ef7c7870023af8d455649214638 from #5343. The automated backport failed with add/add conflicts across the whole tree (bot clone issue, not a real conflict) — the local cherry-pick applied cleanly.