### PR TITLE
fix(querier): serve sharded windows whose shards are at mixed compaction levels

### DIFF
--- a/pkg/querier/replication.go
+++ b/pkg/querier/replication.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/tracing"
+	"github.com/prometheus/common/model"
 	"github.com/samber/lo"
 	"golang.org/x/sync/errgroup"
 
@@ -202,92 +203,121 @@ func (r *replicasPerBlockID) removeBlock(ulid string) {
 	delete(r.meta, ulid)
 }
 
-// this step removes sharded blocks that don't have all the shards present for a time window
-func (r *replicasPerBlockID) pruneIncompleteShardedBlocks() (bool, error) {
-	type compactionKey struct {
-		level   int32
-		minTime int64
+// hasShardedBlocks reports whether any block carries a compactor shard label.
+func (r *replicasPerBlockID) hasShardedBlocks() bool {
+	for blockID := range r.m {
+		if meta, ok := r.meta[blockID]; ok {
+			if _, _, ok := shardFromBlock(meta); ok {
+				return true
+			}
+		}
 	}
-	compactions := make(map[compactionKey][]string)
+	return false
+}
 
-	// group blocks by compaction level
+// pruneIncompleteShardedBlocks drops sharded blocks for any window instant that
+// is missing a shard. It must run before pruneSupersededBlocks, so an incomplete
+// set's lower-level ancestors survive as a fallback. deduplicationLevel is the
+// level at/above which blocks are deduplicated (3 when sharded).
+func (r *replicasPerBlockID) pruneIncompleteShardedBlocks(deduplicationLevel int32) error {
+	// Completeness is checked per sharding (shard count) and per time instant, not
+	// by compaction level: a window's shards can legitimately sit at different
+	// levels (a partial late re-merge advances only some), so keying on level would
+	// falsely split a complete window and prune it. Different shard counts (e.g. a
+	// shard-count reconfiguration) are separate shardings and checked independently.
+	//
+	// For each distinct window start we require every shard to have a trusted block
+	// covering that instant. Coverage (minTime <= t < maxTime), rather than an exact
+	// minTime match, keeps a wider block (a shard merged to a longer span) counted
+	// for the later windows it overlaps, so sibling shards' blocks there are not
+	// orphaned and silently pruned. Only blocks >= deduplicationLevel count;
+	// intermediate lower blocks are never served (pruneSupersededBlocks drops them)
+	// so must not satisfy a shard.
+	type shardedBlock struct {
+		id      string
+		shard   uint64
+		minTime int64
+		maxTime int64
+	}
+	byShardCount := make(map[uint64][]shardedBlock)
 	for blockID := range r.m {
 		meta, ok := r.meta[blockID]
 		if !ok {
-			return false, fmt.Errorf("meta missing for block id %s", blockID)
+			return fmt.Errorf("meta missing for block id %s", blockID)
 		}
-
-		key := compactionKey{
-			level:   0,
-			minTime: meta.MinTime,
-		}
-
-		if meta.Compaction != nil {
-			key.level = meta.Compaction.Level
-		}
-		compactions[key] = append(compactions[key], blockID)
-	}
-
-	// now we go through every group and check if we see at least a block for each shard
-	var (
-		shardsSeen       []bool
-		shardedBlocks    []string
-		hasShardedBlocks bool
-	)
-	for _, blocks := range compactions {
-		shardsSeen = shardsSeen[:0]
-		shardedBlocks = shardedBlocks[:0]
-		for _, block := range blocks {
-			meta, ok := r.meta[block]
-			if !ok {
-				return false, fmt.Errorf("meta missing for block id %s", block)
-			}
-
-			shardIdx, shards, ok := shardFromBlock(meta)
-			if !ok {
-				// not a sharded block continue
-				continue
-			}
-			hasShardedBlocks = true
-			shardedBlocks = append(shardedBlocks, block)
-
-			if len(shardsSeen) == 0 {
-				if cap(shardsSeen) < int(shards) {
-					shardsSeen = make([]bool, shards)
-				} else {
-					shardsSeen = shardsSeen[:shards]
-					for idx := range shardsSeen {
-						shardsSeen[idx] = false
-					}
-				}
-			}
-
-			if len(shardsSeen) != int(shards) {
-				return false, fmt.Errorf("shard length mismatch, shards seen: %d, shards as per label: %d", len(shardsSeen), shards)
-			}
-
-			shardsSeen[shardIdx] = true
-		}
-		// check if all shards are present
-		allShardsPresent := true
-		for _, shardSeen := range shardsSeen {
-			if !shardSeen {
-				allShardsPresent = false
-				break
-			}
-		}
-
-		if allShardsPresent {
+		shard, shardCount, ok := shardFromBlock(meta)
+		if !ok {
 			continue
 		}
+		if meta.Compaction == nil || meta.Compaction.Level < deduplicationLevel {
+			continue
+		}
+		byShardCount[shardCount] = append(byShardCount[shardCount],
+			shardedBlock{id: blockID, shard: shard, minTime: meta.MinTime, maxTime: meta.MaxTime})
+	}
 
-		// now remove all blocks that are shareded but not complete
-		for _, block := range shardedBlocks {
-			r.removeBlock(block)
+	for shardCount, blocks := range byShardCount {
+		// Distinct window starts, ascending: pruning an earlier incomplete window
+		// first removes wide blocks that would otherwise mask a gap in a later one.
+		starts := make([]int64, 0, len(blocks))
+		seen := make(map[int64]struct{}, len(blocks))
+		for _, b := range blocks {
+			if _, ok := seen[b.minTime]; !ok {
+				seen[b.minTime] = struct{}{}
+				starts = append(starts, b.minTime)
+			}
+		}
+		sort.Slice(starts, func(i, j int) bool { return starts[i] < starts[j] })
+
+		shardsSeen := make([]bool, shardCount)
+		for _, t := range starts {
+			for i := range shardsSeen {
+				shardsSeen[i] = false
+			}
+			for _, b := range blocks {
+				if _, live := r.m[b.id]; !live {
+					continue // already pruned by an earlier incomplete window
+				}
+				if b.shard < shardCount && b.minTime <= t && t < b.maxTime {
+					shardsSeen[b.shard] = true
+				}
+			}
+			complete := true
+			for _, s := range shardsSeen {
+				if !s {
+					complete = false
+					break
+				}
+			}
+			if complete {
+				continue
+			}
+
+			// A shard is missing at this instant; dropping these can hide data (there
+			// may be no lower-level fallback), so log rather than prune silently. We
+			// prune the blocks that start here and fall back to the lower levels.
+			var pruned int
+			for _, b := range blocks {
+				if b.minTime != t {
+					continue
+				}
+				if _, live := r.m[b.id]; live {
+					r.removeBlock(b.id)
+					pruned++
+				}
+			}
+			if pruned > 0 {
+				level.Warn(r.logger).Log(
+					"msg", "pruning incomplete sharded blocks from query plan; a shard is missing for this time window and its data will not be queried",
+					"min_time", model.Time(t).Time().String(),
+					"shards_expected", shardCount,
+					"blocks_pruned", pruned,
+				)
+			}
 		}
 	}
 
-	return hasShardedBlocks, nil
+	return nil
 }
 
 // prunes blocks that are contained by a higher compaction level block
@@ -355,13 +385,10 @@ func (r *replicasPerBlockID) blockPlan(ctx context.Context) map[string]*blockPla
 		hash                    = xxhash.New()
 		plan                    = make(map[string]*blockPlanEntry)
 		smallestCompactionLevel = int32(0)
+		shardCounts             = make(map[uint64]struct{})
 	)
 
-	sharded, err := r.pruneIncompleteShardedBlocks()
-	if err != nil {
-		level.Warn(r.logger).Log("msg", "block planning failed to prune incomplete sharded blocks", "err", err)
-		return nil
-	}
+	sharded := r.hasShardedBlocks()
 
 	// Depending on whether split sharding is used, the compaction level at
 	// which the data gets deduplicated differs: if split sharding is enabled,
@@ -369,6 +396,13 @@ func (r *replicasPerBlockID) blockPlan(ctx context.Context) map[string]*blockPla
 	var deduplicationLevel int32 = 2
 	if sharded {
 		deduplicationLevel = 3
+	}
+
+	// Prune incomplete sharded sets first, so that any lower-level ancestors
+	// survive as a fallback, then collapse the surviving blocks per shard.
+	if err := r.pruneIncompleteShardedBlocks(deduplicationLevel); err != nil {
+		level.Warn(r.logger).Log("msg", "block planning failed to prune incomplete sharded blocks", "err", err)
+		return nil
 	}
 
 	if err := r.pruneSupersededBlocks(sharded); err != nil {
@@ -391,6 +425,11 @@ func (r *replicasPerBlockID) blockPlan(ctx context.Context) map[string]*blockPla
 		// or a block without compaction section, we want the queriers to deduplicate
 		if meta.Compaction == nil || meta.Compaction.Level < deduplicationLevel {
 			deduplicate = true
+		}
+
+		// track the distinct shardings present in the plan (see below).
+		if _, shardCount, ok := shardFromBlock(meta); ok {
+			shardCounts[shardCount] = struct{}{}
 		}
 
 		// record the lowest compaction level
@@ -440,6 +479,16 @@ func (r *replicasPerBlockID) blockPlan(ctx context.Context) map[string]*blockPla
 
 		// set the selected replica
 		r.m[blockID] = []string{selectedReplica}
+	}
+
+	// If more than one sharding scheme survived into the plan (e.g. an _of_2 and
+	// an _of_4 set for overlapping data), they partition the same series
+	// differently, so a series can appear in both. The sharded fast path assumes
+	// each series is served by exactly one block, which only holds for a single
+	// complete sharding - so force query-time deduplication to reconcile the
+	// overlap instead of double-counting.
+	if len(shardCounts) > 1 {
+		deduplicate = true
 	}
 
 	// adapt the plan to make sure all replicas will deduplicate

--- a/pkg/querier/replication_test.go
+++ b/pkg/querier/replication_test.go
@@ -1,6 +1,7 @@
 package querier
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sort"
@@ -89,6 +90,16 @@ func validatePlanBlocksOnReplica(replica string, blocks ...string) validatorFunc
 		require.True(t, ok, fmt.Sprintf("replica %s not found in plan", replica))
 		for _, block := range blocks {
 			require.Contains(t, planEntry.Ulids, block, "block %s not found in replica's %s plan", block, replica)
+		}
+	}
+}
+
+// validatePlanDeduplication asserts the deduplication hint on every planned replica.
+func validatePlanDeduplication(expected bool) validatorFunc {
+	return func(t *testing.T, plan map[string]*blockPlanEntry) {
+		require.NotEmpty(t, plan, "expected a non-empty plan to assert deduplication on")
+		for replica, planEntry := range plan {
+			require.Equal(t, expected, planEntry.Deduplication, "unexpected deduplication hint for replica %s", replica)
 		}
 	}
 }
@@ -223,6 +234,284 @@ func Test_replicasPerBlockID_blockPlan(t *testing.T) {
 			},
 		},
 		{
+			// A window whose shards sit at different levels (shard 2 at L3, the rest
+			// at L4, same minTime) is complete and must be queried, not pruned.
+			name: "keep sharded window with shards at mixed compaction levels",
+			inputs: func(r *replicasPerBlockID) {
+				t1, _ := time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")
+				r.add([]ResponseFromReplica[[]*typesv1.BlockInfo]{
+					{
+						addr: "store-gateway-0",
+						response: []*typesv1.BlockInfo{
+							newBlockInfo("s0").
+								withCompactionLevel(4).
+								withCompactorShard(0, 4).
+								withMinTime(t1, 2*time.Hour).
+								info(),
+							newBlockInfo("s1").
+								withCompactionLevel(4).
+								withCompactorShard(1, 4).
+								withMinTime(t1, 2*time.Hour).
+								info(),
+							// shard 2 lagged behind at level 3 (no late data touched it).
+							newBlockInfo("s2").
+								withCompactionLevel(3).
+								withCompactorShard(2, 4).
+								withMinTime(t1, time.Hour). // different maxTime, same minTime
+								info(),
+							newBlockInfo("s3").
+								withCompactionLevel(4).
+								withCompactorShard(3, 4).
+								withMinTime(t1, 2*time.Hour).
+								info(),
+						},
+					},
+				}, storeGatewayInstance)
+			},
+			validators: []validatorFunc{
+				// Pre-fix, (level, minTime) grouping split this into incomplete L3
+				// and L4 groups and emptied the plan.
+				validatePlanBlockIDs("s0", "s1", "s2", "s3"),
+				// Complete deduplicated set -> served without query-time dedup.
+				validatePlanDeduplication(false),
+			},
+		},
+		{
+			// Shard 0 has both its L3 and derived L4 present; shard 1 lags at L3.
+			// Window is complete, and superseding collapses shard 0 to just its L4.
+			name: "collapse L3+L4 duplicate of a shard within a mixed-level window",
+			inputs: func(r *replicasPerBlockID) {
+				t1, _ := time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")
+				r.add([]ResponseFromReplica[[]*typesv1.BlockInfo]{
+					{
+						addr: "store-gateway-0",
+						response: []*typesv1.BlockInfo{
+							// shard 0: L4 derived from its L3 parent; both still present.
+							newBlockInfo("s0-l4").
+								withCompactionLevel(4).
+								withCompactionSources("s0-l3").
+								withCompactionParents("s0-l3").
+								withCompactorShard(0, 2).
+								withMinTime(t1, 2*time.Hour).
+								info(),
+							newBlockInfo("s0-l3").
+								withCompactionLevel(3).
+								withCompactorShard(0, 2).
+								withMinTime(t1, time.Hour).
+								info(),
+							// shard 1: lagged at L3, no L4 derived yet.
+							newBlockInfo("s1-l3").
+								withCompactionLevel(3).
+								withCompactorShard(1, 2).
+								withMinTime(t1, time.Hour).
+								info(),
+						},
+					},
+				}, storeGatewayInstance)
+			},
+			validators: []validatorFunc{
+				// One block per shard: shard 0's L3 superseded by its L4.
+				validatePlanBlockIDs("s0-l4", "s1-l3"),
+			},
+		},
+		{
+			// Mixed spans: shard 0 merged to a wide [t1,t1+4h) block, while shard 1
+			// still has two narrower blocks [t1,t1+2h) and [t1+2h,t1+4h). Completeness
+			// must credit the wide block for the later window it covers, so shard 1's
+			// [t1+2h,t1+4h) block is NOT orphaned and pruned. All three are kept.
+			name: "keep mixed-span shards when a wide block covers a later window",
+			inputs: func(r *replicasPerBlockID) {
+				t1, _ := time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")
+				t3 := t1.Add(2 * time.Hour)
+				r.add([]ResponseFromReplica[[]*typesv1.BlockInfo]{
+					{
+						addr: "store-gateway-0",
+						response: []*typesv1.BlockInfo{
+							newBlockInfo("s0-wide").withCompactionLevel(4).withCompactorShard(0, 2).withMinTime(t1, 4*time.Hour).info(),
+							newBlockInfo("s1-a").withCompactionLevel(3).withCompactorShard(1, 2).withMinTime(t1, 2*time.Hour).info(),
+							newBlockInfo("s1-b").withCompactionLevel(3).withCompactorShard(1, 2).withMinTime(t3, 2*time.Hour).info(),
+						},
+					},
+				}, storeGatewayInstance)
+			},
+			validators: []validatorFunc{
+				// Pre-fix, the (t1+2h) group saw only shard 1 and pruned s1-b, losing
+				// shard 1's data for [t1+2h,t1+4h).
+				validatePlanBlockIDs("s0-wide", "s1-a", "s1-b"),
+				validatePlanDeduplication(false),
+			},
+		},
+		{
+			// A window with a genuinely missing shard (absent at every level) must
+			// still be pruned: shard 2 of 4 has no block at any level.
+			name: "prune sharded window with a shard missing at all levels",
+			inputs: func(r *replicasPerBlockID) {
+				t1, _ := time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")
+				r.add([]ResponseFromReplica[[]*typesv1.BlockInfo]{
+					{
+						addr: "ingester-0",
+						response: []*typesv1.BlockInfo{
+							newBlockInfo("fallback").withMinTime(t1, 2*time.Hour).info(),
+						},
+					},
+				}, ingesterInstance)
+				r.add([]ResponseFromReplica[[]*typesv1.BlockInfo]{
+					{
+						addr: "store-gateway-0",
+						response: []*typesv1.BlockInfo{
+							newBlockInfo("s0").
+								withCompactionLevel(4).
+								withCompactorShard(0, 4).
+								withMinTime(t1, 2*time.Hour).
+								info(),
+							newBlockInfo("s1").
+								withCompactionLevel(3).
+								withCompactorShard(1, 4).
+								withMinTime(t1, time.Hour).
+								info(),
+							// shard 2 is missing entirely; shard 3 too.
+							newBlockInfo("s3").
+								withCompactionLevel(4).
+								withCompactorShard(3, 4).
+								withMinTime(t1, 2*time.Hour).
+								info(),
+						},
+					},
+				}, storeGatewayInstance)
+			},
+			validators: []validatorFunc{
+				// Incomplete across all levels -> sharded blocks pruned, fallback kept.
+				validatePlanBlockIDs("fallback"),
+				// Low-level fallback -> query-time dedup enabled.
+				validatePlanDeduplication(true),
+			},
+		},
+		{
+			// Shard-count change (2 -> 4): a complete _of_2 and a partial _of_4
+			// scheme share a level and minTime, so only shardCount separates them.
+			// The _of_4 is pruned, the complete _of_2 served. Pre-fix, pooling by
+			// {level, minTime} tripped the shard-length-mismatch guard and emptied
+			// the plan.
+			name: "serve complete old sharding when a shard-count change leaves a partial new one",
+			inputs: func(r *replicasPerBlockID) {
+				t1, _ := time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")
+				r.add([]ResponseFromReplica[[]*typesv1.BlockInfo]{
+					{
+						addr: "store-gateway-0",
+						response: []*typesv1.BlockInfo{
+							// complete old 2-shard scheme
+							newBlockInfo("old0").withCompactionLevel(4).withCompactorShard(0, 2).withMinTime(t1, 2*time.Hour).info(),
+							newBlockInfo("old1").withCompactionLevel(4).withCompactorShard(1, 2).withMinTime(t1, 2*time.Hour).info(),
+							// partial new 4-shard scheme (shards 0 and 3 not yet produced)
+							newBlockInfo("new1").withCompactionLevel(4).withCompactorShard(1, 4).withMinTime(t1, 2*time.Hour).info(),
+							newBlockInfo("new2").withCompactionLevel(4).withCompactorShard(2, 4).withMinTime(t1, 2*time.Hour).info(),
+						},
+					},
+				}, storeGatewayInstance)
+			},
+			validators: []validatorFunc{
+				validatePlanBlockIDs("old0", "old1"),
+				validatePlanDeduplication(false),
+			},
+		},
+		{
+			// Two complete, unrelated shardings (_of_2 and _of_4) for the same
+			// window: each is complete on its own so neither is pruned, and neither
+			// supersedes the other. They partition the same series differently, so a
+			// series can appear in both - query-time deduplication must be forced to
+			// avoid double-counting.
+			name: "deduplicate when two complete shardings overlap",
+			inputs: func(r *replicasPerBlockID) {
+				t1, _ := time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")
+				r.add([]ResponseFromReplica[[]*typesv1.BlockInfo]{
+					{
+						addr: "store-gateway-0",
+						response: []*typesv1.BlockInfo{
+							newBlockInfo("of2-0").withCompactionLevel(4).withCompactorShard(0, 2).withMinTime(t1, 2*time.Hour).info(),
+							newBlockInfo("of2-1").withCompactionLevel(4).withCompactorShard(1, 2).withMinTime(t1, 2*time.Hour).info(),
+							newBlockInfo("of4-0").withCompactionLevel(4).withCompactorShard(0, 4).withMinTime(t1, 2*time.Hour).info(),
+							newBlockInfo("of4-1").withCompactionLevel(4).withCompactorShard(1, 4).withMinTime(t1, 2*time.Hour).info(),
+							newBlockInfo("of4-2").withCompactionLevel(4).withCompactorShard(2, 4).withMinTime(t1, 2*time.Hour).info(),
+							newBlockInfo("of4-3").withCompactionLevel(4).withCompactorShard(3, 4).withMinTime(t1, 2*time.Hour).info(),
+						},
+					},
+				}, storeGatewayInstance)
+			},
+			validators: []validatorFunc{
+				// Both complete shardings survive; nothing is dropped.
+				validatePlanBlockIDs("of2-0", "of2-1", "of4-0", "of4-1", "of4-2", "of4-3"),
+				// Overlapping schemes -> query-time dedup forced.
+				validatePlanDeduplication(true),
+			},
+		},
+		{
+			// Counterpart to the previous case: when the new _of_4 sharding is
+			// derived from the old _of_2 one (lists it as sources), pruneSupersededBlocks
+			// removes the superseded _of_2 blocks, leaving a single sharding. The
+			// multi-sharding dedup guard must NOT fire here - the fast path
+			// (Deduplication=false) is preserved.
+			name: "single sharding after superseding keeps the fast path",
+			inputs: func(r *replicasPerBlockID) {
+				t1, _ := time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")
+				r.add([]ResponseFromReplica[[]*typesv1.BlockInfo]{
+					{
+						addr: "store-gateway-0",
+						response: []*typesv1.BlockInfo{
+							newBlockInfo("of2-0").withCompactionLevel(3).withCompactorShard(0, 2).withMinTime(t1, 2*time.Hour).info(),
+							newBlockInfo("of2-1").withCompactionLevel(3).withCompactorShard(1, 2).withMinTime(t1, 2*time.Hour).info(),
+							// _of_4, one level up, derived from the _of_2 blocks.
+							newBlockInfo("of4-0").withCompactionLevel(4).withCompactionSources("of2-0", "of2-1").withCompactorShard(0, 4).withMinTime(t1, 2*time.Hour).info(),
+							newBlockInfo("of4-1").withCompactionLevel(4).withCompactionSources("of2-0", "of2-1").withCompactorShard(1, 4).withMinTime(t1, 2*time.Hour).info(),
+							newBlockInfo("of4-2").withCompactionLevel(4).withCompactionSources("of2-0", "of2-1").withCompactorShard(2, 4).withMinTime(t1, 2*time.Hour).info(),
+							newBlockInfo("of4-3").withCompactionLevel(4).withCompactionSources("of2-0", "of2-1").withCompactorShard(3, 4).withMinTime(t1, 2*time.Hour).info(),
+						},
+					},
+				}, storeGatewayInstance)
+			},
+			validators: []validatorFunc{
+				// _of_2 superseded by the derived _of_4; only one sharding remains.
+				validatePlanBlockIDs("of4-0", "of4-1", "of4-2", "of4-3"),
+				validatePlanDeduplication(false),
+			},
+		},
+		{
+			// Mid-merge: shard 0 at L3, shard 1 only in an intermediate L2 block, no
+			// L1. The L2 block gets dropped by superseding, so it must not count shard
+			// 1 as present - otherwise we'd serve shard 0 alone (half the data). The
+			// set is incomplete -> everything pruned (transient empty, not undercount).
+			name: "do not let an intermediate L2 block satisfy shard completeness",
+			inputs: func(r *replicasPerBlockID) {
+				t1, _ := time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")
+				r.add([]ResponseFromReplica[[]*typesv1.BlockInfo]{
+					{
+						addr: "store-gateway-0",
+						response: []*typesv1.BlockInfo{
+							newBlockInfo("s0-l3").
+								withCompactionLevel(3).
+								withCompactionSources("s0-l2").
+								withCompactorShard(0, 2).
+								withMinTime(t1, time.Hour).
+								info(),
+							newBlockInfo("s0-l2").
+								withCompactionLevel(2).
+								withCompactorShard(0, 2).
+								withMinTime(t1, time.Hour).
+								info(),
+							// shard 1 only exists as an intermediate L2 block.
+							newBlockInfo("s1-l2").
+								withCompactionLevel(2).
+								withCompactorShard(1, 2).
+								withMinTime(t1, time.Hour).
+								info(),
+						},
+					},
+				}, storeGatewayInstance)
+			},
+			validators: []validatorFunc{
+				validatePlanBlockIDs(),
+			},
+		},
+		{
 			// Using a split-and-merge compactor, deduplication happens at level 3,
 			// level 2 is intermediate step, where series distributed among shards
 			// but not yet deduplicated.
@@ -282,4 +571,49 @@ func Test_replicasPerBlockID_blockPlan(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Pruning an incomplete window must emit a WARN (it was previously silent); a
+// healthy mixed-level window must not.
+func Test_pruneIncompleteShardedBlocks_logging(t *testing.T) {
+	t1, _ := time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")
+
+	const warnMsg = "a shard is missing for this time window"
+
+	t.Run("warns when pruning an incomplete sharded window", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := newReplicasPerBlockID(log.NewLogfmtLogger(&buf))
+		// shard 0 of 2 present, shard 1 missing at every level, no fallback.
+		r.add([]ResponseFromReplica[[]*typesv1.BlockInfo]{
+			{
+				addr: "store-gateway-0",
+				response: []*typesv1.BlockInfo{
+					newBlockInfo("s0").withCompactionLevel(3).withCompactorShard(0, 2).withMinTime(t1, 2*time.Hour).info(),
+				},
+			},
+		}, storeGatewayInstance)
+
+		plan := r.blockPlan(context.TODO())
+		require.Empty(t, plan)
+		require.Contains(t, buf.String(), warnMsg, "expected a WARN when an incomplete window is pruned")
+	})
+
+	t.Run("does not warn for a complete mixed-level window", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := newReplicasPerBlockID(log.NewLogfmtLogger(&buf))
+		// both shards present, at different levels.
+		r.add([]ResponseFromReplica[[]*typesv1.BlockInfo]{
+			{
+				addr: "store-gateway-0",
+				response: []*typesv1.BlockInfo{
+					newBlockInfo("s0").withCompactionLevel(4).withCompactorShard(0, 2).withMinTime(t1, 2*time.Hour).info(),
+					newBlockInfo("s1").withCompactionLevel(3).withCompactorShard(1, 2).withMinTime(t1, time.Hour).info(),
+				},
+			},
+		}, storeGatewayInstance)
+
+		plan := r.blockPlan(context.TODO())
+		require.NotEmpty(t, plan)
+		require.NotContains(t, buf.String(), warnMsg, "must not warn for a complete window")
+	})
 }


### PR DESCRIPTION
## Summary

Fixes a query-time false-negative that silently returned **zero results for a fully-intact time window** whose sharded blocks happened to sit at different compaction levels.

`pruneIncompleteShardedBlocks` (`pkg/querier/replication.go`) grouped blocks by `{compaction level, minTime}` and dropped every block in any group missing a shard. But the N shards of one window can legitimately be at **different compaction levels**: when late-arriving source blocks re-merge only the shards their data touches (notably with `compaction_split_by: stacktracePartition`, where a small increment hashes to a subset of shards), those shards advance a level while the rest lag. Keying completeness on `level` then split one complete window into multiple sub-groups — each missing shards — and pruned all of them. With no lower-level fallback present, the query returns nothing, with no error and no log.

## Fix

Check shard completeness **per sharding (shard count) and per time instant**, ignoring compaction level:

- For each distinct window start `t`, require every shard to have a trusted block **covering** `t` (`minTime ≤ t < maxTime`). A window whose shards span e.g. L3/L4 is now seen as complete; `pruneSupersededBlocks` then collapses the per-shard level duplicates (an L3 and its L4 descendant) down to one block per shard.
- **Coverage, not an exact `minTime` match.** A shard merged to a wider span still counts for the later windows it overlaps, so sibling shards' blocks there are not orphaned and silently pruned. (Mixed-span case from review — see below.)
- **Different shard counts are distinct shardings**, checked independently. A `2_of_4` and a `2_of_8` block cover different hash ranges (e.g. after a `split-and-merge-shards` reconfiguration), so they can't be pooled. This also removes the old `shard length mismatch` error, which is now structurally impossible.

### Subtleties, each of which would otherwise reintroduce a silent miscount

1. **Only blocks at/above the deduplication level count.** Intermediate L2 split blocks are never served — `pruneSupersededBlocks` always drops them in favour of the deduplicated L1 ancestor — so letting an L2 block satisfy a shard would make an incomplete set look whole and under-count once the L2 is dropped.
2. **`pruneIncompleteShardedBlocks` runs *before* `pruneSupersededBlocks`.** An incomplete sharded set is dropped while its lower-level ancestors still exist, so those ancestors survive as a query-time fallback. (A kept sharded block would otherwise supersede its shared, un-sharded ancestor — the very fallback the missing shards need.)
3. **Multiple surviving shardings force query-time dedup.** If more than one sharding (shard count) survives into the plan for overlapping data (e.g. a complete `_of_2` *and* a complete `_of_4`), they partition the same series differently, so a series can appear in both. The sharded fast path assumes each series is served by exactly one block, which only holds for a single complete sharding — so we set `Deduplication=true` to reconcile the overlap instead of double-counting. (Normally a window has one sharding, and when a new sharding is derived from an old one `pruneSupersededBlocks` collapses to one, so the fast path is preserved.)

A genuinely incomplete window (a shard absent at every trusted level) is still pruned — and now emits a `WARN` log, so this can never again silently hide data.

### Mixed-span note (from review)

An earlier revision keyed completeness on `{minTime, shardCount}` (exact start match). That under-counted a transient mixed-*span* window — one shard merged to a wide block while a sibling still had separate blocks in the tail — by orphaning the tail blocks. The per-instant **coverage** check above resolves it. It's a self-healing transient (a compaction cycle merges the lagging shard and converges), but coverage handles it correctly rather than serving a partial result.

## Scope

This is the **v1 read path** only (`pkg/querier`). v2's read path (`pkg/querybackend` + metastore-driven `queryplan`) has no analogous completeness guard and is unaffected.

A related, separate limitation remains and is **not** addressed here: a genuinely low-cardinality window (some shards legitimately empty, so the compactor omits them per `compact.go`) is also treated as incomplete and falls back to L1. The querier can't distinguish "empty shard" from "missing shard" without compactor-side metadata; that's a follow-up.

## Why this layer (vs. lockstep-promoting shards in the compactor)

Compaction level means "how many merge generations / has this been deduplicated," not "is this window complete." Shards are independent partitions with no reason to share a generation count. The bug was the read path assuming `level ≈ completeness`; the fix removes that assumption where it lives. Forcing lockstep levels on the write path (e.g. emitting empty/placeholder blocks) would reshape the write path to satisfy a read-path invariant that shouldn't exist, at ongoing storage/I-O cost, and would remain racy. The `fingerprint` split mode already yields lockstep levels implicitly if that property is desired.

## Testing

`go test ./pkg/querier/` passes. Cases in `Test_replicasPerBlockID_blockPlan`:

- **`keep sharded window with shards at mixed compaction levels`** — the incident. Verified it fails pre-fix (empty plan) and passes after. Asserts `Deduplication=false` (complete set served directly).
- **`keep mixed-span shards when a wide block covers a later window`** — the mixed-span review case: a wide block + sibling tail blocks; all kept, no orphaning.
- **`collapse L3+L4 duplicate of a shard within a mixed-level window`** — a shard with both its L3 and derived L4 present collapses to the L4.
- **`prune sharded window with a shard missing at all levels`** — genuinely-missing shard still pruned, falls back to the non-sharded block (`Deduplication=true`).
- **`serve complete old sharding when a shard-count change leaves a partial new one`** — distinct shardings counted separately; verified it fails against upstream (shard-length-mismatch empties the plan).
- **`deduplicate when two complete shardings overlap`** — two complete, unrelated shardings both kept with `Deduplication=true` (no double-count).
- **`single sharding after superseding keeps the fast path`** — a derived `_of_4` supersedes the `_of_2`; one sharding remains, `Deduplication=false` (guard doesn't over-trigger).
- **`do not let an intermediate L2 block satisfy shard completeness`** — a mid-merge window must not serve a shard alone off an about-to-be-dropped L2 block.

`Test_pruneIncompleteShardedBlocks_logging` — a WARN is emitted when a genuinely incomplete window is pruned, and not for a healthy mixed-level window. The pre-existing `ignore_incomplete_shards` case still passes (fallback preserved by the prune-before-supersede ordering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
