### PR TITLE
ci(helm): bump update-helm-repo workflow to pick up signed index.yaml commits

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   call-update-helm-repo-pyroscope:
-    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@77e5ea2de369fa1ff3441b08765c164be209eaa2
+    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@8ac07d41b2fa02ca16dc0fc084d8f145cb690988
     permissions:
       contents: "write"
       id-token: "write"
@@ -19,7 +19,7 @@ jobs:
       ct_configfile: operations/pyroscope/helm/ct.yaml
       github_app: grafana-pyroscope-releases
   call-update-helm-repo-pyroscope-monitoring:
-    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@77e5ea2de369fa1ff3441b08765c164be209eaa2
+    uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@8ac07d41b2fa02ca16dc0fc084d8f145cb690988
     permissions:
       contents: "write"
       id-token: "write"


### PR DESCRIPTION
The v2.1.1 Helm chart release [failed pushing `index.yaml` to gh-pages](https://github.com/grafana/pyroscope/actions/runs/29113496513/job/86431235372) with GH013 `Commits must have verified signatures` — same ruleset rollout that broke the Homebrew formula update (#5347). grafana/helm-charts fixed their shared `update-helm-repo` workflow on 2026-05-26 ([grafana/helm-charts@d7c4f4491](https://github.com/grafana/helm-charts/commit/d7c4f4491), same `planetscale/ghcommit-action` approach we used in #5347); our pin predates the fix, so this bumps it to current upstream main. The only changes between the pins are the signing fix and its merge commit.

Note: the failed run already pushed the `pyroscope-2.1.1` tag and published the chart release, so the shared workflow's "tag exists" check will skip a re-release. After this merges, the tag needs to be deleted and the workflow re-run so the index picks up 2.1.1 (currently `helm repo` users can't see it).