### PR TITLE
chore(helm): improve chart description, re-triggering the 2.1.1 release

### DIFF
--- a/operations/pyroscope/helm/pyroscope/Chart.yaml
+++ b/operations/pyroscope/helm/pyroscope/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pyroscope
-description: horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
+description: A horizontally scalable, highly available, multi-tenant continuous profiling database.
 home: https://grafana.com/oss/pyroscope/
 type: application
 version: 2.1.1

--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -2,7 +2,7 @@
 
 ![Version: 2.1.1](https://img.shields.io/badge/Version-2.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
 
-horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
+A horizontally scalable, highly available, multi-tenant continuous profiling database.
 
 **Homepage:** <https://grafana.com/oss/pyroscope/>
 


### PR DESCRIPTION
The v2.1.1 chart release [failed at the index.yaml push](https://github.com/grafana/pyroscope/actions/runs/29113496513/job/86431235372) (GH013, fixed by #5351), so the chart tgz and GitHub release exist but `pyroscope-2.1.1` is missing from https://grafana.github.io/helm-charts and cannot be installed via `helm repo`.

Re-running the workflow does not help: `ct list-changed` compares against the latest tag reachable from main. Opting for this minor improvement instead of bumping to 2.1.2.