### PR TITLE
fix(query): return trace IDs in span heatmaps

### DIFF
--- a/api/connect-openapi/gen/ingester/v1/ingester.openapi.yaml
+++ b/api/connect-openapi/gen/ingester/v1/ingester.openapi.yaml
@@ -1089,6 +1089,12 @@ components:
           description: |-
             Labels specific to this exemplar (e.g., pod name, node name). When an exemplar
              label overlaps with the series label, it is not included here.
+        traceId:
+          type: string
+          examples:
+            - 4bf92f3577b34da6a3ce929d0e0e4736
+          title: trace_id
+          description: Trace ID associated with the span, encoded as 32 lowercase hexadecimal characters.
       title: Exemplar
       additionalProperties: false
       description: |-

--- a/api/connect-openapi/gen/querier/v1/querier.openapi.yaml
+++ b/api/connect-openapi/gen/querier/v1/querier.openapi.yaml
@@ -1763,6 +1763,12 @@ components:
           description: |-
             Labels specific to this exemplar (e.g., pod name, node name). When an exemplar
              label overlaps with the series label, it is not included here.
+        traceId:
+          type: string
+          examples:
+            - 4bf92f3577b34da6a3ce929d0e0e4736
+          title: trace_id
+          description: Trace ID associated with the span, encoded as 32 lowercase hexadecimal characters.
       title: Exemplar
       additionalProperties: false
       description: |-

--- a/api/connect-openapi/gen/query/v1/query.openapi.yaml
+++ b/api/connect-openapi/gen/query/v1/query.openapi.yaml
@@ -742,6 +742,11 @@ components:
             format: int64
           title: attribute_refs
           description: labels as references into AttributeTable
+        traceId:
+          type: string
+          title: trace_id
+          format: byte
+          description: Trace ID associated with the span, if present.
       title: HeatmapPoint
       additionalProperties: false
     query.v1.HeatmapQuery:
@@ -1399,6 +1404,12 @@ components:
           description: |-
             Labels specific to this exemplar (e.g., pod name, node name). When an exemplar
              label overlaps with the series label, it is not included here.
+        traceId:
+          type: string
+          examples:
+            - 4bf92f3577b34da6a3ce929d0e0e4736
+          title: trace_id
+          description: Trace ID associated with the span, encoded as 32 lowercase hexadecimal characters.
       title: Exemplar
       additionalProperties: false
       description: |-

--- a/api/connect-openapi/gen/storegateway/v1/storegateway.openapi.yaml
+++ b/api/connect-openapi/gen/storegateway/v1/storegateway.openapi.yaml
@@ -908,6 +908,12 @@ components:
           description: |-
             Labels specific to this exemplar (e.g., pod name, node name). When an exemplar
              label overlaps with the series label, it is not included here.
+        traceId:
+          type: string
+          examples:
+            - 4bf92f3577b34da6a3ce929d0e0e4736
+          title: trace_id
+          description: Trace ID associated with the span, encoded as 32 lowercase hexadecimal characters.
       title: Exemplar
       additionalProperties: false
       description: |-

--- a/api/gen/proto/go/query/v1/query.pb.go
+++ b/api/gen/proto/go/query/v1/query.pb.go
@@ -2067,6 +2067,7 @@ type HeatmapPoint struct {
 	SpanId        uint64                 `protobuf:"varint,3,opt,name=span_id,json=spanId,proto3" json:"span_id,omitempty"`                             // Span ID if this profile was split by span during ingestion
 	Value         int64                  `protobuf:"varint,4,opt,name=value,proto3" json:"value,omitempty"`                                             // Total sample value for this profile (e.g., CPU nanoseconds, bytes allocated).
 	AttributeRefs []int64                `protobuf:"varint,5,rep,packed,name=attribute_refs,json=attributeRefs,proto3" json:"attribute_refs,omitempty"` // labels as references into AttributeTable
+	TraceId       []byte                 `protobuf:"bytes,6,opt,name=trace_id,json=traceId,proto3" json:"trace_id,omitempty"`                           // Trace ID associated with the span, if present.
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2132,6 +2133,13 @@ func (x *HeatmapPoint) GetValue() int64 {
 func (x *HeatmapPoint) GetAttributeRefs() []int64 {
 	if x != nil {
 		return x.AttributeRefs
+	}
+	return nil
+}
+
+func (x *HeatmapPoint) GetTraceId() []byte {
+	if x != nil {
+		return x.TraceId
 	}
 	return nil
 }
@@ -2672,14 +2680,15 @@ const file_query_v1_query_proto_rawDesc = "" +
 	"\rexemplar_type\x18\x05 \x01(\x0e2\x16.types.v1.ExemplarTypeR\fexemplarType\"<\n" +
 	"\x0eAttributeTable\x12\x12\n" +
 	"\x04keys\x18\x01 \x03(\tR\x04keys\x12\x16\n" +
-	"\x06values\x18\x02 \x03(\tR\x06values\"\xa1\x01\n" +
+	"\x06values\x18\x02 \x03(\tR\x06values\"\xbc\x01\n" +
 	"\fHeatmapPoint\x12\x1c\n" +
 	"\ttimestamp\x18\x01 \x01(\x03R\ttimestamp\x12\x1d\n" +
 	"\n" +
 	"profile_id\x18\x02 \x01(\x03R\tprofileId\x12\x17\n" +
 	"\aspan_id\x18\x03 \x01(\x04R\x06spanId\x12\x14\n" +
 	"\x05value\x18\x04 \x01(\x03R\x05value\x12%\n" +
-	"\x0eattribute_refs\x18\x05 \x03(\x03R\rattributeRefs\"f\n" +
+	"\x0eattribute_refs\x18\x05 \x03(\x03R\rattributeRefs\x12\x19\n" +
+	"\btrace_id\x18\x06 \x01(\fR\atraceId\"f\n" +
 	"\rHeatmapSeries\x12%\n" +
 	"\x0eattribute_refs\x18\x01 \x03(\x03R\rattributeRefs\x12.\n" +
 	"\x06points\x18\x02 \x03(\v2\x16.query.v1.HeatmapPointR\x06points\"\xc0\x01\n" +

--- a/api/gen/proto/go/query/v1/query_vtproto.pb.go
+++ b/api/gen/proto/go/query/v1/query_vtproto.pb.go
@@ -796,6 +796,11 @@ func (m *HeatmapPoint) CloneVT() *HeatmapPoint {
 		copy(tmpContainer, rhs)
 		r.AttributeRefs = tmpContainer
 	}
+	if rhs := m.TraceId; rhs != nil {
+		tmpBytes := make([]byte, len(rhs))
+		copy(tmpBytes, rhs)
+		r.TraceId = tmpBytes
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -2083,6 +2088,9 @@ func (this *HeatmapPoint) EqualVT(that *HeatmapPoint) bool {
 		if vx != vy {
 			return false
 		}
+	}
+	if string(this.TraceId) != string(that.TraceId) {
+		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -4488,6 +4496,13 @@ func (m *HeatmapPoint) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.TraceId) > 0 {
+		i -= len(m.TraceId)
+		copy(dAtA[i:], m.TraceId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.TraceId)))
+		i--
+		dAtA[i] = 0x32
+	}
 	if len(m.AttributeRefs) > 0 {
 		var pksize2 int
 		for _, num := range m.AttributeRefs {
@@ -5750,6 +5765,10 @@ func (m *HeatmapPoint) SizeVT() (n int) {
 			l += protohelpers.SizeOfVarint(uint64(e))
 		}
 		n += 1 + protohelpers.SizeOfVarint(uint64(l)) + l
+	}
+	l = len(m.TraceId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -10796,6 +10815,40 @@ func (m *HeatmapPoint) UnmarshalVT(dAtA []byte) error {
 			} else {
 				return fmt.Errorf("proto: wrong wireType = %d for field AttributeRefs", wireType)
 			}
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TraceId", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.TraceId = append(m.TraceId[:0], dAtA[iNdEx:postIndex]...)
+			if m.TraceId == nil {
+				m.TraceId = []byte{}
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/api/gen/proto/go/types/v1/types.pb.go
+++ b/api/gen/proto/go/types/v1/types.pb.go
@@ -1117,7 +1117,9 @@ type Exemplar struct {
 	Value int64 `protobuf:"varint,4,opt,name=value,proto3" json:"value,omitempty"`
 	// Labels specific to this exemplar (e.g., pod name, node name). When an exemplar
 	// label overlaps with the series label, it is not included here.
-	Labels        []*LabelPair `protobuf:"bytes,5,rep,name=labels,proto3" json:"labels,omitempty"`
+	Labels []*LabelPair `protobuf:"bytes,5,rep,name=labels,proto3" json:"labels,omitempty"`
+	// Trace ID associated with the span, encoded as 32 lowercase hexadecimal characters.
+	TraceId       string `protobuf:"bytes,6,opt,name=trace_id,json=traceId,proto3" json:"trace_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1185,6 +1187,13 @@ func (x *Exemplar) GetLabels() []*LabelPair {
 		return x.Labels
 	}
 	return nil
+}
+
+func (x *Exemplar) GetTraceId() string {
+	if x != nil {
+		return x.TraceId
+	}
+	return ""
 }
 
 type HeatmapSeries struct {
@@ -1382,7 +1391,7 @@ const file_types_v1_types_proto_rawDesc = "" +
 	"\x17GetProfileStatsResponse\x12#\n" +
 	"\rdata_ingested\x18\x01 \x01(\bR\fdataIngested\x12.\n" +
 	"\x13oldest_profile_time\x18\x02 \x01(\x03R\x11oldestProfileTime\x12.\n" +
-	"\x13newest_profile_time\x18\x03 \x01(\x03R\x11newestProfileTime\"\x92\x02\n" +
+	"\x13newest_profile_time\x18\x03 \x01(\x03R\x11newestProfileTime\"\xd6\x02\n" +
 	"\bExemplar\x122\n" +
 	"\ttimestamp\x18\x01 \x01(\x03B\x14\xbaG\x11:\x0f\x12\r1730000023000R\ttimestamp\x12J\n" +
 	"\n" +
@@ -1390,7 +1399,8 @@ const file_types_v1_types_proto_rawDesc = "" +
 	"\aspan_id\x18\x03 \x01(\tB\x17\xbaG\x14:\x12\x12\x1000f067aa0ba902b7R\x06spanId\x12'\n" +
 	"\x05value\x18\x04 \x01(\x03B\x11\xbaG\x0e:\f\x12\n" +
 	"2450000000R\x05value\x12+\n" +
-	"\x06labels\x18\x05 \x03(\v2\x13.types.v1.LabelPairR\x06labels\"i\n" +
+	"\x06labels\x18\x05 \x03(\v2\x13.types.v1.LabelPairR\x06labels\x12B\n" +
+	"\btrace_id\x18\x06 \x01(\tB'\xbaG$:\"\x12 4bf92f3577b34da6a3ce929d0e0e4736R\atraceId\"i\n" +
 	"\rHeatmapSeries\x12+\n" +
 	"\x06labels\x18\x01 \x03(\v2\x13.types.v1.LabelPairR\x06labels\x12+\n" +
 	"\x05slots\x18\x02 \x03(\v2\x15.types.v1.HeatmapSlotR\x05slots\"\x8a\x01\n" +

--- a/api/gen/proto/go/types/v1/types_vtproto.pb.go
+++ b/api/gen/proto/go/types/v1/types_vtproto.pb.go
@@ -410,6 +410,7 @@ func (m *Exemplar) CloneVT() *Exemplar {
 	r.ProfileId = m.ProfileId
 	r.SpanId = m.SpanId
 	r.Value = m.Value
+	r.TraceId = m.TraceId
 	if rhs := m.Labels; rhs != nil {
 		tmpContainer := make([]*LabelPair, len(rhs))
 		for k, v := range rhs {
@@ -1058,6 +1059,9 @@ func (this *Exemplar) EqualVT(that *Exemplar) bool {
 				return false
 			}
 		}
+	}
+	if this.TraceId != that.TraceId {
+		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -2094,6 +2098,13 @@ func (m *Exemplar) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.TraceId) > 0 {
+		i -= len(m.TraceId)
+		copy(dAtA[i:], m.TraceId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.TraceId)))
+		i--
+		dAtA[i] = 0x32
+	}
 	if len(m.Labels) > 0 {
 		for iNdEx := len(m.Labels) - 1; iNdEx >= 0; iNdEx-- {
 			size, err := m.Labels[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
@@ -2646,6 +2657,10 @@ func (m *Exemplar) SizeVT() (n int) {
 			l = e.SizeVT()
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
+	}
+	l = len(m.TraceId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -4911,6 +4926,38 @@ func (m *Exemplar) UnmarshalVT(dAtA []byte) error {
 			if err := m.Labels[len(m.Labels)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TraceId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.TraceId = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/api/query/v1/query.proto
+++ b/api/query/v1/query.proto
@@ -273,6 +273,7 @@ message HeatmapPoint {
   uint64 span_id = 3; // Span ID if this profile was split by span during ingestion
   int64 value = 4; // Total sample value for this profile (e.g., CPU nanoseconds, bytes allocated).
   repeated int64 attribute_refs = 5; // labels as references into AttributeTable
+  bytes trace_id = 6; // Trace ID associated with the span, if present.
 }
 
 message HeatmapSeries {

--- a/api/types/v1/types.proto
+++ b/api/types/v1/types.proto
@@ -162,6 +162,9 @@ message Exemplar {
   // Labels specific to this exemplar (e.g., pod name, node name). When an exemplar
   // label overlaps with the series label, it is not included here.
   repeated LabelPair labels = 5;
+
+  // Trace ID associated with the span, encoded as 32 lowercase hexadecimal characters.
+  string trace_id = 6 [(gnostic.openapi.v3.property).example = {yaml: "4bf92f3577b34da6a3ce929d0e0e4736"}];
 }
 
 message HeatmapSeries {

--- a/cmd/profilecli/query-exemplars.go
+++ b/cmd/profilecli/query-exemplars.go
@@ -394,8 +394,22 @@ func outputSpanExemplarsJSON(ctx context.Context, entries []exemplarEntry, from,
 }
 
 func outputSpanExemplarsTable(ctx context.Context, entries []exemplarEntry, sampleUnit string, labelColumns []string) error {
-	headers := []string{"Trace ID", "Span ID", "Timestamp", fmt.Sprintf("Value (%s)", sampleUnit)}
-	aligns := []int{tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT, tablewriter.ALIGN_RIGHT}
+	// Only show the Trace ID column when at least one entry actually has one,
+	// since blocks without a trace ID column will leave it empty for every row.
+	hasTraceID := false
+	for _, e := range entries {
+		if e.TraceID != "" {
+			hasTraceID = true
+			break
+		}
+	}
+
+	headers := []string{"Span ID", "Timestamp", fmt.Sprintf("Value (%s)", sampleUnit)}
+	aligns := []int{tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT, tablewriter.ALIGN_RIGHT}
+	if hasTraceID {
+		headers = append([]string{"Trace ID"}, headers...)
+		aligns = append([]int{tablewriter.ALIGN_LEFT}, aligns...)
+	}
 	for _, name := range labelColumns {
 		headers = append(headers, name)
 		aligns = append(aligns, tablewriter.ALIGN_LEFT)
@@ -406,7 +420,10 @@ func outputSpanExemplarsTable(ctx context.Context, entries []exemplarEntry, samp
 	table.SetColumnAlignment(aligns)
 
 	for _, e := range entries {
-		row := []string{e.TraceID, e.SpanID, e.Timestamp.Format(time.RFC3339), formatUnit(float64(e.Value), sampleUnit)}
+		row := []string{e.SpanID, e.Timestamp.Format(time.RFC3339), formatUnit(float64(e.Value), sampleUnit)}
+		if hasTraceID {
+			row = append([]string{e.TraceID}, row...)
+		}
 		for _, name := range labelColumns {
 			row = append(row, e.Labels[name])
 		}

--- a/cmd/profilecli/query-exemplars.go
+++ b/cmd/profilecli/query-exemplars.go
@@ -42,6 +42,7 @@ type exemplarEntry struct {
 	Timestamp time.Time
 	Value     int64
 	SpanID    string
+	TraceID   string
 	Labels    map[string]string
 }
 
@@ -114,6 +115,7 @@ func queryExemplars(ctx context.Context, params *queryExemplarsParams) error {
 					Timestamp: time.UnixMilli(ex.Timestamp),
 					Value:     ex.Value,
 					SpanID:    ex.SpanId,
+					TraceID:   ex.TraceId,
 					Labels:    lbls,
 				})
 			}
@@ -224,6 +226,7 @@ func outputExemplarsJSON(ctx context.Context, entries []exemplarEntry, from, to 
 		Timestamp time.Time         `json:"timestamp"`
 		Value     int64             `json:"value"`
 		SpanID    string            `json:"span_id,omitempty"`
+		TraceID   string            `json:"trace_id,omitempty"`
 		Labels    map[string]string `json:"labels,omitempty"`
 	}
 	type jsonOutput struct {
@@ -245,6 +248,7 @@ func outputExemplarsJSON(ctx context.Context, entries []exemplarEntry, from, to 
 			Timestamp: e.Timestamp,
 			Value:     e.Value,
 			SpanID:    e.SpanID,
+			TraceID:   e.TraceID,
 			Labels:    filterLabels(e.Labels),
 		}
 	}
@@ -319,6 +323,7 @@ func querySpanExemplars(ctx context.Context, params *queryExemplarsParams) error
 				}
 				entries = append(entries, exemplarEntry{
 					SpanID:    ex.SpanId,
+					TraceID:   ex.TraceId,
 					Timestamp: time.UnixMilli(ex.Timestamp),
 					Value:     ex.Value,
 					Labels:    lbls,
@@ -356,6 +361,7 @@ func querySpanExemplars(ctx context.Context, params *queryExemplarsParams) error
 func outputSpanExemplarsJSON(ctx context.Context, entries []exemplarEntry, from, to time.Time, profileType string) error {
 	type jsonExemplar struct {
 		SpanID    string            `json:"span_id"`
+		TraceID   string            `json:"trace_id,omitempty"`
 		Timestamp time.Time         `json:"timestamp"`
 		Value     int64             `json:"value"`
 		Labels    map[string]string `json:"labels,omitempty"`
@@ -376,6 +382,7 @@ func outputSpanExemplarsJSON(ctx context.Context, entries []exemplarEntry, from,
 	for i, e := range entries {
 		out.Exemplars[i] = jsonExemplar{
 			SpanID:    e.SpanID,
+			TraceID:   e.TraceID,
 			Timestamp: e.Timestamp,
 			Value:     e.Value,
 			Labels:    filterLabels(e.Labels),
@@ -387,8 +394,8 @@ func outputSpanExemplarsJSON(ctx context.Context, entries []exemplarEntry, from,
 }
 
 func outputSpanExemplarsTable(ctx context.Context, entries []exemplarEntry, sampleUnit string, labelColumns []string) error {
-	headers := []string{"Span ID", "Timestamp", fmt.Sprintf("Value (%s)", sampleUnit)}
-	aligns := []int{tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT, tablewriter.ALIGN_RIGHT}
+	headers := []string{"Trace ID", "Span ID", "Timestamp", fmt.Sprintf("Value (%s)", sampleUnit)}
+	aligns := []int{tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT, tablewriter.ALIGN_RIGHT}
 	for _, name := range labelColumns {
 		headers = append(headers, name)
 		aligns = append(aligns, tablewriter.ALIGN_LEFT)
@@ -399,7 +406,7 @@ func outputSpanExemplarsTable(ctx context.Context, entries []exemplarEntry, samp
 	table.SetColumnAlignment(aligns)
 
 	for _, e := range entries {
-		row := []string{e.SpanID, e.Timestamp.Format(time.RFC3339), formatUnit(float64(e.Value), sampleUnit)}
+		row := []string{e.TraceID, e.SpanID, e.Timestamp.Format(time.RFC3339), formatUnit(float64(e.Value), sampleUnit)}
 		for _, name := range labelColumns {
 			row = append(row, e.Labels[name])
 		}

--- a/cmd/profilecli/query-exemplars_test.go
+++ b/cmd/profilecli/query-exemplars_test.go
@@ -128,6 +128,30 @@ func TestOutputExemplarsJSON(t *testing.T) {
 	assert.NotContains(t, result.Exemplars[0].Labels, "__profile_type__")
 }
 
+func TestOutputSpanExemplarsIncludesTraceID(t *testing.T) {
+	t.Parallel()
+
+	entries := []exemplarEntry{{
+		SpanID:    "00f067aa0ba902b7",
+		TraceID:   "4bf92f3577b34da6a3ce929d0e0e4736",
+		Timestamp: time.Date(2024, 3, 20, 9, 30, 0, 0, time.UTC),
+		Value:     42000,
+	}}
+	from := time.Date(2024, 3, 20, 9, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 3, 20, 10, 0, 0, 0, time.UTC)
+
+	var jsonBuf bytes.Buffer
+	err := outputSpanExemplarsJSON(withOutput(context.Background(), &jsonBuf), entries, from, to, "process_cpu:cpu:nanoseconds:cpu:nanoseconds")
+	require.NoError(t, err)
+	assert.Contains(t, jsonBuf.String(), `"trace_id": "4bf92f3577b34da6a3ce929d0e0e4736"`)
+
+	var tableBuf bytes.Buffer
+	err = outputSpanExemplarsTable(withOutput(context.Background(), &tableBuf), entries, "nanoseconds", nil)
+	require.NoError(t, err)
+	assert.Contains(t, tableBuf.String(), "Trace ID")
+	assert.Contains(t, tableBuf.String(), "4bf92f3577b34da6a3ce929d0e0e4736")
+}
+
 func TestOutputExemplarsTable_Empty(t *testing.T) {
 	t.Parallel()
 
@@ -210,6 +234,7 @@ func TestExemplarEntry_FromProtoExemplar(t *testing.T) {
 		Timestamp: 1710928800000, // 2024-03-20T10:00:00Z in millis
 		ProfileId: "550e8400-e29b-41d4-a716-446655440000",
 		SpanId:    "deadbeef",
+		TraceId:   "4bf92f3577b34da6a3ce929d0e0e4736",
 		Value:     99999,
 		Labels: []*typesv1.LabelPair{
 			{Name: "pod", Value: "frontend-abc"},
@@ -221,6 +246,7 @@ func TestExemplarEntry_FromProtoExemplar(t *testing.T) {
 		Timestamp: time.UnixMilli(ex.Timestamp),
 		Value:     ex.Value,
 		SpanID:    ex.SpanId,
+		TraceID:   ex.TraceId,
 		Labels:    map[string]string{"pod": "frontend-abc"},
 	}
 
@@ -228,5 +254,6 @@ func TestExemplarEntry_FromProtoExemplar(t *testing.T) {
 	assert.Equal(t, time.UnixMilli(1710928800000), entry.Timestamp)
 	assert.Equal(t, int64(99999), entry.Value)
 	assert.Equal(t, "deadbeef", entry.SpanID)
+	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", entry.TraceID)
 	assert.Equal(t, "frontend-abc", entry.Labels["pod"])
 }

--- a/pkg/model/attributetable/attributetable.go
+++ b/pkg/model/attributetable/attributetable.go
@@ -133,16 +133,17 @@ func SpanIDToHex(spanID uint64) string {
 }
 
 // resolveExemplar is the shared implementation for converting to a public Exemplar.
-// ProfileId and SpanId must already be resolved to strings by the caller.
-func resolveExemplar(timestamp, value int64, profileID, spanID string, attributeRefs []int64, table *queryv1.AttributeTable) *typesv1.Exemplar {
+// ProfileId, SpanId, and TraceId must already be resolved to strings by the caller.
+func resolveExemplar(timestamp, value int64, profileID, spanID, traceID string, attributeRefs []int64, table *queryv1.AttributeTable) *typesv1.Exemplar {
 	labels := ResolveLabelPairs(attributeRefs, table)
-	if profileID == "" && spanID == "" && len(labels) == 0 {
+	if profileID == "" && spanID == "" && traceID == "" && len(labels) == 0 {
 		return nil
 	}
 	return &typesv1.Exemplar{
 		Timestamp: timestamp,
 		ProfileId: profileID,
 		SpanId:    spanID,
+		TraceId:   traceID,
 		Value:     value,
 		Labels:    labels,
 	}
@@ -155,7 +156,7 @@ func ResolveExemplars(exemplars []*queryv1.Exemplar, table *queryv1.AttributeTab
 	}
 	result := make([]*typesv1.Exemplar, 0, len(exemplars))
 	for _, ex := range exemplars {
-		if e := resolveExemplar(ex.Timestamp, ex.Value, ex.ProfileId, ex.SpanId, ex.AttributeRefs, table); e != nil {
+		if e := resolveExemplar(ex.Timestamp, ex.Value, ex.ProfileId, ex.SpanId, "", ex.AttributeRefs, table); e != nil {
 			result = append(result, e)
 		}
 	}
@@ -174,5 +175,10 @@ func ResolveHeatmapExemplar(point *queryv1.HeatmapPoint, table *queryv1.Attribut
 		profileID = table.Values[point.ProfileId]
 	}
 
-	return resolveExemplar(point.Timestamp, point.Value, profileID, SpanIDToHex(point.SpanId), point.AttributeRefs, table)
+	traceID := ""
+	if len(point.TraceId) == len(model.TraceID{}) {
+		traceID = hex.EncodeToString(point.TraceId)
+	}
+
+	return resolveExemplar(point.Timestamp, point.Value, profileID, SpanIDToHex(point.SpanId), traceID, point.AttributeRefs, table)
 }

--- a/pkg/model/attributetable/attributetable.go
+++ b/pkg/model/attributetable/attributetable.go
@@ -175,6 +175,9 @@ func ResolveHeatmapExemplar(point *queryv1.HeatmapPoint, table *queryv1.Attribut
 		profileID = table.Values[point.ProfileId]
 	}
 
+	// TraceId is only populated when it round-trips through model.TraceID (16 bytes).
+	// Silently drop anything else (e.g. absent/empty) rather than emitting a
+	// malformed trace ID that wouldn't satisfy the documented 32-hex-char contract.
 	traceID := ""
 	if len(point.TraceId) == len(model.TraceID{}) {
 		traceID = hex.EncodeToString(point.TraceId)

--- a/pkg/model/heatmap/heatmap.go
+++ b/pkg/model/heatmap/heatmap.go
@@ -42,7 +42,7 @@ func (h *Builder) newSeries(labels model.Labels) *heatmapSeries {
 	return s
 }
 
-func (h *Builder) Add(fp prommodel.Fingerprint, labels model.Labels, ts int64, profileID string, spanID uint64, value int64) {
+func (h *Builder) Add(fp prommodel.Fingerprint, labels model.Labels, ts int64, profileID string, spanID uint64, traceID model.TraceID, value int64) {
 	// TODO: Support annotations
 	if profileID == "" && spanID == 0 {
 		return
@@ -58,7 +58,7 @@ func (h *Builder) Add(fp prommodel.Fingerprint, labels model.Labels, ts int64, p
 	}
 
 	pointLabels := labels.WithoutLabels(h.by...)
-	series.pointsBuilder.add(fp, pointLabels, ts, profileID, spanID, value)
+	series.pointsBuilder.add(fp, pointLabels, ts, profileID, spanID, traceID, value)
 }
 
 func (h *Builder) Build(report *queryv1.HeatmapReport) *queryv1.HeatmapReport {
@@ -83,12 +83,15 @@ func (h *Builder) Build(report *queryv1.HeatmapReport) *queryv1.HeatmapReport {
 		points := make([]queryv1.HeatmapPoint, series.pointsBuilder.count())
 		r.Points = make([]*queryv1.HeatmapPoint, 0, series.pointsBuilder.count())
 		idx := 0
-		series.pointsBuilder.forEach(func(labels model.Labels, ts int64, profileID string, spanID uint64, value int64) {
+		series.pointsBuilder.forEach(func(labels model.Labels, ts int64, profileID string, spanID uint64, traceID model.TraceID, value int64) {
 			p := &points[idx]
 			p.AttributeRefs = at.Refs(labels, p.AttributeRefs)
 			p.Timestamp = ts
 			p.ProfileId = at.LookupOrAdd(attributetable.Key{Key: unique.Make(""), Value: unique.Make(profileID)})
 			p.SpanId = spanID
+			if traceID != (model.TraceID{}) {
+				p.TraceId = append(p.TraceId[:0], traceID[:]...)
+			}
 			p.Value = value
 
 			r.Points = append(r.Points, p)

--- a/pkg/model/heatmap/heatmap_test.go
+++ b/pkg/model/heatmap/heatmap_test.go
@@ -650,7 +650,7 @@ func TestHeatmapBuilder(t *testing.T) {
 			// Add all input points
 			for _, p := range tt.input {
 				fp := prommodel.Fingerprint(p.labels.Hash())
-				builder.Add(fp, p.labels, p.timestamp, p.profileID, p.spanID, p.value)
+				builder.Add(fp, p.labels, p.timestamp, p.profileID, p.spanID, p.traceID, p.value)
 			}
 
 			result := builder.Build(nil)
@@ -683,6 +683,8 @@ func TestHeatmapBuilder(t *testing.T) {
 						"series %d point %d profileID mismatch", i, j)
 					assert.Equal(t, expectedPoint.spanID, actualPoint.spanID,
 						"series %d point %d spanID mismatch", i, j)
+					assert.Equal(t, expectedPoint.traceID, actualPoint.traceID,
+						"series %d point %d traceID mismatch", i, j)
 					assert.Equal(t, expectedPoint.value, actualPoint.value,
 						"series %d point %d value mismatch", i, j)
 				}
@@ -697,6 +699,7 @@ type testPoint struct {
 	timestamp int64
 	profileID string
 	spanID    uint64
+	traceID   model.TraceID
 	value     int64
 }
 
@@ -732,11 +735,14 @@ func resultToTestSeries(report *queryv1.HeatmapReport) []testSeries {
 				}
 			}
 
+			var traceID model.TraceID
+			copy(traceID[:], p.TraceId)
 			points[j] = testPoint{
 				labels:    pointLabels,
 				timestamp: p.Timestamp,
 				profileID: report.AttributeTable.Values[p.ProfileId],
 				spanID:    p.SpanId,
+				traceID:   traceID,
 				value:     p.Value,
 			}
 		}

--- a/pkg/model/heatmap/merger.go
+++ b/pkg/model/heatmap/merger.go
@@ -1,6 +1,7 @@
 package heatmap
 
 import (
+	"bytes"
 	"slices"
 	"sort"
 	"strconv"
@@ -65,6 +66,7 @@ func (m *Merger) MergeHeatmap(report *queryv1.HeatmapReport) {
 					Timestamp:     p.Timestamp,
 					ProfileId:     remapper.Ref(p.ProfileId),
 					SpanId:        p.SpanId,
+					TraceId:       p.TraceId,
 					Value:         p.Value,
 					AttributeRefs: remapper.Refs(p.AttributeRefs),
 				}
@@ -128,20 +130,23 @@ func seriesKey(refs []int64) string {
 	return sb.String()
 }
 
-// mergePoints merges points with the same timestamp/profileID/spanID
+// mergePoints merges points with the same timestamp/profileID/spanID/traceID
 func (m *Merger) mergePoints(points []*queryv1.HeatmapPoint) int {
 	l := len(points)
 	if l < 2 {
 		return l
 	}
 
-	// Sort by timestamp, then spanID, then profileID
+	// Sort by timestamp, then spanID, traceID, and profileID.
 	slices.SortFunc(points, func(a, b *queryv1.HeatmapPoint) int {
 		if a.Timestamp != b.Timestamp {
 			return int(a.Timestamp - b.Timestamp)
 		}
 		if a.SpanId != b.SpanId {
 			return int(a.SpanId - b.SpanId)
+		}
+		if c := bytes.Compare(a.TraceId, b.TraceId); c != 0 {
+			return c
 		}
 		if a.ProfileId != b.ProfileId {
 			return int(a.ProfileId - b.ProfileId)
@@ -155,6 +160,7 @@ func (m *Merger) mergePoints(points []*queryv1.HeatmapPoint) int {
 		if points[j].Timestamp != points[i].Timestamp ||
 			points[j].ProfileId != points[i].ProfileId ||
 			points[j].SpanId != points[i].SpanId ||
+			!bytes.Equal(points[j].TraceId, points[i].TraceId) ||
 			!m.sum {
 			j++
 			points[j] = points[i]

--- a/pkg/model/heatmap/merger_test.go
+++ b/pkg/model/heatmap/merger_test.go
@@ -1,0 +1,60 @@
+package heatmap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+)
+
+func TestMerger_DoesNotMergeDifferentTraceIDs(t *testing.T) {
+	traceID1 := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+	traceID2 := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}
+	report := &queryv1.HeatmapReport{
+		AttributeTable: &queryv1.AttributeTable{
+			Keys:   []string{""},
+			Values: []string{"profile-id"},
+		},
+		HeatmapSeries: []*queryv1.HeatmapSeries{{
+			Points: []*queryv1.HeatmapPoint{
+				{Timestamp: 100, ProfileId: 0, SpanId: 123, TraceId: traceID1, Value: 1000},
+				{Timestamp: 100, ProfileId: 0, SpanId: 123, TraceId: traceID2, Value: 2000},
+			},
+		}},
+	}
+
+	merger := NewMerger(true)
+	merger.MergeHeatmap(report)
+	result := merger.Build()
+
+	require.Len(t, result.HeatmapSeries, 1)
+	require.Len(t, result.HeatmapSeries[0].Points, 2)
+	assert.Equal(t, traceID1, result.HeatmapSeries[0].Points[0].TraceId)
+	assert.Equal(t, traceID2, result.HeatmapSeries[0].Points[1].TraceId)
+}
+
+func TestMerger_MergesMatchingTraceIDs(t *testing.T) {
+	traceID := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+	report := &queryv1.HeatmapReport{
+		AttributeTable: &queryv1.AttributeTable{
+			Keys:   []string{""},
+			Values: []string{"profile-id"},
+		},
+		HeatmapSeries: []*queryv1.HeatmapSeries{{
+			Points: []*queryv1.HeatmapPoint{
+				{Timestamp: 100, ProfileId: 0, SpanId: 123, TraceId: traceID, Value: 1000},
+				{Timestamp: 100, ProfileId: 0, SpanId: 123, TraceId: traceID, Value: 2000},
+			},
+		}},
+	}
+
+	merger := NewMerger(true)
+	merger.MergeHeatmap(report)
+	result := merger.Build()
+
+	require.Len(t, result.HeatmapSeries, 1)
+	require.Len(t, result.HeatmapSeries[0].Points, 1)
+	assert.Equal(t, int64(3000), result.HeatmapSeries[0].Points[0].Value)
+}

--- a/pkg/model/heatmap/points_builder.go
+++ b/pkg/model/heatmap/points_builder.go
@@ -1,6 +1,7 @@
 package heatmap
 
 import (
+	"bytes"
 	"slices"
 	"strings"
 
@@ -20,6 +21,7 @@ type exemplar struct {
 	timestamp   int64
 	profileID   string
 	spanID      uint64
+	traceID     model.TraceID
 	labelSetRef int
 	value       int64
 }
@@ -34,7 +36,7 @@ func newPointsBuilder() *pointsBuilder {
 }
 
 // Add adds an exemplar with its full labels.
-func (pb *pointsBuilder) add(fp prommodel.Fingerprint, labels model.Labels, ts int64, profileID string, spanID uint64, value int64) {
+func (pb *pointsBuilder) add(fp prommodel.Fingerprint, labels model.Labels, ts int64, profileID string, spanID uint64, traceID model.TraceID, value int64) {
 	if profileID == "" && spanID == 0 {
 		return
 	}
@@ -43,6 +45,7 @@ func (pb *pointsBuilder) add(fp prommodel.Fingerprint, labels model.Labels, ts i
 		timestamp: ts,
 		profileID: profileID,
 		spanID:    spanID,
+		traceID:   traceID,
 		value:     value,
 	}
 
@@ -95,12 +98,15 @@ func cmpExemplar(a, b exemplar) int {
 	if a.spanID > b.spanID {
 		return 1
 	}
+	if c := bytes.Compare(a.traceID[:], b.traceID[:]); c != 0 {
+		return c
+	}
 	return strings.Compare(a.profileID, b.profileID)
 }
 
-func (pb *pointsBuilder) forEach(f func(labels model.Labels, ts int64, profileID string, spanID uint64, value int64)) {
+func (pb *pointsBuilder) forEach(f func(labels model.Labels, ts int64, profileID string, spanID uint64, traceID model.TraceID, value int64)) {
 	for _, exemplar := range pb.exemplars {
-		f(pb.labelSets[exemplar.labelSetRef], exemplar.timestamp, exemplar.profileID, exemplar.spanID, exemplar.value)
+		f(pb.labelSets[exemplar.labelSetRef], exemplar.timestamp, exemplar.profileID, exemplar.spanID, exemplar.traceID, exemplar.value)
 	}
 }
 

--- a/pkg/model/heatmap/points_builder_test.go
+++ b/pkg/model/heatmap/points_builder_test.go
@@ -30,16 +30,16 @@ func TestPointsBuilder_SameFingerprintDifferentExemplars(t *testing.T) {
 	fp := model.Fingerprint(commonLabels.Hash())
 
 	// Add three exemplars with the same fingerprint but different timestamps
-	pb.add(fp, labels1, 100, "profile1", 0, 1000)
-	pb.add(fp, labels2, 200, "profile2", 0, 2000)
-	pb.add(fp, labels3, 300, "profile3", 0, 3000)
+	pb.add(fp, labels1, 100, "profile1", 0, pkgmodel.TraceID{}, 1000)
+	pb.add(fp, labels2, 200, "profile2", 0, pkgmodel.TraceID{}, 2000)
+	pb.add(fp, labels3, 300, "profile3", 0, pkgmodel.TraceID{}, 3000)
 
 	// Verify we have 3 exemplars
 	assert.Equal(t, 3, pb.count())
 
 	// Verify they all share the same labelSet (only common labels)
 	var collectedLabels []pkgmodel.Labels
-	pb.forEach(func(labels pkgmodel.Labels, ts int64, profileID string, spanID uint64, value int64) {
+	pb.forEach(func(labels pkgmodel.Labels, ts int64, profileID string, spanID uint64, traceID pkgmodel.TraceID, value int64) {
 		collectedLabels = append(collectedLabels, labels)
 	})
 
@@ -64,19 +64,39 @@ func TestPointsBuilder_DuplicateExemplarsSum(t *testing.T) {
 	fp := model.Fingerprint(labels.Hash())
 
 	// Add the same exemplar 3 times
-	pb.add(fp, labels, 100, "profile1", 123, 1000)
-	pb.add(fp, labels, 100, "profile1", 123, 2000)
-	pb.add(fp, labels, 100, "profile1", 123, 3000)
+	pb.add(fp, labels, 100, "profile1", 123, pkgmodel.TraceID{}, 1000)
+	pb.add(fp, labels, 100, "profile1", 123, pkgmodel.TraceID{}, 2000)
+	pb.add(fp, labels, 100, "profile1", 123, pkgmodel.TraceID{}, 3000)
 
 	// Should only have 1 exemplar with summed value
 	assert.Equal(t, 1, pb.count())
 
 	var totalValue int64
-	pb.forEach(func(labels pkgmodel.Labels, ts int64, profileID string, spanID uint64, value int64) {
+	pb.forEach(func(labels pkgmodel.Labels, ts int64, profileID string, spanID uint64, traceID pkgmodel.TraceID, value int64) {
 		totalValue = value
 	})
 
 	assert.Equal(t, int64(6000), totalValue, "Values should be summed")
+}
+
+func TestPointsBuilder_SameSpanDifferentTraceIDs(t *testing.T) {
+	pb := newPointsBuilder()
+	labels := pkgmodel.Labels{
+		&typesv1.LabelPair{Name: "service", Value: "api"},
+	}
+	fp := model.Fingerprint(labels.Hash())
+	traceID1 := pkgmodel.TraceID{15: 1}
+	traceID2 := pkgmodel.TraceID{15: 2}
+
+	pb.add(fp, labels, 100, "profile1", 123, traceID1, 1000)
+	pb.add(fp, labels, 100, "profile1", 123, traceID2, 2000)
+
+	require.Equal(t, 2, pb.count())
+	var traceIDs []pkgmodel.TraceID
+	pb.forEach(func(labels pkgmodel.Labels, ts int64, profileID string, spanID uint64, traceID pkgmodel.TraceID, value int64) {
+		traceIDs = append(traceIDs, traceID)
+	})
+	assert.Equal(t, []pkgmodel.TraceID{traceID1, traceID2}, traceIDs)
 }
 
 func TestPointsBuilder_LabelIntersection(t *testing.T) {
@@ -108,9 +128,9 @@ func TestPointsBuilder_LabelIntersection(t *testing.T) {
 	fp := model.Fingerprint(12345)
 
 	// Add exemplars with different labels
-	pb.add(fp, labels1, 100, "profile1", 0, 1000)
-	pb.add(fp, labels2, 200, "profile2", 0, 2000)
-	pb.add(fp, labels3, 300, "profile3", 0, 3000)
+	pb.add(fp, labels1, 100, "profile1", 0, pkgmodel.TraceID{}, 1000)
+	pb.add(fp, labels2, 200, "profile2", 0, pkgmodel.TraceID{}, 2000)
+	pb.add(fp, labels3, 300, "profile3", 0, pkgmodel.TraceID{}, 3000)
 
 	// Verify we have 3 exemplars
 	assert.Equal(t, 3, pb.count())
@@ -121,7 +141,7 @@ func TestPointsBuilder_LabelIntersection(t *testing.T) {
 		&typesv1.LabelPair{Name: "cluster", Value: "prod"},
 	}
 
-	pb.forEach(func(labels pkgmodel.Labels, ts int64, profileID string, spanID uint64, value int64) {
+	pb.forEach(func(labels pkgmodel.Labels, ts int64, profileID string, spanID uint64, traceID pkgmodel.TraceID, value int64) {
 		assert.Equal(t, expectedCommonLabels, labels,
 			"Should only contain labels common to all exemplars")
 	})
@@ -137,7 +157,7 @@ func TestPointsBuilder_EmptyProfileIDAndSpanID(t *testing.T) {
 	fp := model.Fingerprint(labels.Hash())
 
 	// Try to add exemplar with empty profileID and zero spanID
-	pb.add(fp, labels, 100, "", 0, 1000)
+	pb.add(fp, labels, 100, "", 0, pkgmodel.TraceID{}, 1000)
 
 	// Should have no exemplars
 	assert.Equal(t, 0, pb.count())
@@ -152,7 +172,7 @@ func TestPointsBuilder_OnlyProfileID(t *testing.T) {
 	}
 	fp := model.Fingerprint(labels.Hash())
 
-	pb.add(fp, labels, 100, "profile1", 0, 1000)
+	pb.add(fp, labels, 100, "profile1", 0, pkgmodel.TraceID{}, 1000)
 
 	// Should have 1 exemplar
 	assert.Equal(t, 1, pb.count())
@@ -167,7 +187,7 @@ func TestPointsBuilder_OnlySpanID(t *testing.T) {
 	}
 	fp := model.Fingerprint(labels.Hash())
 
-	pb.add(fp, labels, 100, "", 123, 1000)
+	pb.add(fp, labels, 100, "", 123, pkgmodel.TraceID{}, 1000)
 
 	// Should have 1 exemplar
 	assert.Equal(t, 1, pb.count())
@@ -183,13 +203,13 @@ func TestPointsBuilder_Sorting(t *testing.T) {
 	fp := model.Fingerprint(labels.Hash())
 
 	// Add exemplars in non-sorted order
-	pb.add(fp, labels, 300, "profile3", 0, 3000)
-	pb.add(fp, labels, 100, "profile1", 0, 1000)
-	pb.add(fp, labels, 200, "profile2", 0, 2000)
+	pb.add(fp, labels, 300, "profile3", 0, pkgmodel.TraceID{}, 3000)
+	pb.add(fp, labels, 100, "profile1", 0, pkgmodel.TraceID{}, 1000)
+	pb.add(fp, labels, 200, "profile2", 0, pkgmodel.TraceID{}, 2000)
 
 	// Verify they come out sorted
 	var timestamps []int64
-	pb.forEach(func(labels pkgmodel.Labels, ts int64, profileID string, spanID uint64, value int64) {
+	pb.forEach(func(labels pkgmodel.Labels, ts int64, profileID string, spanID uint64, traceID pkgmodel.TraceID, value int64) {
 		timestamps = append(timestamps, ts)
 	})
 

--- a/pkg/model/heatmap/range_test.go
+++ b/pkg/model/heatmap/range_test.go
@@ -21,6 +21,33 @@ func TestRangeHeatmap_EmptyReport(t *testing.T) {
 	assert.Nil(t, series)
 }
 
+func TestRangeHeatmap_SpanExemplarIncludesTraceID(t *testing.T) {
+	traceID := []byte{0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d, 0xa6, 0xa3, 0xce, 0x92, 0x9d, 0x0e, 0x0e, 0x47, 0x36}
+	reports := []*queryv1.HeatmapReport{{
+		AttributeTable: &queryv1.AttributeTable{
+			Keys:   []string{""},
+			Values: []string{"profile-id"},
+		},
+		HeatmapSeries: []*queryv1.HeatmapSeries{{
+			Points: []*queryv1.HeatmapPoint{{
+				Timestamp: 500,
+				ProfileId: 0,
+				SpanId:    0x0102030405060708,
+				TraceId:   traceID,
+				Value:     1000,
+			}},
+		}},
+	}}
+
+	series := RangeHeatmap(reports, 0, 1000, 100, typesv1.ExemplarType_EXEMPLAR_TYPE_SPAN)
+	require.Len(t, series, 1)
+	require.Len(t, series[0].Slots, 1)
+	require.Len(t, series[0].Slots[0].Exemplars, 1)
+	exemplar := series[0].Slots[0].Exemplars[0]
+	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", exemplar.TraceId)
+	assert.Equal(t, "0807060504030201", exemplar.SpanId)
+}
+
 func TestRangeHeatmap_SinglePoint(t *testing.T) {
 	reports := []*queryv1.HeatmapReport{
 		{

--- a/pkg/querybackend/block_reader_test.go
+++ b/pkg/querybackend/block_reader_test.go
@@ -3,6 +3,7 @@ package querybackend
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"os"
@@ -15,6 +16,7 @@ import (
 
 	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	"github.com/grafana/pyroscope/v2/pkg/block"
@@ -751,6 +753,35 @@ const (
 	fixtureMatchingTraceID    = "00000000000000000000000000000001"
 	fixtureNonMatchingTraceID = "ffffffffffffffffffffffffffffffff"
 )
+
+func (s *testSuite) Test_SpanHeatmapIncludesTraceID() {
+	resp, err := s.reader.Invoke(s.ctx, &queryv1.InvokeRequest{
+		StartTime:     startTime.UnixMilli(),
+		EndTime:       startTime.Add(5 * time.Minute).UnixMilli(),
+		LabelSelector: "{}",
+		QueryPlan:     s.plan,
+		Query: []*queryv1.Query{{
+			QueryType: queryv1.QueryType_QUERY_HEATMAP,
+			Heatmap: &queryv1.HeatmapQuery{
+				QueryType:    querierv1.HeatmapQueryType_HEATMAP_QUERY_TYPE_SPAN,
+				ExemplarType: typesv1.ExemplarType_EXEMPLAR_TYPE_SPAN,
+			},
+		}},
+		Tenant: s.tenant,
+	})
+	s.Require().NoError(err)
+	s.Require().Len(resp.Reports, 1)
+
+	for _, series := range resp.Reports[0].Heatmap.HeatmapSeries {
+		for _, point := range series.Points {
+			if hex.EncodeToString(point.TraceId) == fixtureMatchingTraceID {
+				s.Require().NotZero(point.SpanId)
+				return
+			}
+		}
+	}
+	s.Fail("span heatmap did not include the fixture trace ID")
+}
 
 func (s *testSuite) Test_TraceSelector() {
 	baselineTree, err := os.ReadFile("testdata/fixtures/tree_16.txt")

--- a/pkg/querybackend/query_heatmap.go
+++ b/pkg/querybackend/query_heatmap.go
@@ -13,6 +13,7 @@ import (
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	"github.com/grafana/pyroscope/v2/pkg/block"
+	"github.com/grafana/pyroscope/v2/pkg/model"
 	"github.com/grafana/pyroscope/v2/pkg/model/heatmap"
 	parquetquery "github.com/grafana/pyroscope/v2/pkg/phlaredb/query"
 	schemav1 "github.com/grafana/pyroscope/v2/pkg/phlaredb/schemas/v1"
@@ -61,6 +62,7 @@ func rowsIndividual(q *queryContext, b *heatmap.Builder) error {
 			int64(row.Row.Timestamp),
 			row.Row.ID,
 			0,
+			model.TraceID{},
 			row.Values[0][0].Int64(),
 		)
 	}
@@ -88,13 +90,20 @@ func rowsSpans(q *queryContext, b *heatmap.Builder) (err error) {
 		return nil
 	}
 
+	indices := []int{
+		columns.SpanID.ColumnIndex,
+		columns.Value.ColumnIndex,
+	}
+	if columns.HasTraceID() {
+		indices = append(indices, columns.TraceID.ColumnIndex)
+	}
+
 	rows := parquetquery.NewRepeatedRowIteratorBatchSize(
 		q.ctx,
 		entries,
 		q.ds.Profiles().RowGroups(),
 		bigBatchSize,
-		columns.SpanID.ColumnIndex,
-		columns.Value.ColumnIndex,
+		indices...,
 	)
 	defer runutil.CloseWithErrCapture(&err, rows, "failed to close column iterator")
 
@@ -102,12 +111,20 @@ func rowsSpans(q *queryContext, b *heatmap.Builder) (err error) {
 		row := rows.At()
 
 		for idx := range row.Values[0] {
+			var traceID model.TraceID
+			if columns.HasTraceID() {
+				traceIDBytes := row.Values[2][idx].Bytes()
+				if len(traceIDBytes) == len(traceID) {
+					copy(traceID[:], traceIDBytes)
+				}
+			}
 			b.Add(
 				row.Row.Fingerprint,
 				row.Row.Labels,
 				int64(row.Row.Timestamp),
 				"",
 				row.Values[0][idx].Uint64(),
+				traceID,
 				row.Values[1][idx].Int64(),
 			)
 		}


### PR DESCRIPTION
## What this PR does

- reads trace IDs from span heatmap sample rows and carries them through heatmap construction
- returns trace IDs in public span exemplars and profilecli output
- includes trace ID in point identity so equal span IDs from different traces are not merged
- adds generated protobuf and OpenAPI artifacts

### Example outout

```
profilecli query exemplars span \
                --profile-type=process_cpu:cpu:nanoseconds:cpu:nanoseconds \
                --query='{service_name="pyroscope-query-backend"}' \
                --from="now-30m" \
                --to="now"  --max-label-columns=0
+----------------------------------+------------------+---------------------------+---------------------+
|             Trace ID             |     Span ID      |         Timestamp         | Value (nanoseconds) |
+----------------------------------+------------------+---------------------------+---------------------+
| eadd35b6c29d493756d6191a96015937 | ab2fe93b328e9abd | 2026-07-15T09:23:03+01:00 |                70ms |
| 2426b8b2ed5d565455724d4acec79cab | 639766feed5f0d1b | 2026-07-15T09:23:24+01:00 |                70ms |
| 4243c9a8ab31751000b57117c0cd3e3a | 0c4df958381c4ced | 2026-07-15T09:18:48+01:00 |                60ms |
+----------------------------------+------------------+---------------------------+---------------------+
```

## Tests

- `go test ./pkg/model/heatmap ./pkg/model/attributetable ./pkg/querybackend ./pkg/frontend/readpath/queryfrontend ./cmd/profilecli`
- `go test ./api/gen/proto/go/query/v1 ./api/gen/proto/go/types/v1`

## Notes

- During a mixed-version rollout, an old query-backend (without this change) can return a heatmap point without a trace ID while a new one returns the same point with a trace ID populated. The merger treats these as distinct points instead of summing them, producing a transient duplicate for that span until the rollout completes. This is expected and self-resolves once all query-backends are upgraded.
