### PR TITLE
chore(deps): bump github.com/grafana/jfr-parser to v0.18.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -218,7 +218,7 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect
 	github.com/googleapis/gax-go/v2 v2.18.0 // indirect
-	github.com/grafana/jfr-parser v0.17.1
+	github.com/grafana/jfr-parser v0.18.0
 	github.com/grafana/otel-profiling-go v0.6.0
 	github.com/hashicorp/consul/api v1.33.7 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -409,8 +409,8 @@ github.com/grafana/alloy/syntax v0.1.0 h1:+1xQakvQPH6N0y9+q2Fu5QePyzrve6i1wMNuXd
 github.com/grafana/alloy/syntax v0.1.0/go.mod h1:8H9ToCc1M8F6A+je4rIH6saIe1MUCmjSk+Uje+LNLEo=
 github.com/grafana/dskit v0.0.0-20260616135346-e96eda8260cd h1:0nhpm/ZeGIeJ25fsYpYo7DeMIYxf7iObMxUdPPAEfu0=
 github.com/grafana/dskit v0.0.0-20260616135346-e96eda8260cd/go.mod h1:T0r0vLv/JwmOoSc/EOZw/5ni7r/djCoCdJ3/JnHDAjQ=
-github.com/grafana/jfr-parser v0.17.1 h1:dTECCXL+B9V6qu5x4msSKE9/FJPKeK0jrwLa5fkpkCA=
-github.com/grafana/jfr-parser v0.17.1/go.mod h1:+4zCC+tEWot6oQWjC72bG9TDDBiiiawMprp4EM1BioU=
+github.com/grafana/jfr-parser v0.18.0 h1:KluVBviZn3n83FGXOVx9CpB2BJaambaH917FzBWvlTQ=
+github.com/grafana/jfr-parser v0.18.0/go.mod h1:YmrPKBeaA6KeXCNVNi2wvoPN1i81yBmXhSIBp8QlKTA=
 github.com/grafana/memberlist v0.3.1-0.20260515134459-1798cf41aca7 h1:F5hMoc+tCK4AeUKfaL1XFEVEPSg+eKQe712fsSO/JA0=
 github.com/grafana/memberlist v0.3.1-0.20260515134459-1798cf41aca7/go.mod h1:OSu8+LHxPUHB67c9v5Gfw5NQZxFWOL3EKmn9TgHvyCo=
 github.com/grafana/otel-profiling-go v0.6.0 h1:W7lOZaJj4IJISXMcM1UBk3fJF3tzF2OD6MJBJaQp1H8=


### PR DESCRIPTION
Bumps `github.com/grafana/jfr-parser` from v0.17.1 to v0.18.0.

## What this picks up

The parser now reads the `traceIdHi` / `traceIdLo` fields emitted by our async-profiler fork and exposes the 128-bit W3C trace id as a `trace_id` pprof label on samples (`ExecutionSample`, `WallClockSample`, `ObjectAllocation{InNewTLAB,OutsideTLAB}`, `JavaMonitorEnter`). This enables trace-to-profile correlation for JFR-formatted profiles.

- jfr-parser PR: grafana/pyroscope-jfr-parser#115
- jfr-parser issue: grafana/pyroscope-jfr-parser#114

## Changes

Only `go.mod` / `go.sum`. The consumer in `pkg/og/convert/jfr` builds unchanged; the new `trace_id` label flows through the existing pprof label path with no code changes required here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)