### PR TITLE
feat(querier): unify merged profile query formats

### DIFF
--- a/api/connect-openapi/gen/querier/v1/querier.openapi.yaml
+++ b/api/connect-openapi/gen/querier/v1/querier.openapi.yaml
@@ -274,9 +274,12 @@ paths:
       tags:
         - scope/public
         - querier.v1.QuerierService
-      summary: SelectMergeProfile returns matching profiles aggregated in pprof format. It  will contain all information stored (so including filenames and line  number, if ingested).
+      summary: 'Deprecated: Use SelectMergeStacktraces with PROFILE_FORMAT_PPROF instead.  This RPC will remain supported in querier.v1 for backward compatibility;  future breaking API changes may be introduced in querier.v2.  SelectMergeProfile returns matching profiles aggregated in pprof format. It  will contain all information stored (so including filenames and line  number, if ingested).'
       description: |-
-        SelectMergeProfile returns matching profiles aggregated in pprof format. It
+        Deprecated: Use SelectMergeStacktraces with PROFILE_FORMAT_PPROF instead.
+         This RPC will remain supported in querier.v1 for backward compatibility;
+         future breaking API changes may be introduced in querier.v2.
+         SelectMergeProfile returns matching profiles aggregated in pprof format. It
          will contain all information stored (so including filenames and line
          number, if ingested).
       operationId: querier.v1.QuerierService.SelectMergeProfile
@@ -314,9 +317,12 @@ paths:
       tags:
         - scope/public
         - querier.v1.QuerierService
-      summary: SelectMergeSpanProfile returns matching profiles aggregated in a flamegraph  format. It will combine samples from within the same callstack, with each  element being grouped by its function name.
+      summary: 'Deprecated: Use SelectMergeStacktraces with span_selector instead.  This RPC will remain supported in querier.v1 for backward compatibility;  future breaking API changes may be introduced in querier.v2.  SelectMergeSpanProfile returns matching profiles aggregated in a flamegraph  format. It will combine samples from within the same callstack, with each  element being grouped by its function name.'
       description: |-
-        SelectMergeSpanProfile returns matching profiles aggregated in a flamegraph
+        Deprecated: Use SelectMergeStacktraces with span_selector instead.
+         This RPC will remain supported in querier.v1 for backward compatibility;
+         future breaking API changes may be introduced in querier.v2.
+         SelectMergeSpanProfile returns matching profiles aggregated in a flamegraph
          format. It will combine samples from within the same callstack, with each
          element being grouped by its function name.
       operationId: querier.v1.QuerierService.SelectMergeSpanProfile
@@ -1027,6 +1033,7 @@ components:
       properties:
         left:
           title: left
+          description: The format of each request is ignored; diff queries always compare trees.
           $ref: '#/components/schemas/querier.v1.SelectMergeStacktracesRequest'
         right:
           title: right
@@ -1127,6 +1134,15 @@ components:
           title: values
       title: Level
       additionalProperties: false
+    querier.v1.PprofProfile:
+      type: object
+      properties:
+        profile:
+          title: profile
+          $ref: '#/components/schemas/google.v1.Profile'
+      title: PprofProfile
+      additionalProperties: false
+      description: PprofProfile contains pprof output and related response metadata.
     querier.v1.ProfileFormat:
       type: string
       title: ProfileFormat
@@ -1135,6 +1151,7 @@ components:
         - PROFILE_FORMAT_FLAMEGRAPH
         - PROFILE_FORMAT_TREE
         - PROFILE_FORMAT_DOT
+        - PROFILE_FORMAT_PPROF
     querier.v1.ProfileTypesRequest:
       type: object
       properties:
@@ -1563,6 +1580,18 @@ components:
               - - 7c9e66797425440de944be07fc1f90ae
           title: trace_id_selector
           description: List of trace IDs (32 hex characters, 128-bit) to filter samples by.
+        spanSelector:
+          type: array
+          examples:
+            - - 9a517183f26a089d
+              - 5a4fe264a9c987fe
+          items:
+            type: string
+            examples:
+              - - 9a517183f26a089d
+                - 5a4fe264a9c987fe
+          title: span_selector
+          description: List of span IDs (16 hex characters, 64-bit) to filter samples by.
       title: SelectMergeStacktracesRequest
       additionalProperties: false
     querier.v1.SelectMergeStacktracesResponse:
@@ -1585,6 +1614,10 @@ components:
           description: (experimental) Used for responding to async queries.
           nullable: true
           $ref: '#/components/schemas/querier.v1.AsyncQueryResponse'
+        pprof:
+          title: pprof
+          description: Profile in pprof format.
+          $ref: '#/components/schemas/querier.v1.PprofProfile'
       title: SelectMergeStacktracesResponse
       additionalProperties: false
     querier.v1.SelectSeriesRequest:

--- a/api/gen/proto/go/querier/v1/querier.pb.go
+++ b/api/gen/proto/go/querier/v1/querier.pb.go
@@ -30,10 +30,24 @@ const (
 type ProfileFormat int32
 
 const (
+	// Equivalent to PROFILE_FORMAT_FLAMEGRAPH. Preserved for backward
+	// compatibility.
 	ProfileFormat_PROFILE_FORMAT_UNSPECIFIED ProfileFormat = 0
-	ProfileFormat_PROFILE_FORMAT_FLAMEGRAPH  ProfileFormat = 1
-	ProfileFormat_PROFILE_FORMAT_TREE        ProfileFormat = 2
-	ProfileFormat_PROFILE_FORMAT_DOT         ProfileFormat = 3
+	// Return a Flamebearer-compatible, single-profile flame graph. Samples
+	// sharing the same function-name call stack are aggregated into the names
+	// and levels representation used by the Pyroscope flame graph renderer.
+	// Format: https://github.com/grafana/pyroscope/blob/main/pkg/og/structs/flamebearer/flamebearer.go
+	ProfileFormat_PROFILE_FORMAT_FLAMEGRAPH ProfileFormat = 1
+	// Return a compact, function-name-only Pyroscope tree serialization in
+	// SelectMergeStacktracesResponse.tree.
+	ProfileFormat_PROFILE_FORMAT_TREE ProfileFormat = 2
+	// Return a Graphviz DOT directed graph. Nodes represent functions and edges
+	// represent caller-callee relationships, annotated with aggregated sample
+	// values. The resulting text can be rendered by Graphviz-compatible tools.
+	ProfileFormat_PROFILE_FORMAT_DOT ProfileFormat = 3
+	// Return a pprof profile, including available mappings, locations, filenames,
+	// and line numbers, in SelectMergeStacktracesResponse.pprof.
+	ProfileFormat_PROFILE_FORMAT_PPROF ProfileFormat = 4
 )
 
 // Enum value maps for ProfileFormat.
@@ -43,12 +57,14 @@ var (
 		1: "PROFILE_FORMAT_FLAMEGRAPH",
 		2: "PROFILE_FORMAT_TREE",
 		3: "PROFILE_FORMAT_DOT",
+		4: "PROFILE_FORMAT_PPROF",
 	}
 	ProfileFormat_value = map[string]int32{
 		"PROFILE_FORMAT_UNSPECIFIED": 0,
 		"PROFILE_FORMAT_FLAMEGRAPH":  1,
 		"PROFILE_FORMAT_TREE":        2,
 		"PROFILE_FORMAT_DOT":         3,
+		"PROFILE_FORMAT_PPROF":       4,
 	}
 )
 
@@ -471,8 +487,10 @@ type SelectMergeStacktracesRequest struct {
 	Async *AsyncQueryRequest `protobuf:"bytes,9,opt,name=async,proto3,oneof" json:"async,omitempty"`
 	// List of trace IDs (32 hex characters, 128-bit) to filter samples by.
 	TraceIdSelector []string `protobuf:"bytes,10,rep,name=trace_id_selector,json=traceIdSelector,proto3" json:"trace_id_selector,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// List of span IDs (16 hex characters, 64-bit) to filter samples by.
+	SpanSelector  []string `protobuf:"bytes,11,rep,name=span_selector,json=spanSelector,proto3" json:"span_selector,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *SelectMergeStacktracesRequest) Reset() {
@@ -575,6 +593,13 @@ func (x *SelectMergeStacktracesRequest) GetTraceIdSelector() []string {
 	return nil
 }
 
+func (x *SelectMergeStacktracesRequest) GetSpanSelector() []string {
+	if x != nil {
+		return x.SpanSelector
+	}
+	return nil
+}
+
 type SelectMergeStacktracesResponse struct {
 	state      protoimpl.MessageState `protogen:"open.v1"`
 	Flamegraph *FlameGraph            `protobuf:"bytes,1,opt,name=flamegraph,proto3" json:"flamegraph,omitempty"`
@@ -583,7 +608,9 @@ type SelectMergeStacktracesResponse struct {
 	// DOT graph representation.
 	Dot string `protobuf:"bytes,3,opt,name=dot,proto3" json:"dot,omitempty"`
 	// (experimental) Used for responding to async queries.
-	Async         *AsyncQueryResponse `protobuf:"bytes,4,opt,name=async,proto3,oneof" json:"async,omitempty"`
+	Async *AsyncQueryResponse `protobuf:"bytes,4,opt,name=async,proto3,oneof" json:"async,omitempty"`
+	// Profile in pprof format.
+	Pprof         *PprofProfile `protobuf:"bytes,5,opt,name=pprof,proto3" json:"pprof,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -646,6 +673,58 @@ func (x *SelectMergeStacktracesResponse) GetAsync() *AsyncQueryResponse {
 	return nil
 }
 
+func (x *SelectMergeStacktracesResponse) GetPprof() *PprofProfile {
+	if x != nil {
+		return x.Pprof
+	}
+	return nil
+}
+
+// PprofProfile contains pprof output and related response metadata.
+type PprofProfile struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Profile       *v11.Profile           `protobuf:"bytes,1,opt,name=profile,proto3" json:"profile,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PprofProfile) Reset() {
+	*x = PprofProfile{}
+	mi := &file_querier_v1_querier_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PprofProfile) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PprofProfile) ProtoMessage() {}
+
+func (x *PprofProfile) ProtoReflect() protoreflect.Message {
+	mi := &file_querier_v1_querier_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PprofProfile.ProtoReflect.Descriptor instead.
+func (*PprofProfile) Descriptor() ([]byte, []int) {
+	return file_querier_v1_querier_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *PprofProfile) GetProfile() *v11.Profile {
+	if x != nil {
+		return x.Profile
+	}
+	return nil
+}
+
 type AsyncQueryRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// If set, this is a polling request.
@@ -658,7 +737,7 @@ type AsyncQueryRequest struct {
 
 func (x *AsyncQueryRequest) Reset() {
 	*x = AsyncQueryRequest{}
-	mi := &file_querier_v1_querier_proto_msgTypes[6]
+	mi := &file_querier_v1_querier_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -670,7 +749,7 @@ func (x *AsyncQueryRequest) String() string {
 func (*AsyncQueryRequest) ProtoMessage() {}
 
 func (x *AsyncQueryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_querier_v1_querier_proto_msgTypes[6]
+	mi := &file_querier_v1_querier_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -683,7 +762,7 @@ func (x *AsyncQueryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AsyncQueryRequest.ProtoReflect.Descriptor instead.
 func (*AsyncQueryRequest) Descriptor() ([]byte, []int) {
-	return file_querier_v1_querier_proto_rawDescGZIP(), []int{6}
+	return file_querier_v1_querier_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *AsyncQueryRequest) GetRequestId() string {
@@ -714,7 +793,7 @@ type AsyncQueryResponse struct {
 
 func (x *AsyncQueryResponse) Reset() {
 	*x = AsyncQueryResponse{}
-	mi := &file_querier_v1_querier_proto_msgTypes[7]
+	mi := &file_querier_v1_querier_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -726,7 +805,7 @@ func (x *AsyncQueryResponse) String() string {
 func (*AsyncQueryResponse) ProtoMessage() {}
 
 func (x *AsyncQueryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_querier_v1_querier_proto_msgTypes[7]
+	mi := &file_querier_v1_querier_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -739,7 +818,7 @@ func (x *AsyncQueryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AsyncQueryResponse.ProtoReflect.Descriptor instead.
 func (*AsyncQueryResponse) Descriptor() ([]byte, []int) {
-	return file_querier_v1_querier_proto_rawDescGZIP(), []int{7}
+	return file_querier_v1_querier_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *AsyncQueryResponse) GetRequestId() string {
@@ -788,7 +867,7 @@ type SelectMergeSpanProfileRequest struct {
 
 func (x *SelectMergeSpanProfileRequest) Reset() {
 	*x = SelectMergeSpanProfileRequest{}
-	mi := &file_querier_v1_querier_proto_msgTypes[8]
+	mi := &file_querier_v1_querier_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -800,7 +879,7 @@ func (x *SelectMergeSpanProfileRequest) String() string {
 func (*SelectMergeSpanProfileRequest) ProtoMessage() {}
 
 func (x *SelectMergeSpanProfileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_querier_v1_querier_proto_msgTypes[8]
+	mi := &file_querier_v1_querier_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -813,7 +892,7 @@ func (x *SelectMergeSpanProfileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SelectMergeSpanProfileRequest.ProtoReflect.Descriptor instead.
 func (*SelectMergeSpanProfileRequest) Descriptor() ([]byte, []int) {
-	return file_querier_v1_querier_proto_rawDescGZIP(), []int{8}
+	return file_querier_v1_querier_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *SelectMergeSpanProfileRequest) GetProfileTypeID() string {
@@ -876,7 +955,7 @@ type SelectMergeSpanProfileResponse struct {
 
 func (x *SelectMergeSpanProfileResponse) Reset() {
 	*x = SelectMergeSpanProfileResponse{}
-	mi := &file_querier_v1_querier_proto_msgTypes[9]
+	mi := &file_querier_v1_querier_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -888,7 +967,7 @@ func (x *SelectMergeSpanProfileResponse) String() string {
 func (*SelectMergeSpanProfileResponse) ProtoMessage() {}
 
 func (x *SelectMergeSpanProfileResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_querier_v1_querier_proto_msgTypes[9]
+	mi := &file_querier_v1_querier_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -901,7 +980,7 @@ func (x *SelectMergeSpanProfileResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SelectMergeSpanProfileResponse.ProtoReflect.Descriptor instead.
 func (*SelectMergeSpanProfileResponse) Descriptor() ([]byte, []int) {
-	return file_querier_v1_querier_proto_rawDescGZIP(), []int{9}
+	return file_querier_v1_querier_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *SelectMergeSpanProfileResponse) GetFlamegraph() *FlameGraph {
@@ -919,7 +998,8 @@ func (x *SelectMergeSpanProfileResponse) GetTree() []byte {
 }
 
 type DiffRequest struct {
-	state         protoimpl.MessageState         `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The format of each request is ignored; diff queries always compare trees.
 	Left          *SelectMergeStacktracesRequest `protobuf:"bytes,1,opt,name=left,proto3" json:"left,omitempty"`
 	Right         *SelectMergeStacktracesRequest `protobuf:"bytes,2,opt,name=right,proto3" json:"right,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -928,7 +1008,7 @@ type DiffRequest struct {
 
 func (x *DiffRequest) Reset() {
 	*x = DiffRequest{}
-	mi := &file_querier_v1_querier_proto_msgTypes[10]
+	mi := &file_querier_v1_querier_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -940,7 +1020,7 @@ func (x *DiffRequest) String() string {
 func (*DiffRequest) ProtoMessage() {}
 
 func (x *DiffRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_querier_v1_querier_proto_msgTypes[10]
+	mi := &file_querier_v1_querier_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -953,7 +1033,7 @@ func (x *DiffRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiffRequest.ProtoReflect.Descriptor instead.
 func (*DiffRequest) Descriptor() ([]byte, []int) {
-	return file_querier_v1_querier_proto_rawDescGZIP(), []int{10}
+	return file_querier_v1_querier_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *DiffRequest) GetLeft() *SelectMergeStacktracesRequest {
@@ -979,7 +1059,7 @@ type DiffResponse struct {
 
 func (x *DiffResponse) Reset() {
 	*x = DiffResponse{}
-	mi := &file_querier_v1_querier_proto_msgTypes[11]
+	mi := &file_querier_v1_querier_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -991,7 +1071,7 @@ func (x *DiffResponse) String() string {
 func (*DiffResponse) ProtoMessage() {}
 
 func (x *DiffResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_querier_v1_querier_proto_msgTypes[11]
+	mi := &file_querier_v1_querier_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1004,7 +1084,7 @@ func (x *DiffResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiffResponse.ProtoReflect.Descriptor instead.
 func (*DiffResponse) Descriptor() ([]byte, []int) {
-	return file_querier_v1_querier_proto_rawDescGZIP(), []int{11}
+	return file_querier_v1_querier_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *DiffResponse) GetFlamegraph() *FlameGraphDiff {
@@ -1026,7 +1106,7 @@ type FlameGraph struct {
 
 func (x *FlameGraph) Reset() {
 	*x = FlameGraph{}
-	mi := &file_querier_v1_querier_proto_msgTypes[12]
+	mi := &file_querier_v1_querier_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1038,7 +1118,7 @@ func (x *FlameGraph) String() string {
 func (*FlameGraph) ProtoMessage() {}
 
 func (x *FlameGraph) ProtoReflect() protoreflect.Message {
-	mi := &file_querier_v1_querier_proto_msgTypes[12]
+	mi := &file_querier_v1_querier_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1051,7 +1131,7 @@ func (x *FlameGraph) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FlameGraph.ProtoReflect.Descriptor instead.
 func (*FlameGraph) Descriptor() ([]byte, []int) {
-	return file_querier_v1_querier_proto_rawDescGZIP(), []int{12}
+	return file_querier_v1_querier_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *FlameGraph) GetNames() []string {
@@ -1096,7 +1176,7 @@ type FlameGraphDiff struct {
 
 func (x *FlameGraphDiff) Reset() {
 	*x = FlameGraphDiff{}
-	mi := &file_querier_v1_querier_proto_msgTypes[13]
+	mi := &file_querier_v1_querier_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1108,7 +1188,7 @@ func (x *FlameGraphDiff) String() string {
 func (*FlameGraphDiff) ProtoMessage() {}
 
 func (x *FlameGraphDiff) ProtoReflect() protoreflect.Message {
-	mi := &file_querier_v1_querier_proto_msgTypes[13]
+	mi := &file_querier_v1_querier_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1121,7 +1201,7 @@ func (x *FlameGraphDiff) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FlameGraphDiff.ProtoReflect.Descriptor instead.
 func (*FlameGraphDiff) Descriptor() ([]byte, []int) {
-	return file_querier_v1_querier_proto_rawDescGZIP(), []int{13}
+	return file_querier_v1_querier_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *FlameGraphDiff) GetNames() []string {
@@ -1175,7 +1255,7 @@ type Level struct {
 
 func (x *Level) Reset() {
 	*x = Level{}
-	mi := &file_querier_v1_querier_proto_msgTypes[14]
+	mi := &file_querier_v1_querier_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1187,7 +1267,7 @@ func (x *Level) String() string {
 func (*Level) ProtoMessage() {}
 
 func (x *Level) ProtoReflect() protoreflect.Message {
-	mi := &file_querier_v1_querier_proto_msgTypes[14]
+	mi := &file_querier_v1_querier_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1200,7 +1280,7 @@ func (x *Level) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Level.ProtoReflect.Descriptor instead.
 func (*Level) Descriptor() ([]byte, []int) {
-	return file_querier_v1_querier_proto_rawDescGZIP(), []int{14}
+	return file_querier_v1_querier_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *Level) GetValues() []int64 {
@@ -1236,7 +1316,7 @@ type SelectMergeProfileRequest struct {
 
 func (x *SelectMergeProfileRequest) Reset() {
 	*x = SelectMergeProfileRequest{}
-	mi := &file_querier_v1_querier_proto_msgTypes[15]
+	mi := &file_querier_v1_querier_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1248,7 +1328,7 @@ func (x *SelectMergeProfileRequest) String() string {
 func (*SelectMergeProfileRequest) ProtoMessage() {}
 
 func (x *SelectMergeProfileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_querier_v1_querier_proto_msgTypes[15]
+	mi := &file_querier_v1_querier_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1261,7 +1341,7 @@ func (x *SelectMergeProfileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SelectMergeProfileRequest.ProtoReflect.Descriptor instead.
 func (*SelectMergeProfileRequest) Descriptor() ([]byte, []int) {
-	return file_querier_v1_querier_proto_rawDescGZIP(), []int{15}
+	return file_querier_v1_querier_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *SelectMergeProfileRequest) GetProfileTypeID() string {
@@ -1347,7 +1427,7 @@ type SelectSeriesRequest struct {
 
 func (x *SelectSeriesRequest) Reset() {
 	*x = SelectSeriesRequest{}
-	mi := &file_querier_v1_querier_proto_msgTypes[16]
+	mi := &file_querier_v1_querier_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1359,7 +1439,7 @@ func (x *SelectSeriesRequest) String() string {
 func (*SelectSeriesRequest) ProtoMessage() {}
 
 func (x *SelectSeriesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_querier_v1_querier_proto_msgTypes[16]
+	mi := &file_querier_v1_querier_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1372,7 +1452,7 @@ func (x *SelectSeriesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SelectSeriesRequest.ProtoReflect.Descriptor instead.
 func (*SelectSeriesRequest) Descriptor() ([]byte, []int) {
-	return file_querier_v1_querier_proto_rawDescGZIP(), []int{16}
+	return file_querier_v1_querier_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *SelectSeriesRequest) GetProfileTypeID() string {
@@ -1454,7 +1534,7 @@ type SelectSeriesResponse struct {
 
 func (x *SelectSeriesResponse) Reset() {
 	*x = SelectSeriesResponse{}
-	mi := &file_querier_v1_querier_proto_msgTypes[17]
+	mi := &file_querier_v1_querier_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1466,7 +1546,7 @@ func (x *SelectSeriesResponse) String() string {
 func (*SelectSeriesResponse) ProtoMessage() {}
 
 func (x *SelectSeriesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_querier_v1_querier_proto_msgTypes[17]
+	mi := &file_querier_v1_querier_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1479,7 +1559,7 @@ func (x *SelectSeriesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SelectSeriesResponse.ProtoReflect.Descriptor instead.
 func (*SelectSeriesResponse) Descriptor() ([]byte, []int) {
-	return file_querier_v1_querier_proto_rawDescGZIP(), []int{17}
+	return file_querier_v1_querier_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *SelectSeriesResponse) GetSeries() []*v1.Series {
@@ -1516,7 +1596,7 @@ type SelectHeatmapRequest struct {
 
 func (x *SelectHeatmapRequest) Reset() {
 	*x = SelectHeatmapRequest{}
-	mi := &file_querier_v1_querier_proto_msgTypes[18]
+	mi := &file_querier_v1_querier_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1528,7 +1608,7 @@ func (x *SelectHeatmapRequest) String() string {
 func (*SelectHeatmapRequest) ProtoMessage() {}
 
 func (x *SelectHeatmapRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_querier_v1_querier_proto_msgTypes[18]
+	mi := &file_querier_v1_querier_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1541,7 +1621,7 @@ func (x *SelectHeatmapRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SelectHeatmapRequest.ProtoReflect.Descriptor instead.
 func (*SelectHeatmapRequest) Descriptor() ([]byte, []int) {
-	return file_querier_v1_querier_proto_rawDescGZIP(), []int{18}
+	return file_querier_v1_querier_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *SelectHeatmapRequest) GetProfileTypeID() string {
@@ -1616,7 +1696,7 @@ type SelectHeatmapResponse struct {
 
 func (x *SelectHeatmapResponse) Reset() {
 	*x = SelectHeatmapResponse{}
-	mi := &file_querier_v1_querier_proto_msgTypes[19]
+	mi := &file_querier_v1_querier_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1628,7 +1708,7 @@ func (x *SelectHeatmapResponse) String() string {
 func (*SelectHeatmapResponse) ProtoMessage() {}
 
 func (x *SelectHeatmapResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_querier_v1_querier_proto_msgTypes[19]
+	mi := &file_querier_v1_querier_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1641,7 +1721,7 @@ func (x *SelectHeatmapResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SelectHeatmapResponse.ProtoReflect.Descriptor instead.
 func (*SelectHeatmapResponse) Descriptor() ([]byte, []int) {
-	return file_querier_v1_querier_proto_rawDescGZIP(), []int{19}
+	return file_querier_v1_querier_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *SelectHeatmapResponse) GetSeries() []*v1.HeatmapSeries {
@@ -1662,7 +1742,7 @@ type AnalyzeQueryRequest struct {
 
 func (x *AnalyzeQueryRequest) Reset() {
 	*x = AnalyzeQueryRequest{}
-	mi := &file_querier_v1_querier_proto_msgTypes[20]
+	mi := &file_querier_v1_querier_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1674,7 +1754,7 @@ func (x *AnalyzeQueryRequest) String() string {
 func (*AnalyzeQueryRequest) ProtoMessage() {}
 
 func (x *AnalyzeQueryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_querier_v1_querier_proto_msgTypes[20]
+	mi := &file_querier_v1_querier_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1687,7 +1767,7 @@ func (x *AnalyzeQueryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AnalyzeQueryRequest.ProtoReflect.Descriptor instead.
 func (*AnalyzeQueryRequest) Descriptor() ([]byte, []int) {
-	return file_querier_v1_querier_proto_rawDescGZIP(), []int{20}
+	return file_querier_v1_querier_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *AnalyzeQueryRequest) GetStart() int64 {
@@ -1721,7 +1801,7 @@ type AnalyzeQueryResponse struct {
 
 func (x *AnalyzeQueryResponse) Reset() {
 	*x = AnalyzeQueryResponse{}
-	mi := &file_querier_v1_querier_proto_msgTypes[21]
+	mi := &file_querier_v1_querier_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1733,7 +1813,7 @@ func (x *AnalyzeQueryResponse) String() string {
 func (*AnalyzeQueryResponse) ProtoMessage() {}
 
 func (x *AnalyzeQueryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_querier_v1_querier_proto_msgTypes[21]
+	mi := &file_querier_v1_querier_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1746,7 +1826,7 @@ func (x *AnalyzeQueryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AnalyzeQueryResponse.ProtoReflect.Descriptor instead.
 func (*AnalyzeQueryResponse) Descriptor() ([]byte, []int) {
-	return file_querier_v1_querier_proto_rawDescGZIP(), []int{21}
+	return file_querier_v1_querier_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *AnalyzeQueryResponse) GetQueryScopes() []*QueryScope {
@@ -1781,7 +1861,7 @@ type QueryScope struct {
 
 func (x *QueryScope) Reset() {
 	*x = QueryScope{}
-	mi := &file_querier_v1_querier_proto_msgTypes[22]
+	mi := &file_querier_v1_querier_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1793,7 +1873,7 @@ func (x *QueryScope) String() string {
 func (*QueryScope) ProtoMessage() {}
 
 func (x *QueryScope) ProtoReflect() protoreflect.Message {
-	mi := &file_querier_v1_querier_proto_msgTypes[22]
+	mi := &file_querier_v1_querier_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1806,7 +1886,7 @@ func (x *QueryScope) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryScope.ProtoReflect.Descriptor instead.
 func (*QueryScope) Descriptor() ([]byte, []int) {
-	return file_querier_v1_querier_proto_rawDescGZIP(), []int{22}
+	return file_querier_v1_querier_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *QueryScope) GetComponentType() string {
@@ -1883,7 +1963,7 @@ type QueryImpact struct {
 
 func (x *QueryImpact) Reset() {
 	*x = QueryImpact{}
-	mi := &file_querier_v1_querier_proto_msgTypes[23]
+	mi := &file_querier_v1_querier_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1895,7 +1975,7 @@ func (x *QueryImpact) String() string {
 func (*QueryImpact) ProtoMessage() {}
 
 func (x *QueryImpact) ProtoReflect() protoreflect.Message {
-	mi := &file_querier_v1_querier_proto_msgTypes[23]
+	mi := &file_querier_v1_querier_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1908,7 +1988,7 @@ func (x *QueryImpact) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryImpact.ProtoReflect.Descriptor instead.
 func (*QueryImpact) Descriptor() ([]byte, []int) {
-	return file_querier_v1_querier_proto_rawDescGZIP(), []int{23}
+	return file_querier_v1_querier_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *QueryImpact) GetTotalBytesInTimeRange() uint64 {
@@ -1951,7 +2031,7 @@ const file_querier_v1_querier_proto_rawDesc = "" +
 	"\x03end\x18\x04 \x01(\x03B\x14\xbaG\x11:\x0f\x12\r1676289600000R\x03end\"A\n" +
 	"\x0eSeriesResponse\x12/\n" +
 	"\n" +
-	"labels_set\x18\x02 \x03(\v2\x10.types.v1.LabelsR\tlabelsSet\"\xe9\x05\n" +
+	"labels_set\x18\x02 \x03(\v2\x10.types.v1.LabelsR\tlabelsSet\"\xbe\x06\n" +
 	"\x1dSelectMergeStacktracesRequest\x12Y\n" +
 	"\x0eprofile_typeID\x18\x01 \x01(\tB2\xbaG/:-\x12+process_cpu:cpu:nanoseconds:cpu:nanosecondsR\rprofileTypeID\x12J\n" +
 	"\x0elabel_selector\x18\x02 \x01(\tB#\xbaG :\x1e\x12\x1c'{namespace=\"my-namespace\"}'R\rlabelSelector\x12*\n" +
@@ -1963,19 +2043,23 @@ const file_querier_v1_querier_proto_rawDesc = "" +
 	"\x13profile_id_selector\x18\b \x03(\tB/\xbaG,:*\x12(['7c9e6679-7425-40de-944b-e07fc1f90ae7']R\x11profileIdSelector\x128\n" +
 	"\x05async\x18\t \x01(\v2\x1d.querier.v1.AsyncQueryRequestH\x02R\x05async\x88\x01\x01\x12W\n" +
 	"\x11trace_id_selector\x18\n" +
-	" \x03(\tB+\xbaG(:&\x12$['7c9e66797425440de944be07fc1f90ae']R\x0ftraceIdSelectorB\f\n" +
+	" \x03(\tB+\xbaG(:&\x12$['7c9e66797425440de944be07fc1f90ae']R\x0ftraceIdSelector\x12S\n" +
+	"\rspan_selector\x18\v \x03(\tB.\xbaG+:)\x12'['9a517183f26a089d','5a4fe264a9c987fe']R\fspanSelectorB\f\n" +
 	"\n" +
 	"_max_nodesB\x17\n" +
 	"\x15_stack_trace_selectorB\b\n" +
-	"\x06_async\"\xc3\x01\n" +
+	"\x06_async\"\xf3\x01\n" +
 	"\x1eSelectMergeStacktracesResponse\x126\n" +
 	"\n" +
 	"flamegraph\x18\x01 \x01(\v2\x16.querier.v1.FlameGraphR\n" +
 	"flamegraph\x12\x12\n" +
 	"\x04tree\x18\x02 \x01(\fR\x04tree\x12\x10\n" +
 	"\x03dot\x18\x03 \x01(\tR\x03dot\x129\n" +
-	"\x05async\x18\x04 \x01(\v2\x1e.querier.v1.AsyncQueryResponseH\x00R\x05async\x88\x01\x01B\b\n" +
-	"\x06_async\"b\n" +
+	"\x05async\x18\x04 \x01(\v2\x1e.querier.v1.AsyncQueryResponseH\x00R\x05async\x88\x01\x01\x12.\n" +
+	"\x05pprof\x18\x05 \x01(\v2\x18.querier.v1.PprofProfileR\x05pprofB\b\n" +
+	"\x06_async\"<\n" +
+	"\fPprofProfile\x12,\n" +
+	"\aprofile\x18\x01 \x01(\v2\x12.google.v1.ProfileR\aprofile\"b\n" +
 	"\x11AsyncQueryRequest\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\tR\trequestId\x12.\n" +
@@ -2090,12 +2174,13 @@ const file_querier_v1_querier_proto_rawDesc = "" +
 	"\vQueryImpact\x128\n" +
 	"\x19total_bytes_in_time_range\x18\x02 \x01(\x04R\x15totalBytesInTimeRange\x120\n" +
 	"\x14total_queried_series\x18\x03 \x01(\x04R\x12totalQueriedSeries\x121\n" +
-	"\x14deduplication_needed\x18\x04 \x01(\bR\x13deduplicationNeeded*\x7f\n" +
+	"\x14deduplication_needed\x18\x04 \x01(\bR\x13deduplicationNeeded*\x99\x01\n" +
 	"\rProfileFormat\x12\x1e\n" +
 	"\x1aPROFILE_FORMAT_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19PROFILE_FORMAT_FLAMEGRAPH\x10\x01\x12\x17\n" +
 	"\x13PROFILE_FORMAT_TREE\x10\x02\x12\x16\n" +
-	"\x12PROFILE_FORMAT_DOT\x10\x03*K\n" +
+	"\x12PROFILE_FORMAT_DOT\x10\x03\x12\x18\n" +
+	"\x14PROFILE_FORMAT_PPROF\x10\x04*K\n" +
 	"\x0eAsyncQueryType\x12\x1d\n" +
 	"\x19ASYNC_QUERY_TYPE_DISABLED\x10\x00\x12\x1a\n" +
 	"\x16ASYNC_QUERY_TYPE_FORCE\x10\x01*\x96\x01\n" +
@@ -2151,7 +2236,7 @@ func file_querier_v1_querier_proto_rawDescGZIP() []byte {
 }
 
 var file_querier_v1_querier_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_querier_v1_querier_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
+var file_querier_v1_querier_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
 var file_querier_v1_querier_proto_goTypes = []any{
 	(ProfileFormat)(0),                     // 0: querier.v1.ProfileFormat
 	(AsyncQueryType)(0),                    // 1: querier.v1.AsyncQueryType
@@ -2163,95 +2248,98 @@ var file_querier_v1_querier_proto_goTypes = []any{
 	(*SeriesResponse)(nil),                 // 7: querier.v1.SeriesResponse
 	(*SelectMergeStacktracesRequest)(nil),  // 8: querier.v1.SelectMergeStacktracesRequest
 	(*SelectMergeStacktracesResponse)(nil), // 9: querier.v1.SelectMergeStacktracesResponse
-	(*AsyncQueryRequest)(nil),              // 10: querier.v1.AsyncQueryRequest
-	(*AsyncQueryResponse)(nil),             // 11: querier.v1.AsyncQueryResponse
-	(*SelectMergeSpanProfileRequest)(nil),  // 12: querier.v1.SelectMergeSpanProfileRequest
-	(*SelectMergeSpanProfileResponse)(nil), // 13: querier.v1.SelectMergeSpanProfileResponse
-	(*DiffRequest)(nil),                    // 14: querier.v1.DiffRequest
-	(*DiffResponse)(nil),                   // 15: querier.v1.DiffResponse
-	(*FlameGraph)(nil),                     // 16: querier.v1.FlameGraph
-	(*FlameGraphDiff)(nil),                 // 17: querier.v1.FlameGraphDiff
-	(*Level)(nil),                          // 18: querier.v1.Level
-	(*SelectMergeProfileRequest)(nil),      // 19: querier.v1.SelectMergeProfileRequest
-	(*SelectSeriesRequest)(nil),            // 20: querier.v1.SelectSeriesRequest
-	(*SelectSeriesResponse)(nil),           // 21: querier.v1.SelectSeriesResponse
-	(*SelectHeatmapRequest)(nil),           // 22: querier.v1.SelectHeatmapRequest
-	(*SelectHeatmapResponse)(nil),          // 23: querier.v1.SelectHeatmapResponse
-	(*AnalyzeQueryRequest)(nil),            // 24: querier.v1.AnalyzeQueryRequest
-	(*AnalyzeQueryResponse)(nil),           // 25: querier.v1.AnalyzeQueryResponse
-	(*QueryScope)(nil),                     // 26: querier.v1.QueryScope
-	(*QueryImpact)(nil),                    // 27: querier.v1.QueryImpact
-	(*v1.ProfileType)(nil),                 // 28: types.v1.ProfileType
-	(*v1.Labels)(nil),                      // 29: types.v1.Labels
-	(*v1.StackTraceSelector)(nil),          // 30: types.v1.StackTraceSelector
-	(v1.TimeSeriesAggregationType)(0),      // 31: types.v1.TimeSeriesAggregationType
-	(v1.ExemplarType)(0),                   // 32: types.v1.ExemplarType
-	(*v1.Series)(nil),                      // 33: types.v1.Series
-	(*v1.HeatmapSeries)(nil),               // 34: types.v1.HeatmapSeries
-	(*v1.LabelValuesRequest)(nil),          // 35: types.v1.LabelValuesRequest
-	(*v1.LabelNamesRequest)(nil),           // 36: types.v1.LabelNamesRequest
-	(*v1.GetProfileStatsRequest)(nil),      // 37: types.v1.GetProfileStatsRequest
-	(*v1.LabelValuesResponse)(nil),         // 38: types.v1.LabelValuesResponse
-	(*v1.LabelNamesResponse)(nil),          // 39: types.v1.LabelNamesResponse
-	(*v11.Profile)(nil),                    // 40: google.v1.Profile
-	(*v1.GetProfileStatsResponse)(nil),     // 41: types.v1.GetProfileStatsResponse
+	(*PprofProfile)(nil),                   // 10: querier.v1.PprofProfile
+	(*AsyncQueryRequest)(nil),              // 11: querier.v1.AsyncQueryRequest
+	(*AsyncQueryResponse)(nil),             // 12: querier.v1.AsyncQueryResponse
+	(*SelectMergeSpanProfileRequest)(nil),  // 13: querier.v1.SelectMergeSpanProfileRequest
+	(*SelectMergeSpanProfileResponse)(nil), // 14: querier.v1.SelectMergeSpanProfileResponse
+	(*DiffRequest)(nil),                    // 15: querier.v1.DiffRequest
+	(*DiffResponse)(nil),                   // 16: querier.v1.DiffResponse
+	(*FlameGraph)(nil),                     // 17: querier.v1.FlameGraph
+	(*FlameGraphDiff)(nil),                 // 18: querier.v1.FlameGraphDiff
+	(*Level)(nil),                          // 19: querier.v1.Level
+	(*SelectMergeProfileRequest)(nil),      // 20: querier.v1.SelectMergeProfileRequest
+	(*SelectSeriesRequest)(nil),            // 21: querier.v1.SelectSeriesRequest
+	(*SelectSeriesResponse)(nil),           // 22: querier.v1.SelectSeriesResponse
+	(*SelectHeatmapRequest)(nil),           // 23: querier.v1.SelectHeatmapRequest
+	(*SelectHeatmapResponse)(nil),          // 24: querier.v1.SelectHeatmapResponse
+	(*AnalyzeQueryRequest)(nil),            // 25: querier.v1.AnalyzeQueryRequest
+	(*AnalyzeQueryResponse)(nil),           // 26: querier.v1.AnalyzeQueryResponse
+	(*QueryScope)(nil),                     // 27: querier.v1.QueryScope
+	(*QueryImpact)(nil),                    // 28: querier.v1.QueryImpact
+	(*v1.ProfileType)(nil),                 // 29: types.v1.ProfileType
+	(*v1.Labels)(nil),                      // 30: types.v1.Labels
+	(*v1.StackTraceSelector)(nil),          // 31: types.v1.StackTraceSelector
+	(*v11.Profile)(nil),                    // 32: google.v1.Profile
+	(v1.TimeSeriesAggregationType)(0),      // 33: types.v1.TimeSeriesAggregationType
+	(v1.ExemplarType)(0),                   // 34: types.v1.ExemplarType
+	(*v1.Series)(nil),                      // 35: types.v1.Series
+	(*v1.HeatmapSeries)(nil),               // 36: types.v1.HeatmapSeries
+	(*v1.LabelValuesRequest)(nil),          // 37: types.v1.LabelValuesRequest
+	(*v1.LabelNamesRequest)(nil),           // 38: types.v1.LabelNamesRequest
+	(*v1.GetProfileStatsRequest)(nil),      // 39: types.v1.GetProfileStatsRequest
+	(*v1.LabelValuesResponse)(nil),         // 40: types.v1.LabelValuesResponse
+	(*v1.LabelNamesResponse)(nil),          // 41: types.v1.LabelNamesResponse
+	(*v1.GetProfileStatsResponse)(nil),     // 42: types.v1.GetProfileStatsResponse
 }
 var file_querier_v1_querier_proto_depIdxs = []int32{
-	28, // 0: querier.v1.ProfileTypesResponse.profile_types:type_name -> types.v1.ProfileType
-	29, // 1: querier.v1.SeriesResponse.labels_set:type_name -> types.v1.Labels
+	29, // 0: querier.v1.ProfileTypesResponse.profile_types:type_name -> types.v1.ProfileType
+	30, // 1: querier.v1.SeriesResponse.labels_set:type_name -> types.v1.Labels
 	0,  // 2: querier.v1.SelectMergeStacktracesRequest.format:type_name -> querier.v1.ProfileFormat
-	30, // 3: querier.v1.SelectMergeStacktracesRequest.stack_trace_selector:type_name -> types.v1.StackTraceSelector
-	10, // 4: querier.v1.SelectMergeStacktracesRequest.async:type_name -> querier.v1.AsyncQueryRequest
-	16, // 5: querier.v1.SelectMergeStacktracesResponse.flamegraph:type_name -> querier.v1.FlameGraph
-	11, // 6: querier.v1.SelectMergeStacktracesResponse.async:type_name -> querier.v1.AsyncQueryResponse
-	1,  // 7: querier.v1.AsyncQueryRequest.type:type_name -> querier.v1.AsyncQueryType
-	2,  // 8: querier.v1.AsyncQueryResponse.status:type_name -> querier.v1.AsyncQueryStatus
-	0,  // 9: querier.v1.SelectMergeSpanProfileRequest.format:type_name -> querier.v1.ProfileFormat
-	16, // 10: querier.v1.SelectMergeSpanProfileResponse.flamegraph:type_name -> querier.v1.FlameGraph
-	8,  // 11: querier.v1.DiffRequest.left:type_name -> querier.v1.SelectMergeStacktracesRequest
-	8,  // 12: querier.v1.DiffRequest.right:type_name -> querier.v1.SelectMergeStacktracesRequest
-	17, // 13: querier.v1.DiffResponse.flamegraph:type_name -> querier.v1.FlameGraphDiff
-	18, // 14: querier.v1.FlameGraph.levels:type_name -> querier.v1.Level
-	18, // 15: querier.v1.FlameGraphDiff.levels:type_name -> querier.v1.Level
-	30, // 16: querier.v1.SelectMergeProfileRequest.stack_trace_selector:type_name -> types.v1.StackTraceSelector
-	31, // 17: querier.v1.SelectSeriesRequest.aggregation:type_name -> types.v1.TimeSeriesAggregationType
-	30, // 18: querier.v1.SelectSeriesRequest.stack_trace_selector:type_name -> types.v1.StackTraceSelector
-	32, // 19: querier.v1.SelectSeriesRequest.exemplar_type:type_name -> types.v1.ExemplarType
-	33, // 20: querier.v1.SelectSeriesResponse.series:type_name -> types.v1.Series
-	3,  // 21: querier.v1.SelectHeatmapRequest.query_type:type_name -> querier.v1.HeatmapQueryType
-	32, // 22: querier.v1.SelectHeatmapRequest.exemplar_type:type_name -> types.v1.ExemplarType
-	34, // 23: querier.v1.SelectHeatmapResponse.series:type_name -> types.v1.HeatmapSeries
-	26, // 24: querier.v1.AnalyzeQueryResponse.query_scopes:type_name -> querier.v1.QueryScope
-	27, // 25: querier.v1.AnalyzeQueryResponse.query_impact:type_name -> querier.v1.QueryImpact
-	4,  // 26: querier.v1.QuerierService.ProfileTypes:input_type -> querier.v1.ProfileTypesRequest
-	35, // 27: querier.v1.QuerierService.LabelValues:input_type -> types.v1.LabelValuesRequest
-	36, // 28: querier.v1.QuerierService.LabelNames:input_type -> types.v1.LabelNamesRequest
-	6,  // 29: querier.v1.QuerierService.Series:input_type -> querier.v1.SeriesRequest
-	8,  // 30: querier.v1.QuerierService.SelectMergeStacktraces:input_type -> querier.v1.SelectMergeStacktracesRequest
-	12, // 31: querier.v1.QuerierService.SelectMergeSpanProfile:input_type -> querier.v1.SelectMergeSpanProfileRequest
-	19, // 32: querier.v1.QuerierService.SelectMergeProfile:input_type -> querier.v1.SelectMergeProfileRequest
-	20, // 33: querier.v1.QuerierService.SelectSeries:input_type -> querier.v1.SelectSeriesRequest
-	22, // 34: querier.v1.QuerierService.SelectHeatmap:input_type -> querier.v1.SelectHeatmapRequest
-	14, // 35: querier.v1.QuerierService.Diff:input_type -> querier.v1.DiffRequest
-	37, // 36: querier.v1.QuerierService.GetProfileStats:input_type -> types.v1.GetProfileStatsRequest
-	24, // 37: querier.v1.QuerierService.AnalyzeQuery:input_type -> querier.v1.AnalyzeQueryRequest
-	5,  // 38: querier.v1.QuerierService.ProfileTypes:output_type -> querier.v1.ProfileTypesResponse
-	38, // 39: querier.v1.QuerierService.LabelValues:output_type -> types.v1.LabelValuesResponse
-	39, // 40: querier.v1.QuerierService.LabelNames:output_type -> types.v1.LabelNamesResponse
-	7,  // 41: querier.v1.QuerierService.Series:output_type -> querier.v1.SeriesResponse
-	9,  // 42: querier.v1.QuerierService.SelectMergeStacktraces:output_type -> querier.v1.SelectMergeStacktracesResponse
-	13, // 43: querier.v1.QuerierService.SelectMergeSpanProfile:output_type -> querier.v1.SelectMergeSpanProfileResponse
-	40, // 44: querier.v1.QuerierService.SelectMergeProfile:output_type -> google.v1.Profile
-	21, // 45: querier.v1.QuerierService.SelectSeries:output_type -> querier.v1.SelectSeriesResponse
-	23, // 46: querier.v1.QuerierService.SelectHeatmap:output_type -> querier.v1.SelectHeatmapResponse
-	15, // 47: querier.v1.QuerierService.Diff:output_type -> querier.v1.DiffResponse
-	41, // 48: querier.v1.QuerierService.GetProfileStats:output_type -> types.v1.GetProfileStatsResponse
-	25, // 49: querier.v1.QuerierService.AnalyzeQuery:output_type -> querier.v1.AnalyzeQueryResponse
-	38, // [38:50] is the sub-list for method output_type
-	26, // [26:38] is the sub-list for method input_type
-	26, // [26:26] is the sub-list for extension type_name
-	26, // [26:26] is the sub-list for extension extendee
-	0,  // [0:26] is the sub-list for field type_name
+	31, // 3: querier.v1.SelectMergeStacktracesRequest.stack_trace_selector:type_name -> types.v1.StackTraceSelector
+	11, // 4: querier.v1.SelectMergeStacktracesRequest.async:type_name -> querier.v1.AsyncQueryRequest
+	17, // 5: querier.v1.SelectMergeStacktracesResponse.flamegraph:type_name -> querier.v1.FlameGraph
+	12, // 6: querier.v1.SelectMergeStacktracesResponse.async:type_name -> querier.v1.AsyncQueryResponse
+	10, // 7: querier.v1.SelectMergeStacktracesResponse.pprof:type_name -> querier.v1.PprofProfile
+	32, // 8: querier.v1.PprofProfile.profile:type_name -> google.v1.Profile
+	1,  // 9: querier.v1.AsyncQueryRequest.type:type_name -> querier.v1.AsyncQueryType
+	2,  // 10: querier.v1.AsyncQueryResponse.status:type_name -> querier.v1.AsyncQueryStatus
+	0,  // 11: querier.v1.SelectMergeSpanProfileRequest.format:type_name -> querier.v1.ProfileFormat
+	17, // 12: querier.v1.SelectMergeSpanProfileResponse.flamegraph:type_name -> querier.v1.FlameGraph
+	8,  // 13: querier.v1.DiffRequest.left:type_name -> querier.v1.SelectMergeStacktracesRequest
+	8,  // 14: querier.v1.DiffRequest.right:type_name -> querier.v1.SelectMergeStacktracesRequest
+	18, // 15: querier.v1.DiffResponse.flamegraph:type_name -> querier.v1.FlameGraphDiff
+	19, // 16: querier.v1.FlameGraph.levels:type_name -> querier.v1.Level
+	19, // 17: querier.v1.FlameGraphDiff.levels:type_name -> querier.v1.Level
+	31, // 18: querier.v1.SelectMergeProfileRequest.stack_trace_selector:type_name -> types.v1.StackTraceSelector
+	33, // 19: querier.v1.SelectSeriesRequest.aggregation:type_name -> types.v1.TimeSeriesAggregationType
+	31, // 20: querier.v1.SelectSeriesRequest.stack_trace_selector:type_name -> types.v1.StackTraceSelector
+	34, // 21: querier.v1.SelectSeriesRequest.exemplar_type:type_name -> types.v1.ExemplarType
+	35, // 22: querier.v1.SelectSeriesResponse.series:type_name -> types.v1.Series
+	3,  // 23: querier.v1.SelectHeatmapRequest.query_type:type_name -> querier.v1.HeatmapQueryType
+	34, // 24: querier.v1.SelectHeatmapRequest.exemplar_type:type_name -> types.v1.ExemplarType
+	36, // 25: querier.v1.SelectHeatmapResponse.series:type_name -> types.v1.HeatmapSeries
+	27, // 26: querier.v1.AnalyzeQueryResponse.query_scopes:type_name -> querier.v1.QueryScope
+	28, // 27: querier.v1.AnalyzeQueryResponse.query_impact:type_name -> querier.v1.QueryImpact
+	4,  // 28: querier.v1.QuerierService.ProfileTypes:input_type -> querier.v1.ProfileTypesRequest
+	37, // 29: querier.v1.QuerierService.LabelValues:input_type -> types.v1.LabelValuesRequest
+	38, // 30: querier.v1.QuerierService.LabelNames:input_type -> types.v1.LabelNamesRequest
+	6,  // 31: querier.v1.QuerierService.Series:input_type -> querier.v1.SeriesRequest
+	8,  // 32: querier.v1.QuerierService.SelectMergeStacktraces:input_type -> querier.v1.SelectMergeStacktracesRequest
+	13, // 33: querier.v1.QuerierService.SelectMergeSpanProfile:input_type -> querier.v1.SelectMergeSpanProfileRequest
+	20, // 34: querier.v1.QuerierService.SelectMergeProfile:input_type -> querier.v1.SelectMergeProfileRequest
+	21, // 35: querier.v1.QuerierService.SelectSeries:input_type -> querier.v1.SelectSeriesRequest
+	23, // 36: querier.v1.QuerierService.SelectHeatmap:input_type -> querier.v1.SelectHeatmapRequest
+	15, // 37: querier.v1.QuerierService.Diff:input_type -> querier.v1.DiffRequest
+	39, // 38: querier.v1.QuerierService.GetProfileStats:input_type -> types.v1.GetProfileStatsRequest
+	25, // 39: querier.v1.QuerierService.AnalyzeQuery:input_type -> querier.v1.AnalyzeQueryRequest
+	5,  // 40: querier.v1.QuerierService.ProfileTypes:output_type -> querier.v1.ProfileTypesResponse
+	40, // 41: querier.v1.QuerierService.LabelValues:output_type -> types.v1.LabelValuesResponse
+	41, // 42: querier.v1.QuerierService.LabelNames:output_type -> types.v1.LabelNamesResponse
+	7,  // 43: querier.v1.QuerierService.Series:output_type -> querier.v1.SeriesResponse
+	9,  // 44: querier.v1.QuerierService.SelectMergeStacktraces:output_type -> querier.v1.SelectMergeStacktracesResponse
+	14, // 45: querier.v1.QuerierService.SelectMergeSpanProfile:output_type -> querier.v1.SelectMergeSpanProfileResponse
+	32, // 46: querier.v1.QuerierService.SelectMergeProfile:output_type -> google.v1.Profile
+	22, // 47: querier.v1.QuerierService.SelectSeries:output_type -> querier.v1.SelectSeriesResponse
+	24, // 48: querier.v1.QuerierService.SelectHeatmap:output_type -> querier.v1.SelectHeatmapResponse
+	16, // 49: querier.v1.QuerierService.Diff:output_type -> querier.v1.DiffResponse
+	42, // 50: querier.v1.QuerierService.GetProfileStats:output_type -> types.v1.GetProfileStatsResponse
+	26, // 51: querier.v1.QuerierService.AnalyzeQuery:output_type -> querier.v1.AnalyzeQueryResponse
+	40, // [40:52] is the sub-list for method output_type
+	28, // [28:40] is the sub-list for method input_type
+	28, // [28:28] is the sub-list for extension type_name
+	28, // [28:28] is the sub-list for extension extendee
+	0,  // [0:28] is the sub-list for field type_name
 }
 
 func init() { file_querier_v1_querier_proto_init() }
@@ -2261,17 +2349,17 @@ func file_querier_v1_querier_proto_init() {
 	}
 	file_querier_v1_querier_proto_msgTypes[4].OneofWrappers = []any{}
 	file_querier_v1_querier_proto_msgTypes[5].OneofWrappers = []any{}
-	file_querier_v1_querier_proto_msgTypes[8].OneofWrappers = []any{}
-	file_querier_v1_querier_proto_msgTypes[15].OneofWrappers = []any{}
+	file_querier_v1_querier_proto_msgTypes[9].OneofWrappers = []any{}
 	file_querier_v1_querier_proto_msgTypes[16].OneofWrappers = []any{}
-	file_querier_v1_querier_proto_msgTypes[18].OneofWrappers = []any{}
+	file_querier_v1_querier_proto_msgTypes[17].OneofWrappers = []any{}
+	file_querier_v1_querier_proto_msgTypes[19].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_querier_v1_querier_proto_rawDesc), len(file_querier_v1_querier_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   24,
+			NumMessages:   25,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/querier/v1/querier_vtproto.pb.go
+++ b/api/gen/proto/go/querier/v1/querier_vtproto.pb.go
@@ -159,6 +159,11 @@ func (m *SelectMergeStacktracesRequest) CloneVT() *SelectMergeStacktracesRequest
 		copy(tmpContainer, rhs)
 		r.TraceIdSelector = tmpContainer
 	}
+	if rhs := m.SpanSelector; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.SpanSelector = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -178,6 +183,7 @@ func (m *SelectMergeStacktracesResponse) CloneVT() *SelectMergeStacktracesRespon
 	r.Flamegraph = m.Flamegraph.CloneVT()
 	r.Dot = m.Dot
 	r.Async = m.Async.CloneVT()
+	r.Pprof = m.Pprof.CloneVT()
 	if rhs := m.Tree; rhs != nil {
 		tmpBytes := make([]byte, len(rhs))
 		copy(tmpBytes, rhs)
@@ -191,6 +197,29 @@ func (m *SelectMergeStacktracesResponse) CloneVT() *SelectMergeStacktracesRespon
 }
 
 func (m *SelectMergeStacktracesResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *PprofProfile) CloneVT() *PprofProfile {
+	if m == nil {
+		return (*PprofProfile)(nil)
+	}
+	r := new(PprofProfile)
+	if rhs := m.Profile; rhs != nil {
+		if vtpb, ok := interface{}(rhs).(interface{ CloneVT() *v11.Profile }); ok {
+			r.Profile = vtpb.CloneVT()
+		} else {
+			r.Profile = proto.Clone(rhs).(*v11.Profile)
+		}
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *PprofProfile) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
@@ -847,6 +876,15 @@ func (this *SelectMergeStacktracesRequest) EqualVT(that *SelectMergeStacktracesR
 			return false
 		}
 	}
+	if len(this.SpanSelector) != len(that.SpanSelector) {
+		return false
+	}
+	for i, vx := range this.SpanSelector {
+		vy := that.SpanSelector[i]
+		if vx != vy {
+			return false
+		}
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -875,11 +913,37 @@ func (this *SelectMergeStacktracesResponse) EqualVT(that *SelectMergeStacktraces
 	if !this.Async.EqualVT(that.Async) {
 		return false
 	}
+	if !this.Pprof.EqualVT(that.Pprof) {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
 func (this *SelectMergeStacktracesResponse) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*SelectMergeStacktracesResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *PprofProfile) EqualVT(that *PprofProfile) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if equal, ok := interface{}(this.Profile).(interface{ EqualVT(*v11.Profile) bool }); ok {
+		if !equal.EqualVT(that.Profile) {
+			return false
+		}
+	} else if !proto.Equal(this.Profile, that.Profile) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *PprofProfile) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*PprofProfile)
 	if !ok {
 		return false
 	}
@@ -1556,10 +1620,16 @@ type QuerierServiceClient interface {
 	// format. It will combine samples from within the same callstack, with each
 	// element being grouped by its function name.
 	SelectMergeStacktraces(ctx context.Context, in *SelectMergeStacktracesRequest, opts ...grpc.CallOption) (*SelectMergeStacktracesResponse, error)
+	// Deprecated: Use SelectMergeStacktraces with span_selector instead.
+	// This RPC will remain supported in querier.v1 for backward compatibility;
+	// future breaking API changes may be introduced in querier.v2.
 	// SelectMergeSpanProfile returns matching profiles aggregated in a flamegraph
 	// format. It will combine samples from within the same callstack, with each
 	// element being grouped by its function name.
 	SelectMergeSpanProfile(ctx context.Context, in *SelectMergeSpanProfileRequest, opts ...grpc.CallOption) (*SelectMergeSpanProfileResponse, error)
+	// Deprecated: Use SelectMergeStacktraces with PROFILE_FORMAT_PPROF instead.
+	// This RPC will remain supported in querier.v1 for backward compatibility;
+	// future breaking API changes may be introduced in querier.v2.
 	// SelectMergeProfile returns matching profiles aggregated in pprof format. It
 	// will contain all information stored (so including filenames and line
 	// number, if ingested).
@@ -1710,10 +1780,16 @@ type QuerierServiceServer interface {
 	// format. It will combine samples from within the same callstack, with each
 	// element being grouped by its function name.
 	SelectMergeStacktraces(context.Context, *SelectMergeStacktracesRequest) (*SelectMergeStacktracesResponse, error)
+	// Deprecated: Use SelectMergeStacktraces with span_selector instead.
+	// This RPC will remain supported in querier.v1 for backward compatibility;
+	// future breaking API changes may be introduced in querier.v2.
 	// SelectMergeSpanProfile returns matching profiles aggregated in a flamegraph
 	// format. It will combine samples from within the same callstack, with each
 	// element being grouped by its function name.
 	SelectMergeSpanProfile(context.Context, *SelectMergeSpanProfileRequest) (*SelectMergeSpanProfileResponse, error)
+	// Deprecated: Use SelectMergeStacktraces with PROFILE_FORMAT_PPROF instead.
+	// This RPC will remain supported in querier.v1 for backward compatibility;
+	// future breaking API changes may be introduced in querier.v2.
 	// SelectMergeProfile returns matching profiles aggregated in pprof format. It
 	// will contain all information stored (so including filenames and line
 	// number, if ingested).
@@ -2309,6 +2385,15 @@ func (m *SelectMergeStacktracesRequest) MarshalToSizedBufferVT(dAtA []byte) (int
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.SpanSelector) > 0 {
+		for iNdEx := len(m.SpanSelector) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.SpanSelector[iNdEx])
+			copy(dAtA[i:], m.SpanSelector[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.SpanSelector[iNdEx])))
+			i--
+			dAtA[i] = 0x5a
+		}
+	}
 	if len(m.TraceIdSelector) > 0 {
 		for iNdEx := len(m.TraceIdSelector) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.TraceIdSelector[iNdEx])
@@ -2426,6 +2511,16 @@ func (m *SelectMergeStacktracesResponse) MarshalToSizedBufferVT(dAtA []byte) (in
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.Pprof != nil {
+		size, err := m.Pprof.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x2a
+	}
 	if m.Async != nil {
 		size, err := m.Async.MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
@@ -2457,6 +2552,61 @@ func (m *SelectMergeStacktracesResponse) MarshalToSizedBufferVT(dAtA []byte) (in
 		}
 		i -= size
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *PprofProfile) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *PprofProfile) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *PprofProfile) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Profile != nil {
+		if vtmsg, ok := interface{}(m.Profile).(interface {
+			MarshalToSizedBufferVT([]byte) (int, error)
+		}); ok {
+			size, err := vtmsg.MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		} else {
+			encoded, err := proto.Marshal(m.Profile)
+			if err != nil {
+				return 0, err
+			}
+			i -= len(encoded)
+			copy(dAtA[i:], encoded)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(encoded)))
+		}
 		i--
 		dAtA[i] = 0xa
 	}
@@ -3764,6 +3914,12 @@ func (m *SelectMergeStacktracesRequest) SizeVT() (n int) {
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
+	if len(m.SpanSelector) > 0 {
+		for _, s := range m.SpanSelector {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -3788,6 +3944,30 @@ func (m *SelectMergeStacktracesResponse) SizeVT() (n int) {
 	}
 	if m.Async != nil {
 		l = m.Async.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Pprof != nil {
+		l = m.Pprof.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *PprofProfile) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Profile != nil {
+		if size, ok := interface{}(m.Profile).(interface {
+			SizeVT() int
+		}); ok {
+			l = size.SizeVT()
+		} else {
+			l = proto.Size(m.Profile)
+		}
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -5023,6 +5203,38 @@ func (m *SelectMergeStacktracesRequest) UnmarshalVT(dAtA []byte) error {
 			}
 			m.TraceIdSelector = append(m.TraceIdSelector, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
+		case 11:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SpanSelector", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SpanSelector = append(m.SpanSelector, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -5210,6 +5422,137 @@ func (m *SelectMergeStacktracesResponse) UnmarshalVT(dAtA []byte) error {
 			}
 			if err := m.Async.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
+			}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pprof", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Pprof == nil {
+				m.Pprof = &PprofProfile{}
+			}
+			if err := m.Pprof.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *PprofProfile) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: PprofProfile: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: PprofProfile: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Profile", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Profile == nil {
+				m.Profile = &v11.Profile{}
+			}
+			if unmarshal, ok := interface{}(m.Profile).(interface {
+				UnmarshalVT([]byte) error
+			}); ok {
+				if err := unmarshal.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+					return err
+				}
+			} else {
+				if err := proto.Unmarshal(dAtA[iNdEx:postIndex], m.Profile); err != nil {
+					return err
+				}
 			}
 			iNdEx = postIndex
 		default:

--- a/api/gen/proto/go/querier/v1/querierv1connect/querier.connect.go
+++ b/api/gen/proto/go/querier/v1/querierv1connect/querier.connect.go
@@ -88,10 +88,16 @@ type QuerierServiceClient interface {
 	// format. It will combine samples from within the same callstack, with each
 	// element being grouped by its function name.
 	SelectMergeStacktraces(context.Context, *connect.Request[v1.SelectMergeStacktracesRequest]) (*connect.Response[v1.SelectMergeStacktracesResponse], error)
+	// Deprecated: Use SelectMergeStacktraces with span_selector instead.
+	// This RPC will remain supported in querier.v1 for backward compatibility;
+	// future breaking API changes may be introduced in querier.v2.
 	// SelectMergeSpanProfile returns matching profiles aggregated in a flamegraph
 	// format. It will combine samples from within the same callstack, with each
 	// element being grouped by its function name.
 	SelectMergeSpanProfile(context.Context, *connect.Request[v1.SelectMergeSpanProfileRequest]) (*connect.Response[v1.SelectMergeSpanProfileResponse], error)
+	// Deprecated: Use SelectMergeStacktraces with PROFILE_FORMAT_PPROF instead.
+	// This RPC will remain supported in querier.v1 for backward compatibility;
+	// future breaking API changes may be introduced in querier.v2.
 	// SelectMergeProfile returns matching profiles aggregated in pprof format. It
 	// will contain all information stored (so including filenames and line
 	// number, if ingested).
@@ -286,10 +292,16 @@ type QuerierServiceHandler interface {
 	// format. It will combine samples from within the same callstack, with each
 	// element being grouped by its function name.
 	SelectMergeStacktraces(context.Context, *connect.Request[v1.SelectMergeStacktracesRequest]) (*connect.Response[v1.SelectMergeStacktracesResponse], error)
+	// Deprecated: Use SelectMergeStacktraces with span_selector instead.
+	// This RPC will remain supported in querier.v1 for backward compatibility;
+	// future breaking API changes may be introduced in querier.v2.
 	// SelectMergeSpanProfile returns matching profiles aggregated in a flamegraph
 	// format. It will combine samples from within the same callstack, with each
 	// element being grouped by its function name.
 	SelectMergeSpanProfile(context.Context, *connect.Request[v1.SelectMergeSpanProfileRequest]) (*connect.Response[v1.SelectMergeSpanProfileResponse], error)
+	// Deprecated: Use SelectMergeStacktraces with PROFILE_FORMAT_PPROF instead.
+	// This RPC will remain supported in querier.v1 for backward compatibility;
+	// future breaking API changes may be introduced in querier.v2.
 	// SelectMergeProfile returns matching profiles aggregated in pprof format. It
 	// will contain all information stored (so including filenames and line
 	// number, if ingested).

--- a/api/querier/v1/querier.proto
+++ b/api/querier/v1/querier.proto
@@ -32,12 +32,18 @@ service QuerierService {
   rpc SelectMergeStacktraces(SelectMergeStacktracesRequest) returns (SelectMergeStacktracesResponse) {
     option (gnostic.openapi.v3.operation).tags = "scope/public";
   }
+  // Deprecated: Use SelectMergeStacktraces with span_selector instead.
+  // This RPC will remain supported in querier.v1 for backward compatibility;
+  // future breaking API changes may be introduced in querier.v2.
   // SelectMergeSpanProfile returns matching profiles aggregated in a flamegraph
   // format. It will combine samples from within the same callstack, with each
   // element being grouped by its function name.
   rpc SelectMergeSpanProfile(SelectMergeSpanProfileRequest) returns (SelectMergeSpanProfileResponse) {
     option (gnostic.openapi.v3.operation).tags = "scope/public";
   }
+  // Deprecated: Use SelectMergeStacktraces with PROFILE_FORMAT_PPROF instead.
+  // This RPC will remain supported in querier.v1 for backward compatibility;
+  // future breaking API changes may be introduced in querier.v2.
   // SelectMergeProfile returns matching profiles aggregated in pprof format. It
   // will contain all information stored (so including filenames and line
   // number, if ingested).
@@ -123,13 +129,29 @@ message SelectMergeStacktracesRequest {
   optional AsyncQueryRequest async = 9;
   // List of trace IDs (32 hex characters, 128-bit) to filter samples by.
   repeated string trace_id_selector = 10 [(gnostic.openapi.v3.property).example = {yaml: "['7c9e66797425440de944be07fc1f90ae']"}];
+  // List of span IDs (16 hex characters, 64-bit) to filter samples by.
+  repeated string span_selector = 11 [(gnostic.openapi.v3.property).example = {yaml: "['9a517183f26a089d','5a4fe264a9c987fe']"}];
 }
 
 enum ProfileFormat {
+  // Equivalent to PROFILE_FORMAT_FLAMEGRAPH. Preserved for backward
+  // compatibility.
   PROFILE_FORMAT_UNSPECIFIED = 0;
+  // Return a Flamebearer-compatible, single-profile flame graph. Samples
+  // sharing the same function-name call stack are aggregated into the names
+  // and levels representation used by the Pyroscope flame graph renderer.
+  // Format: https://github.com/grafana/pyroscope/blob/main/pkg/og/structs/flamebearer/flamebearer.go
   PROFILE_FORMAT_FLAMEGRAPH = 1;
+  // Return a compact, function-name-only Pyroscope tree serialization in
+  // SelectMergeStacktracesResponse.tree.
   PROFILE_FORMAT_TREE = 2;
+  // Return a Graphviz DOT directed graph. Nodes represent functions and edges
+  // represent caller-callee relationships, annotated with aggregated sample
+  // values. The resulting text can be rendered by Graphviz-compatible tools.
   PROFILE_FORMAT_DOT = 3;
+  // Return a pprof profile, including available mappings, locations, filenames,
+  // and line numbers, in SelectMergeStacktracesResponse.pprof.
+  PROFILE_FORMAT_PPROF = 4;
 }
 
 message SelectMergeStacktracesResponse {
@@ -140,6 +162,13 @@ message SelectMergeStacktracesResponse {
   string dot = 3;
   // (experimental) Used for responding to async queries.
   optional AsyncQueryResponse async = 4;
+  // Profile in pprof format.
+  PprofProfile pprof = 5;
+}
+
+// PprofProfile contains pprof output and related response metadata.
+message PprofProfile {
+  google.v1.Profile profile = 1;
 }
 
 message AsyncQueryRequest {
@@ -199,6 +228,7 @@ message SelectMergeSpanProfileResponse {
 }
 
 message DiffRequest {
+  // The format of each request is ignored; diff queries always compare trees.
   SelectMergeStacktracesRequest left = 1;
   SelectMergeStacktracesRequest right = 2;
 }

--- a/cmd/profilecli/canary_exporter_probes.go
+++ b/cmd/profilecli/canary_exporter_probes.go
@@ -309,7 +309,7 @@ func (ce *canaryExporter) testIngestOTLPHttpProtobuf(ctx context.Context, now ti
 	return nil
 }
 func (ce *canaryExporter) testSelectMergeProfile(ctx context.Context, now time.Time) error {
-	respQuery, err := ce.params.queryClient().SelectMergeProfile(ctx, connect.NewRequest(&querierv1.SelectMergeProfileRequest{
+	respQuery, err := ce.params.queryClient().SelectMergeProfile(ctx, connect.NewRequest(&querierv1.SelectMergeProfileRequest{ //nolint:staticcheck // Legacy querier.v1 compatibility probe.
 		Start:         now.UnixMilli(),
 		End:           now.Add(5 * time.Second).UnixMilli(),
 		LabelSelector: ce.createLabelSelector(),
@@ -366,7 +366,7 @@ func (ce *canaryExporter) testSelectMergeOTLPProfile(ctx context.Context, now ti
 	// Query specifically for OTLP gRPC ingested profiles using the custom profile type
 	//labelSelector := fmt.Sprintf(`{service_name="%s", job="canary-exporter", instance="%s"}`, canaryExporterServiceName, ce.hostname)
 
-	respQuery, err := ce.params.queryClient().SelectMergeProfile(ctx, connect.NewRequest(&querierv1.SelectMergeProfileRequest{
+	respQuery, err := ce.params.queryClient().SelectMergeProfile(ctx, connect.NewRequest(&querierv1.SelectMergeProfileRequest{ //nolint:staticcheck // Legacy querier.v1 compatibility probe.
 		Start:         now.UnixMilli(),
 		End:           now.Add(5 * time.Second).UnixMilli(),
 		LabelSelector: ce.createLabelSelector(),
@@ -617,7 +617,7 @@ func (ce *canaryExporter) testSelectMergeStacktraces(ctx context.Context, now ti
 }
 
 func (ce *canaryExporter) testSelectMergeSpanProfile(ctx context.Context, now time.Time) error {
-	respQuery, err := ce.params.queryClient().SelectMergeSpanProfile(ctx, connect.NewRequest(&querierv1.SelectMergeSpanProfileRequest{
+	respQuery, err := ce.params.queryClient().SelectMergeSpanProfile(ctx, connect.NewRequest(&querierv1.SelectMergeSpanProfileRequest{ //nolint:staticcheck // Legacy querier.v1 compatibility probe.
 		Start:         now.UnixMilli(),
 		End:           now.Add(5 * time.Second).UnixMilli(),
 		LabelSelector: ce.createLabelSelector(),

--- a/cmd/profilecli/query.go
+++ b/cmd/profilecli/query.go
@@ -204,13 +204,13 @@ func queryProfile(ctx context.Context, params *queryProfileParams, outputFlag st
 }
 
 func querySpanProfile(ctx context.Context, params *queryProfileParams, from time.Time, to time.Time) (*googlev1.Profile, error) {
-	req := &querierv1.SelectMergeSpanProfileRequest{
+	req := &querierv1.SelectMergeStacktracesRequest{
 		ProfileTypeID: params.ProfileType,
 		Start:         from.UnixMilli(),
 		End:           to.UnixMilli(),
 		LabelSelector: params.Query,
 		SpanSelector:  params.SpanSelector,
-		Format:        querierv1.ProfileFormat_PROFILE_FORMAT_TREE,
+		Format:        querierv1.ProfileFormat_PROFILE_FORMAT_PPROF,
 	}
 
 	if params.MaxNodes > 0 {
@@ -218,32 +218,49 @@ func querySpanProfile(ctx context.Context, params *queryProfileParams, from time
 	}
 
 	qc := params.phlareClient.queryClient()
-	resp, err := qc.SelectMergeSpanProfile(ctx, connect.NewRequest(req))
+	resp, err := qc.SelectMergeStacktraces(ctx, connect.NewRequest(req))
 	if err != nil {
 		return nil, fmt.Errorf("failed to query span profile: %w", err)
 	}
 
 	logDiagnostics(params.phlareClient, resp.Header())
 
-	tree, err := model.UnmarshalTree[model.FunctionName, model.FunctionNameI](resp.Msg.Tree)
+	if resp.Msg.GetPprof().GetProfile() != nil {
+		return resp.Msg.Pprof.Profile, nil
+	}
+
+	legacyReq := &querierv1.SelectMergeSpanProfileRequest{
+		ProfileTypeID: req.ProfileTypeID,
+		LabelSelector: req.LabelSelector,
+		SpanSelector:  req.SpanSelector,
+		Start:         req.Start,
+		End:           req.End,
+		MaxNodes:      req.MaxNodes,
+		Format:        querierv1.ProfileFormat_PROFILE_FORMAT_TREE,
+	}
+	legacyResp, err := qc.SelectMergeSpanProfile(ctx, connect.NewRequest(legacyReq))
+	if err != nil {
+		return nil, fmt.Errorf("failed to query span profile using legacy API: %w", err)
+	}
+	logDiagnostics(params.phlareClient, legacyResp.Header())
+	tree, err := model.UnmarshalTree[model.FunctionName, model.FunctionNameI](legacyResp.Msg.Tree)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal tree: %w", err)
 	}
-
-	ty, err := model.ParseProfileTypeSelector(params.ProfileType)
+	profileType, err := model.ParseProfileTypeSelector(params.ProfileType)
 	if err != nil {
 		return nil, err
 	}
-
-	return pprof.FromTree(tree, ty, req.End*1e6), nil
+	return pprof.FromTree(tree, profileType, req.End*1e6), nil
 }
 
 func queryProfilePprof(ctx context.Context, params *queryProfileParams, from time.Time, to time.Time, locations []*typesv1.Location) (*googlev1.Profile, error) {
-	req := &querierv1.SelectMergeProfileRequest{
+	req := &querierv1.SelectMergeStacktracesRequest{
 		ProfileTypeID: params.ProfileType,
 		Start:         from.UnixMilli(),
 		End:           to.UnixMilli(),
 		LabelSelector: params.Query,
+		Format:        querierv1.ProfileFormat_PROFILE_FORMAT_PPROF,
 	}
 
 	if params.MaxNodes > 0 {
@@ -267,14 +284,13 @@ func queryProfilePprof(ctx context.Context, params *queryProfileParams, from tim
 
 	qc := params.phlareClient.queryClient()
 
-	resp, err := qc.SelectMergeProfile(ctx, connect.NewRequest(req))
+	profile, headers, err := queryPprofWithFallback(ctx, qc, req)
 	if err != nil {
 		return nil, err
 	}
 
-	logDiagnostics(params.phlareClient, resp.Header())
-
-	return resp.Msg, err
+	logDiagnostics(params.phlareClient, headers)
+	return profile, nil
 }
 
 func queryProfileTree(ctx context.Context, params *queryProfileParams, from time.Time, to time.Time, locations []*typesv1.Location) (*googlev1.Profile, error) {
@@ -326,16 +342,45 @@ func queryProfileTree(ctx context.Context, params *queryProfileParams, from time
 	return pprof.FromTree(tree, ty, req.End*1e6), nil
 }
 
-func selectMergeProfile(ctx context.Context, client *phlareClient, outputFlag string, force bool, req *querierv1.SelectMergeProfileRequest) error {
+func selectMergeProfile(ctx context.Context, client *phlareClient, outputFlag string, force bool, req *querierv1.SelectMergeStacktracesRequest) error {
+	req.Format = querierv1.ProfileFormat_PROFILE_FORMAT_PPROF
 	qc := client.queryClient()
-	resp, err := qc.SelectMergeProfile(ctx, connect.NewRequest(req))
+	profile, headers, err := queryPprofWithFallback(ctx, qc, req)
 	if err != nil {
 		return fmt.Errorf("failed to query: %w", err)
 	}
 
-	logDiagnostics(client, resp.Header())
+	logDiagnostics(client, headers)
+	return outputMergeProfile(ctx, outputFlag, force, profile)
+}
 
-	return outputMergeProfile(ctx, outputFlag, force, resp.Msg)
+func queryPprofWithFallback(
+	ctx context.Context,
+	client querierv1connect.QuerierServiceClient,
+	req *querierv1.SelectMergeStacktracesRequest,
+) (*googlev1.Profile, http.Header, error) {
+	resp, err := client.SelectMergeStacktraces(ctx, connect.NewRequest(req))
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.Msg.GetPprof().GetProfile() != nil {
+		return resp.Msg.Pprof.Profile, resp.Header(), nil
+	}
+
+	legacyResp, err := client.SelectMergeProfile(ctx, connect.NewRequest(&querierv1.SelectMergeProfileRequest{
+		ProfileTypeID:      req.ProfileTypeID,
+		LabelSelector:      req.LabelSelector,
+		Start:              req.Start,
+		End:                req.End,
+		MaxNodes:           req.MaxNodes,
+		StackTraceSelector: req.StackTraceSelector,
+		ProfileIdSelector:  req.ProfileIdSelector,
+		TraceIdSelector:    req.TraceIdSelector,
+	}))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to query profile using legacy API: %w", err)
+	}
+	return legacyResp.Msg, legacyResp.Header(), nil
 }
 
 func logDiagnostics(client *phlareClient, headers http.Header) {
@@ -389,7 +434,7 @@ func queryGoPGO(ctx context.Context, params *queryGoPGOParams, outputFlag string
 		},
 	}
 
-	req := &querierv1.SelectMergeProfileRequest{
+	req := &querierv1.SelectMergeStacktracesRequest{
 		ProfileTypeID:      params.ProfileType,
 		Start:              from.UnixMilli(),
 		End:                to.UnixMilli(),

--- a/cmd/profilecli/query_test.go
+++ b/cmd/profilecli/query_test.go
@@ -1,12 +1,43 @@
 package main
 
 import (
+	"context"
 	"testing"
 
+	"connectrpc.com/connect"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockquerierv1connect"
 )
+
+func TestQueryPprofWithFallback(t *testing.T) {
+	client := mockquerierv1connect.NewMockQuerierServiceClient(t)
+	req := &querierv1.SelectMergeStacktracesRequest{
+		ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+		LabelSelector: "{}",
+		Start:         1,
+		End:           2,
+		Format:        querierv1.ProfileFormat_PROFILE_FORMAT_PPROF,
+	}
+	client.On("SelectMergeStacktraces", mock.Anything, connect.NewRequest(req)).
+		Return(connect.NewResponse(&querierv1.SelectMergeStacktracesResponse{
+			Flamegraph: &querierv1.FlameGraph{},
+		}), nil).Once()
+	want := &profilev1.Profile{Sample: []*profilev1.Sample{{Value: []int64{1}}}}
+	client.On("SelectMergeProfile", mock.Anything, mock.MatchedBy(func(req *connect.Request[querierv1.SelectMergeProfileRequest]) bool {
+		return req.Msg.ProfileTypeID == "process_cpu:cpu:nanoseconds:cpu:nanoseconds" && req.Msg.Start == 1 && req.Msg.End == 2
+	})).Return(connect.NewResponse(want), nil).Once()
+
+	got, _, err := queryPprofWithFallback(context.Background(), client, req)
+
+	require.NoError(t, err)
+	require.Same(t, want, got)
+}
 
 func TestQueryProfileParams_ProfileIDValidation(t *testing.T) {
 	t.Parallel()

--- a/docs/sources/reference-server-api/index.md
+++ b/docs/sources/reference-server-api/index.md
@@ -125,11 +125,12 @@ A request body with the following fields is required:
 |`left.end` | Milliseconds since epoch. | `1676289600000` |
 |`left.async.requestId` | If set, this is a polling request. |  |
 |`left.async.type` | Sets the kind of async query.. Possible values: `ASYNC_QUERY_TYPE_DISABLED`, `ASYNC_QUERY_TYPE_FORCE` |  |
-|`left.format` | Profile format specifies the format of profile to be returned.  If not specified, the profile will be returned in flame graph format.. Possible values: `PROFILE_FORMAT_UNSPECIFIED`, `PROFILE_FORMAT_FLAMEGRAPH`, `PROFILE_FORMAT_TREE`, `PROFILE_FORMAT_DOT` |  |
+|`left.format` | Profile format specifies the format of profile to be returned.  If not specified, the profile will be returned in flame graph format.. Possible values: `PROFILE_FORMAT_UNSPECIFIED`, `PROFILE_FORMAT_FLAMEGRAPH`, `PROFILE_FORMAT_TREE`, `PROFILE_FORMAT_DOT`, `PROFILE_FORMAT_PPROF` |  |
 |`left.labelSelector` | Label selector string | `{namespace="my-namespace"}` |
 |`left.maxNodes` | Limit the nodes returned to only show the node with the max_node's biggest  total |  |
 |`left.profileIdSelector` | List of Profile UUIDs to query | `["7c9e6679-7425-40de-944b-e07fc1f90ae7"]` |
 |`left.profileTypeID` | Profile Type ID string in the form  <name>:<type>:<unit>:<period_type>:<period_unit>. | `process_cpu:cpu:nanoseconds:cpu:nanoseconds` |
+|`left.spanSelector` | List of span IDs (16 hex characters, 64-bit) to filter samples by. | `["9a517183f26a089d","5a4fe264a9c987fe"]` |
 |`left.stackTraceSelector.callSite[].name` |  |  |
 |`left.stackTraceSelector.goPgo.aggregateCallees` | Aggregate callees causes the leaf location line number to be ignored,  thus aggregating all callee samples (but not callers). |  |
 |`left.stackTraceSelector.goPgo.keepLocations` | Specifies the number of leaf locations to keep. |  |
@@ -138,11 +139,12 @@ A request body with the following fields is required:
 |`right.end` | Milliseconds since epoch. | `1676289600000` |
 |`right.async.requestId` | If set, this is a polling request. |  |
 |`right.async.type` | Sets the kind of async query.. Possible values: `ASYNC_QUERY_TYPE_DISABLED`, `ASYNC_QUERY_TYPE_FORCE` |  |
-|`right.format` | Profile format specifies the format of profile to be returned.  If not specified, the profile will be returned in flame graph format.. Possible values: `PROFILE_FORMAT_UNSPECIFIED`, `PROFILE_FORMAT_FLAMEGRAPH`, `PROFILE_FORMAT_TREE`, `PROFILE_FORMAT_DOT` |  |
+|`right.format` | Profile format specifies the format of profile to be returned.  If not specified, the profile will be returned in flame graph format.. Possible values: `PROFILE_FORMAT_UNSPECIFIED`, `PROFILE_FORMAT_FLAMEGRAPH`, `PROFILE_FORMAT_TREE`, `PROFILE_FORMAT_DOT`, `PROFILE_FORMAT_PPROF` |  |
 |`right.labelSelector` | Label selector string | `{namespace="my-namespace"}` |
 |`right.maxNodes` | Limit the nodes returned to only show the node with the max_node's biggest  total |  |
 |`right.profileIdSelector` | List of Profile UUIDs to query | `["7c9e6679-7425-40de-944b-e07fc1f90ae7"]` |
 |`right.profileTypeID` | Profile Type ID string in the form  <name>:<type>:<unit>:<period_type>:<period_unit>. | `process_cpu:cpu:nanoseconds:cpu:nanoseconds` |
+|`right.spanSelector` | List of span IDs (16 hex characters, 64-bit) to filter samples by. | `["9a517183f26a089d","5a4fe264a9c987fe"]` |
 |`right.stackTraceSelector.callSite[].name` |  |  |
 |`right.stackTraceSelector.goPgo.aggregateCallees` | Aggregate callees causes the leaf location line number to be ignored,  thus aggregating all callee samples (but not callers). |  |
 |`right.stackTraceSelector.goPgo.keepLocations` | Specifies the number of leaf locations to keep. |  |
@@ -160,6 +162,10 @@ curl \
           "7c9e6679-7425-40de-944b-e07fc1f90ae7"
         ],
         "profileTypeID": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+        "spanSelector": [
+          "9a517183f26a089d",
+          "5a4fe264a9c987fe"
+        ],
         "start": '$(expr $(date +%s) - 3600 )000',
         "traceIdSelector": [
           "7c9e66797425440de944be07fc1f90ae"
@@ -172,6 +178,10 @@ curl \
           "7c9e6679-7425-40de-944b-e07fc1f90ae7"
         ],
         "profileTypeID": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+        "spanSelector": [
+          "9a517183f26a089d",
+          "5a4fe264a9c987fe"
+        ],
         "start": '$(expr $(date +%s) - 3600 )000',
         "traceIdSelector": [
           "7c9e66797425440de944be07fc1f90ae"
@@ -192,6 +202,10 @@ body = {
         "7c9e6679-7425-40de-944b-e07fc1f90ae7"
       ],
       "profileTypeID": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+      "spanSelector": [
+        "9a517183f26a089d",
+        "5a4fe264a9c987fe"
+      ],
       "start": int((datetime.datetime.now()- datetime.timedelta(hours = 1)).timestamp() * 1000),
       "traceIdSelector": [
         "7c9e66797425440de944be07fc1f90ae"
@@ -204,6 +218,10 @@ body = {
         "7c9e6679-7425-40de-944b-e07fc1f90ae7"
       ],
       "profileTypeID": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+      "spanSelector": [
+        "9a517183f26a089d",
+        "5a4fe264a9c987fe"
+      ],
       "start": int((datetime.datetime.now()- datetime.timedelta(hours = 1)).timestamp() * 1000),
       "traceIdSelector": [
         "7c9e66797425440de944be07fc1f90ae"
@@ -390,7 +408,10 @@ print(resp.content)
 {{< /code >}}
 #### `/querier.v1.QuerierService/SelectMergeProfile`
 
-SelectMergeProfile returns matching profiles aggregated in pprof format. It
+Deprecated: Use SelectMergeStacktraces with PROFILE_FORMAT_PPROF instead.
+ This RPC will remain supported in querier.v1 for backward compatibility;
+ future breaking API changes may be introduced in querier.v2.
+ SelectMergeProfile returns matching profiles aggregated in pprof format. It
  will contain all information stored (so including filenames and line
  number, if ingested).
 
@@ -452,7 +473,10 @@ print(resp.content)
 {{< /code >}}
 #### `/querier.v1.QuerierService/SelectMergeSpanProfile`
 
-SelectMergeSpanProfile returns matching profiles aggregated in a flamegraph
+Deprecated: Use SelectMergeStacktraces with span_selector instead.
+ This RPC will remain supported in querier.v1 for backward compatibility;
+ future breaking API changes may be introduced in querier.v2.
+ SelectMergeSpanProfile returns matching profiles aggregated in a flamegraph
  format. It will combine samples from within the same callstack, with each
  element being grouped by its function name.
 
@@ -462,7 +486,7 @@ A request body with the following fields is required:
 |:-----|:------------|:--------|
 |`start` | Milliseconds since epoch. | `1676282400000` |
 |`end` | Milliseconds since epoch. | `1676289600000` |
-|`format` | Profile format specifies the format of profile to be returned.  If not specified, the profile will be returned in flame graph format.. Possible values: `PROFILE_FORMAT_UNSPECIFIED`, `PROFILE_FORMAT_FLAMEGRAPH`, `PROFILE_FORMAT_TREE`, `PROFILE_FORMAT_DOT` |  |
+|`format` | Profile format specifies the format of profile to be returned.  If not specified, the profile will be returned in flame graph format.. Possible values: `PROFILE_FORMAT_UNSPECIFIED`, `PROFILE_FORMAT_FLAMEGRAPH`, `PROFILE_FORMAT_TREE`, `PROFILE_FORMAT_DOT`, `PROFILE_FORMAT_PPROF` |  |
 |`labelSelector` | Label selector string | `{namespace="my-namespace"}` |
 |`maxNodes` | Limit the nodes returned to only show the node with the max_node's biggest  total |  |
 |`profileTypeID` | Profile Type ID string in the form  <name>:<type>:<unit>:<period_type>:<period_unit>. | `process_cpu:cpu:nanoseconds:cpu:nanoseconds` |
@@ -519,11 +543,12 @@ A request body with the following fields is required:
 |`end` | Milliseconds since epoch. | `1676289600000` |
 |`async.requestId` | If set, this is a polling request. |  |
 |`async.type` | Sets the kind of async query.. Possible values: `ASYNC_QUERY_TYPE_DISABLED`, `ASYNC_QUERY_TYPE_FORCE` |  |
-|`format` | Profile format specifies the format of profile to be returned.  If not specified, the profile will be returned in flame graph format.. Possible values: `PROFILE_FORMAT_UNSPECIFIED`, `PROFILE_FORMAT_FLAMEGRAPH`, `PROFILE_FORMAT_TREE`, `PROFILE_FORMAT_DOT` |  |
+|`format` | Profile format specifies the format of profile to be returned.  If not specified, the profile will be returned in flame graph format.. Possible values: `PROFILE_FORMAT_UNSPECIFIED`, `PROFILE_FORMAT_FLAMEGRAPH`, `PROFILE_FORMAT_TREE`, `PROFILE_FORMAT_DOT`, `PROFILE_FORMAT_PPROF` |  |
 |`labelSelector` | Label selector string | `{namespace="my-namespace"}` |
 |`maxNodes` | Limit the nodes returned to only show the node with the max_node's biggest  total |  |
 |`profileIdSelector` | List of Profile UUIDs to query | `["7c9e6679-7425-40de-944b-e07fc1f90ae7"]` |
 |`profileTypeID` | Profile Type ID string in the form  <name>:<type>:<unit>:<period_type>:<period_unit>. | `process_cpu:cpu:nanoseconds:cpu:nanoseconds` |
+|`spanSelector` | List of span IDs (16 hex characters, 64-bit) to filter samples by. | `["9a517183f26a089d","5a4fe264a9c987fe"]` |
 |`stackTraceSelector.callSite[].name` |  |  |
 |`stackTraceSelector.goPgo.aggregateCallees` | Aggregate callees causes the leaf location line number to be ignored,  thus aggregating all callee samples (but not callers). |  |
 |`stackTraceSelector.goPgo.keepLocations` | Specifies the number of leaf locations to keep. |  |
@@ -540,6 +565,10 @@ curl \
         "7c9e6679-7425-40de-944b-e07fc1f90ae7"
       ],
       "profileTypeID": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+      "spanSelector": [
+        "9a517183f26a089d",
+        "5a4fe264a9c987fe"
+      ],
       "start": '$(expr $(date +%s) - 3600 )000',
       "traceIdSelector": [
         "7c9e66797425440de944be07fc1f90ae"
@@ -558,6 +587,10 @@ body = {
       "7c9e6679-7425-40de-944b-e07fc1f90ae7"
     ],
     "profileTypeID": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+    "spanSelector": [
+      "9a517183f26a089d",
+      "5a4fe264a9c987fe"
+    ],
     "start": int((datetime.datetime.now()- datetime.timedelta(hours = 1)).timestamp() * 1000),
     "traceIdSelector": [
       "7c9e66797425440de944be07fc1f90ae"

--- a/pkg/frontend/async/handler.go
+++ b/pkg/frontend/async/handler.go
@@ -124,6 +124,7 @@ func (h *Handler) poll(
 			resp.Flamegraph = result.Response.Flamegraph
 			resp.Tree = result.Response.Tree
 			resp.Dot = result.Response.Dot
+			resp.Pprof = result.Response.Pprof
 		}
 	case StatusFailure:
 		resp.Async.Status = querierv1.AsyncQueryStatus_ASYNC_QUERY_STATUS_FAILURE

--- a/pkg/frontend/async/handler_test.go
+++ b/pkg/frontend/async/handler_test.go
@@ -1,0 +1,35 @@
+package async
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+	"google.golang.org/protobuf/proto"
+
+	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+)
+
+func TestHandlerPollCopiesPprofResponse(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket())
+	const (
+		tenantID  = "tenant-a"
+		requestID = "550e8400-e29b-41d4-a716-446655440000"
+	)
+	require.NoError(t, store.create(ctx, tenantID, requestID))
+	want := &profilev1.Profile{Sample: []*profilev1.Sample{{Value: []int64{1}}}}
+	require.NoError(t, store.complete(ctx, tenantID, requestID, &querierv1.SelectMergeStacktracesResponse{
+		Pprof: &querierv1.PprofProfile{Profile: want},
+	}))
+
+	handler := &Handler{coordinator: &Coordinator{store: store}}
+	resp, err := handler.poll(ctx, tenantID, requestID)
+
+	require.NoError(t, err)
+	require.Equal(t, querierv1.AsyncQueryStatus_ASYNC_QUERY_STATUS_SUCCESS, resp.Msg.GetAsync().GetStatus())
+	require.True(t, proto.Equal(want, resp.Msg.GetPprof().GetProfile()))
+}

--- a/pkg/frontend/frontend_diff_test.go
+++ b/pkg/frontend/frontend_diff_test.go
@@ -3,6 +3,7 @@ package frontend
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -159,4 +160,44 @@ func Test_Frontend_Diff(t *testing.T) {
 		)
 	})
 
+	t.Run("span-filtered diff", func(t *testing.T) {
+		leftSpan := []string{"0000000000000001"}
+		rightSpan := []string{"0000000000000002"}
+		frontend.GRPCRoundTripper = &mockRoundTripper{callback: func(ctx context.Context, req *httpgrpc.HTTPRequest) (*httpgrpc.HTTPResponse, error) {
+			return connectgrpc.HandleUnary[querierv1.SelectMergeSpanProfileRequest, querierv1.SelectMergeSpanProfileResponse](ctx, req, func(_ context.Context, req *connect.Request[querierv1.SelectMergeSpanProfileRequest]) (*connect.Response[querierv1.SelectMergeSpanProfileResponse], error) {
+				want := rightSpan
+				if req.Msg.Start == now {
+					want = leftSpan
+				}
+				if !slices.Equal(req.Msg.SpanSelector, want) {
+					return nil, errors.New("unexpected span selector")
+				}
+				tree := new(model.FunctionNameTree)
+				tree.InsertStack(1, "foo")
+				return connect.NewResponse(&querierv1.SelectMergeSpanProfileResponse{Tree: tree.Bytes(-1, nil)}), nil
+			})
+		}}
+
+		resp, err := frontend.Diff(ctx, connect.NewRequest(&querierv1.DiffRequest{
+			Left: &querierv1.SelectMergeStacktracesRequest{
+				ProfileTypeID: profileType,
+				LabelSelector: "{}",
+				Start:         now,
+				End:           now + 1000,
+				Format:        querierv1.ProfileFormat_PROFILE_FORMAT_PPROF,
+				SpanSelector:  leftSpan,
+			},
+			Right: &querierv1.SelectMergeStacktracesRequest{
+				ProfileTypeID: profileType,
+				LabelSelector: "{}",
+				Start:         now + 2000,
+				End:           now + 3000,
+				Format:        querierv1.ProfileFormat_PROFILE_FORMAT_DOT,
+				SpanSelector:  rightSpan,
+			},
+		}))
+
+		require.NoError(t, err)
+		require.NotNil(t, resp.Msg.Flamegraph)
+	})
 }

--- a/pkg/frontend/frontend_select_merge_stacktraces.go
+++ b/pkg/frontend/frontend_select_merge_stacktraces.go
@@ -13,6 +13,7 @@ import (
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	"github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect"
 	phlaremodel "github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/pprof"
 	"github.com/grafana/pyroscope/v2/pkg/util/connectgrpc"
 	validationutil "github.com/grafana/pyroscope/v2/pkg/util/validation"
 	"github.com/grafana/pyroscope/v2/pkg/validation"
@@ -28,6 +29,12 @@ func (f *Frontend) SelectMergeStacktraces(
 	// trace_id_selector is v2-only; this legacy frontend would drop it on split.
 	if len(c.Msg.TraceIdSelector) > 0 {
 		return nil, connect.NewError(connect.CodeUnimplemented, errors.New("trace_id_selector is only supported with the v2 query backend"))
+	}
+	if len(c.Msg.SpanSelector) > 0 && (c.Msg.StackTraceSelector != nil || len(c.Msg.ProfileIdSelector) > 0) {
+		return nil, connect.NewError(connect.CodeUnimplemented, errors.New("combining span_selector with stack_trace_selector or profile_id_selector is only supported with the v2 query backend"))
+	}
+	if c.Msg.Format == querierv1.ProfileFormat_PROFILE_FORMAT_PPROF {
+		return f.selectMergeStacktracesPprof(ctx, c)
 	}
 	t, err := f.selectMergeStacktracesTree(ctx, c)
 	if err != nil {
@@ -47,6 +54,22 @@ func (f *Frontend) selectMergeStacktracesTree(
 	ctx context.Context,
 	c *connect.Request[querierv1.SelectMergeStacktracesRequest],
 ) (*phlaremodel.FunctionNameTree, error) {
+	if len(c.Msg.SpanSelector) > 0 {
+		resp, err := f.SelectMergeSpanProfile(ctx, connect.NewRequest(&querierv1.SelectMergeSpanProfileRequest{
+			ProfileTypeID: c.Msg.ProfileTypeID,
+			LabelSelector: c.Msg.LabelSelector,
+			SpanSelector:  c.Msg.SpanSelector,
+			Start:         c.Msg.Start,
+			End:           c.Msg.End,
+			MaxNodes:      c.Msg.MaxNodes,
+			Format:        querierv1.ProfileFormat_PROFILE_FORMAT_TREE,
+		}))
+		if err != nil {
+			return nil, err
+		}
+		return phlaremodel.UnmarshalTree[phlaremodel.FunctionName, phlaremodel.FunctionNameI](resp.Msg.Tree)
+	}
+
 	ctx = connectgrpc.WithProcedure(ctx, querierv1connect.QuerierServiceSelectMergeStacktracesProcedure)
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
@@ -106,4 +129,40 @@ func (f *Frontend) selectMergeStacktracesTree(
 	}
 
 	return m.Tree(), nil
+}
+
+func (f *Frontend) selectMergeStacktracesPprof(
+	ctx context.Context,
+	c *connect.Request[querierv1.SelectMergeStacktracesRequest],
+) (*connect.Response[querierv1.SelectMergeStacktracesResponse], error) {
+	if len(c.Msg.SpanSelector) == 0 {
+		resp, err := f.SelectMergeProfile(ctx, connect.NewRequest(&querierv1.SelectMergeProfileRequest{
+			ProfileTypeID:      c.Msg.ProfileTypeID,
+			LabelSelector:      c.Msg.LabelSelector,
+			Start:              c.Msg.Start,
+			End:                c.Msg.End,
+			MaxNodes:           c.Msg.MaxNodes,
+			StackTraceSelector: c.Msg.StackTraceSelector,
+			ProfileIdSelector:  c.Msg.ProfileIdSelector,
+			TraceIdSelector:    c.Msg.TraceIdSelector,
+		}))
+		if err != nil {
+			return nil, err
+		}
+		return connect.NewResponse(&querierv1.SelectMergeStacktracesResponse{
+			Pprof: &querierv1.PprofProfile{Profile: resp.Msg},
+		}), nil
+	}
+
+	tree, err := f.selectMergeStacktracesTree(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	profileType, err := phlaremodel.ParseProfileTypeSelector(c.Msg.ProfileTypeID)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	return connect.NewResponse(&querierv1.SelectMergeStacktracesResponse{
+		Pprof: &querierv1.PprofProfile{Profile: pprof.FromTree(tree, profileType, c.Msg.End*1e6)},
+	}), nil
 }

--- a/pkg/frontend/frontend_select_merge_stacktraces_test.go
+++ b/pkg/frontend/frontend_select_merge_stacktraces_test.go
@@ -1,0 +1,56 @@
+package frontend
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/grafana/dskit/user"
+	"github.com/stretchr/testify/require"
+
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockfrontend"
+	"github.com/grafana/pyroscope/v2/pkg/util/connectgrpc"
+	"github.com/grafana/pyroscope/v2/pkg/util/httpgrpc"
+)
+
+func TestFrontend_SelectMergeStacktraces_SpanPprofUsesLegacySpanRPC(t *testing.T) {
+	limits := mockfrontend.NewMockLimits(t)
+	limits.On("MaxFlameGraphNodesDefault", "test").Return(10_000)
+	limits.On("MaxQueryLookback", "test").Return(time.Duration(0))
+	limits.On("MaxQueryLength", "test").Return(time.Duration(0))
+	limits.On("MaxQueryParallelism", "test").Return(100)
+	limits.On("QuerySplitDuration", "test").Return(time.Hour)
+
+	spanSelector := []string{"0000000000000001"}
+	frontend := &Frontend{limits: limits}
+	frontend.GRPCRoundTripper = &mockRoundTripper{callback: func(ctx context.Context, req *httpgrpc.HTTPRequest) (*httpgrpc.HTTPResponse, error) {
+		return connectgrpc.HandleUnary[querierv1.SelectMergeSpanProfileRequest, querierv1.SelectMergeSpanProfileResponse](ctx, req, func(_ context.Context, req *connect.Request[querierv1.SelectMergeSpanProfileRequest]) (*connect.Response[querierv1.SelectMergeSpanProfileResponse], error) {
+			if !slices.Equal(spanSelector, req.Msg.SpanSelector) {
+				return nil, errors.New("unexpected span selector")
+			}
+			tree := new(model.FunctionNameTree)
+			tree.InsertStack(1, "foo")
+			return connect.NewResponse(&querierv1.SelectMergeSpanProfileResponse{Tree: tree.Bytes(-1, nil)}), nil
+		})
+	}}
+
+	ctx := user.InjectOrgID(context.Background(), "test")
+	now := time.Now()
+	resp, err := frontend.SelectMergeStacktraces(ctx, connect.NewRequest(&querierv1.SelectMergeStacktracesRequest{
+		ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+		LabelSelector: "{}",
+		Start:         now.UnixMilli(),
+		End:           now.Add(time.Minute).UnixMilli(),
+		Format:        querierv1.ProfileFormat_PROFILE_FORMAT_PPROF,
+		SpanSelector:  spanSelector,
+	}))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp.Msg.GetPprof().GetProfile())
+	require.Len(t, resp.Msg.Pprof.Profile.Sample, 1)
+}

--- a/pkg/frontend/readpath/query_service_handler.go
+++ b/pkg/frontend/readpath/query_service_handler.go
@@ -2,6 +2,7 @@ package readpath
 
 import (
 	"context"
+	"errors"
 	"slices"
 
 	"connectrpc.com/connect"
@@ -64,6 +65,31 @@ func (r *Router) SelectMergeStacktraces(
 	ctx context.Context,
 	c *connect.Request[querierv1.SelectMergeStacktracesRequest],
 ) (*connect.Response[querierv1.SelectMergeStacktracesResponse], error) {
+	if c.Msg.Format == querierv1.ProfileFormat_PROFILE_FORMAT_PPROF {
+		return Query[querierv1.SelectMergeStacktracesRequest, querierv1.SelectMergeStacktracesResponse](ctx, r, c,
+			func(_, _ *querierv1.SelectMergeStacktracesRequest) {},
+			func(a, b *querierv1.SelectMergeStacktracesResponse) (*querierv1.SelectMergeStacktracesResponse, error) {
+				var m pprof.ProfileMerge
+				left := a.GetPprof().GetProfile()
+				if left == nil {
+					return nil, connect.NewError(connect.CodeInternal, errors.New("old read path returned no pprof profile"))
+				}
+				right := b.GetPprof().GetProfile()
+				if right == nil {
+					return nil, connect.NewError(connect.CodeInternal, errors.New("new read path returned no pprof profile"))
+				}
+				if err := m.Merge(left, false); err != nil {
+					return nil, err
+				}
+				if err := m.Merge(right, false); err != nil {
+					return nil, err
+				}
+				return &querierv1.SelectMergeStacktracesResponse{
+					Pprof: &querierv1.PprofProfile{Profile: m.Profile()},
+				}, nil
+			})
+	}
+
 	// We always query data in the tree format and
 	// return it in the format requested by the client.
 	f := c.Msg.Format
@@ -190,6 +216,12 @@ func (r *Router) Diff(
 	g, ctx := errgroup.WithContext(ctx)
 	getTree := func(dst *phlaremodel.FunctionNameTree, req *querierv1.SelectMergeStacktracesRequest) func() error {
 		return func() error {
+			if req == nil {
+				req = &querierv1.SelectMergeStacktracesRequest{}
+			} else {
+				req = req.CloneVT()
+			}
+			req.Format = querierv1.ProfileFormat_PROFILE_FORMAT_TREE
 			resp, err := r.SelectMergeStacktraces(ctx, connect.NewRequest(req))
 			if err != nil {
 				return err

--- a/pkg/frontend/readpath/queryfrontend/diagnostics/client_wrapper.go
+++ b/pkg/frontend/readpath/queryfrontend/diagnostics/client_wrapper.go
@@ -115,7 +115,7 @@ func (w *Wrapper) SelectMergeStacktraces(ctx context.Context, req *connect.Reque
 }
 
 func (w *Wrapper) SelectMergeSpanProfile(ctx context.Context, req *connect.Request[querierv1.SelectMergeSpanProfileRequest]) (*connect.Response[querierv1.SelectMergeSpanProfileResponse], error) {
-	resp, err := w.client.SelectMergeSpanProfile(ctx, req)
+	resp, err := w.client.SelectMergeSpanProfile(ctx, req) //nolint:staticcheck // Required querier.v1 compatibility wrapper.
 	if resp != nil {
 		flushDiagnostics(w, ctx, "SelectMergeSpanProfile", req, resp)
 	}
@@ -123,7 +123,7 @@ func (w *Wrapper) SelectMergeSpanProfile(ctx context.Context, req *connect.Reque
 }
 
 func (w *Wrapper) SelectMergeProfile(ctx context.Context, req *connect.Request[querierv1.SelectMergeProfileRequest]) (*connect.Response[profilev1.Profile], error) {
-	resp, err := w.client.SelectMergeProfile(ctx, req)
+	resp, err := w.client.SelectMergeProfile(ctx, req) //nolint:staticcheck // Required querier.v1 compatibility wrapper.
 	if resp != nil {
 		flushDiagnostics(w, ctx, "SelectMergeProfile", req, resp)
 	}

--- a/pkg/frontend/readpath/queryfrontend/query_diff_test.go
+++ b/pkg/frontend/readpath/queryfrontend/query_diff_test.go
@@ -1,0 +1,86 @@
+package queryfrontend
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+	phlaremodel "github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/tenant"
+	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockfrontend"
+	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockmetastorev1"
+	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockqueryfrontend"
+)
+
+func TestDiff_ForwardsSpanSelectors(t *testing.T) {
+	leftSpan := []string{"0000000000000001"}
+	rightSpan := []string{"0000000000000002"}
+	tree := new(phlaremodel.FunctionNameTree)
+	tree.InsertStack(1, "foo")
+	treeBytes := tree.Bytes(-1, nil)
+
+	mockLimits := mockfrontend.NewMockLimits(t)
+	mockLimits.On("MaxQueryLookback", smpTenant).Return(time.Duration(0))
+	mockLimits.On("MaxQueryLength", smpTenant).Return(time.Duration(0))
+	mockLimits.On("MaxFlameGraphNodesDefault", smpTenant).Return(0)
+	mockLimits.On("QuerySanitizeOnMerge", smpTenant).Return(false)
+
+	mockMetadata := new(mockmetastorev1.MockMetadataQueryServiceClient)
+	mockMetadata.On("QueryMetadata", mock.Anything, mock.Anything).Return(smpOneBlock(), nil)
+
+	observed := make(map[string][]string)
+	var observedMu sync.Mutex
+	mockBackend := mockqueryfrontend.NewMockQueryBackend(t)
+	mockBackend.On("Invoke", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			req := args.Get(1).(*queryv1.InvokeRequest)
+			side := "right"
+			if strings.Contains(req.LabelSelector, `side="left"`) {
+				side = "left"
+			}
+			observedMu.Lock()
+			observed[side] = req.Query[0].Tree.GetSpanSelector()
+			observedMu.Unlock()
+		}).
+		Return(func(context.Context, *queryv1.InvokeRequest) *queryv1.InvokeResponse {
+			return &queryv1.InvokeResponse{Reports: []*queryv1.Report{{
+				ReportType: queryv1.ReportType_REPORT_TREE,
+				Tree:       &queryv1.TreeReport{Tree: treeBytes},
+			}}}
+		}, nil)
+
+	qf := newSMPQueryFrontend(t, mockLimits, mockMetadata, mockBackend)
+	ctx := tenant.InjectTenantID(context.Background(), smpTenant)
+	start, end := smpValidTimeRange()
+	resp, err := qf.Diff(ctx, connect.NewRequest(&querierv1.DiffRequest{
+		Left: &querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: smpProfileType,
+			LabelSelector: `{side="left"}`,
+			Start:         start,
+			End:           end,
+			Format:        querierv1.ProfileFormat_PROFILE_FORMAT_PPROF,
+			SpanSelector:  leftSpan,
+		},
+		Right: &querierv1.SelectMergeStacktracesRequest{
+			ProfileTypeID: smpProfileType,
+			LabelSelector: `{side="right"}`,
+			Start:         start,
+			End:           end,
+			Format:        querierv1.ProfileFormat_PROFILE_FORMAT_DOT,
+			SpanSelector:  rightSpan,
+		},
+	}))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp.Msg.Flamegraph)
+	require.Equal(t, leftSpan, observed["left"])
+	require.Equal(t, rightSpan, observed["right"])
+}

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_profile.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_profile.go
@@ -22,19 +22,39 @@ func (q *QueryFrontend) SelectMergeProfile(
 	ctx context.Context,
 	c *connect.Request[querierv1.SelectMergeProfileRequest],
 ) (*connect.Response[profilev1.Profile], error) {
+	p, err := q.selectMergeStacktracesPprof(ctx, &querierv1.SelectMergeStacktracesRequest{
+		ProfileTypeID:      c.Msg.ProfileTypeID,
+		LabelSelector:      c.Msg.LabelSelector,
+		Start:              c.Msg.Start,
+		End:                c.Msg.End,
+		MaxNodes:           c.Msg.MaxNodes,
+		StackTraceSelector: c.Msg.StackTraceSelector,
+		ProfileIdSelector:  c.Msg.ProfileIdSelector,
+		TraceIdSelector:    c.Msg.TraceIdSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(p), nil
+}
+
+func (q *QueryFrontend) selectMergeStacktracesPprof(
+	ctx context.Context,
+	req *querierv1.SelectMergeStacktracesRequest,
+) (*profilev1.Profile, error) {
 	tenantIDs, err := tenant.TenantIDs(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
-	empty, err := validation.SanitizeTimeRange(q.limits, tenantIDs, &c.Msg.Start, &c.Msg.End)
+	empty, err := validation.SanitizeTimeRange(q.limits, tenantIDs, &req.Start, &req.End)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	if empty {
-		return connect.NewResponse(&profilev1.Profile{}), nil
+		return &profilev1.Profile{}, nil
 	}
 
-	profileType, err := phlaremodel.ParseProfileTypeSelector(c.Msg.ProfileTypeID)
+	profileType, err := phlaremodel.ParseProfileTypeSelector(req.ProfileTypeID)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
@@ -49,15 +69,15 @@ func (q *QueryFrontend) SelectMergeProfile(
 		}
 	}
 
-	maxNodes := c.Msg.GetMaxNodes()
+	maxNodes := req.GetMaxNodes()
 	if maxNodesEnabled {
-		maxNodes, err = validation.ValidateMaxNodes(q.limits, tenantIDs, c.Msg.GetMaxNodes())
+		maxNodes, err = validation.ValidateMaxNodes(q.limits, tenantIDs, req.GetMaxNodes())
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInvalidArgument, err)
 		}
 	}
 
-	labelSelector, err := buildLabelSelectorWithProfileType(c.Msg.LabelSelector, c.Msg.ProfileTypeID)
+	labelSelector, err := buildLabelSelectorWithProfileType(req.LabelSelector, req.ProfileTypeID)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
@@ -65,7 +85,7 @@ func (q *QueryFrontend) SelectMergeProfile(
 	// TODO: Remove this path and answer all queries using the tree
 	// PGO queries always use the pprof path, as query tree doesn't support the truncation
 	useQueryTree := false
-	if c.Msg.StackTraceSelector.GetGoPgo() == nil {
+	if req.StackTraceSelector.GetGoPgo() == nil {
 		for _, tenantID := range tenantIDs {
 			if q.limits.QueryTreeEnabled(tenantID) {
 				useQueryTree = true
@@ -79,16 +99,17 @@ func (q *QueryFrontend) SelectMergeProfile(
 		shouldSymbolize := false
 		report, err := q.querySingle(ctx,
 			&queryv1.QueryRequest{
-				StartTime:     c.Msg.Start,
-				EndTime:       c.Msg.End,
+				StartTime:     req.Start,
+				EndTime:       req.End,
 				LabelSelector: labelSelector,
 				Query: []*queryv1.Query{{
 					QueryType: queryv1.QueryType_QUERY_PPROF,
 					Pprof: &queryv1.PprofQuery{
 						MaxNodes:           maxNodes,
-						StackTraceSelector: c.Msg.StackTraceSelector,
-						ProfileIdSelector:  c.Msg.ProfileIdSelector,
-						TraceIdSelector:    c.Msg.TraceIdSelector,
+						StackTraceSelector: req.StackTraceSelector,
+						ProfileIdSelector:  req.ProfileIdSelector,
+						TraceIdSelector:    req.TraceIdSelector,
+						SpanSelector:       req.SpanSelector,
 					},
 				}},
 			},
@@ -102,7 +123,7 @@ func (q *QueryFrontend) SelectMergeProfile(
 			return nil, err
 		}
 		if report == nil {
-			return connect.NewResponse(&profilev1.Profile{}), nil
+			return &profilev1.Profile{}, nil
 		}
 		var p profilev1.Profile
 		if err = pprof.Unmarshal(report.Pprof.Pprof, &p); err != nil {
@@ -113,21 +134,21 @@ func (q *QueryFrontend) SelectMergeProfile(
 				return nil, fmt.Errorf("failed to symbolize profile: %w", err)
 			}
 		}
-		return connect.NewResponse(&p), nil
+		return &p, nil
 	}
 
 	// From now on answer using the more experimental tree based approach
-	return q.selectMergeProfileTree(ctx, c.Msg, labelSelector, maxNodes, profileType, tenantIDs)
+	return q.selectMergeProfileTree(ctx, req, labelSelector, maxNodes, profileType, tenantIDs)
 }
 
 func (q *QueryFrontend) selectMergeProfileTree(
 	ctx context.Context,
-	req *querierv1.SelectMergeProfileRequest,
+	req *querierv1.SelectMergeStacktracesRequest,
 	labelSelector string,
 	maxNodes int64,
 	profileType *typesv1.ProfileType,
 	tenantIDs []string,
-) (*connect.Response[profilev1.Profile], error) {
+) (*profilev1.Profile, error) {
 	level.Info(q.logger).Log("msg", "use tree query-backend based query")
 	shouldSymbolize := false
 	report, err := q.querySingle(ctx,
@@ -142,6 +163,7 @@ func (q *QueryFrontend) selectMergeProfileTree(
 					StackTraceSelector: req.StackTraceSelector,
 					ProfileIdSelector:  req.ProfileIdSelector,
 					TraceIdSelector:    req.TraceIdSelector,
+					SpanSelector:       req.SpanSelector,
 					FullSymbols:        true,
 				},
 			}},
@@ -156,7 +178,7 @@ func (q *QueryFrontend) selectMergeProfileTree(
 		return nil, err
 	}
 	if report == nil {
-		return connect.NewResponse(&profilev1.Profile{}), nil
+		return &profilev1.Profile{}, nil
 	}
 
 	var p profilev1.Profile
@@ -239,5 +261,5 @@ func (q *QueryFrontend) selectMergeProfileTree(
 		}
 	}
 
-	return connect.NewResponse(&p), nil
+	return &p, nil
 }

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_profile_test.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_profile_test.go
@@ -336,8 +336,9 @@ func TestSelectMergeProfile_TreePath_ReconstructsProfile(t *testing.T) {
 	require.NotNil(t, resp.Msg.PeriodType)
 }
 
-func TestSelectMergeProfile_TreePath_SendsQueryTreeWithFullSymbols(t *testing.T) {
-	// Ensure the tree path sends QUERY_TREE with FullSymbols=true to the backend.
+func TestSelectMergeStacktraces_PprofTreePathForwardsSpanSelector(t *testing.T) {
+	// Ensure the tree-backed pprof path requests full symbols and forwards spans.
+	spanSelector := []string{"0000000000000001"}
 	mockLimits := mockfrontend.NewMockLimits(t)
 	mockLimits.On("MaxQueryLookback", smpTenant).Return(time.Duration(0))
 	mockLimits.On("MaxQueryLength", smpTenant).Return(time.Duration(0))
@@ -379,17 +380,21 @@ func TestSelectMergeProfile_TreePath_SendsQueryTreeWithFullSymbols(t *testing.T)
 	ctx := user.InjectOrgID(context.Background(), smpTenant)
 	start, end := smpValidTimeRange()
 
-	_, err := qf.SelectMergeProfile(ctx, connect.NewRequest(&querierv1.SelectMergeProfileRequest{
+	resp, err := qf.SelectMergeStacktraces(ctx, connect.NewRequest(&querierv1.SelectMergeStacktracesRequest{
 		ProfileTypeID: smpProfileType,
 		LabelSelector: "{}",
 		Start:         start,
 		End:           end,
+		Format:        querierv1.ProfileFormat_PROFILE_FORMAT_PPROF,
+		SpanSelector:  spanSelector,
 	}))
 
 	require.NoError(t, err)
+	require.NotNil(t, resp.Msg.GetPprof().GetProfile())
 	require.NotNil(t, capturedQuery)
 	assert.Equal(t, queryv1.QueryType_QUERY_TREE, capturedQuery.QueryType)
 	assert.True(t, capturedQuery.Tree.GetFullSymbols(), "tree path must request full symbols")
+	assert.Equal(t, spanSelector, capturedQuery.Tree.GetSpanSelector())
 }
 
 func TestSelectMergeProfile_TreePath_OtherLocationRef(t *testing.T) {

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_span_profile.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_span_profile.go
@@ -4,85 +4,33 @@ import (
 	"context"
 
 	"connectrpc.com/connect"
-	"github.com/grafana/dskit/tenant"
 
-	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
-	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
-	phlaremodel "github.com/grafana/pyroscope/v2/pkg/model"
-	"github.com/grafana/pyroscope/v2/pkg/validation"
 )
 
 func (q *QueryFrontend) SelectMergeSpanProfile(
 	ctx context.Context,
 	c *connect.Request[querierv1.SelectMergeSpanProfileRequest],
 ) (*connect.Response[querierv1.SelectMergeSpanProfileResponse], error) {
-	tenantIDs, err := tenant.TenantIDs(ctx)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	format := c.Msg.Format
+	if format != querierv1.ProfileFormat_PROFILE_FORMAT_TREE {
+		// The deprecated RPC historically treated every non-tree format as a flamegraph.
+		format = querierv1.ProfileFormat_PROFILE_FORMAT_FLAMEGRAPH
 	}
-	empty, err := validation.SanitizeTimeRange(q.limits, tenantIDs, &c.Msg.Start, &c.Msg.End)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
-	}
-	if empty {
-		return connect.NewResponse(&querierv1.SelectMergeSpanProfileResponse{}), nil
-	}
-
-	_, err = phlaremodel.ParseProfileTypeSelector(c.Msg.ProfileTypeID)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
-	}
-
-	maxNodes, err := validation.ValidateMaxNodes(q.limits, tenantIDs, c.Msg.GetMaxNodes())
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
-	}
-	labelSelector, err := buildLabelSelectorWithProfileType(c.Msg.LabelSelector, c.Msg.ProfileTypeID)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
-	}
-	report, err := q.querySingle(ctx,
-		&queryv1.QueryRequest{
-			StartTime:     c.Msg.Start,
-			EndTime:       c.Msg.End,
-			LabelSelector: labelSelector,
-			Query: []*queryv1.Query{{
-				QueryType: queryv1.QueryType_QUERY_TREE,
-				Tree: &queryv1.TreeQuery{
-					MaxNodes:     maxNodes,
-					SpanSelector: c.Msg.SpanSelector,
-				},
-			}},
-		},
-		func(ctx context.Context, upstream QueryBackend, blocks []*metastorev1.BlockMeta) QueryBackend {
-			shouldSymbolize := q.shouldSymbolize(ctx, tenantIDs, blocks)
-			if !shouldSymbolize {
-				return upstream
-			}
-			return &backendTreeSymbolizer{
-				upstream:   upstream,
-				symbolizer: q.symbolizer,
-			}
-		},
-	)
+	resp, err := q.SelectMergeStacktraces(ctx, connect.NewRequest(&querierv1.SelectMergeStacktracesRequest{
+		ProfileTypeID: c.Msg.ProfileTypeID,
+		LabelSelector: c.Msg.LabelSelector,
+		Start:         c.Msg.Start,
+		End:           c.Msg.End,
+		MaxNodes:      c.Msg.MaxNodes,
+		Format:        format,
+		SpanSelector:  c.Msg.SpanSelector,
+	}))
 	if err != nil {
 		return nil, err
 	}
-	if report == nil {
-		return connect.NewResponse(&querierv1.SelectMergeSpanProfileResponse{}), nil
-	}
-
-	var resp querierv1.SelectMergeSpanProfileResponse
-	switch c.Msg.Format {
-	case querierv1.ProfileFormat_PROFILE_FORMAT_TREE:
-		resp.Tree = report.Tree.Tree
-	default:
-		t, err := phlaremodel.UnmarshalTree[phlaremodel.FunctionName, phlaremodel.FunctionNameI](report.Tree.Tree)
-		if err != nil {
-			return nil, err
-		}
-		resp.Flamegraph = phlaremodel.NewFlameGraph(t, c.Msg.GetMaxNodes())
-	}
-	return connect.NewResponse(&resp), nil
+	return connect.NewResponse(&querierv1.SelectMergeSpanProfileResponse{
+		Flamegraph: resp.Msg.Flamegraph,
+		Tree:       resp.Msg.Tree,
+	}), nil
 }

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces.go
@@ -2,6 +2,7 @@ package queryfrontend
 
 import (
 	"context"
+	"errors"
 
 	"connectrpc.com/connect"
 	"github.com/grafana/dskit/tenant"
@@ -18,6 +19,10 @@ func (q *QueryFrontend) SelectMergeStacktraces(
 	ctx context.Context,
 	c *connect.Request[querierv1.SelectMergeStacktracesRequest],
 ) (*connect.Response[querierv1.SelectMergeStacktracesResponse], error) {
+	if len(c.Msg.SpanSelector) > 0 && len(c.Msg.TraceIdSelector) > 0 {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("span_selector and trace_id_selector cannot be combined"))
+	}
+
 	switch c.Msg.Format {
 	case querierv1.ProfileFormat_PROFILE_FORMAT_DOT:
 		return q.selectMergeStacktracesDot(ctx, c)

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces.go
@@ -18,8 +18,17 @@ func (q *QueryFrontend) SelectMergeStacktraces(
 	ctx context.Context,
 	c *connect.Request[querierv1.SelectMergeStacktracesRequest],
 ) (*connect.Response[querierv1.SelectMergeStacktracesResponse], error) {
-	if c.Msg.Format == querierv1.ProfileFormat_PROFILE_FORMAT_DOT {
+	switch c.Msg.Format {
+	case querierv1.ProfileFormat_PROFILE_FORMAT_DOT:
 		return q.selectMergeStacktracesDot(ctx, c)
+	case querierv1.ProfileFormat_PROFILE_FORMAT_PPROF:
+		p, err := q.selectMergeStacktracesPprof(ctx, c.Msg)
+		if err != nil {
+			return nil, err
+		}
+		return connect.NewResponse(&querierv1.SelectMergeStacktracesResponse{
+			Pprof: &querierv1.PprofProfile{Profile: p},
+		}), nil
 	}
 
 	b, err := q.selectMergeStacktracesTree(ctx, c)
@@ -58,7 +67,7 @@ func (q *QueryFrontend) selectMergeStacktracesDot(
 		}
 	}
 
-	pprofResp, err := q.SelectMergeProfile(ctx, connect.NewRequest(&querierv1.SelectMergeProfileRequest{
+	profile, err := q.selectMergeStacktracesPprof(ctx, &querierv1.SelectMergeStacktracesRequest{
 		ProfileTypeID:      c.Msg.ProfileTypeID,
 		LabelSelector:      c.Msg.LabelSelector,
 		Start:              c.Msg.Start,
@@ -67,15 +76,16 @@ func (q *QueryFrontend) selectMergeStacktracesDot(
 		StackTraceSelector: c.Msg.StackTraceSelector,
 		ProfileIdSelector:  c.Msg.ProfileIdSelector,
 		TraceIdSelector:    c.Msg.TraceIdSelector,
-	}))
+		SpanSelector:       c.Msg.SpanSelector,
+	})
 	if err != nil {
 		return nil, err
 	}
-	if pprofResp.Msg == nil || len(pprofResp.Msg.Sample) == 0 {
+	if profile == nil || len(profile.Sample) == 0 {
 		return connect.NewResponse(&querierv1.SelectMergeStacktracesResponse{}), nil
 	}
 
-	d, err := dot.FromProfile(pprofResp.Msg, int(dotMaxNodes))
+	d, err := dot.FromProfile(profile, int(dotMaxNodes))
 	if err != nil {
 		return nil, err
 	}
@@ -124,6 +134,7 @@ func (q *QueryFrontend) selectMergeStacktracesTree(
 					StackTraceSelector: c.Msg.StackTraceSelector,
 					ProfileIdSelector:  c.Msg.ProfileIdSelector,
 					TraceIdSelector:    c.Msg.TraceIdSelector,
+					SpanSelector:       c.Msg.SpanSelector,
 				},
 			}},
 		},

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces_test.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces_test.go
@@ -24,6 +24,18 @@ import (
 	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockqueryfrontend"
 )
 
+func TestSelectMergeStacktraces_RejectsSpanAndTraceSelectors(t *testing.T) {
+	qf := new(QueryFrontend)
+	resp, err := qf.SelectMergeStacktraces(context.Background(), connect.NewRequest(&querierv1.SelectMergeStacktracesRequest{
+		SpanSelector:    []string{"0000000000000001"},
+		TraceIdSelector: []string{"00000000000000000000000000000001"},
+	}))
+
+	require.Nil(t, resp)
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	require.ErrorContains(t, err, "span_selector and trace_id_selector cannot be combined")
+}
+
 func TestSelectMergeStacktraces_SpanSelectorTreeFormats(t *testing.T) {
 	spanSelector := []string{"0000000000000001"}
 	tree := new(phlaremodel.FunctionNameTree)

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces_test.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces_test.go
@@ -16,12 +16,135 @@ import (
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
 	"github.com/grafana/pyroscope/v2/pkg/block/metadata"
+	phlaremodel "github.com/grafana/pyroscope/v2/pkg/model"
 	"github.com/grafana/pyroscope/v2/pkg/pprof"
 	"github.com/grafana/pyroscope/v2/pkg/tenant"
 	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockfrontend"
 	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockmetastorev1"
 	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockqueryfrontend"
 )
+
+func TestSelectMergeStacktraces_SpanSelectorTreeFormats(t *testing.T) {
+	spanSelector := []string{"0000000000000001"}
+	tree := new(phlaremodel.FunctionNameTree)
+	tree.InsertStack(1, "foo")
+	treeBytes := tree.Bytes(-1, nil)
+
+	tests := []struct {
+		name   string
+		format querierv1.ProfileFormat
+		check  func(*testing.T, *querierv1.SelectMergeStacktracesResponse)
+	}{
+		{
+			name: "unspecified returns flamegraph",
+			check: func(t *testing.T, resp *querierv1.SelectMergeStacktracesResponse) {
+				require.NotNil(t, resp.Flamegraph)
+				require.Empty(t, resp.Tree)
+				require.Nil(t, resp.Pprof)
+			},
+		},
+		{
+			name:   "flamegraph",
+			format: querierv1.ProfileFormat_PROFILE_FORMAT_FLAMEGRAPH,
+			check: func(t *testing.T, resp *querierv1.SelectMergeStacktracesResponse) {
+				require.NotNil(t, resp.Flamegraph)
+				require.Empty(t, resp.Tree)
+				require.Nil(t, resp.Pprof)
+			},
+		},
+		{
+			name:   "tree",
+			format: querierv1.ProfileFormat_PROFILE_FORMAT_TREE,
+			check: func(t *testing.T, resp *querierv1.SelectMergeStacktracesResponse) {
+				require.Equal(t, treeBytes, resp.Tree)
+				require.Nil(t, resp.Flamegraph)
+				require.Nil(t, resp.Pprof)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockLimits := mockfrontend.NewMockLimits(t)
+			mockLimits.On("MaxQueryLookback", smpTenant).Return(time.Duration(0))
+			mockLimits.On("MaxQueryLength", smpTenant).Return(time.Duration(0))
+			mockLimits.On("MaxFlameGraphNodesDefault", smpTenant).Return(0)
+			mockLimits.On("QuerySanitizeOnMerge", smpTenant).Return(false)
+
+			mockMetadata := new(mockmetastorev1.MockMetadataQueryServiceClient)
+			mockMetadata.On("QueryMetadata", mock.Anything, mock.Anything).Return(smpOneBlock(), nil)
+
+			mockBackend := mockqueryfrontend.NewMockQueryBackend(t)
+			mockBackend.On("Invoke", mock.Anything, mock.Anything).
+				Run(func(args mock.Arguments) {
+					req := args.Get(1).(*queryv1.InvokeRequest)
+					require.Equal(t, spanSelector, req.Query[0].Tree.GetSpanSelector())
+				}).
+				Return(&queryv1.InvokeResponse{Reports: []*queryv1.Report{{
+					ReportType: queryv1.ReportType_REPORT_TREE,
+					Tree:       &queryv1.TreeReport{Tree: treeBytes},
+				}}}, nil)
+
+			qf := newSMPQueryFrontend(t, mockLimits, mockMetadata, mockBackend)
+			ctx := tenant.InjectTenantID(context.Background(), smpTenant)
+			start, end := smpValidTimeRange()
+			resp, err := qf.SelectMergeStacktraces(ctx, connect.NewRequest(&querierv1.SelectMergeStacktracesRequest{
+				ProfileTypeID: smpProfileType,
+				LabelSelector: "{}",
+				Start:         start,
+				End:           end,
+				Format:        tt.format,
+				SpanSelector:  spanSelector,
+			}))
+
+			require.NoError(t, err)
+			tt.check(t, resp.Msg)
+		})
+	}
+}
+
+func TestSelectMergeStacktraces_SpanSelectorPprof(t *testing.T) {
+	spanSelector := []string{"0000000000000001"}
+	mockLimits := mockfrontend.NewMockLimits(t)
+	mockLimits.On("MaxQueryLookback", smpTenant).Return(time.Duration(0))
+	mockLimits.On("MaxQueryLength", smpTenant).Return(time.Duration(0))
+	mockLimits.On("MaxFlameGraphNodesOnSelectMergeProfile", smpTenant).Return(false)
+	mockLimits.On("QueryTreeEnabled", smpTenant).Return(false)
+	mockLimits.On("QuerySanitizeOnMerge", smpTenant).Return(false)
+
+	mockMetadata := new(mockmetastorev1.MockMetadataQueryServiceClient)
+	mockMetadata.On("QueryMetadata", mock.Anything, mock.Anything).Return(smpOneBlock(), nil)
+
+	mockBackend := mockqueryfrontend.NewMockQueryBackend(t)
+	mockBackend.On("Invoke", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			req := args.Get(1).(*queryv1.InvokeRequest)
+			require.Equal(t, queryv1.QueryType_QUERY_PPROF, req.Query[0].QueryType)
+			require.Equal(t, spanSelector, req.Query[0].Pprof.GetSpanSelector())
+		}).
+		Return(&queryv1.InvokeResponse{Reports: []*queryv1.Report{{
+			ReportType: queryv1.ReportType_REPORT_PPROF,
+			Pprof:      &queryv1.PprofReport{Pprof: createProfile(t)},
+		}}}, nil)
+
+	qf := newSMPQueryFrontend(t, mockLimits, mockMetadata, mockBackend)
+	ctx := tenant.InjectTenantID(context.Background(), smpTenant)
+	start, end := smpValidTimeRange()
+	resp, err := qf.SelectMergeStacktraces(ctx, connect.NewRequest(&querierv1.SelectMergeStacktracesRequest{
+		ProfileTypeID: smpProfileType,
+		LabelSelector: "{}",
+		Start:         start,
+		End:           end,
+		Format:        querierv1.ProfileFormat_PROFILE_FORMAT_PPROF,
+		SpanSelector:  spanSelector,
+	}))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp.Msg.GetPprof().GetProfile())
+	require.Len(t, resp.Msg.Pprof.Profile.Sample, 1)
+	require.Nil(t, resp.Msg.Flamegraph)
+	require.Empty(t, resp.Msg.Tree)
+}
 
 func TestSelectMergeStacktrace_Symbolization(t *testing.T) {
 	// pprofBytes contains a profile with one sample at location 1, where location 1
@@ -175,6 +298,7 @@ func TestSelectMergeStacktrace_Symbolization(t *testing.T) {
 }
 
 func TestSelectMergeStacktraces_DotFormat(t *testing.T) {
+	spanSelector := []string{"0000000000000001"}
 	p := &profilev1.Profile{
 		StringTable: []string{"", "my_func", "samples", "count", "", ""},
 		Function:    []*profilev1.Function{{Id: 1, Name: 1}},
@@ -195,7 +319,10 @@ func TestSelectMergeStacktraces_DotFormat(t *testing.T) {
 	mockLimits.On("QuerySanitizeOnMerge", "tenant1").Return(false)
 
 	mockQueryBackend := mockqueryfrontend.NewMockQueryBackend(t)
-	mockQueryBackend.On("Invoke", mock.Anything, mock.Anything).Return(&queryv1.InvokeResponse{
+	mockQueryBackend.On("Invoke", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		req := args.Get(1).(*queryv1.InvokeRequest)
+		require.Equal(t, spanSelector, req.Query[0].Pprof.GetSpanSelector())
+	}).Return(&queryv1.InvokeResponse{
 		Reports: []*queryv1.Report{{
 			ReportType: queryv1.ReportType_REPORT_PPROF,
 			Pprof:      &queryv1.PprofReport{Pprof: pprofBytes},
@@ -222,6 +349,7 @@ func TestSelectMergeStacktraces_DotFormat(t *testing.T) {
 		Start:         start,
 		End:           end,
 		Format:        querierv1.ProfileFormat_PROFILE_FORMAT_DOT,
+		SpanSelector:  spanSelector,
 	}))
 
 	require.NoError(t, err)

--- a/pkg/frontend/readpath/read_path_test.go
+++ b/pkg/frontend/readpath/read_path_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"math"
+	"slices"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	"github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/pprof"
 	"github.com/grafana/pyroscope/v2/pkg/tenant"
 	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockquerierv1connect"
 )
@@ -204,6 +206,70 @@ func (s *routerTestSuite) Test_Series() {
 	resp, err := s.router.Series(s.ctx, req)
 	s.Require().NoError(err)
 	s.Assert().Equal(expected, resp)
+}
+
+func (s *routerTestSuite) Test_SelectMergeStacktraces_Pprof() {
+	s.overrides.On("ReadPathOverrides", "tenant-a").Return(Config{
+		EnableQueryBackend:     true,
+		EnableQueryBackendFrom: QueryBackendFrom{Time: time.Unix(5, 0)},
+	})
+
+	profileType, err := model.ParseProfileTypeSelector("process_cpu:cpu:nanoseconds:cpu:nanoseconds")
+	s.Require().NoError(err)
+	makeProfile := func(value int64) *querierv1.SelectMergeStacktracesResponse {
+		tree := new(model.FunctionNameTree)
+		tree.InsertStack(value, "foo")
+		return &querierv1.SelectMergeStacktracesResponse{
+			Pprof: &querierv1.PprofProfile{Profile: pprof.FromTree(tree, profileType, 0)},
+		}
+	}
+
+	spanSelector := []string{"0000000000000001"}
+	matchRequest := mock.MatchedBy(func(req *connect.Request[querierv1.SelectMergeStacktracesRequest]) bool {
+		return req.Msg.Format == querierv1.ProfileFormat_PROFILE_FORMAT_PPROF &&
+			slices.Equal(req.Msg.SpanSelector, spanSelector)
+	})
+	s.oldFrontend.On("SelectMergeStacktraces", mock.Anything, matchRequest).
+		Return(connect.NewResponse(makeProfile(1)), nil).Once()
+	s.newFrontend.On("SelectMergeStacktraces", mock.Anything, matchRequest).
+		Return(connect.NewResponse(makeProfile(2)), nil).Once()
+
+	resp, err := s.router.SelectMergeStacktraces(s.ctx, connect.NewRequest(&querierv1.SelectMergeStacktracesRequest{
+		ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+		Start:         10,
+		End:           10000,
+		Format:        querierv1.ProfileFormat_PROFILE_FORMAT_PPROF,
+		SpanSelector:  spanSelector,
+	}))
+
+	s.Require().NoError(err)
+	s.Require().NotNil(resp.Msg.GetPprof().GetProfile())
+	s.Require().Len(resp.Msg.Pprof.Profile.Sample, 1)
+	s.Equal([]int64{3}, resp.Msg.Pprof.Profile.Sample[0].Value)
+}
+
+func (s *routerTestSuite) Test_SelectMergeStacktraces_PprofRejectsMissingPayload() {
+	s.overrides.On("ReadPathOverrides", "tenant-a").Return(Config{
+		EnableQueryBackend:     true,
+		EnableQueryBackendFrom: QueryBackendFrom{Time: time.Unix(5, 0)},
+	})
+
+	s.oldFrontend.On("SelectMergeStacktraces", mock.Anything, mock.Anything).
+		Return(connect.NewResponse(&querierv1.SelectMergeStacktracesResponse{
+			Flamegraph: &querierv1.FlameGraph{},
+		}), nil).Once()
+	s.newFrontend.On("SelectMergeStacktraces", mock.Anything, mock.Anything).
+		Return(connect.NewResponse(&querierv1.SelectMergeStacktracesResponse{
+			Pprof: &querierv1.PprofProfile{},
+		}), nil).Once()
+
+	_, err := s.router.SelectMergeStacktraces(s.ctx, connect.NewRequest(&querierv1.SelectMergeStacktracesRequest{
+		Start:  10,
+		End:    10000,
+		Format: querierv1.ProfileFormat_PROFILE_FORMAT_PPROF,
+	}))
+
+	s.Require().ErrorContains(err, "old read path returned no pprof profile")
 }
 
 func (s *routerTestSuite) Test_TimeSeries_Limit() {

--- a/pkg/frontend/readpath/router.go
+++ b/pkg/frontend/readpath/router.go
@@ -174,9 +174,9 @@ func query[Req, Resp any](
 	case *connect.Request[querierv1.SelectMergeStacktracesRequest]:
 		resp, err = svc.SelectMergeStacktraces(ctx, r)
 	case *connect.Request[querierv1.SelectMergeSpanProfileRequest]:
-		resp, err = svc.SelectMergeSpanProfile(ctx, r)
+		resp, err = svc.SelectMergeSpanProfile(ctx, r) //nolint:staticcheck // Required querier.v1 compatibility routing.
 	case *connect.Request[querierv1.SelectMergeProfileRequest]:
-		resp, err = svc.SelectMergeProfile(ctx, r)
+		resp, err = svc.SelectMergeProfile(ctx, r) //nolint:staticcheck // Required querier.v1 compatibility routing.
 	case *connect.Request[querierv1.SelectSeriesRequest]:
 		resp, err = svc.SelectSeries(ctx, r)
 	case *connect.Request[querierv1.SelectHeatmapRequest]:

--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -154,7 +154,7 @@ func (q *QueryHandlers) Render(w http.ResponseWriter, req *http.Request) {
 				sourceProfileMaxNodes = dotProfileMaxNodes
 			}
 		}
-		resp, err := q.client.SelectMergeProfile(req.Context(), connect.NewRequest(&querierv1.SelectMergeProfileRequest{
+		resp, err := q.client.SelectMergeProfile(req.Context(), connect.NewRequest(&querierv1.SelectMergeProfileRequest{ //nolint:staticcheck // Legacy querier.v1 render path.
 			Start:         selectParams.Start,
 			End:           selectParams.End,
 			ProfileTypeID: selectParams.ProfileTypeID,

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -556,7 +556,7 @@ func (q *Querier) Diff(ctx context.Context, req *connect.Request[querierv1.DiffR
 	g, gCtx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		res, err := q.selectTree(gCtx, req.Msg.Left)
+		res, err := q.selectStacktracesTree(gCtx, req.Msg.Left)
 		if err != nil {
 			return err
 		}
@@ -566,7 +566,7 @@ func (q *Querier) Diff(ctx context.Context, req *connect.Request[querierv1.DiffR
 	})
 
 	g.Go(func() error {
-		res, err := q.selectTree(gCtx, req.Msg.Right)
+		res, err := q.selectStacktracesTree(gCtx, req.Msg.Right)
 		if err != nil {
 			return err
 		}
@@ -657,11 +657,6 @@ func (q *Querier) SelectMergeStacktraces(ctx context.Context, req *connect.Reque
 		sp.Finish()
 	}()
 
-	if req.Msg.MaxNodes == nil || *req.Msg.MaxNodes == 0 {
-		mn := maxNodesDefault
-		req.Msg.MaxNodes = &mn
-	}
-
 	if len(req.Msg.ProfileIdSelector) > 0 {
 		return nil, connect.NewError(connect.CodeUnimplemented, errors.New("profile_id_selector is only supported with the v2 query backend"))
 	}
@@ -673,8 +668,32 @@ func (q *Querier) SelectMergeStacktraces(ctx context.Context, req *connect.Reque
 	if req.Msg.Format == querierv1.ProfileFormat_PROFILE_FORMAT_DOT {
 		return nil, connect.NewError(connect.CodeUnimplemented, errors.New("dot format is only supported with the v2 query backend"))
 	}
+	if len(req.Msg.SpanSelector) > 0 && req.Msg.StackTraceSelector != nil {
+		return nil, connect.NewError(connect.CodeUnimplemented, errors.New("combining span_selector with stack_trace_selector is only supported with the v2 query backend"))
+	}
+	if req.Msg.Format == querierv1.ProfileFormat_PROFILE_FORMAT_PPROF && len(req.Msg.SpanSelector) == 0 {
+		resp, err := q.SelectMergeProfile(ctx, connect.NewRequest(&querierv1.SelectMergeProfileRequest{
+			ProfileTypeID:      req.Msg.ProfileTypeID,
+			LabelSelector:      req.Msg.LabelSelector,
+			Start:              req.Msg.Start,
+			End:                req.Msg.End,
+			MaxNodes:           req.Msg.MaxNodes,
+			StackTraceSelector: req.Msg.StackTraceSelector,
+		}))
+		if err != nil {
+			return nil, err
+		}
+		return connect.NewResponse(&querierv1.SelectMergeStacktracesResponse{
+			Pprof: &querierv1.PprofProfile{Profile: resp.Msg},
+		}), nil
+	}
 
-	t, err := q.selectTree(ctx, req.Msg)
+	if req.Msg.MaxNodes == nil || *req.Msg.MaxNodes == 0 {
+		mn := maxNodesDefault
+		req.Msg.MaxNodes = &mn
+	}
+
+	t, err := q.selectStacktracesTree(ctx, req.Msg)
 	if err != nil {
 		return nil, err
 	}
@@ -685,6 +704,12 @@ func (q *Querier) SelectMergeStacktraces(ctx context.Context, req *connect.Reque
 		resp.Flamegraph = phlaremodel.NewFlameGraph(t, req.Msg.GetMaxNodes())
 	case querierv1.ProfileFormat_PROFILE_FORMAT_TREE:
 		resp.Tree = t.Bytes(req.Msg.GetMaxNodes(), nil)
+	case querierv1.ProfileFormat_PROFILE_FORMAT_PPROF:
+		profileType, err := phlaremodel.ParseProfileTypeSelector(req.Msg.ProfileTypeID)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInvalidArgument, err)
+		}
+		resp.Pprof = &querierv1.PprofProfile{Profile: pprof.FromTree(t, profileType, req.Msg.End*1e6)}
 	}
 	return connect.NewResponse(&resp), nil
 }
@@ -789,6 +814,24 @@ func (q *Querier) selectTree(ctx context.Context, req *querierv1.SelectMergeStac
 	}
 	storegatewayTree.Merge(ingesterTree)
 	return storegatewayTree, nil
+}
+
+func (q *Querier) selectStacktracesTree(ctx context.Context, req *querierv1.SelectMergeStacktracesRequest) (*phlaremodel.FunctionNameTree, error) {
+	if len(req.SpanSelector) == 0 {
+		return q.selectTree(ctx, req)
+	}
+	if req.StackTraceSelector != nil || len(req.ProfileIdSelector) > 0 {
+		return nil, connect.NewError(connect.CodeUnimplemented, errors.New("combining span_selector with stack_trace_selector or profile_id_selector is only supported with the v2 query backend"))
+	}
+	return q.selectSpanProfile(ctx, &querierv1.SelectMergeSpanProfileRequest{
+		ProfileTypeID: req.ProfileTypeID,
+		LabelSelector: req.LabelSelector,
+		SpanSelector:  req.SpanSelector,
+		Start:         req.Start,
+		End:           req.End,
+		MaxNodes:      req.MaxNodes,
+		Format:        querierv1.ProfileFormat_PROFILE_FORMAT_TREE,
+	})
 }
 
 type storeQuery struct {

--- a/pkg/test/integration/helper.go
+++ b/pkg/test/integration/helper.go
@@ -511,7 +511,7 @@ func (b *RequestBuilder) SelectMergeProfile(metric string, query map[string]stri
 	}
 	selector.WriteString("}")
 	qc := b.QueryClient()
-	resp, err := qc.SelectMergeProfile(context.Background(), connect.NewRequest(&querierv1.SelectMergeProfileRequest{
+	resp, err := qc.SelectMergeProfile(context.Background(), connect.NewRequest(&querierv1.SelectMergeProfileRequest{ //nolint:staticcheck // Legacy querier.v1 integration coverage.
 		ProfileTypeID: metric,
 		Start:         time.Unix(1, 0).UnixMilli(),
 		End:           time.Now().UnixMilli(),

--- a/pkg/test/integration/microservices_test.go
+++ b/pkg/test/integration/microservices_test.go
@@ -465,7 +465,7 @@ func (tc *testCtx) runQueryTest(ctx context.Context, t *testing.T) {
 					Start:         tc.now.Add(-time.Hour).UnixMilli(),
 					End:           tc.now.Add(time.Hour).UnixMilli(),
 				}
-				resp, err := tc.querier.SelectMergeProfile(ctx, connect.NewRequest(req))
+				resp, err := tc.querier.SelectMergeProfile(ctx, connect.NewRequest(req)) //nolint:staticcheck // Legacy querier.v1 integration coverage.
 				require.NoError(t, err)
 
 				// no services, no samples profile
@@ -658,7 +658,7 @@ func (tc *testCtx) runFederatedQueryTest(ctx context.Context, t *testing.T) {
 		End:           tc.now.Add(time.Hour).UnixMilli(),
 	})
 	smpReq.Header().Set("X-Scope-OrgID", orgID)
-	resp, err := tc.querier.SelectMergeProfile(ctx, smpReq)
+	resp, err := tc.querier.SelectMergeProfile(ctx, smpReq) //nolint:staticcheck // Legacy querier.v1 integration coverage.
 	require.NoError(t, err)
 	require.NotNil(t, resp.Msg)
 	assert.NotEmpty(t, resp.Msg.Sample, "federated profile must contain samples")

--- a/pkg/test/integration/symbolization_test.go
+++ b/pkg/test/integration/symbolization_test.go
@@ -261,7 +261,7 @@ Mappings
 				LabelSelector: `{service_name="` + serviceName + `"}`,
 			})
 			require.Eventually(t, func() bool {
-				resp, err := querier.SelectMergeProfile(ctx, q)
+				resp, err := querier.SelectMergeProfile(ctx, q) //nolint:staticcheck // Legacy querier.v1 integration coverage.
 				if err != nil {
 					t.Logf("Error querying profile: %v", err)
 					return false
@@ -318,7 +318,7 @@ Mappings
 
 			queried := false
 			for deadline := time.Now().Add(8 * time.Second); time.Now().Before(deadline); time.Sleep(500 * time.Millisecond) {
-				resp, err := querier.SelectMergeProfile(ctx, q)
+				resp, err := querier.SelectMergeProfile(ctx, q) //nolint:staticcheck // Legacy querier.v1 integration coverage.
 				if err != nil {
 					t.Logf("Error querying profile: %v", err)
 					continue

--- a/pkg/util/spanlogger/query_log.go
+++ b/pkg/util/spanlogger/query_log.go
@@ -175,6 +175,7 @@ func (l LogSpanParametersWrapper) SelectMergeStacktraces(ctx context.Context, c 
 		"format", c.Msg.Format,
 		"max_nodes", c.Msg.GetMaxNodes(),
 		"profile_id_selector", lazyJoin(c.Msg.ProfileIdSelector),
+		"span_selector", lazyJoin(c.Msg.SpanSelector),
 	}, func() (err error) {
 		resp, err = l.client.SelectMergeStacktraces(ctx, c)
 		return err
@@ -199,7 +200,7 @@ func (l LogSpanParametersWrapper) SelectMergeSpanProfile(ctx context.Context, c 
 		"format", c.Msg.Format,
 		"max_nodes", c.Msg.GetMaxNodes(),
 	}, func() (err error) {
-		resp, err = l.client.SelectMergeSpanProfile(ctx, c)
+		resp, err = l.client.SelectMergeSpanProfile(ctx, c) //nolint:staticcheck // Required querier.v1 compatibility wrapper.
 		return err
 	})
 	return resp, err
@@ -223,7 +224,7 @@ func (l LogSpanParametersWrapper) SelectMergeProfile(ctx context.Context, c *con
 		"stacktrace_selector", c.Msg.GetStackTraceSelector(),
 		"profile_id_selector", lazyJoin(c.Msg.ProfileIdSelector),
 	}, func() (err error) {
-		resp, err = l.client.SelectMergeProfile(ctx, c)
+		resp, err = l.client.SelectMergeProfile(ctx, c) //nolint:staticcheck // Required querier.v1 compatibility wrapper.
 		return err
 	})
 	return resp, err
@@ -307,6 +308,7 @@ func (l LogSpanParametersWrapper) Diff(ctx context.Context, c *connect.Request[q
 		"left_profile_type", left.ProfileTypeID,
 		"left_format", left.Format,
 		"left_max_nodes", left.GetMaxNodes(),
+		"left_span_selector", lazyJoin(left.SpanSelector),
 		"right_start", model.Time(right.Start).Time().String(),
 		"right_end", model.Time(right.End).Time().String(),
 		"right_query_window", model.Time(right.End).Sub(model.Time(right.Start)).String(),
@@ -314,6 +316,7 @@ func (l LogSpanParametersWrapper) Diff(ctx context.Context, c *connect.Request[q
 		"right_profile_type", right.ProfileTypeID,
 		"right_format", right.Format,
 		"right_max_nodes", right.GetMaxNodes(),
+		"right_span_selector", lazyJoin(right.SpanSelector),
 	}, func() (err error) {
 		resp, err = l.client.Diff(ctx, c)
 		return err


### PR DESCRIPTION
## Summary

- make `SelectMergeStacktraces` support span-filtered flamegraph, tree, DOT, and pprof responses
- expose pprof through an extensible `PprofProfile` response wrapper and preserve legacy RPC compatibility
- forward span selectors through V1, V2, mixed read paths, async polling, and diff requests
- migrate profilecli to the unified RPC with fallback support for older servers
- document the profile formats and legacy RPC deprecations
- keep deprecated RPCs supported in `querier.v1`; future breaking API evolution may use `querier.v2`

## Tests

- `go test ./pkg/frontend/... ./pkg/querier/... ./pkg/util/spanlogger ./cmd/profilecli/...`
- `go test ./pkg/querybackend -run 'TestSuite/Test_SpanSelector|TestSuite/Test_SpanAndTraceSelector_Combined_Errors'`\n- `go test -race ./pkg/frontend/readpath/queryfrontend -run TestDiff_ForwardsSpanSelectors`\n\nCloses #5356