### PR TITLE
fix(profilecli): query top over-counts by one step of pre-window data

### DIFF
--- a/cmd/profilecli/query-top.go
+++ b/cmd/profilecli/query-top.go
@@ -13,6 +13,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	"github.com/grafana/pyroscope/v2/pkg/model"
 )
 
@@ -74,11 +75,9 @@ func queryTop(ctx context.Context, params *queryTopParams) error {
 	}
 
 	totals := make([]seriesTotal, 0, len(series))
+	startMs := from.UnixMilli()
 	for _, s := range series {
-		var total float64
-		for _, p := range s.Points {
-			total += p.Value
-		}
+		total := sumPointsAfter(s.Points, startMs)
 		lbls := model.Labels(s.Labels)
 		vals := make([]string, len(params.LabelNames))
 		for i, name := range params.LabelNames {
@@ -157,6 +156,22 @@ func queryTop(ctx context.Context, params *queryTopParams) error {
 	}
 
 	return nil
+}
+
+// sumPointsAfter sums point values with timestamps strictly after startMs.
+// SelectSeries fetches one extra step before the window so that the boundary
+// point at `start` renders as a complete bucket in charts; that point
+// aggregates (start-step, start], which lies entirely before the requested
+// window. With step = window size, counting it roughly doubles the total.
+func sumPointsAfter(points []*typesv1.Point, startMs int64) float64 {
+	var total float64
+	for _, p := range points {
+		if p.Timestamp <= startMs {
+			continue
+		}
+		total += p.Value
+	}
+	return total
 }
 
 func formatUnit(v float64, unit string) string {

--- a/cmd/profilecli/query-top_test.go
+++ b/cmd/profilecli/query-top_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+)
+
+func TestSumPointsAfter(t *testing.T) {
+	const startMs = int64(1_784_130_300_000) // window start
+	const stepMs = int64(3_600_000)
+
+	// SelectSeries with step = window size returns two points: the boundary
+	// point at `start` holding pre-window data, and the point at `end`
+	// holding the actual window total.
+	points := []*typesv1.Point{
+		{Timestamp: startMs, Value: 8_778_052_796_311},
+		{Timestamp: startMs + stepMs, Value: 4_005_116_752_500},
+	}
+	require.Equal(t, float64(4_005_116_752_500), sumPointsAfter(points, startMs))
+
+	t.Run("all points within window", func(t *testing.T) {
+		points := []*typesv1.Point{
+			{Timestamp: startMs + 1, Value: 1},
+			{Timestamp: startMs + 2, Value: 2},
+		}
+		require.Equal(t, float64(3), sumPointsAfter(points, startMs))
+	})
+
+	t.Run("no points", func(t *testing.T) {
+		require.Equal(t, float64(0), sumPointsAfter(nil, startMs))
+	})
+}


### PR DESCRIPTION
`profilecli query top` reports totals ~2x larger than the flamegraph or `query profile` for the same selector and window, because it sums the boundary point that `SelectSeries` returns at `start`.

`SelectSeries` intentionally fetches one extra step before the window ([v1 querier](https://github.com/grafana/pyroscope/blob/main/pkg/querier/querier.go#L1076-L1078), [v2 read path](https://github.com/grafana/pyroscope/blob/main/pkg/frontend/readpath/queryfrontend/query_select_time_series.go#L48-L49)) so the first point renders as a complete bucket in charts. That point aggregates `(start-step, start]` — entirely before the requested window. `query top` sets `step = to - from`, so summing it adds one full extra window of data: with steady load the total roughly doubles, otherwise it's off by whatever the previous window did.

Verified against a dev cluster (`memory:alloc_space`, 1h window), `query top` total vs sum of samples from `query profile --output=pprof`:

| service | query top (before) | pprof sum | query top (after) |
|---|---|---|---|
| service_a | 12,783,169,548,811 | 4,005,116,752,500 | 4,005,116,752,500 |
| service_b | 12,153,682,722,477 | 5,735,292,915,190 | 5,735,292,915,190 |
| service_c | 6,507,635,725,124 | 3,094,411,371,703 | 3,094,411,371,703 |

After skipping points at or before the window start, totals match the merged profile byte-exact across all services and windows tested (5m/1h/6h), for both alloc_space and process_cpu.