### PR TITLE
fix(metastore): retain shards with recent data

### DIFF
--- a/pkg/metastore/index/cleaner/retention/retention.go
+++ b/pkg/metastore/index/cleaner/retention/retention.go
@@ -286,9 +286,9 @@ func (rp *TimeBasedRetentionPolicy) createTombstones(q *indexstore.PartitionQuer
 		if len(rp.tombstones) >= rp.maxTombstones {
 			return false
 		}
-		maxTime := time.Unix(0, shard.ShardIndex.MaxTime)
+		maxTime := time.UnixMilli(shard.ShardIndex.MaxTime)
 		if maxTime.Before(m.timestamp) {
-			// The shard does not contain data before the marker.
+			// The shard does not contain data after the marker.
 			name := shard.TombstoneName()
 			level.Debug(rp.logger).Log("msg", "creating tombstone", "name", name)
 			rp.tombstones = append(rp.tombstones, &metastorev1.Tombstones{

--- a/pkg/metastore/index/cleaner/retention/retention_test.go
+++ b/pkg/metastore/index/cleaner/retention/retention_test.go
@@ -202,6 +202,22 @@ func TestTimeBasedRetentionPolicy(t *testing.T) {
 			expectedTombstones: 1,
 		},
 		{
+			name:          "old partition with recent data is retained",
+			defaultConfig: Config{RetentionPeriod: model.Duration(12 * time.Hour)},
+			gracePeriod:   time.Hour,
+			maxTombstones: 10,
+			now:           now,
+			blocks: []testBlock{
+				{
+					tenant:    "tenant-1",
+					shard:     1,
+					createdAt: now.Add(-30 * time.Hour),
+					minTime:   now.Add(-2 * time.Hour),
+					maxTime:   now.Add(-time.Hour),
+				},
+			},
+		},
+		{
 			name:          "anonymous tenant deleted when no other tenant shards",
 			defaultConfig: Config{RetentionPeriod: model.Duration(12 * time.Hour)},
 			overrides:     map[string]Config{},
@@ -364,8 +380,8 @@ func TestTimeBasedRetentionPolicy(t *testing.T) {
 						Id:          test.ULID(block.createdAt.Format(time.RFC3339)),
 						Tenant:      1,
 						Shard:       block.shard,
-						MinTime:     block.minTime.UnixNano(),
-						MaxTime:     block.maxTime.UnixNano(),
+						MinTime:     block.minTime.UnixMilli(),
+						MaxTime:     block.maxTime.UnixMilli(),
 						StringTable: []string{"", block.tenant},
 					}))
 				}


### PR DESCRIPTION
## What this does

- interpret shard index timestamps as Unix milliseconds during retention cleanup
- retain old partitions when their shards contain recent data
- update retention test fixtures to use production timestamp units and add regression coverage

## Verification

- `go test -count=1 ./pkg/metastore/index/cleaner/retention ./pkg/metastore/index/store`