### PR TITLE
feat(metastore): index shards by profile data interval

### DIFF
--- a/docs/sources/view-and-analyze-profile-data/profile-cli.md
+++ b/docs/sources/view-and-analyze-profile-data/profile-cli.md
@@ -168,6 +168,18 @@ Use `profilecli upload` when you have an exported pprof file and want to:
 - Ensure you have `profilecli` installed on your system by following the [installation](#install-profile-cli) steps above.
 - Have a profile file ready for upload. Note that you can only upload pprof files at this time.
 
+{{< admonition type="note" >}}
+Pyroscope preserves the timestamp in an uploaded profile unless you use `--override-timestamp`. By default, the server rejects profiles more than one hour old and limits queries to the last seven days. To import and query older profiles in a self-hosted deployment, configure limits that cover the historical period. For example:
+
+```yaml
+limits:
+  reject_older_than: 90d
+  max_query_lookback: 90d
+```
+
+Setting either limit to `0s` disables it. The default maximum query length is 24 hours, so query a narrow interval around the profile timestamp or increase `max_query_length`. Also ensure that `retention_period` provides the required availability after import.
+{{< /admonition >}}
+
 ### Upload steps
 
 1. Identify the pprof file.

--- a/pkg/metastore/index/README.md
+++ b/pkg/metastore/index/README.md
@@ -70,6 +70,8 @@ Partition (6h window)
 
 Metadata entries are stored in shard buckets as key-value pairs, where the key is the block ID (ULID) and the value is the serialized block metadata. The block identifier is a ULID, where the timestamp represents the block's creation time. However, blocks span data ranges defined by the actual timestamps of the data they contain (specified in the block metadata). When blocks are compacted together (merged), the output block identifier uses the timestamp of the oldest block in the input set and reflects the actual time range of the compacted data.
 
+Because the partition key represents block creation time, it does not necessarily overlap the contained data time. Historical imports are one example. Metadata queries inspect the requested tenant shards across partitions and filter them using the actual data range stored in each `ShardIndex`.
+
 Every block is assigned to a shard at [data distribution](../../ingester/client/distributor/README.md) time, and this assignment never changes. The assigned shard identifier is stored in the block metadata entry and is used to locate the block within the tenant bucket.
 
 Shard-level structures:

--- a/pkg/metastore/index/index.go
+++ b/pkg/metastore/index/index.go
@@ -34,8 +34,8 @@ type Config struct {
 	Cleaner  cleaner.Config `yaml:",inline"`
 	Recovery dlq.Config     `yaml:",inline"`
 
-	partitionDuration     time.Duration
-	queryLookaroundPeriod time.Duration
+	partitionDuration       time.Duration
+	restoreLookaroundPeriod time.Duration
 }
 
 var DefaultConfig = Config{
@@ -49,15 +49,9 @@ var DefaultConfig = Config{
 	// Partition key MUST be an input parameter.
 	partitionDuration: 6 * time.Hour,
 
-	// FIXME(kolesnikovae): Remove: build an interval tree.
-	//
-	// Currently, we do not use information about the time range of data each
-	// partition refers to. For example, it's possible – though very unlikely
-	// – for data from the past hour to be stored in a partition created a day
-	// ago. We need to be cautious: when querying, we must identify all
-	// partitions that may include the query time range. To ensure we catch
-	// such "misplaced" data, we extend the query time range using this period.
-	queryLookaroundPeriod: 24 * time.Hour,
+	// Only shards in partitions around the current time are restored into the
+	// write cache. Other shards are loaded on demand.
+	restoreLookaroundPeriod: 24 * time.Hour,
 }
 
 func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
@@ -67,7 +61,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.IntVar(&cfg.BlockWriteCacheSize, prefix+"block-write-cache-size", DefaultConfig.BlockWriteCacheSize, "Maximum number of written blocks to keep in memory")
 	f.IntVar(&cfg.BlockReadCacheSize, prefix+"block-read-cache-size", DefaultConfig.BlockReadCacheSize, "Maximum number of read blocks to keep in memory")
 	cfg.partitionDuration = DefaultConfig.partitionDuration
-	cfg.queryLookaroundPeriod = DefaultConfig.queryLookaroundPeriod
+	cfg.restoreLookaroundPeriod = DefaultConfig.restoreLookaroundPeriod
 }
 
 type Store interface {
@@ -79,21 +73,25 @@ type Store interface {
 }
 
 type Index struct {
-	logger log.Logger
-	config Config
-	store  Store
-	shards *shardCache
-	blocks *blockCache
+	logger    log.Logger
+	config    Config
+	store     Store
+	shards    *shardCache
+	blocks    *blockCache
+	intervals *shardIntervalIndex
 }
 
 func NewIndex(logger log.Logger, s Store, cfg Config, reg prometheus.Registerer) *Index {
 	m := newMetrics(reg)
+	intervals := newShardIntervalIndex()
+	intervals.disable()
 	return &Index{
-		logger: logger,
-		config: cfg,
-		store:  s,
-		shards: newShardCache(cfg.ShardCacheSize, s, m),
-		blocks: newBlockCache(cfg.BlockReadCacheSize, cfg.BlockWriteCacheSize, m),
+		logger:    logger,
+		config:    cfg,
+		store:     s,
+		shards:    newShardCache(cfg.ShardCacheSize, s, m),
+		blocks:    newBlockCache(cfg.BlockReadCacheSize, cfg.BlockWriteCacheSize, m),
+		intervals: intervals,
 	}
 }
 
@@ -102,21 +100,26 @@ func NewStore() *indexstore.IndexStore { return indexstore.NewIndexStore() }
 func (i *Index) Init(tx *bbolt.Tx) error { return i.store.CreateBuckets(tx) }
 
 func (i *Index) Restore(tx *bbolt.Tx) error {
-	// See comment in DefaultConfig.queryLookaroundPeriod.
+	intervals := newShardIntervalIndex()
+	// See comment in DefaultConfig.restoreLookaroundPeriod.
 	now := time.Now()
-	start := now.Add(-i.config.queryLookaroundPeriod)
-	end := now.Add(i.config.queryLookaroundPeriod)
+	start := now.Add(-i.config.restoreLookaroundPeriod)
+	end := now.Add(i.config.restoreLookaroundPeriod)
 	for p := range i.store.Partitions(tx) {
-		if !p.Overlaps(start, end) {
-			continue
-		}
-		level.Info(i.logger).Log("msg", "loading partition in memory")
 		q := p.Query(tx)
 		if q == nil {
 			continue
 		}
+		loadShard := p.Overlaps(start, end)
+		if loadShard {
+			level.Info(i.logger).Log("msg", "loading partition in memory")
+		}
 		for tenant := range q.Tenants() {
 			for shard := range q.Shards(tenant) {
+				intervals.upsertUnsafe(shard)
+				if !loadShard {
+					continue
+				}
 				if _, err := i.shards.getForWrite(tx, p, tenant, shard.Shard); err != nil {
 					level.Error(i.logger).Log(
 						"msg", "failed to load tenant partition shard",
@@ -130,6 +133,7 @@ func (i *Index) Restore(tx *bbolt.Tx) error {
 			}
 		}
 	}
+	i.intervals.replace(intervals)
 	return nil
 }
 
@@ -140,6 +144,7 @@ func (i *Index) InsertBlock(tx *bbolt.Tx, b *metastorev1.BlockMeta) error {
 			return err
 		}
 		i.blocks.put(s, b)
+		i.intervals.upsert(*s)
 		return nil
 	})
 }
@@ -196,6 +201,7 @@ func (i *Index) DeleteShard(tx *bbolt.Tx, key indexstore.Partition, tenant strin
 		return err
 	}
 	i.shards.delete(key, tenant, shard)
+	i.intervals.remove(tx.ID(), key, tenant, shard)
 	return nil
 }
 
@@ -256,7 +262,7 @@ func (i *Index) QueryMetadata(tx *bbolt.Tx, ctx context.Context, query MetadataQ
 	if err != nil {
 		return nil, err
 	}
-	r, err := newBlockMetadataQuerier(tx, q).queryBlocks(ctx)
+	r, err := newBlockMetadataQuerier(ctx, tx, q).queryBlocks(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +274,7 @@ func (i *Index) QueryMetadataLabels(tx *bbolt.Tx, ctx context.Context, query Met
 	if err != nil {
 		return nil, err
 	}
-	c, err := newMetadataLabelQuerier(tx, q).queryLabels(ctx)
+	c, err := newMetadataLabelQuerier(ctx, tx, q).queryLabels(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/metastore/index/index_bench_test.go
+++ b/pkg/metastore/index/index_bench_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -107,6 +108,62 @@ func BenchmarkIndex_GetTenantStats(b *testing.B) {
 					require.NotEqual(b, int64(0), stats.OldestProfileTime)
 					require.NotEqual(b, int64(0), stats.NewestProfileTime)
 				}
+			}
+		})
+	}
+}
+
+func BenchmarkIndex_QueryHistoricalData(b *testing.B) {
+	const (
+		partitionDuration = 6 * time.Hour
+		tenant            = "tenant"
+	)
+
+	for _, numPartitions := range []int{4 * 31, 4 * 365} {
+		b.Run(fmt.Sprintf("Partitions%d", numPartitions), func(b *testing.B) {
+			db := test.BoltDB(b)
+			idx := NewIndex(util.Logger, NewStore(), DefaultConfig, nil)
+			require.NoError(b, db.Update(idx.Init))
+
+			startTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+			for i := 0; i < numPartitions; i++ {
+				creationTime := startTime.Add(time.Duration(i) * partitionDuration)
+				dataTime := creationTime
+				if i == numPartitions-1 {
+					dataTime = startTime
+				}
+				minTime := dataTime.UnixMilli()
+				maxTime := dataTime.Add(time.Hour).UnixMilli()
+				md := &metastorev1.BlockMeta{
+					Id:      test.ULID(creationTime.Format(time.RFC3339Nano)),
+					Tenant:  1,
+					Shard:   1,
+					MinTime: minTime,
+					MaxTime: maxTime,
+					Datasets: []*metastorev1.Dataset{{
+						Tenant:  1,
+						MinTime: minTime,
+						MaxTime: maxTime,
+					}},
+					StringTable: []string{"", tenant},
+				}
+				require.NoError(b, db.Update(func(tx *bbolt.Tx) error {
+					return idx.InsertBlock(tx, md)
+				}))
+			}
+
+			query := MetadataQuery{
+				Expr:      `{}`,
+				StartTime: startTime,
+				EndTime:   startTime.Add(time.Hour),
+				Tenant:    []string{tenant},
+			}
+			b.ResetTimer()
+			for b.Loop() {
+				require.NoError(b, db.View(func(tx *bbolt.Tx) error {
+					_, err := idx.QueryMetadata(tx, context.Background(), query)
+					return err
+				}))
 			}
 		})
 	}

--- a/pkg/metastore/index/index_test.go
+++ b/pkg/metastore/index/index_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -138,7 +139,7 @@ func findShard(t *testing.T, db *bbolt.DB, partition indexstore.Partition, tenan
 func TestIndex_RestoreTimeBasedLoading(t *testing.T) {
 	db := test.BoltDB(t)
 	config := DefaultConfig
-	config.queryLookaroundPeriod = time.Hour
+	config.restoreLookaroundPeriod = time.Hour
 
 	idx := NewIndex(util.Logger, NewStore(), config, nil)
 	require.NoError(t, db.Update(idx.Init))
@@ -200,7 +201,6 @@ func TestIndex_RestoreTimeBasedLoading(t *testing.T) {
 func TestShardIterator_TimeFiltering(t *testing.T) {
 	db := test.BoltDB(t)
 	config := DefaultConfig
-	config.queryLookaroundPeriod = 0
 	idx := NewIndex(util.Logger, NewStore(), config, nil)
 	require.NoError(t, db.Update(idx.Init))
 
@@ -243,7 +243,7 @@ func TestShardIterator_TimeFiltering(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var loaded []uint32
 			require.NoError(t, db.View(func(tx *bbolt.Tx) error {
-				iter := newShardIterator(tx, idx, test.Time(tc.startTime), test.Time(tc.endTime), tenant)
+				iter := newShardIterator(context.Background(), tx, idx, test.Time(tc.startTime), test.Time(tc.endTime), tenant)
 				for iter.Next() {
 					loaded = append(loaded, iter.At().Shard)
 				}
@@ -252,6 +252,94 @@ func TestShardIterator_TimeFiltering(t *testing.T) {
 			assert.ElementsMatch(t, tc.expected, loaded)
 		})
 	}
+}
+
+func TestShardIterator_StaleSnapshotAfterShardDeletion(t *testing.T) {
+	db := test.BoltDB(t)
+	idx := NewIndex(util.Logger, NewStore(), DefaultConfig, nil)
+	require.NoError(t, db.Update(idx.Init))
+
+	const tenant = "tenant"
+	block := &metastorev1.BlockMeta{
+		Id:          test.ULID("2024-01-01T10:00:00.000Z"),
+		Tenant:      1,
+		Shard:       1,
+		MinTime:     test.UnixMilli("2024-01-01T10:00:00.000Z"),
+		MaxTime:     test.UnixMilli("2024-01-01T11:00:00.000Z"),
+		StringTable: []string{"", tenant},
+	}
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		return idx.InsertBlock(tx, block)
+	}))
+	require.NoError(t, db.View(idx.Restore))
+
+	stale, err := db.Begin(false)
+	require.NoError(t, err)
+	defer func() { _ = stale.Rollback() }()
+
+	partition := idx.partitionKeyForBlock(block.Id)
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		return idx.DeleteShard(tx, partition, tenant, block.Shard)
+	}))
+
+	iter := newShardIterator(context.Background(), stale, idx, time.UnixMilli(block.MinTime), time.UnixMilli(block.MaxTime), tenant)
+	require.True(t, iter.Next())
+	assert.Equal(t, block.Shard, iter.At().Shard)
+	assert.False(t, iter.Next())
+	require.NoError(t, iter.Err())
+
+	require.NoError(t, db.View(func(tx *bbolt.Tx) error {
+		iter := newShardIterator(context.Background(), tx, idx, time.UnixMilli(block.MinTime), time.UnixMilli(block.MaxTime), tenant)
+		assert.False(t, iter.Next())
+		return iter.Err()
+	}))
+}
+
+func TestShardIterator_RestoresRolledBackShardDeletion(t *testing.T) {
+	db := test.BoltDB(t)
+	idx := NewIndex(util.Logger, NewStore(), DefaultConfig, nil)
+	require.NoError(t, db.Update(idx.Init))
+
+	const tenant = "tenant"
+	block := &metastorev1.BlockMeta{
+		Id:          test.ULID("2024-01-01T10:00:00.000Z"),
+		Tenant:      1,
+		Shard:       1,
+		MinTime:     test.UnixMilli("2024-01-01T10:00:00.000Z"),
+		MaxTime:     test.UnixMilli("2024-01-01T11:00:00.000Z"),
+		StringTable: []string{"", tenant},
+	}
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		return idx.InsertBlock(tx, block)
+	}))
+	require.NoError(t, db.View(idx.Restore))
+
+	tx, err := db.Begin(true)
+	require.NoError(t, err)
+	require.NoError(t, idx.DeleteShard(tx, idx.partitionKeyForBlock(block.Id), tenant, block.Shard))
+	require.NoError(t, tx.Rollback())
+
+	// Bolt reuses the rolled-back transaction ID. Commit an unrelated write to
+	// verify that the pending deletion is reconciled instead of becoming a miss.
+	unrelated := &metastorev1.BlockMeta{
+		Id:          test.ULID("2024-01-01T12:00:00.000Z"),
+		Tenant:      1,
+		Shard:       2,
+		MinTime:     test.UnixMilli("2024-01-01T12:00:00.000Z"),
+		MaxTime:     test.UnixMilli("2024-01-01T13:00:00.000Z"),
+		StringTable: []string{"", tenant},
+	}
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		return idx.InsertBlock(tx, unrelated)
+	}))
+
+	require.NoError(t, db.View(func(tx *bbolt.Tx) error {
+		iter := newShardIterator(context.Background(), tx, idx, time.UnixMilli(block.MinTime), time.UnixMilli(block.MaxTime), tenant)
+		require.True(t, iter.Next())
+		assert.Equal(t, block.Shard, iter.At().Shard)
+		assert.False(t, iter.Next())
+		return iter.Err()
+	}))
 }
 
 func TestIndex_DeleteShard(t *testing.T) {

--- a/pkg/metastore/index/query.go
+++ b/pkg/metastore/index/query.go
@@ -99,10 +99,10 @@ func (q *metadataQuery) overlapsUnixMilli(start, end int64) bool {
 	return q.overlaps(time.UnixMilli(start), time.UnixMilli(end))
 }
 
-func newBlockMetadataQuerier(tx *bbolt.Tx, q *metadataQuery) *blockMetadataQuerier {
+func newBlockMetadataQuerier(ctx context.Context, tx *bbolt.Tx, q *metadataQuery) *blockMetadataQuerier {
 	return &blockMetadataQuerier{
 		query:  q,
-		shards: newShardIterator(tx, q.index, q.startTime, q.endTime, q.tenants...),
+		shards: newShardIterator(ctx, tx, q.index, q.startTime, q.endTime, q.tenants...),
 		metas:  make([]*metastorev1.BlockMeta, 0, 256),
 	}
 }
@@ -216,10 +216,10 @@ func cloneDatasetMetadataForQuery(ds *metastorev1.Dataset) *metastorev1.Dataset 
 	}
 }
 
-func newMetadataLabelQuerier(tx *bbolt.Tx, q *metadataQuery) *metadataLabelQuerier {
+func newMetadataLabelQuerier(ctx context.Context, tx *bbolt.Tx, q *metadataQuery) *metadataLabelQuerier {
 	return &metadataLabelQuerier{
 		query:  q,
-		shards: newShardIterator(tx, q.index, q.startTime, q.endTime, q.tenants...),
+		shards: newShardIterator(ctx, tx, q.index, q.startTime, q.endTime, q.tenants...),
 		labels: metadata.NewLabelsCollector(q.labels...),
 	}
 }
@@ -283,10 +283,7 @@ type shardIterator struct {
 	endTime   time.Time
 }
 
-func newShardIterator(tx *bbolt.Tx, index *Index, startTime, endTime time.Time, tenants ...string) *shardIterator {
-	// See comment in DefaultConfig.queryLookaroundPeriod.
-	startTime = startTime.Add(-index.config.queryLookaroundPeriod)
-	endTime = endTime.Add(index.config.queryLookaroundPeriod)
+func newShardIterator(ctx context.Context, tx *bbolt.Tx, index *Index, startTime, endTime time.Time, tenants ...string) *shardIterator {
 	si := shardIterator{
 		tx:        tx,
 		tenants:   tenants,
@@ -294,11 +291,29 @@ func newShardIterator(tx *bbolt.Tx, index *Index, startTime, endTime time.Time, 
 		startTime: startTime,
 		endTime:   endTime,
 	}
-	for p := range index.store.Partitions(tx) {
-		if !p.Overlaps(startTime, endTime) {
-			continue
+	if shards, ok, err := index.intervals.candidates(tx, index.store, startTime.UnixMilli(), endTime.UnixMilli(), tenants...); err != nil {
+		si.err = err
+	} else if ok {
+		si.shards = shards
+	} else {
+		// A concurrent retention deletion may have removed a tree node that is
+		// still visible to this older Bolt snapshot.
+		si.collectShards(ctx)
+	}
+	slices.SortFunc(si.shards, compareShards)
+	si.shards = slices.Compact(si.shards)
+	return &si
+}
+
+func (si *shardIterator) collectShards(ctx context.Context) {
+	// Partition timestamps come from block ULIDs and represent creation time,
+	// which may differ arbitrarily from the profile data time during backfills.
+	for p := range si.index.store.Partitions(si.tx) {
+		if err := ctx.Err(); err != nil {
+			si.err = err
+			break
 		}
-		q := p.Query(tx)
+		q := p.Query(si.tx)
 		if q == nil {
 			continue
 		}
@@ -310,9 +325,6 @@ func newShardIterator(tx *bbolt.Tx, index *Index, startTime, endTime time.Time, 
 			}
 		}
 	}
-	slices.SortFunc(si.shards, compareShards)
-	si.shards = slices.Compact(si.shards)
-	return &si
 }
 
 func (si *shardIterator) Err() error { return si.err }
@@ -332,7 +344,20 @@ func (si *shardIterator) Next() bool {
 func compareShards(a, b store.Shard) int {
 	cmp := strings.Compare(a.Tenant, b.Tenant)
 	if cmp == 0 {
-		return int(a.Shard) - int(b.Shard)
+		if a.Shard != b.Shard {
+			if a.Shard < b.Shard {
+				return -1
+			}
+			return 1
+		}
+		if cmp = a.Partition.Timestamp.Compare(b.Partition.Timestamp); cmp == 0 {
+			if a.Partition.Duration < b.Partition.Duration {
+				return -1
+			}
+			if a.Partition.Duration > b.Partition.Duration {
+				return 1
+			}
+		}
 	}
 	return cmp
 }

--- a/pkg/metastore/index/query_test.go
+++ b/pkg/metastore/index/query_test.go
@@ -325,6 +325,98 @@ func TestIndex_Query(t *testing.T) {
 	})
 }
 
+func TestIndex_QueryMetadata_BlockCreationTimeDiffersFromDataTime(t *testing.T) {
+	const tenant = "tenant-a"
+	dataTime := test.Time("2024-01-01T10:00:00.000Z")
+	creationTime := dataTime.Add(8 * 7 * 24 * time.Hour)
+
+	newBlock := func(idTime time.Time) *metastorev1.BlockMeta {
+		minTime := dataTime.UnixMilli()
+		maxTime := dataTime.Add(time.Hour).UnixMilli()
+		return &metastorev1.BlockMeta{
+			Id:      test.ULID(idTime.Format(time.RFC3339Nano)),
+			Tenant:  1,
+			Shard:   1,
+			MinTime: minTime,
+			MaxTime: maxTime,
+			Datasets: []*metastorev1.Dataset{{
+				Tenant:  1,
+				MinTime: minTime,
+				MaxTime: maxTime,
+				Labels:  []int32{1, 2, 3},
+			}},
+			StringTable: []string{"", tenant, "service_name", "backfill"},
+		}
+	}
+
+	assertQueryable := func(t *testing.T, db *bbolt.DB, idx *Index, expectedIDs ...string) {
+		t.Helper()
+		req := MetadataQuery{
+			Expr:      `{service_name="backfill"}`,
+			StartTime: dataTime,
+			EndTime:   dataTime.Add(time.Hour),
+			Tenant:    []string{tenant},
+			Labels:    []string{"service_name"},
+		}
+		require.NoError(t, db.View(func(tx *bbolt.Tx) error {
+			blocks, err := idx.QueryMetadata(tx, context.Background(), req)
+			require.NoError(t, err)
+			require.Len(t, blocks, len(expectedIDs))
+			actualIDs := make([]string, len(blocks))
+			for i := range blocks {
+				actualIDs[i] = blocks[i].Id
+			}
+			assert.ElementsMatch(t, expectedIDs, actualIDs)
+
+			foundLabels, err := idx.QueryMetadataLabels(tx, context.Background(), req)
+			require.NoError(t, err)
+			require.Len(t, foundLabels, 1)
+			assert.Equal(t, "backfill", foundLabels[0].Labels[0].Value)
+			return nil
+		}))
+	}
+
+	db := test.BoltDB(t)
+	idx := NewIndex(util.Logger, NewStore(), DefaultConfig, nil)
+	require.NoError(t, db.Update(idx.Init))
+
+	backfilled := newBlock(creationTime)
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		return idx.InsertBlock(tx, backfilled.CloneVT())
+	}))
+	assertQueryable(t, db, idx, backfilled.Id)
+
+	t.Run("restored", func(t *testing.T) {
+		restored := NewIndex(util.Logger, NewStore(), DefaultConfig, nil)
+		require.NoError(t, db.View(restored.Restore))
+		assertQueryable(t, db, restored, backfilled.Id)
+	})
+
+	compacted := newBlock(creationTime.Add(time.Hour))
+	compacted.CompactionLevel = 1
+	t.Run("compaction replacement", func(t *testing.T) {
+		require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+			return idx.ReplaceBlocks(tx, &metastorev1.CompactedBlocks{
+				SourceBlocks: &metastorev1.BlockList{
+					Tenant: tenant,
+					Shard:  1,
+					Blocks: []string{backfilled.Id},
+				},
+				NewBlocks: []*metastorev1.BlockMeta{compacted.CloneVT()},
+			})
+		}))
+		assertQueryable(t, db, idx, compacted.Id)
+	})
+
+	t.Run("block created before data", func(t *testing.T) {
+		createdBeforeData := newBlock(dataTime.Add(-8 * 7 * 24 * time.Hour))
+		require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+			return idx.InsertBlock(tx, createdBeforeData.CloneVT())
+		}))
+		assertQueryable(t, db, idx, createdBeforeData.Id, compacted.Id)
+	})
+}
+
 func TestIndex_QueryMetadata_StaleReadCacheReloadsShard(t *testing.T) {
 	db := test.BoltDB(t)
 	idxWriter := NewIndex(util.Logger, NewStore(), DefaultConfig, nil)

--- a/pkg/metastore/index/shard_intervals.go
+++ b/pkg/metastore/index/shard_intervals.go
@@ -1,0 +1,307 @@
+package index
+
+import (
+	"cmp"
+	"sync"
+
+	"go.etcd.io/bbolt"
+
+	indexstore "github.com/grafana/pyroscope/v2/pkg/metastore/index/store"
+)
+
+// shardIntervalIndex narrows metadata queries to shard summaries whose data
+// range may overlap the request. Its contents are derived from ShardIndex and
+// are therefore safe to rebuild from Bolt at any time.
+type shardIntervalIndex struct {
+	mu      sync.RWMutex
+	tenants map[string]*tenantShardIntervals
+	removed map[shardIntervalKey]int
+	ready   bool
+}
+
+type tenantShardIntervals struct {
+	root    *intervalNode
+	entries map[shardIntervalKey]intervalShard
+	legacy  map[shardIntervalKey]intervalShard
+}
+
+type shardIntervalKey struct {
+	partition indexstore.Partition
+	tenant    string
+	shard     uint32
+}
+
+type intervalShard struct {
+	shard indexstore.Shard
+	min   int64
+	max   int64
+}
+
+type intervalNode struct {
+	item   intervalShard
+	left   *intervalNode
+	right  *intervalNode
+	height int
+	maxEnd int64
+}
+
+func newShardIntervalIndex() *shardIntervalIndex {
+	return &shardIntervalIndex{
+		tenants: make(map[string]*tenantShardIntervals),
+		removed: make(map[shardIntervalKey]int),
+		ready:   true,
+	}
+}
+
+func (i *shardIntervalIndex) disable() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.ready = false
+}
+
+func (i *shardIntervalIndex) replace(replacement *shardIntervalIndex) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.tenants = replacement.tenants
+	i.removed = replacement.removed
+	i.ready = true
+}
+
+func (i *shardIntervalIndex) upsert(shard indexstore.Shard) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.upsertUnsafe(shard)
+}
+
+func (i *shardIntervalIndex) upsertUnsafe(shard indexstore.Shard) {
+	tree := i.tenants[shard.Tenant]
+	if tree == nil {
+		tree = &tenantShardIntervals{
+			entries: make(map[shardIntervalKey]intervalShard),
+			legacy:  make(map[shardIntervalKey]intervalShard),
+		}
+		i.tenants[shard.Tenant] = tree
+	}
+	key := shardIntervalKey{partition: shard.Partition, tenant: shard.Tenant, shard: shard.Shard}
+	if previous, ok := tree.entries[key]; ok && !previous.matchesAll() {
+		tree.root = deleteIntervalNode(tree.root, previous)
+	}
+	delete(tree.legacy, key)
+	entry := intervalShard{
+		shard: indexstore.Shard{
+			Partition:  shard.Partition,
+			Tenant:     shard.Tenant,
+			Shard:      shard.Shard,
+			ShardIndex: shard.ShardIndex,
+		},
+		min: shard.ShardIndex.MinTime,
+		max: shard.ShardIndex.MaxTime,
+	}
+	tree.entries[key] = entry
+	delete(i.removed, key)
+	if entry.matchesAll() {
+		tree.legacy[key] = entry
+	} else {
+		tree.root = insertIntervalNode(tree.root, entry)
+	}
+}
+
+func (i *shardIntervalIndex) remove(txID int, partition indexstore.Partition, tenant string, shard uint32) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	tree := i.tenants[tenant]
+	if tree == nil {
+		return
+	}
+	key := shardIntervalKey{partition: partition, tenant: tenant, shard: shard}
+	entry, ok := tree.entries[key]
+	if !ok {
+		return
+	}
+	if !entry.matchesAll() {
+		tree.root = deleteIntervalNode(tree.root, entry)
+	}
+	delete(tree.entries, key)
+	delete(tree.legacy, key)
+	if len(tree.entries) == 0 {
+		delete(i.tenants, tenant)
+	}
+	i.removed[key] = txID
+}
+
+// candidates returns false when this in-memory index has observed a deletion
+// newer than the caller's Bolt snapshot. The caller must then scan Bolt to
+// avoid excluding a shard that still exists in that older snapshot. Deletions
+// are reconciled against newer snapshots because Bolt reuses IDs after a
+// rolled-back write transaction.
+func (i *shardIntervalIndex) candidates(tx *bbolt.Tx, store Store, start, end int64, tenants ...string) ([]indexstore.Shard, bool, error) {
+	i.mu.RLock()
+	if !i.ready {
+		i.mu.RUnlock()
+		return nil, false, nil
+	}
+	if len(i.removed) == 0 {
+		shards := i.collectCandidates(start, end, tenants...)
+		i.mu.RUnlock()
+		return shards, true, nil
+	}
+	i.mu.RUnlock()
+
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if !i.ready {
+		return nil, false, nil
+	}
+	for key, removedAt := range i.removed {
+		if tx.ID() < removedAt {
+			return nil, false, nil
+		}
+		shard, err := store.LoadShard(tx, key.partition, key.tenant, key.shard)
+		if err != nil {
+			return nil, false, err
+		}
+		if shard != nil {
+			i.upsertUnsafe(*shard)
+		}
+		delete(i.removed, key)
+	}
+	return i.collectCandidates(start, end, tenants...), true, nil
+}
+
+func (i *shardIntervalIndex) collectCandidates(start, end int64, tenants ...string) []indexstore.Shard {
+	shards := make([]indexstore.Shard, 0)
+	for _, tenant := range tenants {
+		tree := i.tenants[tenant]
+		if tree == nil {
+			continue
+		}
+		for _, entry := range tree.legacy {
+			shards = append(shards, entry.shard)
+		}
+		collectIntervalOverlaps(tree.root, start, end, &shards)
+	}
+	return shards
+}
+
+func (s intervalShard) matchesAll() bool { return s.min == 0 || s.max == 0 }
+
+func collectIntervalOverlaps(node *intervalNode, start, end int64, shards *[]indexstore.Shard) {
+	if node == nil {
+		return
+	}
+	if node.left != nil && node.left.maxEnd >= start {
+		collectIntervalOverlaps(node.left, start, end, shards)
+	}
+	if node.item.min <= end && node.item.max >= start {
+		*shards = append(*shards, node.item.shard)
+	}
+	if node.item.min <= end {
+		collectIntervalOverlaps(node.right, start, end, shards)
+	}
+}
+
+func insertIntervalNode(node *intervalNode, item intervalShard) *intervalNode {
+	if node == nil {
+		return &intervalNode{item: item, height: 1, maxEnd: item.max}
+	}
+	if compareIntervalShards(item, node.item) < 0 {
+		node.left = insertIntervalNode(node.left, item)
+	} else {
+		node.right = insertIntervalNode(node.right, item)
+	}
+	return balanceIntervalNode(node)
+}
+
+func deleteIntervalNode(node *intervalNode, item intervalShard) *intervalNode {
+	if node == nil {
+		return nil
+	}
+	switch cmp := compareIntervalShards(item, node.item); {
+	case cmp < 0:
+		node.left = deleteIntervalNode(node.left, item)
+	case cmp > 0:
+		node.right = deleteIntervalNode(node.right, item)
+	default:
+		if node.left == nil {
+			return node.right
+		}
+		if node.right == nil {
+			return node.left
+		}
+		successor := node.right
+		for successor.left != nil {
+			successor = successor.left
+		}
+		node.item = successor.item
+		node.right = deleteIntervalNode(node.right, successor.item)
+	}
+	return balanceIntervalNode(node)
+}
+
+func compareIntervalShards(a, b intervalShard) int {
+	if c := cmp.Compare(a.min, b.min); c != 0 {
+		return c
+	}
+	if c := a.shard.Partition.Timestamp.Compare(b.shard.Partition.Timestamp); c != 0 {
+		return c
+	}
+	if c := cmp.Compare(a.shard.Partition.Duration, b.shard.Partition.Duration); c != 0 {
+		return c
+	}
+	return cmp.Compare(a.shard.Shard, b.shard.Shard)
+}
+
+func balanceIntervalNode(node *intervalNode) *intervalNode {
+	updateIntervalNode(node)
+	balance := intervalNodeHeight(node.left) - intervalNodeHeight(node.right)
+	if balance > 1 {
+		if intervalNodeHeight(node.left.left) < intervalNodeHeight(node.left.right) {
+			node.left = rotateIntervalLeft(node.left)
+		}
+		return rotateIntervalRight(node)
+	}
+	if balance < -1 {
+		if intervalNodeHeight(node.right.right) < intervalNodeHeight(node.right.left) {
+			node.right = rotateIntervalRight(node.right)
+		}
+		return rotateIntervalLeft(node)
+	}
+	return node
+}
+
+func rotateIntervalLeft(node *intervalNode) *intervalNode {
+	right := node.right
+	node.right = right.left
+	right.left = node
+	updateIntervalNode(node)
+	updateIntervalNode(right)
+	return right
+}
+
+func rotateIntervalRight(node *intervalNode) *intervalNode {
+	left := node.left
+	node.left = left.right
+	left.right = node
+	updateIntervalNode(node)
+	updateIntervalNode(left)
+	return left
+}
+
+func updateIntervalNode(node *intervalNode) {
+	node.height = max(intervalNodeHeight(node.left), intervalNodeHeight(node.right)) + 1
+	node.maxEnd = max(node.item.max, max(intervalNodeMaxEnd(node.left), intervalNodeMaxEnd(node.right)))
+}
+
+func intervalNodeHeight(node *intervalNode) int {
+	if node == nil {
+		return 0
+	}
+	return node.height
+}
+
+func intervalNodeMaxEnd(node *intervalNode) int64 {
+	if node == nil {
+		return -1 << 63
+	}
+	return node.maxEnd
+}

--- a/pkg/metastore/index/shard_intervals_test.go
+++ b/pkg/metastore/index/shard_intervals_test.go
@@ -1,0 +1,72 @@
+package index
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/pyroscope/v2/pkg/block/metadata"
+	indexstore "github.com/grafana/pyroscope/v2/pkg/metastore/index/store"
+)
+
+func TestShardIntervalIndex(t *testing.T) {
+	index := newShardIntervalIndex()
+	partition := func(hour int) indexstore.Partition {
+		return indexstore.NewPartition(time.Date(2024, 1, 1, hour, 0, 0, 0, time.UTC), time.Hour)
+	}
+	shard := func(tenant string, p indexstore.Partition, id uint32, min, max int64) indexstore.Shard {
+		return indexstore.Shard{
+			Partition:  p,
+			Tenant:     tenant,
+			Shard:      id,
+			ShardIndex: indexstore.ShardIndex{MinTime: min, MaxTime: max},
+		}
+	}
+
+	first := shard("tenant-a", partition(1), 1, 10, 20)
+	first.StringTable = metadata.NewStringTable()
+	sameShardOtherPartition := shard("tenant-a", partition(4), 1, 10, 20)
+	nested := shard("tenant-a", partition(2), 2, 5, 30)
+	legacy := shard("tenant-a", partition(3), 3, 0, 0)
+	otherTenant := shard("tenant-b", partition(1), 1, 10, 20)
+	for _, s := range []indexstore.Shard{first, sameShardOtherPartition, nested, legacy, otherTenant} {
+		index.upsert(s)
+	}
+	assert.Nil(t, index.tenants[first.Tenant].entries[shardIntervalKey{
+		partition: first.Partition,
+		tenant:    first.Tenant,
+		shard:     first.Shard,
+	}].shard.StringTable)
+	assert.Len(t, index.tenants[first.Tenant].legacy, 1)
+
+	candidates, ok, err := index.candidates(nil, nil, 15, 15, "tenant-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.ElementsMatch(t, []uint32{1, 1, 2, 3}, shardIDs(candidates))
+
+	candidates, ok, err = index.candidates(nil, nil, 15, 15, "tenant-b")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, []uint32{1}, shardIDs(candidates))
+
+	// Updating an existing shard widens its persisted summary without creating
+	// a duplicate tree node.
+	widened := first
+	widened.ShardIndex.MinTime = 1
+	widened.ShardIndex.MaxTime = 40
+	index.upsert(widened)
+	candidates, ok, err = index.candidates(nil, nil, 35, 35, "tenant-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.ElementsMatch(t, []uint32{1, 3}, shardIDs(candidates))
+}
+
+func shardIDs(shards []indexstore.Shard) []uint32 {
+	ids := make([]uint32, len(shards))
+	for n, shard := range shards {
+		ids[n] = shard.Shard
+	}
+	return ids
+}

--- a/pkg/test/integration/backfill_test.go
+++ b/pkg/test/integration/backfill_test.go
@@ -1,0 +1,41 @@
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/grafana/pyroscope/v2/pkg/pprof/testhelper"
+)
+
+func TestV2HistoricalBackfill(t *testing.T) {
+	p := new(PyroscopeTest).Configure(t, true)
+	p.start(t)
+	t.Cleanup(p.stop)
+
+	profileTime := time.Now().Add(-8 * 7 * 24 * time.Hour).Truncate(time.Second)
+	profile := testhelper.NewProfileBuilder(profileTime.UnixNano()).
+		CPUProfile().
+		ForStacktraceString("historical", "work").
+		AddSamples(239)
+	rawProfile, err := profile.MarshalVT()
+	require.NoError(t, err)
+
+	rb := p.NewRequestBuilder(t)
+	rb.Push(rb.PushPPROFRequestFromBytes(rawProfile, "process_cpu"), 200, "")
+
+	req := connect.NewRequest(&querierv1.SelectMergeProfileRequest{
+		ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+		Start:         profileTime.Add(-time.Minute).UnixMilli(),
+		End:           profileTime.Add(time.Minute).UnixMilli(),
+		LabelSelector: `{service_name="` + rb.AppName + `"}`,
+	})
+	require.Eventually(t, func() bool {
+		resp, err := rb.QueryClient().SelectMergeProfile(context.Background(), req)
+		return err == nil && len(resp.Msg.Sample) > 0
+	}, 10*time.Second, 100*time.Millisecond)
+}


### PR DESCRIPTION
## Summary

- select metastore shards by their persisted profile-data interval instead of block creation time
- keep historical backfills queryable when block ULID and profile timestamps differ
- add stale-snapshot handling, compatibility for legacy shard summaries, and backfill coverage

Fixes #5361

## Test plan

- `go test -count=1 -race ./pkg/metastore/index/...`
- `pkg/test/integration/backfill_test.go`