### PR TITLE
docs: document Python SDK fork safety

### DIFF
--- a/docs/sources/configure-client/language-sdks/python.md
+++ b/docs/sources/configure-client/language-sdks/python.md
@@ -82,6 +82,21 @@ pyroscope.configure(
 )
 ```
 
+{{< admonition type="caution" >}}
+If your application forks processes, initialize the Python client after the fork.
+Refer to [Use the Python client with forked processes](#use-the-python-client-with-forked-processes) for details.
+{{< /admonition >}}
+
+## Add profiling labels to Python applications
+
+You can add tags to certain parts of your code:
+
+```python
+# You can use a wrapper:
+with pyroscope.tag_wrapper({ "controller": "slow_controller_i_want_to_profile" }):
+    slow_code()
+```
+
 ## Use the Python client with forked processes
 
 The Python client starts background threads when you call `pyroscope.configure()`.
@@ -131,16 +146,6 @@ You must synchronize this sequence with every thread that can use the client.
 Prefer initializing after the fork because forking a multithreaded process can also be unsafe for libraries other than Pyroscope.
 
 For a runnable configuration, refer to the [Django and Gunicorn example](https://github.com/grafana/pyroscope/tree/main/examples/language-sdk-instrumentation/python/rideshare/django).
-
-## Add profiling labels to Python applications
-
-You can add tags to certain parts of your code:
-
-```python
-# You can use a wrapper:
-with pyroscope.tag_wrapper({ "controller": "slow_controller_i_want_to_profile" }):
-    slow_code()
-```
 
 ## Sending data to Pyroscope OSS or Grafana Cloud Profiles with Python SDK
 

--- a/docs/sources/configure-client/language-sdks/python.md
+++ b/docs/sources/configure-client/language-sdks/python.md
@@ -82,6 +82,56 @@ pyroscope.configure(
 )
 ```
 
+## Use the Python client with forked processes
+
+The Python client starts background threads when you call `pyroscope.configure()`.
+The client isn't fork-safe after those threads have started.
+If a process calls `fork()` after configuring the client, the child can inherit locks and other synchronization state from threads that no longer exist.
+This can cause the child to deadlock or behave unpredictably.
+
+{{< admonition type="caution" >}}
+Call `pyroscope.configure()` only after the last fork in each process that you want to profile.
+Don't initialize the client in a parent process that later forks.
+{{< /admonition >}}
+
+For pre-fork application servers such as Gunicorn, initialize Pyroscope in a post-fork hook.
+For example:
+
+```python
+# gunicorn.conf.py
+import os
+
+import pyroscope
+
+preload_app = True
+
+
+def post_fork(server, worker):
+    pyroscope.configure(
+        application_name="my.python.app",
+        server_address=os.getenv(
+            "PYROSCOPE_SERVER_ADDRESS",
+            "http://my-pyroscope-server:4040",
+        ),
+    )
+```
+
+Start Gunicorn with the configuration file:
+
+```bash
+gunicorn --config gunicorn.conf.py myapp.wsgi:application
+```
+
+When `preload_app` is enabled, Gunicorn imports application modules in the parent process before it forks workers.
+Keep `pyroscope.configure()` out of those modules and call it only from `post_fork`.
+The same rule applies to other pre-fork servers and direct uses of `os.fork()`: initialize the client separately in each child after the fork.
+
+If you can't avoid forking after profiling has started, stop all code that interacts with the Pyroscope client, call `pyroscope.shutdown()`, perform the fork, and call `pyroscope.configure()` again in each process that you want to profile.
+You must synchronize this sequence with every thread that can use the client.
+Prefer initializing after the fork because forking a multithreaded process can also be unsafe for libraries other than Pyroscope.
+
+For a runnable configuration, refer to the [Django and Gunicorn example](https://github.com/grafana/pyroscope/tree/main/examples/language-sdk-instrumentation/python/rideshare/django).
+
 ## Add profiling labels to Python applications
 
 You can add tags to certain parts of your code:

--- a/examples/language-sdk-instrumentation/python/rideshare/django/README.md
+++ b/examples/language-sdk-instrumentation/python/rideshare/django/README.md
@@ -1,5 +1,12 @@
 # Django Example
 
+This example runs Django with Gunicorn and preloads the application before Gunicorn forks its workers.
+The Pyroscope Python client starts background threads and must not be initialized in the Gunicorn master process before those forks.
+
+The [`post_fork` hook](app/gunicorn.conf.py) calls `pyroscope.configure()` separately in each worker.
+Don't move that call into Django settings or another application module: Gunicorn imports those modules in the master process when `preload_app` is enabled.
+For more information, refer to the [Python client documentation](https://grafana.com/docs/pyroscope/latest/configure-client/language-sdks/python/#use-the-python-client-with-forked-processes).
+
 To run the example run the following commands:
 ```
 # Pull latest pyroscope and grafana images:

--- a/examples/language-sdk-instrumentation/python/rideshare/django/app/gunicorn.conf.py
+++ b/examples/language-sdk-instrumentation/python/rideshare/django/app/gunicorn.conf.py
@@ -1,6 +1,7 @@
 import os
 
 import pyroscope
+from django.db import connections
 
 
 bind = "0.0.0.0:8000"
@@ -9,6 +10,8 @@ preload_app = True
 
 
 def post_fork(server, worker):
+    # Don't share connections opened while preloading the app with workers.
+    connections.close_all()
     server.log.info("Configuring Pyroscope in worker pid %s", worker.pid)
     pyroscope.configure(
         application_name=os.getenv("PYROSCOPE_APPLICATION_NAME", "ride-sharing-app"),

--- a/examples/language-sdk-instrumentation/python/rideshare/django/app/gunicorn.conf.py
+++ b/examples/language-sdk-instrumentation/python/rideshare/django/app/gunicorn.conf.py
@@ -1,0 +1,21 @@
+import os
+
+import pyroscope
+
+
+bind = "0.0.0.0:8000"
+workers = 2
+preload_app = True
+
+
+def post_fork(server, worker):
+    server.log.info("Configuring Pyroscope in worker pid %s", worker.pid)
+    pyroscope.configure(
+        application_name=os.getenv("PYROSCOPE_APPLICATION_NAME", "ride-sharing-app"),
+        server_address=os.getenv("PYROSCOPE_SERVER_ADDRESS", "http://pyroscope:4040"),
+        basic_auth_username=os.getenv("PYROSCOPE_BASIC_AUTH_USER", ""),
+        basic_auth_password=os.getenv("PYROSCOPE_BASIC_AUTH_PASSWORD", ""),
+        tags={
+            "region": os.getenv("REGION", ""),
+        },
+    )

--- a/examples/language-sdk-instrumentation/python/rideshare/django/app/hello_django/settings.py
+++ b/examples/language-sdk-instrumentation/python/rideshare/django/app/hello_django/settings.py
@@ -11,7 +11,6 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 
 import os
-import pyroscope
 from pathlib import Path
 
 
@@ -135,18 +134,3 @@ MEDIA_ROOT = BASE_DIR / "mediafiles"
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
-
-app_name = os.getenv("PYROSCOPE_APPLICATION_NAME", "ride-sharing-app")
-server_addr = os.getenv("PYROSCOPE_SERVER_ADDRESS", "http://pyroscope:4040")
-basic_auth_username = os.getenv("PYROSCOPE_BASIC_AUTH_USER", "")
-basic_auth_password = os.getenv("PYROSCOPE_BASIC_AUTH_PASSWORD", "")
-
-pyroscope.configure(
-	application_name = app_name,
-	server_address   = server_addr,
-    basic_auth_username = basic_auth_username,
-    basic_auth_password = basic_auth_password,
-	tags           = {
-        "region":   f'{os.getenv("REGION")}',
-	}
-)

--- a/examples/language-sdk-instrumentation/python/rideshare/django/docker-compose.yml
+++ b/examples/language-sdk-instrumentation/python/rideshare/django/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - db
   us-east:
     build: ./app
-    command: python manage.py runserver 0.0.0.0:8000
+    command: gunicorn --config gunicorn.conf.py hello_django.wsgi:application
     env_file:
       - ./.env.dev
     environment:
@@ -24,7 +24,7 @@ services:
         condition: service_completed_successfully
   eu-north:
     build: ./app
-    command: python manage.py runserver 0.0.0.0:8000
+    command: gunicorn --config gunicorn.conf.py hello_django.wsgi:application
     env_file:
       - ./.env.dev
     environment:
@@ -34,7 +34,7 @@ services:
         condition: service_completed_successfully
   ap-south:
     build: ./app
-    command: python manage.py runserver 0.0.0.0:8000
+    command: gunicorn --config gunicorn.conf.py hello_django.wsgi:application
     env_file:
     - ./.env.dev
     environment:


### PR DESCRIPTION
## What this changes

- document that the Python SDK is not safe when `fork()` happens after `pyroscope.configure()` starts background threads
- show how to initialize Pyroscope from Gunicorn’s `post_fork` hook
- convert the Django rideshare example to preload the application while starting Pyroscope independently in each worker

This documents the limitation tracked in grafana/pyroscope-python#122 and provides a runnable safe configuration.

## Validation

- `docker compose config --quiet`
- Python syntax and diff checks
- example readiness helper unit tests
- targeted Django example integration test through the repository test harness
- verified all three regional endpoints and post-fork worker initialization