### PR TITLE
ci(examples): run all examples for harness changes

### DIFF
--- a/tools/examples/select-examples.sh
+++ b/tools/examples/select-examples.sh
@@ -7,7 +7,9 @@
 #   - If TARGET is set, select every example at or under that path prefix
 #     (e.g. TARGET=examples/tracing selects all tracing examples).
 #   - Else if BASE_REF is set, select every example that has a changed file in
-#     the diff against BASE_REF (used for pull requests).
+#     the diff against BASE_REF (used for pull requests). If a top-level Go file
+#     under examples/ changes, select all examples because those files implement
+#     the shared test harness.
 #   - Else select all examples.
 #
 # Environment:
@@ -37,6 +39,12 @@ fi
 
 if [[ -n "${BASE_REF:-}" ]]; then
   mapfile -t changed < <(git diff --name-only "${BASE_REF}"...HEAD -- examples)
+  for f in "${changed[@]:-}"; do
+    if [[ "$f" =~ ^examples/[^/]+\.go$ ]]; then
+      printf '%s\n' "${all_dirs[@]}"
+      exit 0
+    fi
+  done
   for d in "${all_dirs[@]}"; do
     for f in "${changed[@]:-}"; do
       if [[ "$f" == "$d"/* ]]; then


### PR DESCRIPTION
## What this changes

- run every runnable example when a top-level `examples/*.go` test harness file changes
- preserve targeted selection for changes nested inside an individual example
- keep `_templates` excluded from runnable examples

This follows up on #5363, where the shared harness changed but CI selected only the Django example because it was the only modified example directory.

## Validation

- `bash -n tools/examples/select-examples.sh`
- mocked selector scenarios for harness-wide, single-example, and `_templates` changes
- `git diff --check origin/main...HEAD`