### PR TITLE
perf(model): merge serialized trees without an intermediate tree

### DIFF
--- a/pkg/model/tree.go
+++ b/pkg/model/tree.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unsafe"
 
 	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 
@@ -60,6 +61,41 @@ func (FunctionNameI) unmarshalNode(b []byte, offset int) (FunctionName, int64, i
 	return name, int64(value), offset, nil
 }
 
+func (FunctionNameI) mergeNode(parent *node[FunctionName], b []byte, offset int, format func(FunctionName) FunctionName, newNode func() *node[FunctionName]) (*node[FunctionName], int, error) { //nolint:unused
+	nameLen, o := varint.Uvarint(b[offset:])
+	if o < 0 {
+		return nil, 0, errMalformedTreeBytes
+	}
+	offset += o
+	if int(nameLen) > len(b)-offset {
+		return nil, 0, errMalformedTreeBytes
+	}
+	nameBytes := b[offset : offset+int(nameLen)]
+	offset += int(nameLen)
+	value, o := varint.Uvarint(b[offset:])
+	if o < 0 {
+		return nil, 0, errMalformedTreeBytes
+	}
+	offset += o
+
+	var n *node[FunctionName]
+	if format != nil {
+		// The format function may retain the name: hand it an owned copy.
+		n = parent.insert(format(FunctionName(nameBytes)), newNode)
+	} else {
+		// Look up the child through a zero-copy view of the name: an owned
+		// copy is only allocated when a new node is actually inserted.
+		name := FunctionName(unsafeString(nameBytes))
+		i, found := parent.find(name)
+		if found == nil {
+			found = parent.insertAt(i, FunctionName(nameBytes), newNode)
+		}
+		n = found
+	}
+	n.self += int64(value)
+	return n, offset, nil
+}
+
 const OtherLocationRef = LocationRefName(-1)
 
 type LocationRefName int
@@ -99,6 +135,27 @@ func (LocationRefNameI) unmarshalNode(b []byte, offset int) (LocationRefName, in
 	return LocationRefName(name), int64(value), offset, nil
 }
 
+func (LocationRefNameI) mergeNode(parent *node[LocationRefName], b []byte, offset int, format func(LocationRefName) LocationRefName, newNode func() *node[LocationRefName]) (*node[LocationRefName], int, error) { //nolint:unused
+	name64, o := varint.Uvarint(b[offset:])
+	if o < 0 {
+		return nil, 0, errMalformedTreeBytes
+	}
+	offset += o
+	value, o := varint.Uvarint(b[offset:])
+	if o < 0 {
+		return nil, 0, errMalformedTreeBytes
+	}
+	offset += o
+
+	name := LocationRefName(name64)
+	if format != nil {
+		name = format(name)
+	}
+	n := parent.insert(name, newNode)
+	n.self += int64(value)
+	return n, offset, nil
+}
+
 type NodeName interface {
 	~string | ~int
 }
@@ -108,6 +165,18 @@ type NodeNameI[N ~string | ~int] interface {
 	newOther() N
 	marshalNode(io.Writer, varint.Writer, *node[N], func(N) N) error
 	unmarshalNode([]byte, int) (N, int64, int, error)
+	// mergeNode parses the node record at the given offset and merges it
+	// into the parent's children: the node's self value is added to the
+	// existing child with the same (optionally formatted) name, or a new
+	// child is inserted. Returns the merged node and the next offset.
+	mergeNode(*node[N], []byte, int, func(N) N, func() *node[N]) (*node[N], int, error)
+}
+
+func unsafeString(b []byte) string { //nolint:unused
+	if len(b) == 0 {
+		return ""
+	}
+	return unsafe.String(&b[0], len(b))
 }
 
 type LocationRefNameTree = Tree[LocationRefName, LocationRefNameI]
@@ -343,12 +412,26 @@ func (n *node[N]) String() string {
 }
 
 func (n *node[N]) insert(name N, newNode func() *node[N]) *node[N] {
+	i, child := n.find(name)
+	if child != nil {
+		return child
+	}
+	return n.insertAt(i, name, newNode)
+}
+
+// find locates the child with the given name, returning the position where
+// it is, or where it would be inserted, and the child itself (nil if absent).
+func (n *node[N]) find(name N) (int, *node[N]) {
 	i := sort.Search(len(n.children), func(i int) bool {
 		return n.children[i].name >= name
 	})
 	if i < len(n.children) && n.children[i].name == name {
-		return n.children[i]
+		return i, n.children[i]
 	}
+	return i, nil
+}
+
+func (n *node[N]) insertAt(i int, name N, newNode func() *node[N]) *node[N] {
 	// We don't clone the name: it is caller responsibility
 	// to maintain the memory ownership.
 	var child *node[N]
@@ -499,25 +582,31 @@ func MustUnmarshalTree[N NodeName, I NodeNameI[N]](b []byte) *Tree[N, I] {
 	return t
 }
 
+// nodeBuffer arena-allocates nodes in chunks. Chunks grow geometrically from
+// the initial size hint and are capped: the hint is derived from the input
+// size and may overestimate the node count severalfold, so allocating (and
+// zeroing) it all upfront wastes more memory than it saves in malloc calls.
+const maxNodeBufferChunk = 8 << 10
+
 type nodeBuffer[N NodeName] struct {
-	size  int
+	chunk int
 	nodes []node[N]
 }
 
 func newNodeBuffer[N NodeName](size int) *nodeBuffer[N] {
 	return &nodeBuffer[N]{
-		size: size,
+		chunk: min(max(size, 64), maxNodeBufferChunk),
 	}
 }
 
 func (nb *nodeBuffer[N]) newNode() *node[N] {
 	if len(nb.nodes) == 0 {
-		nb.nodes = make([]node[N], nb.size)
+		nb.nodes = make([]node[N], nb.chunk)
+		nb.chunk = min(nb.chunk*2, maxNodeBufferChunk)
 	}
 	n := &nb.nodes[0]
 	nb.nodes = nb.nodes[1:]
 	return n
-
 }
 
 func UnmarshalTree[N NodeName, I NodeNameI[N]](b []byte) (*Tree[N, I], error) {
@@ -530,7 +619,7 @@ func UnmarshalTree[N NodeName, I NodeNameI[N]](b []byte) (*Tree[N, I], error) {
 	if e := len(b) / estimateBytesPerNode; e > estimateBytesPerNode {
 		size = e
 	}
-	parents := make([]*node[N], 1, size)
+	parents := make([]*node[N], 1, min(size, 4<<10))
 	// Virtual root node.
 	root := new(node[N])
 	parents[0] = root
@@ -539,6 +628,7 @@ func UnmarshalTree[N NodeName, I NodeNameI[N]](b []byte) (*Tree[N, I], error) {
 
 	nodeBuffer := newNodeBuffer[N](size)
 
+	var records int
 	for len(parents) > 0 {
 		parent, parents = parents[len(parents)-1], parents[:len(parents)-1]
 		// specific start
@@ -559,12 +649,7 @@ func UnmarshalTree[N NodeName, I NodeNameI[N]](b []byte) (*Tree[N, I], error) {
 		n := parent.insert(name, nodeBuffer.newNode)
 		n.children = make([]*node[N], 0, childrenLen)
 		n.self = value
-
-		pn := n
-		for pn.parent != nil {
-			pn.total += n.self
-			pn = pn.parent
-		}
+		records++
 
 		for i := uint64(0); i < childrenLen; i++ {
 			parents = append(parents, n)
@@ -573,8 +658,95 @@ func UnmarshalTree[N NodeName, I NodeNameI[N]](b []byte) (*Tree[N, I], error) {
 
 	// Remove the virtual root.
 	t.root = root.children[0].children
+	t.recomputeTotals(records)
 
 	return t, nil
+}
+
+// mergeBytes merges a marshaled tree directly into t, without materializing
+// an intermediate tree. Node totals are NOT maintained: the caller must
+// recompute them (see recomputeTotals) before the totals are read.
+// Returns the number of node records merged, which bounds the tree growth.
+// On a malformed input an error is returned and t may be partially merged.
+func (t *Tree[N, I]) mergeBytes(b []byte, format func(N) N) (int, error) {
+	var initializer I
+	if len(b) < 2 {
+		return 0, nil
+	}
+	// The stream starts with a virtual root record; its name and value
+	// are ignored, only the children count matters.
+	_, _, offset, err := initializer.unmarshalNode(b, 0)
+	if err != nil {
+		return 0, err
+	}
+	childrenLen, o := varint.Uvarint(b[offset:])
+	if o < 0 {
+		return 0, errMalformedTreeBytes
+	}
+	offset += o
+
+	root := &node[N]{children: t.root}
+	parents := make([]*node[N], 0, defaultDFSSize)
+	for i := uint64(0); i < childrenLen; i++ {
+		parents = append(parents, root)
+	}
+
+	// Most records of a merged tree are expected to hit existing nodes,
+	// so the arena starts small and grows on demand.
+	nodeBuffer := newNodeBuffer[N](256)
+
+	var records int
+	var parent *node[N]
+	for len(parents) > 0 {
+		parent, parents = parents[len(parents)-1], parents[:len(parents)-1]
+
+		n, next, err := initializer.mergeNode(parent, b, offset, format, nodeBuffer.newNode)
+		if err != nil {
+			return records, err
+		}
+		offset = next
+		records++
+
+		childrenLen, o = varint.Uvarint(b[offset:])
+		if o < 0 {
+			return records, errMalformedTreeBytes
+		}
+		offset += o
+
+		if childrenLen > 0 {
+			if cap(n.children) == 0 {
+				n.children = make([]*node[N], 0, childrenLen)
+			}
+			for i := uint64(0); i < childrenLen; i++ {
+				parents = append(parents, n)
+			}
+		}
+	}
+
+	t.root = root.children
+	return records, nil
+}
+
+// recomputeTotals derives every node's total from the self values of its
+// subtree in a single pass: in reverse level order all children of a node
+// are visited before the node itself. The size hint pre-allocates the
+// traversal buffer; it does not have to be exact.
+func (t *Tree[N, I]) recomputeTotals(sizeHint int) {
+	if len(t.root) == 0 {
+		return
+	}
+	order := make([]*node[N], 0, max(sizeHint, 1024))
+	order = append(order, t.root...)
+	for i := 0; i < len(order); i++ {
+		order = append(order, order[i].children...)
+	}
+	for i := len(order) - 1; i >= 0; i-- {
+		n := order[i]
+		n.total = n.self
+		for _, c := range n.children {
+			n.total += c.total
+		}
+	}
 }
 
 // TreeFromBackendProfile is a wrapper...

--- a/pkg/model/tree_merger.go
+++ b/pkg/model/tree_merger.go
@@ -7,6 +7,11 @@ import (
 type TreeMerger[N NodeName, I NodeNameI[N]] struct {
 	mu sync.Mutex
 	t  *Tree[N, I]
+	// Totals of t are deferred while merging serialized trees and
+	// recomputed on access: see finalize. nodes is a lower bound of the
+	// tree size (the largest single merged tree), used as a size hint.
+	dirty bool
+	nodes int
 }
 
 func NewTreeMerger[N NodeName, I NodeNameI[N]]() *TreeMerger[N, I] {
@@ -17,6 +22,8 @@ func (m *TreeMerger[N, I]) MergeTree(t *Tree[N, I]) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.t != nil {
+		// Tree.Merge reads totals of both trees.
+		m.finalize()
 		m.t.Merge(t)
 	} else {
 		m.t = t
@@ -35,33 +42,48 @@ func WithTreeMergeFormatNodeNames[N any](f func(N) N) TreeMergeOption[N] {
 	}
 }
 
+// MergeTreeBytes merges a marshaled tree into the merger's tree, reading
+// the raw bytes directly. On a malformed input an error is returned and
+// the merger's tree may include a partially merged prefix of the input.
 func (m *TreeMerger[N, I]) MergeTreeBytes(b []byte, opts ...TreeMergeOption[N]) error {
 	var o = new(treeMergeOption[N])
 	for _, f := range opts {
 		f(o)
 	}
 
-	// TODO(kolesnikovae): Ideally, we should not have
-	// the intermediate tree t but update m.t reading
-	// raw bytes b directly.
-	t, err := UnmarshalTree[N, I](b)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.t == nil {
+		m.t = new(Tree[N, I])
+	}
+	records, err := m.t.mergeBytes(b, o.formatNodeNames)
 	if err != nil {
 		return err
 	}
-	if o.formatNodeNames != nil {
-		t.FormatNodeNames(o.formatNodeNames)
-	}
-	m.MergeTree(t)
+	m.dirty = true
+	m.nodes = max(m.nodes, records)
 	return nil
 }
 
 func (m *TreeMerger[N, I]) Tree() *Tree[N, I] {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.t == nil {
 		return new(Tree[N, I])
 	}
+	m.finalize()
 	return m.t
 }
 
+func (m *TreeMerger[N, I]) finalize() {
+	if m.dirty {
+		m.t.recomputeTotals(m.nodes)
+		m.dirty = false
+	}
+}
+
 func (m *TreeMerger[N, I]) IsEmpty() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.t == nil
 }

--- a/pkg/model/tree_merger_bench_test.go
+++ b/pkg/model/tree_merger_bench_test.go
@@ -1,0 +1,121 @@
+package model
+
+import (
+	"math/rand"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Benchmarks reproducing the query-backend report aggregation cost: N
+// serialized tree reports of the same service (heavily overlapping) merged
+// into one tree. Tree().Total() forces finalization so deferred work is
+// always measured.
+
+var mergeBenchData = struct {
+	once   sync.Once
+	small  [][]byte // ~15 shards of a modest tree (worker-level aggregation)
+	large  [][]byte // ~15 shards of a large tree (root-level aggregation)
+	sizes  map[string]int
+	fixmux sync.Mutex
+	fix    [][]byte // real trees from testdata (diff fixtures)
+}{}
+
+func mergeBenchShards(b *testing.B, kind string) [][]byte {
+	mergeBenchData.once.Do(func() {
+		rng := rand.New(rand.NewSource(42))
+		small := generateMergeTestStacks(rng, 8_000, 2_000, mkFunctionName)
+		mergeBenchData.small = buildShardTreeBytes[FunctionName, FunctionNameI](rng, small, 15, -1, nil)
+		large := generateMergeTestStacks(rng, 60_000, 8_000, mkFunctionName)
+		mergeBenchData.large = buildShardTreeBytes[FunctionName, FunctionNameI](rng, large, 15, -1, nil)
+	})
+	switch kind {
+	case "small":
+		return mergeBenchData.small
+	case "large":
+		return mergeBenchData.large
+	default:
+		b.Fatalf("unknown shard kind %q", kind)
+		return nil
+	}
+}
+
+func fixtureTreeBytes(b *testing.B) [][]byte {
+	mergeBenchData.fixmux.Lock()
+	defer mergeBenchData.fixmux.Unlock()
+	if mergeBenchData.fix == nil {
+		left, err := os.ReadFile("testdata/diff_left_tree.bin")
+		require.NoError(b, err)
+		right, err := os.ReadFile("testdata/diff_right_tree.bin")
+		require.NoError(b, err)
+		mergeBenchData.fix = [][]byte{left, right}
+	}
+	return mergeBenchData.fix
+}
+
+func benchmarkMergeTreeBytes(b *testing.B, shards [][]byte) {
+	var total int
+	for _, s := range shards {
+		total += len(s)
+	}
+	b.SetBytes(int64(total))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m := NewTreeMerger[FunctionName, FunctionNameI]()
+		for _, s := range shards {
+			if err := m.MergeTreeBytes(s); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if m.Tree().Total() == 0 {
+			b.Fatal("empty merge result")
+		}
+	}
+}
+
+func Benchmark_MergeTreeBytes_Sharded_Small(b *testing.B) {
+	benchmarkMergeTreeBytes(b, mergeBenchShards(b, "small"))
+}
+
+func Benchmark_MergeTreeBytes_Sharded_Large(b *testing.B) {
+	benchmarkMergeTreeBytes(b, mergeBenchShards(b, "large"))
+}
+
+func Benchmark_MergeTreeBytes_Fixture(b *testing.B) {
+	benchmarkMergeTreeBytes(b, fixtureTreeBytes(b))
+}
+
+func Benchmark_UnmarshalTree_Fixture(b *testing.B) {
+	data := fixtureTreeBytes(b)[0]
+	b.SetBytes(int64(len(data)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		t, err := UnmarshalTree[FunctionName, FunctionNameI](data)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if t.Total() == 0 {
+			b.Fatal("empty tree")
+		}
+	}
+}
+
+func Benchmark_UnmarshalTree_Sharded_Large(b *testing.B) {
+	data := mergeBenchShards(b, "large")[0]
+	b.SetBytes(int64(len(data)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		t, err := UnmarshalTree[FunctionName, FunctionNameI](data)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if t.Total() == 0 {
+			b.Fatal("empty tree")
+		}
+	}
+}

--- a/pkg/model/tree_merger_test.go
+++ b/pkg/model/tree_merger_test.go
@@ -1,0 +1,276 @@
+package model
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+// The tests in this file assert that TreeMerger.MergeTreeBytes is equivalent
+// to the reference algorithm it replaces: unmarshal every serialized tree and
+// merge the in-memory trees one by one. UnmarshalTree and Tree.Merge keep
+// their semantics, so the reference is expressed through them.
+
+type mergeTestStack[N NodeName] struct {
+	stack []N
+	value int64
+}
+
+// generateMergeTestStacks produces a universe of stack traces with a
+// realistic call-tree shape: new stacks reuse a random prefix of an existing
+// stack and append a fresh suffix, so prefixes are heavily shared and the
+// resulting tree is deep and wide, like a real service profile.
+func generateMergeTestStacks[N NodeName](rng *rand.Rand, numStacks, corpusSize int, mkName func(int) N) []mergeTestStack[N] {
+	corpus := make([]N, corpusSize)
+	for i := range corpus {
+		corpus[i] = mkName(i)
+	}
+	pick := func() N { return corpus[rng.Intn(len(corpus))] }
+
+	stacks := make([]mergeTestStack[N], 0, numStacks)
+	stacks = append(stacks, mergeTestStack[N]{
+		stack: []N{mkName(0), mkName(1)},
+		value: 1,
+	})
+	for len(stacks) < numStacks {
+		base := stacks[rng.Intn(len(stacks))].stack
+		prefix := base[:rng.Intn(len(base))+1]
+		if len(prefix) > 80 {
+			prefix = prefix[:80]
+		}
+		stack := make([]N, 0, len(prefix)+8)
+		stack = append(stack, prefix...)
+		for i, n := 0, 1+rng.Intn(8); i < n; i++ {
+			stack = append(stack, pick())
+		}
+		value := rng.Int63n(10_000) + 1
+		if rng.Intn(50) == 0 {
+			value *= 1000
+		}
+		stacks = append(stacks, mergeTestStack[N]{stack: stack, value: value})
+	}
+	return stacks
+}
+
+func mkFunctionName(i int) FunctionName {
+	switch i % 3 {
+	case 0:
+		return FunctionName(fmt.Sprintf("github.com/grafana/pyroscope/pkg/pkg%03d.(*worker%02d).processBatchItems%04d", i%97, i%13, i))
+	case 1:
+		return FunctionName(fmt.Sprintf("com.example.rt.surge.delivery.internal.dispatch.Dispatcher%02d.handleRequestWithRetries%05d", i%31, i))
+	default:
+		return FunctionName(fmt.Sprintf("net/http.(*conn%02d).serve.func%d", i%7, i))
+	}
+}
+
+func mkLocationRefName(i int) LocationRefName { return LocationRefName(i) }
+
+// buildShardTreeBytes distributes the stacks over overlapping shards
+// (mimicking blocks of the same service) and returns each shard tree
+// serialized with MarshalTruncate.
+// keepName is required by LocationRefName marshaling (the symbols to retain);
+// FunctionName trees ignore it and take nil.
+func buildShardTreeBytes[N NodeName, I NodeNameI[N]](
+	rng *rand.Rand,
+	stacks []mergeTestStack[N],
+	numShards int,
+	maxNodes int64,
+	keepName func(N) N,
+) [][]byte {
+	trees := make([]*Tree[N, I], numShards)
+	for i := range trees {
+		trees[i] = new(Tree[N, I])
+	}
+	for _, s := range stacks {
+		assigned := false
+		for i := range trees {
+			if rng.Float64() < 0.6 {
+				trees[i].InsertStack(s.value+rng.Int63n(100), s.stack...)
+				assigned = true
+			}
+		}
+		if !assigned {
+			trees[rng.Intn(numShards)].InsertStack(s.value, s.stack...)
+		}
+	}
+	shards := make([][]byte, numShards)
+	for i, t := range trees {
+		shards[i] = t.Bytes(maxNodes, keepName)
+	}
+	return shards
+}
+
+// referenceMergeTreeBytes is the original merge algorithm: unmarshal each
+// serialized tree, then merge the in-memory trees.
+func referenceMergeTreeBytes[N NodeName, I NodeNameI[N]](tb testing.TB, shards [][]byte, format func(N) N) *Tree[N, I] {
+	dst := new(Tree[N, I])
+	for _, b := range shards {
+		src, err := UnmarshalTree[N, I](b)
+		require.NoError(tb, err)
+		if format != nil {
+			src.FormatNodeNames(format)
+		}
+		dst.Merge(src)
+	}
+	return dst
+}
+
+// requireTreesEqual compares two trees node by node, including totals.
+// Children are expected in name order, which every construction path
+// (InsertStack, Merge, UnmarshalTree, MergeTreeBytes) maintains.
+func requireTreesEqual[N NodeName, I NodeNameI[N]](tb testing.TB, expected, actual *Tree[N, I]) {
+	type pair struct{ e, a *node[N] }
+	stack := []pair{{
+		e: &node[N]{children: expected.root},
+		a: &node[N]{children: actual.root},
+	}}
+	var visited int
+	for len(stack) > 0 {
+		p := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		require.Equal(tb, p.e.name, p.a.name)
+		require.Equal(tb, p.e.self, p.a.self, "self mismatch at node %v", p.e.name)
+		require.Equal(tb, p.e.total, p.a.total, "total mismatch at node %v", p.e.name)
+		require.Equal(tb, len(p.e.children), len(p.a.children), "children count mismatch at node %v", p.e.name)
+		for i := range p.e.children {
+			stack = append(stack, pair{e: p.e.children[i], a: p.a.children[i]})
+		}
+		visited++
+	}
+	require.Greater(tb, visited, 0)
+}
+
+func Test_TreeMerger_MergeTreeBytes_Sharded(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	stacks := generateMergeTestStacks(rng, 20_000, 4_000, mkFunctionName)
+	shards := buildShardTreeBytes[FunctionName, FunctionNameI](rng, stacks, 15, -1, nil)
+
+	expected := referenceMergeTreeBytes[FunctionName, FunctionNameI](t, shards, nil)
+
+	m := NewTreeMerger[FunctionName, FunctionNameI]()
+	for _, b := range shards {
+		require.NoError(t, m.MergeTreeBytes(b))
+	}
+	require.False(t, m.IsEmpty())
+	requireTreesEqual(t, expected, m.Tree())
+}
+
+func Test_TreeMerger_MergeTreeBytes_TruncatedShards(t *testing.T) {
+	// Truncated shard trees contain "other" placeholder nodes, which must
+	// merge like regular nodes.
+	rng := rand.New(rand.NewSource(2))
+	stacks := generateMergeTestStacks(rng, 5_000, 1_000, mkFunctionName)
+	shards := buildShardTreeBytes[FunctionName, FunctionNameI](rng, stacks, 8, 500, nil)
+
+	expected := referenceMergeTreeBytes[FunctionName, FunctionNameI](t, shards, nil)
+
+	m := NewTreeMerger[FunctionName, FunctionNameI]()
+	for _, b := range shards {
+		require.NoError(t, m.MergeTreeBytes(b))
+	}
+	requireTreesEqual(t, expected, m.Tree())
+}
+
+func Test_TreeMerger_MergeTreeBytes_Concurrent(t *testing.T) {
+	// The aggregator merges reports concurrently; exercise the same pattern
+	// so the race detector can catch locking regressions.
+	rng := rand.New(rand.NewSource(3))
+	stacks := generateMergeTestStacks(rng, 10_000, 2_000, mkFunctionName)
+	shards := buildShardTreeBytes[FunctionName, FunctionNameI](rng, stacks, 15, -1, nil)
+
+	expected := referenceMergeTreeBytes[FunctionName, FunctionNameI](t, shards, nil)
+
+	m := NewTreeMerger[FunctionName, FunctionNameI]()
+	var g errgroup.Group
+	for _, b := range shards {
+		g.Go(func() error { return m.MergeTreeBytes(b) })
+	}
+	require.NoError(t, g.Wait())
+	requireTreesEqual(t, expected, m.Tree())
+}
+
+func Test_TreeMerger_MixedMergeTreeAndBytes(t *testing.T) {
+	// MergeTree (in-memory) and MergeTreeBytes may be used on the same
+	// merger; totals must come out right regardless of the interleaving.
+	rng := rand.New(rand.NewSource(4))
+	stacks := generateMergeTestStacks(rng, 2_000, 500, mkFunctionName)
+	shards := buildShardTreeBytes[FunctionName, FunctionNameI](rng, stacks, 4, -1, nil)
+
+	expected := referenceMergeTreeBytes[FunctionName, FunctionNameI](t, shards, nil)
+
+	for _, inMemory := range []int{0, 1, 3} {
+		m := NewTreeMerger[FunctionName, FunctionNameI]()
+		for i, b := range shards {
+			if i == inMemory {
+				src, err := UnmarshalTree[FunctionName, FunctionNameI](b)
+				require.NoError(t, err)
+				m.MergeTree(src)
+				continue
+			}
+			require.NoError(t, m.MergeTreeBytes(b))
+		}
+		requireTreesEqual(t, expected, m.Tree())
+	}
+}
+
+func Test_TreeMerger_FormatNodeNames(t *testing.T) {
+	// The FullSymbols path merges LocationRefName trees while remapping
+	// references through the symbol merger. The remap function may map
+	// distinct names to the same value; such siblings must be merged,
+	// matching FormatNodeNames+Fix semantics of the reference.
+	rng := rand.New(rand.NewSource(5))
+	stacks := generateMergeTestStacks(rng, 5_000, 1_000, mkLocationRefName)
+	shards := buildShardTreeBytes[LocationRefName, LocationRefNameI](rng, stacks, 6, -1, func(n LocationRefName) LocationRefName { return n })
+
+	format := func(n LocationRefName) LocationRefName { return n / 2 }
+	expected := referenceMergeTreeBytes[LocationRefName, LocationRefNameI](t, shards, format)
+
+	m := NewTreeMerger[LocationRefName, LocationRefNameI]()
+	for _, b := range shards {
+		require.NoError(t, m.MergeTreeBytes(b, WithTreeMergeFormatNodeNames(format)))
+	}
+	requireTreesEqual(t, expected, m.Tree())
+}
+
+func Test_TreeMerger_SingleShard(t *testing.T) {
+	rng := rand.New(rand.NewSource(6))
+	stacks := generateMergeTestStacks(rng, 1_000, 300, mkFunctionName)
+	shards := buildShardTreeBytes[FunctionName, FunctionNameI](rng, stacks, 1, -1, nil)
+
+	expected, err := UnmarshalTree[FunctionName, FunctionNameI](shards[0])
+	require.NoError(t, err)
+
+	m := NewTreeMerger[FunctionName, FunctionNameI]()
+	require.NoError(t, m.MergeTreeBytes(shards[0]))
+	requireTreesEqual(t, expected, m.Tree())
+}
+
+func Test_TreeMerger_EmptyAndMalformed(t *testing.T) {
+	t.Run("empty bytes are a no-op", func(t *testing.T) {
+		m := NewTreeMerger[FunctionName, FunctionNameI]()
+		require.NoError(t, m.MergeTreeBytes(nil))
+		require.NoError(t, m.MergeTreeBytes([]byte{}))
+		require.Equal(t, int64(0), m.Tree().Total())
+	})
+
+	t.Run("empty tree bytes merged into existing tree", func(t *testing.T) {
+		tree := new(FunctionNameTree)
+		tree.InsertStack(1, "a", "b")
+		b := tree.Bytes(-1, nil)
+
+		empty := new(FunctionNameTree).Bytes(-1, nil)
+
+		m := NewTreeMerger[FunctionName, FunctionNameI]()
+		require.NoError(t, m.MergeTreeBytes(b))
+		require.NoError(t, m.MergeTreeBytes(empty))
+		require.Equal(t, int64(1), m.Tree().Total())
+	})
+
+	t.Run("malformed bytes return an error", func(t *testing.T) {
+		m := NewTreeMerger[FunctionName, FunctionNameI]()
+		require.Error(t, m.MergeTreeBytes([]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01}))
+	})
+}


### PR DESCRIPTION
While investigating a slow flamegraph query (1h range, 60 blocks, a tenant with a high \`max_nodes\` limit so trees are never truncated), most of the time turned out to be spent merging tree reports rather than reading data: \`TreeMerger.MergeTreeBytes\` unmarshals every report into a temporary tree and then merges it into the destination. In CPU profiles of the query path this shows up as ~15% of query-backend CPU in \`MergeTreeBytes\`, plus another ~11% in \`memclr\` zeroing the node arena that \`UnmarshalTree\` over-allocates severalfold (its size estimate of 16 bytes/node is far below real name-bearing records). The cost is paid at every level of the fan-out: block → worker aggregation, worker → root aggregation, and again in the frontend.

This addresses the TODO in \`tree_merger.go\` by merging the serialized (DFS-encoded) tree directly into the destination tree:

- no intermediate tree is materialized; node names are looked up through a zero-copy view of the input and only copied when a node is actually inserted (on heavily overlapping trees most records hit existing nodes),
- totals are no longer maintained per record: the merger recomputes them in a single pass when the tree is read,
- \`UnmarshalTree\` keeps its semantics, but allocates its node arena in capped, geometrically growing chunks and derives totals in one reverse-level-order pass instead of an O(depth) parent walk per node.

benchstat on the new benchmarks (15 overlapping shards mimic the aggregation shape; fixtures are the existing real ~4MB trees in \`testdata/\`):

```
                                  │  baseline   │        streaming        │
Benchmark_MergeTreeBytes_Sharded_Small   34.79m ±  0%   19.13m ± 2%  -45.01%
Benchmark_MergeTreeBytes_Sharded_Large   304.3m ± 13%   154.2m ± 1%  -49.33%
Benchmark_MergeTreeBytes_Fixture         50.61m ±  2%   27.58m ± 1%  -45.49%
Benchmark_UnmarshalTree_Fixture          23.09m ±  0%   13.14m ± 3%  -43.11%

B/op
Benchmark_MergeTreeBytes_Sharded_Small  134.28Mi ± 0%   14.33Mi ± 0%  -89.33%
Benchmark_MergeTreeBytes_Sharded_Large  1005.4Mi ± 0%   106.1Mi ± 0%  -89.45%
```

There was no direct test coverage of \`TreeMerger\`, so the new tests pin the result node-by-node (self and total) to the previous algorithm expressed through \`UnmarshalTree\` + \`Tree.Merge\`, which are left semantically unchanged: truncated shards with \`other\` nodes, concurrent merging (run with \`-race\`), mixed \`MergeTree\`/\`MergeTreeBytes\` usage, and the \`LocationRefName\` + \`WithTreeMergeFormatNodeNames\` path with name collisions.

Notes:

- The serialized tree format is untouched (only consumption changes), so mixed-version deployments are unaffected; this also applies to the v1 read path (\`pkg/querier/select_merge.go\`) which shares the merger.
- On malformed input the merger may now retain a partially merged tree, where it previously stayed untouched. All callers propagate the error and discard the merge, so this is not observable, but it is a behavior change.
- Follow-ups from the same investigation, not part of this PR: passing in-memory trees through reports for same-process aggregation in the query backend, and building the flamegraph directly from tree bytes in the frontend.