### PR TITLE
docs(segment-writer): document object storage cost tuning

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -42,7 +42,7 @@ Usage of ./pyroscope:
   -architecture.storage value
     	Storage architecture layer. Use 'v1' to use legacy ingester-based storage, 'v2' for new storage, and 'v1-v2-dual' to use new storage while being able to query old data. (default "v1-v2-dual")
   -async-ingest
-    	If true, the write path will not wait for the segment-writer to finish processing the request. Writes to ingester always synchronous.
+    	If true, the write path does not wait for the segment-writer to durably store and index the profile before responding. This reduces ingestion latency and allows a larger -segment-writer.segment-duration, but removes the read-after-write consistency and synchronous durability guarantee. Writes to the ingester are always synchronous.
   -auth.multitenancy-enabled
     	When set to true, incoming HTTP requests must specify tenant ID in HTTP X-Scope-OrgId header. When set to false, tenant ID anonymous is used instead.
   -blocks-storage.bucket-store.ignore-blocks-within duration

--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -42,7 +42,7 @@ Usage of ./pyroscope:
   -architecture.storage value
     	Storage architecture layer. Use 'v1' to use legacy ingester-based storage, 'v2' for new storage, and 'v1-v2-dual' to use new storage while being able to query old data. (default "v1-v2-dual")
   -async-ingest
-    	If true, the write path does not wait for the segment-writer to durably store and index the profile before responding. This reduces ingestion latency and allows a larger -segment-writer.segment-duration, but removes the read-after-write consistency and synchronous durability guarantee. Writes to the ingester are always synchronous.
+    	If true, the write path doesn't wait for the segment-writer to durably store and index the profile before responding. This reduces ingestion latency and allows a larger -segment-writer.segment-duration, but removes the read-after-write consistency and synchronous durability guarantee. Writes to the ingester are always synchronous.
   -auth.multitenancy-enabled
     	When set to true, incoming HTTP requests must specify tenant ID in HTTP X-Scope-OrgId header. When set to false, tenant ID anonymous is used instead.
   -blocks-storage.bucket-store.ignore-blocks-within duration

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -3379,6 +3379,14 @@ distributor_usage_groups:
 # CLI flag: -validation.reject-newer-than
 [reject_newer_than: <duration> | default = 10m]
 
+# (advanced) If true, the write path does not wait for the segment-writer to
+# durably store and index the profile before responding. This reduces ingestion
+# latency and allows a larger -segment-writer.segment-duration, but removes the
+# read-after-write consistency and synchronous durability guarantee. Writes to
+# the ingester are always synchronous.
+# CLI flag: -async-ingest
+[async_ingest: <boolean> | default = false]
+
 # Maximum number of recording rules a tenant can create. 0 to disable.
 # CLI flag: -recording-rules.max-rules-per-tenant
 [max_recording_rules: <int> | default = 25]

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -3379,7 +3379,7 @@ distributor_usage_groups:
 # CLI flag: -validation.reject-newer-than
 [reject_newer_than: <duration> | default = 10m]
 
-# (advanced) If true, the write path does not wait for the segment-writer to
+# (advanced) If true, the write path doesn't wait for the segment-writer to
 # durably store and index the profile before responding. This reduces ingestion
 # latency and allows a larger -segment-writer.segment-duration, but removes the
 # read-after-write consistency and synchronous durability guarantee. Writes to

--- a/docs/sources/reference-pyroscope-v2-architecture/components/segment-writer.md
+++ b/docs/sources/reference-pyroscope-v2-architecture/components/segment-writer.md
@@ -86,3 +86,25 @@ The segment-writer flush behavior can be configured to balance between:
 - **Latency**: How quickly data becomes queryable
 - **Cost**: Number of write operations to object storage
 - **Memory usage**: Amount of data held in memory before flush
+
+### Reduce object storage costs
+
+Because each flush results in write operations to object storage (and each subsequent query results in read operations), the flush frequency and the number of objects produced per flush directly affect your object storage bill. Use the following levers to reduce `PUT` and `GET` costs:
+
+- **Increase the segment duration**: `-segment-writer.segment-duration` (default `500ms`) controls how long profiles accumulate in memory before a segment is flushed. Increasing it produces fewer, larger segments and therefore fewer write operations.
+
+  {{< admonition type="warning" >}}
+  With the default synchronous ingestion, the segment duration must stay within the ingestion client's request timeout. Clients block until the segment is flushed, so a segment duration close to or exceeding the client timeout causes rejected profiles with errors such as `context deadline exceeded` and `context canceled`, and `422` responses on `/ingest`. Raise the segment duration gradually and keep it comfortably below the client timeout.
+  {{< /admonition >}}
+
+- **Reduce shards per segment-writer**: `-segment-writer.num-tokens` (default `4`) controls how many shards each segment-writer owns. Each shard produces its own object per flush, so lowering this value (down to `1`) reduces the number of objects written per flush cycle, and consequently the number of read operations at query time.
+
+- **Account for replicas**: The number of segment-writer replicas scales the volume of requests to object storage roughly linearly. More replicas means more objects and more requests.
+
+[Compaction-workers](../compaction-worker/) further reduce costs over time by merging small segments into larger blocks, which lowers the object count and read amplification during queries.
+
+### Trade consistency for headroom
+
+By default, ingestion is synchronous: clients wait until profiles are durably stored and indexed, which provides read-after-write consistency but bounds how large `-segment-writer.segment-duration` can be.
+
+If read-after-write consistency and synchronous durability confirmation are not required, set `-async-ingest=true`. The write path then responds without waiting for the segment-writer to flush and index the profile, which allows a larger segment duration (and therefore lower object storage costs) without triggering client timeouts. The trade-off is that a successful ingestion response no longer guarantees the profile is durable and immediately queryable.

--- a/docs/sources/reference-pyroscope-v2-architecture/components/segment-writer.md
+++ b/docs/sources/reference-pyroscope-v2-architecture/components/segment-writer.md
@@ -91,7 +91,7 @@ The segment-writer flush behavior can be configured to balance between:
 
 Because each flush results in write operations to object storage (and each subsequent query results in read operations), the flush frequency and the number of objects produced per flush directly affect your object storage bill. Use the following levers to reduce `PUT` and `GET` costs:
 
-- **Increase the segment duration**: `-segment-writer.segment-duration` (default `500ms`) controls how long profiles accumulate in memory before a segment is flushed. Increasing it produces fewer, larger segments and therefore fewer write operations.
+- **Increase the segment duration**: `-segment-writer.segment-duration` (default `500ms`) controls how long profiles accumulate in memory before a segment is flushed. Increasing it produces fewer, larger segments and therefore fewer write operations, but increases memory usage and, with synchronous ingestion, latency.
 
   {{< admonition type="warning" >}}
   With the default synchronous ingestion, the segment duration must stay within the ingestion client's request timeout. Clients block until the segment is flushed, so a segment duration close to or exceeding the client timeout causes rejected profiles with errors such as `context deadline exceeded` and `context canceled`, and `422` responses on `/ingest`. Raise the segment duration gradually and keep it comfortably below the client timeout.

--- a/docs/sources/reference-pyroscope-v2-architecture/deployment-modes/index.md
+++ b/docs/sources/reference-pyroscope-v2-architecture/deployment-modes/index.md
@@ -128,3 +128,5 @@ Plan for object storage costs based on:
 - **Write operations**: Segment flushes and compaction uploads
 - **Read operations**: Query execution
 - **Storage**: Retained profile data
+
+To reduce write and read operation costs, refer to the [segment-writer configuration](../components/segment-writer/#reduce-object-storage-costs) for tuning the segment duration, shards per writer, and ingestion consistency.

--- a/pkg/distributor/writepath/write_path.go
+++ b/pkg/distributor/writepath/write_path.go
@@ -88,7 +88,7 @@ type Config struct {
 	SegmentWriterWeight  float64       `yaml:"write_path_segment_writer_weight" json:"write_path_segment_writer_weight" category:"advanced" doc:"hidden"`
 	SegmentWriterTimeout time.Duration `yaml:"write_path_segment_writer_timeout" json:"write_path_segment_writer_timeout" category:"advanced" doc:"hidden"`
 	Compression          Compression   `yaml:"write_path_compression" json:"write_path_compression" category:"advanced" doc:"hidden"`
-	AsyncIngest          bool          `yaml:"async_ingest" json:"async_ingest" category:"advanced" doc:"hidden"`
+	AsyncIngest          bool          `yaml:"async_ingest" json:"async_ingest" category:"advanced"`
 }
 
 func (o *Config) RegisterFlags(f *flag.FlagSet) {
@@ -101,5 +101,5 @@ func (o *Config) RegisterFlags(f *flag.FlagSet) {
 		"Specifies the fraction [0:1] that should be send to segment-writer in combined mode. 0 means no traffics is sent to segment-writer. 1 means 100% of requests are sent to segment-writer.")
 	f.DurationVar(&o.SegmentWriterTimeout, "write-path.segment-writer-timeout", 5*time.Second, "Timeout for segment writer requests.")
 	f.Var(&o.Compression, "write-path.compression", "Compression algorithm to use for segment writer requests; "+validCompressionOptionsString+".")
-	f.BoolVar(&o.AsyncIngest, "async-ingest", false, "If true, the write path will not wait for the segment-writer to finish processing the request. Writes to ingester always synchronous.")
+	f.BoolVar(&o.AsyncIngest, "async-ingest", false, "If true, the write path does not wait for the segment-writer to durably store and index the profile before responding. This reduces ingestion latency and allows a larger -segment-writer.segment-duration, but removes the read-after-write consistency and synchronous durability guarantee. Writes to the ingester are always synchronous.")
 }

--- a/pkg/distributor/writepath/write_path.go
+++ b/pkg/distributor/writepath/write_path.go
@@ -101,5 +101,5 @@ func (o *Config) RegisterFlags(f *flag.FlagSet) {
 		"Specifies the fraction [0:1] that should be send to segment-writer in combined mode. 0 means no traffics is sent to segment-writer. 1 means 100% of requests are sent to segment-writer.")
 	f.DurationVar(&o.SegmentWriterTimeout, "write-path.segment-writer-timeout", 5*time.Second, "Timeout for segment writer requests.")
 	f.Var(&o.Compression, "write-path.compression", "Compression algorithm to use for segment writer requests; "+validCompressionOptionsString+".")
-	f.BoolVar(&o.AsyncIngest, "async-ingest", false, "If true, the write path does not wait for the segment-writer to durably store and index the profile before responding. This reduces ingestion latency and allows a larger -segment-writer.segment-duration, but removes the read-after-write consistency and synchronous durability guarantee. Writes to the ingester are always synchronous.")
+	f.BoolVar(&o.AsyncIngest, "async-ingest", false, "If true, the write path doesn't wait for the segment-writer to durably store and index the profile before responding. This reduces ingestion latency and allows a larger -segment-writer.segment-duration, but removes the read-after-write consistency and synchronous durability guarantee. Writes to the ingester are always synchronous.")
 }


### PR DESCRIPTION
## Description

Documents how to reduce object storage PUT/GET costs after upgrading to Pyroscope v2, based on a recurring support question.

After upgrading v1→v2, users see a significant increase in object storage costs, and naively raising the segment flush interval causes ingestion errors (`context deadline exceeded`, `context canceled`, and `422` responses on `/ingest`) because the segment duration exceeds the client's synchronous ingestion timeout.

### Changes

- **`segment-writer.md`**: Complete the previously stubbed `## Configuration` section with two subsections:
  - **Reduce object storage costs** — tune `-segment-writer.segment-duration` (default `500ms`) and `-segment-writer.num-tokens` (default `4`, down to `1`), with a warning about the client-timeout caveat that causes the rejection errors above; notes that replica count scales requests linearly and that compaction reduces object count over time.
  - **Trade consistency for headroom** — document `-async-ingest=true` and its read-after-write consistency trade-off.
- **`deployment-modes/index.md`**: Cross-reference the new tuning section from the Object storage resource-planning list.
- **`write_path.go`**: Un-hide the `-async-ingest` flag (remove `doc:"hidden"`) so it appears in the generated configuration reference, and improve its help text.
- **`reference-configuration-parameters/index.md`**: Regenerated via `make generate` to include `-async-ingest`.

### Verification

- `go build ./pkg/distributor/writepath/` passes
- `make generate` produces only the intended config-reference change
- Cross-reference anchor matches the heading slug