### PR TITLE
fix(metastore): don't let a single bad DLQ object block recovery

### DIFF
--- a/pkg/metastore/index/dlq/recovery.go
+++ b/pkg/metastore/index/dlq/recovery.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"flag"
 	"io"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/oklog/ulid/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/thanos-io/objstore"
 	"google.golang.org/grpc/codes"
@@ -110,15 +112,29 @@ func (r *Recovery) recoverTick(ctx context.Context) {
 	}
 }
 
-func (r *Recovery) recover(ctx context.Context, path string) (err error) {
-	defer func() {
-		if err == nil {
-			// In case we return no error, the block is considered recovered and will be deleted.
-			if delErr := r.bucket.Delete(ctx, path); delErr != nil {
-				level.Warn(r.logger).Log("msg", "failed to delete block metadata", "err", delErr, "path", path)
-			}
-		}
-	}()
+// recover processes a single DLQ object.
+//
+// It returns a non-nil error only when the whole recovery sweep must be
+// stopped (e.g. context cancellation or a raft leadership change); in that
+// case the current object is left in place to be retried later. All per-object
+// failures (stray keys, empty/corrupt objects, transient read or metastore
+// errors) are handled here and reported via metrics, and nil is returned so
+// that iteration continues over the remaining DLQ entries. Otherwise a single
+// bad object would block the recovery of every entry that follows it.
+func (r *Recovery) recover(ctx context.Context, path string) error {
+	// Pyroscope only ever writes DLQ objects at
+	// "dlq/<shard>/<tenant>/<block-ulid>/meta.pb" (see block.MetadataDLQObjectPath).
+	// Anything else under the prefix was not written by us: most commonly a
+	// zero-byte "folder placeholder" such as "dlq/" or "dlq/1/" created by S3
+	// tooling, multipart leftovers, or operator/backup artifacts. Such stray
+	// keys can never be read as block metadata and, before this guard, caused
+	// an EOF read error that aborted the whole sweep. We skip them and keep
+	// iterating; we do not delete them.
+	if !isDLQMetadataPath(path) {
+		r.metrics.recoveryAttempts.WithLabelValues("stray").Inc()
+		level.Warn(r.logger).Log("msg", "unexpected object in DLQ; skipping", "path", path)
+		return nil
+	}
 
 	b, err := r.readObject(ctx, path)
 	switch {
@@ -133,30 +149,66 @@ func (r *Recovery) recover(ctx context.Context, path string) (err error) {
 		r.metrics.recoveryAttempts.WithLabelValues("not_found").Inc()
 		level.Warn(r.logger).Log("msg", "block metadata not found; skipping", "path", path)
 		return nil
+	case errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF):
+		// A zero-byte meta.pb object: object stores (e.g. S3) surface an empty
+		// object as EOF on the first read. It can never unmarshal into a valid
+		// block, so retrying forever only spams logs. Delete it and continue.
+		r.metrics.recoveryAttempts.WithLabelValues("empty").Inc()
+		level.Warn(r.logger).Log("msg", "empty block metadata; deleting", "path", path)
+		if delErr := r.bucket.Delete(ctx, path); delErr != nil {
+			level.Warn(r.logger).Log("msg", "failed to delete empty block metadata", "err", delErr, "path", path)
+		}
+		return nil
 	default:
 		// This is somewhat opportunistic, as we don't know if the error is transient or not.
 		// we should consider an explicit retry mechanism with backoff and a limit on the
-		// number of attempts.
+		// number of attempts. We keep the object and continue the sweep so that a single
+		// transient failure does not block the recovery of the remaining entries.
 		r.metrics.recoveryAttempts.WithLabelValues("read_error").Inc()
 		level.Warn(r.logger).Log("msg", "failed to read block metadata; to be retried", "err", err, "path", path)
-		return err
+		return nil
+	}
+
+	if len(b) == 0 {
+		// Same as the EOF case above, but for object stores that return an empty
+		// reader without an error for zero-byte objects.
+		r.metrics.recoveryAttempts.WithLabelValues("empty").Inc()
+		level.Warn(r.logger).Log("msg", "empty block metadata; deleting", "path", path)
+		if delErr := r.bucket.Delete(ctx, path); delErr != nil {
+			level.Warn(r.logger).Log("msg", "failed to delete empty block metadata", "err", delErr, "path", path)
+		}
+		return nil
 	}
 
 	var meta metastorev1.BlockMeta
-	if err = meta.UnmarshalVT(b); err != nil {
+	if err := meta.UnmarshalVT(b); err != nil {
+		// Corrupt metadata can never be recovered; deleting it prevents endless
+		// retries and log spam. Matches the pre-refactor behaviour.
 		r.metrics.recoveryAttempts.WithLabelValues("unmarshal_error").Inc()
-		level.Error(r.logger).Log("msg", "failed to unmarshal block metadata; skipping", "err", err, "path", path)
+		level.Error(r.logger).Log("msg", "failed to unmarshal block metadata; deleting", "err", err, "path", path)
+		if delErr := r.bucket.Delete(ctx, path); delErr != nil {
+			level.Warn(r.logger).Log("msg", "failed to delete corrupt block metadata", "err", delErr, "path", path)
+		}
 		return nil
 	}
 
-	switch _, err = r.metastore.AddRecoveredBlock(ctx, &metastorev1.AddBlockRequest{Block: &meta}); {
+	switch _, err := r.metastore.AddRecoveredBlock(ctx, &metastorev1.AddBlockRequest{Block: &meta}); {
 	case err == nil:
 		r.metrics.recoveryAttempts.WithLabelValues("success").Inc()
 		level.Debug(r.logger).Log("msg", "successfully recovered block from DLQ", "block_id", meta.Id, "path", path)
+		// The block is now recorded in the metastore; remove it from the DLQ.
+		if delErr := r.bucket.Delete(ctx, path); delErr != nil {
+			level.Warn(r.logger).Log("msg", "failed to delete block metadata", "err", delErr, "path", path)
+		}
 		return nil
 	case status.Code(err) == codes.InvalidArgument:
+		// The metastore permanently rejected the metadata; deleting it prevents
+		// endless retries. Matches the pre-refactor behaviour.
 		r.metrics.recoveryAttempts.WithLabelValues("invalid_metadata").Inc()
-		level.Error(r.logger).Log("msg", "block metadata rejected by metastore; skipping", "err", err, "block_id", meta.Id, "path", path)
+		level.Error(r.logger).Log("msg", "block metadata rejected by metastore; deleting", "err", err, "block_id", meta.Id, "path", path)
+		if delErr := r.bucket.Delete(ctx, path); delErr != nil {
+			level.Warn(r.logger).Log("msg", "failed to delete rejected block metadata", "err", delErr, "path", path)
+		}
 		return nil
 	case raftnode.IsRaftLeadershipError(err):
 		r.metrics.recoveryAttempts.WithLabelValues("leadership_change").Inc()
@@ -165,7 +217,7 @@ func (r *Recovery) recover(ctx context.Context, path string) (err error) {
 	default:
 		r.metrics.recoveryAttempts.WithLabelValues("metastore_error").Inc()
 		level.Error(r.logger).Log("msg", "failed to add block metadata; to be retried", "err", err, "path", path)
-		return err
+		return nil
 	}
 }
 
@@ -178,4 +230,34 @@ func (r *Recovery) readObject(ctx context.Context, path string) ([]byte, error) 
 		_ = rc.Close()
 	}()
 	return io.ReadAll(rc)
+}
+
+// isDLQMetadataPath reports whether path matches the exact layout that
+// block.MetadataDLQObjectPath produces:
+//
+//	dlq/<shard>/<tenant>/<block-ulid>/meta.pb
+//
+// Anything else found under the "dlq/" prefix (folder placeholders, multipart
+// leftovers, operator artifacts, etc.) is not a DLQ entry written by Pyroscope
+// and must be ignored rather than read as block metadata.
+func isDLQMetadataPath(path string) bool {
+	parts := strings.Split(path, "/")
+	if len(parts) != 5 {
+		return false
+	}
+	if parts[0] != block.DirNameDLQ {
+		return false
+	}
+	// parts[1] shard, parts[2] tenant: non-empty, structural.
+	if parts[1] == "" || parts[2] == "" {
+		return false
+	}
+	if parts[4] != block.FileNameMetadataObject {
+		return false
+	}
+	// parts[3] must be a valid block ULID.
+	if _, err := ulid.Parse(parts[3]); err != nil {
+		return false
+	}
+	return true
 }

--- a/pkg/metastore/index/dlq/recovery.go
+++ b/pkg/metastore/index/dlq/recovery.go
@@ -139,7 +139,7 @@ func (r *Recovery) recover(ctx context.Context, path string) error {
 	b, err := r.readObject(ctx, path)
 	switch {
 	case err == nil:
-	case errors.Is(err, context.Canceled):
+	case errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded):
 		r.metrics.recoveryAttempts.WithLabelValues("canceled").Inc()
 		return err
 	case r.bucket.IsObjNotFoundErr(err):
@@ -149,7 +149,7 @@ func (r *Recovery) recover(ctx context.Context, path string) error {
 		r.metrics.recoveryAttempts.WithLabelValues("not_found").Inc()
 		level.Warn(r.logger).Log("msg", "block metadata not found; skipping", "path", path)
 		return nil
-	case errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF):
+	case errors.Is(err, io.EOF):
 		// A zero-byte meta.pb object: object stores (e.g. S3) surface an empty
 		// object as EOF on the first read. It can never unmarshal into a valid
 		// block, so retrying forever only spams logs. Delete it and continue.
@@ -210,6 +210,9 @@ func (r *Recovery) recover(ctx context.Context, path string) error {
 			level.Warn(r.logger).Log("msg", "failed to delete rejected block metadata", "err", delErr, "path", path)
 		}
 		return nil
+	case errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded):
+		r.metrics.recoveryAttempts.WithLabelValues("canceled").Inc()
+		return err
 	case raftnode.IsRaftLeadershipError(err):
 		r.metrics.recoveryAttempts.WithLabelValues("leadership_change").Inc()
 		level.Warn(r.logger).Log("msg", "leadership change; recovery interrupted", "err", err, "path", path)

--- a/pkg/metastore/index/dlq/recovery_test.go
+++ b/pkg/metastore/index/dlq/recovery_test.go
@@ -1,7 +1,10 @@
 package dlq
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"io"
 	"sync"
 	"testing"
 	"time"
@@ -11,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -166,4 +170,184 @@ func TestStartStop(t *testing.T) {
 func addMeta(bucket *memory.InMemBucket, meta *metastorev1.BlockMeta) {
 	data, _ := meta.MarshalVT()
 	bucket.Set(block.MetadataDLQObjectPath(meta), data)
+}
+
+// s3LikeBucket wraps the in-memory bucket to reproduce the behaviour of
+// object stores such as S3, where reading a zero-byte object surfaces io.EOF
+// on the first read (via the getRange prefetch) rather than an empty reader.
+type s3LikeBucket struct {
+	*memory.InMemBucket
+}
+
+func (b *s3LikeBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+	rc, err := b.InMemBucket.Get(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	data, err := io.ReadAll(rc)
+	_ = rc.Close()
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, io.EOF
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+// TestRecoverTick_StrayPlaceholderDoesNotBlock verifies that a stray, zero-byte
+// "folder placeholder" object (e.g. "dlq/1/") that sorts before valid entries
+// does not abort the recovery sweep: the valid metas are still recovered.
+func TestRecoverTick_StrayPlaceholderDoesNotBlock(t *testing.T) {
+	metas := []*metastorev1.BlockMeta{
+		{Id: test.ULID("2024-09-23T01:00:00Z"), Shard: 1},
+		{Id: test.ULID("2024-09-23T02:00:00Z"), Shard: 2},
+	}
+
+	var recovered int
+	srv := mockdlq.NewMockMetastore(t)
+	srv.On("AddRecoveredBlock", mock.Anything, mock.Anything).
+		Times(2).
+		Run(func(mock.Arguments) { recovered++ }).
+		Return(&metastorev1.AddBlockResponse{}, nil)
+
+	bucket := &s3LikeBucket{InMemBucket: memory.NewInMemBucket()}
+	// Stray zero-byte placeholder that sorts before the valid meta.pb entries.
+	bucket.Set(block.DirNameDLQ+"/1/", nil)
+	for _, meta := range metas {
+		data, _ := meta.MarshalVT()
+		bucket.Set(block.MetadataDLQObjectPath(meta), data)
+	}
+
+	r := NewRecovery(test.NewTestingLogger(t), Config{}, srv, bucket, prometheus.NewRegistry())
+	r.recoverTick(context.Background())
+
+	assert.Equal(t, 2, recovered)
+	assert.Equal(t, 2.0, testutil.ToFloat64(r.metrics.recoveryAttempts.WithLabelValues("success")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(r.metrics.recoveryAttempts.WithLabelValues("stray")))
+
+	// The stray placeholder is skipped, not deleted; the recovered entries are removed.
+	_, ok := bucket.Objects()[block.DirNameDLQ+"/1/"]
+	assert.True(t, ok, "stray placeholder should not be deleted")
+	assert.Equal(t, 1, len(bucket.Objects()))
+}
+
+// TestRecoverTick_EmptyMetaDeletedAndContinues verifies that an empty
+// (zero-byte) meta.pb object is treated as permanently invalid: it is deleted,
+// counted, and does not prevent recovery of the remaining entries.
+func TestRecoverTick_EmptyMetaDeletedAndContinues(t *testing.T) {
+	valid := &metastorev1.BlockMeta{Id: test.ULID("2024-09-23T05:00:00Z"), Shard: 2}
+	empty := &metastorev1.BlockMeta{Id: test.ULID("2024-09-23T02:00:00Z"), Shard: 1}
+
+	var recovered int
+	srv := mockdlq.NewMockMetastore(t)
+	srv.On("AddRecoveredBlock", mock.Anything, mock.Anything).
+		Once().
+		Run(func(mock.Arguments) { recovered++ }).
+		Return(&metastorev1.AddBlockResponse{}, nil)
+
+	bucket := &s3LikeBucket{InMemBucket: memory.NewInMemBucket()}
+	emptyPath := block.MetadataDLQObjectPath(empty)
+	bucket.Set(emptyPath, nil) // zero-byte meta.pb -> EOF on read
+	validData, _ := valid.MarshalVT()
+	bucket.Set(block.MetadataDLQObjectPath(valid), validData)
+
+	r := NewRecovery(test.NewTestingLogger(t), Config{}, srv, bucket, prometheus.NewRegistry())
+	r.recoverTick(context.Background())
+
+	assert.Equal(t, 1, recovered)
+	assert.Equal(t, 1.0, testutil.ToFloat64(r.metrics.recoveryAttempts.WithLabelValues("success")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(r.metrics.recoveryAttempts.WithLabelValues("empty")))
+
+	// The empty object is deleted; nothing left in the DLQ.
+	_, ok := bucket.Objects()[emptyPath]
+	assert.False(t, ok, "empty meta.pb should be deleted")
+	assert.Equal(t, 0, len(bucket.Objects()))
+}
+
+// TestRecoverTick_TransientErrorRetainsAndContinues verifies that a transient
+// metastore error on one object retains that object (for a later retry) while
+// still allowing sibling entries to be recovered in the same sweep.
+func TestRecoverTick_TransientErrorRetainsAndContinues(t *testing.T) {
+	failing := &metastorev1.BlockMeta{Id: test.ULID("2024-09-23T01:00:00Z"), Shard: 1}
+	ok := &metastorev1.BlockMeta{Id: test.ULID("2024-09-23T02:00:00Z"), Shard: 2}
+
+	failingPath := block.MetadataDLQObjectPath(failing)
+	okPath := block.MetadataDLQObjectPath(ok)
+
+	var recovered int
+	srv := mockdlq.NewMockMetastore(t)
+	srv.On("AddRecoveredBlock", mock.Anything, mock.Anything).
+		Return(func(_ context.Context, req *metastorev1.AddBlockRequest) (*metastorev1.AddBlockResponse, error) {
+			if req.Block.Id == failing.Id {
+				return nil, errors.New("transient metastore error")
+			}
+			recovered++
+			return &metastorev1.AddBlockResponse{}, nil
+		})
+
+	bucket := &s3LikeBucket{InMemBucket: memory.NewInMemBucket()}
+	failingData, _ := failing.MarshalVT()
+	bucket.Set(failingPath, failingData)
+	okData, _ := ok.MarshalVT()
+	bucket.Set(okPath, okData)
+
+	r := NewRecovery(test.NewTestingLogger(t), Config{}, srv, bucket, prometheus.NewRegistry())
+	r.recoverTick(context.Background())
+
+	assert.Equal(t, 1, recovered)
+	assert.Equal(t, 1.0, testutil.ToFloat64(r.metrics.recoveryAttempts.WithLabelValues("success")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(r.metrics.recoveryAttempts.WithLabelValues("metastore_error")))
+
+	// The failing object is retained for retry; the good one is deleted.
+	objs := bucket.Objects()
+	_, failingKept := objs[failingPath]
+	_, okDeleted := objs[okPath]
+	assert.True(t, failingKept, "failing object should be retained for retry")
+	assert.False(t, okDeleted, "successfully recovered object should be deleted")
+}
+
+var _ objstore.Bucket = (*s3LikeBucket)(nil)
+
+func TestIsDLQMetadataPath(t *testing.T) {
+	// A real path produced by the writer must be accepted.
+	level0 := block.MetadataDLQObjectPath(&metastorev1.BlockMeta{
+		Id:    test.ULID("2024-09-23T01:00:00Z"),
+		Shard: 1,
+	})
+	compacted := block.MetadataDLQObjectPath(&metastorev1.BlockMeta{
+		Id:              test.ULID("2024-09-23T02:00:00Z"),
+		Shard:           7,
+		CompactionLevel: 1,
+		StringTable:     []string{"", "tenant-a"},
+		Tenant:          1,
+	})
+
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{level0, true},
+		{compacted, true},
+
+		// Stray keys that must be rejected.
+		{"dlq/", false},
+		{"dlq/1/", false},
+		{"dlq/1/anonymous/", false},
+		{"dlq", false},
+		{"dlq/1/anonymous/01J8E68YM0Z2RRKCY9SYGX3054", false}, // missing meta.pb
+		{"dlq/1/anonymous/01J8E68YM0Z2RRKCY9SYGX3054/meta.pb/extra", false},
+		{"dlq/1/anonymous/not-a-ulid/meta.pb", false},                    // bad block id
+		{"dlq/1/anonymous/01J8E68YM0Z2RRKCY9SYGX3054/x.pb", false},       // wrong filename
+		{"blocks/1/anonymous/01J8E68YM0Z2RRKCY9SYGX3054/meta.pb", false}, // wrong prefix
+		{"dlq//01J8E68YM0Z2RRKCY9SYGX3054/anonymous/meta.pb", false},     // empty shard
+		{"dlq/1//01J8E68YM0Z2RRKCY9SYGX3054/meta.pb", false},             // empty tenant
+		{"dlq/1/anonymous/meta.pb", false},                               // too few parts
+	}
+
+	for _, c := range cases {
+		t.Run(c.path, func(t *testing.T) {
+			assert.Equal(t, c.want, isDLQMetadataPath(c.path))
+		})
+	}
 }

--- a/pkg/metastore/index/dlq/recovery_test.go
+++ b/pkg/metastore/index/dlq/recovery_test.go
@@ -83,6 +83,10 @@ func TestNotRaftLeader(t *testing.T) {
 			Id:    test.ULID("2024-09-23T01:00:00Z"),
 			Shard: 2,
 		},
+		{
+			Id:    test.ULID("2024-09-23T02:00:00Z"),
+			Shard: 2,
+		},
 	}
 
 	srv := mockdlq.NewMockMetastore(t)
@@ -102,10 +106,38 @@ func TestNotRaftLeader(t *testing.T) {
 	r := NewRecovery(test.NewTestingLogger(t), Config{}, srv, bucket, prometheus.NewRegistry())
 	r.recoverTick(context.Background())
 
-	assert.Equal(t, 1, len(bucket.Objects()))
+	assert.Equal(t, 2, len(bucket.Objects()))
 
-	assert.Equal(t, 1.0, testutil.ToFloat64(r.metrics.recoveryAttempts.WithLabelValues("metastore_error")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(r.metrics.recoveryAttempts.WithLabelValues("leadership_change")))
+	assert.Equal(t, 0.0, testutil.ToFloat64(r.metrics.recoveryAttempts.WithLabelValues("metastore_error")))
 	assert.Equal(t, 0.0, testutil.ToFloat64(r.metrics.recoveryAttempts.WithLabelValues("success")))
+}
+
+func TestRecoverTick_StopsOnMetastoreContextError(t *testing.T) {
+	for _, err := range []error{context.Canceled, context.DeadlineExceeded} {
+		t.Run(err.Error(), func(t *testing.T) {
+			metas := []*metastorev1.BlockMeta{
+				{Id: test.ULID("2024-09-23T01:00:00Z"), Shard: 1},
+				{Id: test.ULID("2024-09-23T02:00:00Z"), Shard: 2},
+			}
+
+			srv := mockdlq.NewMockMetastore(t)
+			srv.On("AddRecoveredBlock", mock.Anything, mock.Anything).
+				Once().
+				Return(nil, err)
+
+			bucket := memory.NewInMemBucket()
+			for _, meta := range metas {
+				addMeta(bucket, meta)
+			}
+
+			r := NewRecovery(test.NewTestingLogger(t), Config{}, srv, bucket, prometheus.NewRegistry())
+			r.recoverTick(context.Background())
+
+			assert.Len(t, bucket.Objects(), 2)
+			assert.Equal(t, 1.0, testutil.ToFloat64(r.metrics.recoveryAttempts.WithLabelValues("canceled")))
+		})
+	}
 }
 
 func TestStartStop(t *testing.T) {
@@ -177,6 +209,30 @@ func addMeta(bucket *memory.InMemBucket, meta *metastorev1.BlockMeta) {
 // on the first read (via the getRange prefetch) rather than an empty reader.
 type s3LikeBucket struct {
 	*memory.InMemBucket
+}
+
+type truncatedReadBucket struct {
+	*memory.InMemBucket
+	path string
+}
+
+func (b *truncatedReadBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
+	if name == b.path {
+		return io.NopCloser(&unexpectedEOFReader{Reader: bytes.NewReader([]byte("partial metadata"))}), nil
+	}
+	return b.InMemBucket.Get(ctx, name)
+}
+
+type unexpectedEOFReader struct {
+	*bytes.Reader
+}
+
+func (r *unexpectedEOFReader) Read(p []byte) (int, error) {
+	n, err := r.Reader.Read(p)
+	if errors.Is(err, io.EOF) {
+		return n, io.ErrUnexpectedEOF
+	}
+	return n, err
 }
 
 func (b *s3LikeBucket) Get(ctx context.Context, name string) (io.ReadCloser, error) {
@@ -263,6 +319,56 @@ func TestRecoverTick_EmptyMetaDeletedAndContinues(t *testing.T) {
 	_, ok := bucket.Objects()[emptyPath]
 	assert.False(t, ok, "empty meta.pb should be deleted")
 	assert.Equal(t, 0, len(bucket.Objects()))
+}
+
+func TestRecoverTick_EmptyReaderMetaDeletedAndContinues(t *testing.T) {
+	empty := &metastorev1.BlockMeta{Id: test.ULID("2024-09-23T01:00:00Z"), Shard: 1}
+	valid := &metastorev1.BlockMeta{Id: test.ULID("2024-09-23T02:00:00Z"), Shard: 2}
+	emptyPath := block.MetadataDLQObjectPath(empty)
+
+	srv := mockdlq.NewMockMetastore(t)
+	srv.On("AddRecoveredBlock", mock.Anything, mock.Anything).
+		Once().
+		Return(&metastorev1.AddBlockResponse{}, nil)
+
+	bucket := memory.NewInMemBucket()
+	bucket.Set(emptyPath, nil)
+	validData, _ := valid.MarshalVT()
+	bucket.Set(block.MetadataDLQObjectPath(valid), validData)
+
+	r := NewRecovery(test.NewTestingLogger(t), Config{}, srv, bucket, prometheus.NewRegistry())
+	r.recoverTick(context.Background())
+
+	_, deleted := bucket.Objects()[emptyPath]
+	assert.False(t, deleted, "empty metadata should be deleted")
+	assert.Equal(t, 1.0, testutil.ToFloat64(r.metrics.recoveryAttempts.WithLabelValues("empty")))
+}
+
+func TestRecoverTick_UnexpectedEOFRetainedAndContinues(t *testing.T) {
+	truncated := &metastorev1.BlockMeta{Id: test.ULID("2024-09-23T01:00:00Z"), Shard: 1}
+	valid := &metastorev1.BlockMeta{Id: test.ULID("2024-09-23T02:00:00Z"), Shard: 2}
+	truncatedPath := block.MetadataDLQObjectPath(truncated)
+
+	srv := mockdlq.NewMockMetastore(t)
+	srv.On("AddRecoveredBlock", mock.Anything, mock.Anything).
+		Once().
+		Return(&metastorev1.AddBlockResponse{}, nil)
+
+	bucket := &truncatedReadBucket{
+		InMemBucket: memory.NewInMemBucket(),
+		path:        truncatedPath,
+	}
+	bucket.Set(truncatedPath, []byte("partial metadata"))
+	validData, _ := valid.MarshalVT()
+	bucket.Set(block.MetadataDLQObjectPath(valid), validData)
+
+	r := NewRecovery(test.NewTestingLogger(t), Config{}, srv, bucket, prometheus.NewRegistry())
+	r.recoverTick(context.Background())
+
+	_, kept := bucket.Objects()[truncatedPath]
+	assert.True(t, kept, "truncated metadata should be retained for retry")
+	assert.Equal(t, 1.0, testutil.ToFloat64(r.metrics.recoveryAttempts.WithLabelValues("read_error")))
+	assert.Equal(t, 0.0, testutil.ToFloat64(r.metrics.recoveryAttempts.WithLabelValues("empty")))
 }
 
 // TestRecoverTick_TransientErrorRetainsAndContinues verifies that a transient

--- a/pkg/metastore/raftnode/errors.go
+++ b/pkg/metastore/raftnode/errors.go
@@ -14,7 +14,13 @@ func IsRaftLeadershipError(err error) bool {
 	return errors.Is(err, raft.ErrLeadershipLost) ||
 		errors.Is(err, raft.ErrNotLeader) ||
 		errors.Is(err, raft.ErrLeadershipTransferInProgress) ||
-		errors.Is(err, raft.ErrRaftShutdown)
+		errors.Is(err, raft.ErrRaftShutdown) ||
+		isRaftLeaderStatusError(err)
+}
+
+func isRaftLeaderStatusError(err error) bool {
+	_, ok := RaftLeaderFromStatusDetails(err)
+	return ok
 }
 
 type RaftLeaderLocator interface {


### PR DESCRIPTION
## Problem

DLQ recovery never completes (observed on v2.0.3 and v2.1.1), with a continuous stream of:

```
caller=recovery.go:141 level=warn component=metastore msg="failed to read block metadata; to be retried" err=EOF path=dlq/1/
```

A stray zero-byte key under `dlq/` (e.g. an S3 "folder placeholder" like `dlq/1/`) returns `io.EOF` on read. That error was returned from the `Iter` callback, aborting the whole sweep — so every valid entry after it was never recovered, and the stray key was never removed.

## Fix

- `recover()` only aborts the sweep for genuine stop conditions (context cancellation, raft leadership change); all per-object failures are logged/metered and iteration continues.
- Structure-aware guard `isDLQMetadataPath` only accepts `dlq/<shard>/<tenant>/<block-ulid>/meta.pb`; stray keys are skipped.
- Empty `meta.pb` objects are deleted (permanently invalid); transient errors retain the object for retry.
- New metric status values: `stray`, `empty`.
- Tests for stray placeholders, empty objects, transient errors, and path validation.