### PR TITLE
fix(ingester): return 429 for ingestion-limit rejections on OTLP and /ingest paths

### DIFF
--- a/pkg/ingester/otlp/ingest_handler.go
+++ b/pkg/ingester/otlp/ingest_handler.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
+	"connectrpc.com/connect"
 	"github.com/dustin/go-humanize"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -200,10 +201,15 @@ func (h *ingestHandler) handleHTTPRequest(w http.ResponseWriter, r *http.Request
 
 	resp, err := h.export(r.Context(), req)
 	if err != nil {
-		level.Error(h.log).Log("msg", "failed to process profiles", "err", err)
-		if isKnownValidationError(err) {
+		switch {
+		case isKnownValidationError(err):
+			level.Warn(h.log).Log("msg", "rejecting invalid profiles", "err", err)
 			http.Error(w, err.Error(), http.StatusBadRequest)
-		} else {
+		case connect.CodeOf(err) == connect.CodeResourceExhausted:
+			level.Warn(h.log).Log("msg", "rejecting profiles over ingestion limit", "err", err)
+			http.Error(w, err.Error(), http.StatusTooManyRequests)
+		default:
+			level.Error(h.log).Log("msg", "failed to process profiles", "err", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 		return

--- a/pkg/ingester/otlp/ingest_handler.go
+++ b/pkg/ingester/otlp/ingest_handler.go
@@ -230,7 +230,21 @@ func (h *ingestHandler) handleHTTPRequest(w http.ResponseWriter, r *http.Request
 }
 
 func (h *ingestHandler) Export(ctx context.Context, er *pprofileotlp.ExportProfilesServiceRequest) (*pprofileotlp.ExportProfilesServiceResponse, error) {
-	return h.export(ctx, er)
+	resp, err := h.export(ctx, er)
+	if err != nil {
+		return resp, toGRPCStatus(err)
+	}
+	return resp, nil
+}
+
+// toGRPCStatus maps push errors that carry a Connect code (e.g. ResourceExhausted
+// when a tenant exceeds its ingestion limit) to the matching gRPC status; errors
+// that already carry a gRPC status pass through unchanged.
+func toGRPCStatus(err error) error {
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+	return status.Error(codes.Code(connect.CodeOf(err)), err.Error())
 }
 
 func (h *ingestHandler) export(ctx context.Context, er *pprofileotlp.ExportProfilesServiceRequest) (*pprofileotlp.ExportProfilesServiceResponse, error) {

--- a/pkg/ingester/otlp/ingest_handler_test.go
+++ b/pkg/ingester/otlp/ingest_handler_test.go
@@ -19,6 +19,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
 	v1experimental2 "go.opentelemetry.io/proto/otlp/collector/profiles/v1development"
@@ -1063,6 +1066,41 @@ func TestHTTPExportErrorStatusCodes(t *testing.T) {
 			httputil.AuthenticateUser(true).Wrap(h).ServeHTTP(w, httpReq)
 
 			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
+func TestExportGRPCStatusCodes(t *testing.T) {
+	req := &v1experimental2.ExportProfilesServiceRequest{}
+	require.NoError(t, protojson.Unmarshal([]byte(otlpProfileJSON), req))
+
+	for _, tc := range []struct {
+		name     string
+		pushErr  error
+		wantCode codes.Code
+	}{
+		{
+			name:     "tenant over ingestion limit maps to ResourceExhausted",
+			pushErr:  connect.NewError(connect.CodeResourceExhausted, fmt.Errorf("limit of 0 B/month reached")),
+			wantCode: codes.ResourceExhausted,
+		},
+		{
+			name:     "unexpected push failure stays Unknown",
+			pushErr:  fmt.Errorf("ingester unreachable"),
+			wantCode: codes.Unknown,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := mockotlp.NewMockPushService(t)
+			svc.On("PushBatch", mock.Anything, mock.Anything).Return(tc.pushErr)
+
+			logger := test.NewTestingLogger(t)
+			h := NewOTLPIngestHandler(testConfig(), svc, logger, defaultLimits())
+
+			ctx := user.InjectOrgID(context.Background(), "tenant-a")
+			_, err := h.Export(ctx, req)
+			require.Error(t, err)
+			assert.Equal(t, tc.wantCode, status.Code(err))
 		})
 	}
 }

--- a/pkg/ingester/otlp/ingest_handler_test.go
+++ b/pkg/ingester/otlp/ingest_handler_test.go
@@ -1014,9 +1014,7 @@ func TestHTTPRequestWithJSONAndTenantAccepted(t *testing.T) {
 	logger := test.NewTestingLogger(t)
 	h := NewOTLPIngestHandler(testConfig(), svc, logger, defaultLimits())
 
-	jsonRequest := otlpProfileJSON
-
-	httpReq := httptest.NewRequest("POST", "/otlp/v1/profiles", bytes.NewReader([]byte(jsonRequest)))
+	httpReq := httptest.NewRequest("POST", "/otlp/v1/profiles", bytes.NewReader([]byte(otlpProfileJSON)))
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set(user.OrgIDHeaderName, "json-tenant")
 
@@ -1028,8 +1026,6 @@ func TestHTTPRequestWithJSONAndTenantAccepted(t *testing.T) {
 }
 
 func TestHTTPExportErrorStatusCodes(t *testing.T) {
-	jsonRequest := otlpProfileJSON
-
 	for _, tc := range []struct {
 		name       string
 		pushErr    error
@@ -1058,7 +1054,7 @@ func TestHTTPExportErrorStatusCodes(t *testing.T) {
 			logger := test.NewTestingLogger(t)
 			h := NewOTLPIngestHandler(testConfig(), svc, logger, defaultLimits())
 
-			httpReq := httptest.NewRequest("POST", "/otlp/v1/profiles", bytes.NewReader([]byte(jsonRequest)))
+			httpReq := httptest.NewRequest("POST", "/otlp/v1/profiles", bytes.NewReader([]byte(otlpProfileJSON)))
 			httpReq.Header.Set("Content-Type", "application/json")
 			httpReq.Header.Set(user.OrgIDHeaderName, "tenant-a")
 
@@ -1171,11 +1167,9 @@ func TestHTTPRequestWithGzipCompressionAndJSON(t *testing.T) {
 	logger := test.NewTestingLogger(t)
 	h := NewOTLPIngestHandler(testConfig(), svc, logger, defaultLimits())
 
-	jsonRequest := otlpProfileJSON
-
 	var gzipBuf bytes.Buffer
 	gzipWriter := gzip.NewWriter(&gzipBuf)
-	_, err := gzipWriter.Write([]byte(jsonRequest))
+	_, err := gzipWriter.Write([]byte(otlpProfileJSON))
 	require.NoError(t, err)
 	err = gzipWriter.Close()
 	require.NoError(t, err)

--- a/pkg/ingester/otlp/ingest_handler_test.go
+++ b/pkg/ingester/otlp/ingest_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"flag"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"connectrpc.com/connect"
 	"github.com/grafana/dskit/server"
 	"github.com/grafana/dskit/user"
 	"github.com/klauspost/compress/gzip"
@@ -978,20 +980,7 @@ func createValidOTLPRequest() *v1experimental2.ExportProfilesServiceRequest {
 	}
 }
 
-func TestHTTPRequestWithJSONAndTenantAccepted(t *testing.T) {
-	svc := mockotlp.NewMockPushService(t)
-	var capturedTenantID string
-	svc.On("PushBatch", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-		ctx := args.Get(0).(context.Context)
-		tenantID, err := tenant.ExtractTenantIDFromContext(ctx)
-		require.NoError(t, err)
-		capturedTenantID = tenantID
-	}).Return(nil, nil)
-
-	logger := test.NewTestingLogger(t)
-	h := NewOTLPIngestHandler(testConfig(), svc, logger, defaultLimits())
-
-	jsonRequest := `{
+const otlpProfileJSON = `{
 		"resourceProfiles": [{
 			"scopeProfiles": [{
 				"profiles": [{
@@ -1009,6 +998,21 @@ func TestHTTPRequestWithJSONAndTenantAccepted(t *testing.T) {
 		}
 	}`
 
+func TestHTTPRequestWithJSONAndTenantAccepted(t *testing.T) {
+	svc := mockotlp.NewMockPushService(t)
+	var capturedTenantID string
+	svc.On("PushBatch", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		ctx := args.Get(0).(context.Context)
+		tenantID, err := tenant.ExtractTenantIDFromContext(ctx)
+		require.NoError(t, err)
+		capturedTenantID = tenantID
+	}).Return(nil, nil)
+
+	logger := test.NewTestingLogger(t)
+	h := NewOTLPIngestHandler(testConfig(), svc, logger, defaultLimits())
+
+	jsonRequest := otlpProfileJSON
+
 	httpReq := httptest.NewRequest("POST", "/otlp/v1/profiles", bytes.NewReader([]byte(jsonRequest)))
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set(user.OrgIDHeaderName, "json-tenant")
@@ -1018,6 +1022,49 @@ func TestHTTPRequestWithJSONAndTenantAccepted(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "json-tenant", capturedTenantID)
+}
+
+func TestHTTPExportErrorStatusCodes(t *testing.T) {
+	jsonRequest := otlpProfileJSON
+
+	for _, tc := range []struct {
+		name       string
+		pushErr    error
+		wantStatus int
+	}{
+		{
+			name:       "tenant over ingestion limit is a client error (429)",
+			pushErr:    connect.NewError(connect.CodeResourceExhausted, fmt.Errorf("limit of 0 B/month reached, next reset at 2026-08-01T00:00:00Z")),
+			wantStatus: http.StatusTooManyRequests,
+		},
+		{
+			name:       "validation failure is a client error (400)",
+			pushErr:    validation.NewErrorf(validation.ProfileSizeLimit, "profile size exceeds limit"),
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "unexpected push failure is a server error (500)",
+			pushErr:    fmt.Errorf("ingester unreachable"),
+			wantStatus: http.StatusInternalServerError,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := mockotlp.NewMockPushService(t)
+			svc.On("PushBatch", mock.Anything, mock.Anything).Return(tc.pushErr)
+
+			logger := test.NewTestingLogger(t)
+			h := NewOTLPIngestHandler(testConfig(), svc, logger, defaultLimits())
+
+			httpReq := httptest.NewRequest("POST", "/otlp/v1/profiles", bytes.NewReader([]byte(jsonRequest)))
+			httpReq.Header.Set("Content-Type", "application/json")
+			httpReq.Header.Set(user.OrgIDHeaderName, "tenant-a")
+
+			w := httptest.NewRecorder()
+			httputil.AuthenticateUser(true).Wrap(h).ServeHTTP(w, httpReq)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
 }
 
 func TestExportSetsDecompressedSizeForOTLP(t *testing.T) {
@@ -1086,23 +1133,7 @@ func TestHTTPRequestWithGzipCompressionAndJSON(t *testing.T) {
 	logger := test.NewTestingLogger(t)
 	h := NewOTLPIngestHandler(testConfig(), svc, logger, defaultLimits())
 
-	jsonRequest := `{
-		"resourceProfiles": [{
-			"scopeProfiles": [{
-				"profiles": [{
-					"sampleType": {"typeStrindex": 0, "unitStrindex": 1},
-					"samples": [{"stackIndex": 0, "values": [100]}],
-					"timeUnixNano": "1234567890"
-				}]
-			}]
-		}],
-		"dictionary": {
-			"stringTable": ["samples", "count", "test.so"],
-			"mappingTable": [{"memoryStart": "4096", "memoryLimit": "8192", "filenameStrindex": 2}],
-			"locationTable": [{"mappingIndex": 0, "address": "4352"}],
-			"stackTable": [{"locationIndices": [0]}]
-		}
-	}`
+	jsonRequest := otlpProfileJSON
 
 	var gzipBuf bytes.Buffer
 	gzipWriter := gzip.NewWriter(&gzipBuf)

--- a/pkg/ingester/pyroscope/ingest_handler.go
+++ b/pkg/ingester/pyroscope/ingest_handler.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/grafana/dskit/tracing"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -104,7 +105,11 @@ func (h ingestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			sp.LogError(err)
 			sp.SetError()
 			otelSpan.AddEvent(msg)
-			httputil.ErrorWithStatus(w, err, http.StatusUnprocessableEntity)
+			if connect.CodeOf(err) == connect.CodeResourceExhausted {
+				httputil.ErrorWithStatus(w, err, http.StatusTooManyRequests)
+			} else {
+				httputil.ErrorWithStatus(w, err, http.StatusUnprocessableEntity)
+			}
 		}
 	}
 }

--- a/pkg/ingester/pyroscope/ingest_handler_test.go
+++ b/pkg/ingester/pyroscope/ingest_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -182,6 +183,49 @@ func createJFRRequestBody(t *testing.T, jfr, labels []byte) ([]byte, string) {
 	err = w.Close()
 	require.NoError(t, err)
 	return b.Bytes(), w.FormDataContentType()
+}
+
+type errorPushService struct{ err error }
+
+func (s *errorPushService) PushBatch(context.Context, *model.PushRequest) error { return s.err }
+
+func (s *errorPushService) Push(context.Context, *connect.Request[pushv1.PushRequest]) (*connect.Response[pushv1.PushResponse], error) {
+	return nil, s.err
+}
+
+func TestIngestPropagatesLimitStatus(t *testing.T) {
+	profile, err := os.ReadFile(repoRoot + "pkg/pprof/testdata/heap")
+	require.NoError(t, err)
+	reqBody, ct := createPProfRequest(t, profile, nil, nil)
+
+	for _, tc := range []struct {
+		name       string
+		pushErr    error
+		wantStatus int
+	}{
+		{
+			name:       "tenant over ingestion limit (429)",
+			pushErr:    connect.NewError(connect.CodeResourceExhausted, fmt.Errorf("limit of 0 B/month reached")),
+			wantStatus: http.StatusTooManyRequests,
+		},
+		{
+			name:       "other ingest failure keeps 422",
+			pushErr:    fmt.Errorf("boom"),
+			wantStatus: http.StatusUnprocessableEntity,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewPyroscopeIngestHandler(&errorPushService{err: tc.pushErr}, validation.MockLimits{}, log.NewNopLogger())
+
+			ctx := tenant.InjectTenantID(context.Background(), "tenant-a")
+			req := httptest.NewRequestWithContext(ctx, "POST", "/ingest?name=pprof.test{qwe=asd}&spyName=foo239", bytes.NewReader(reqBody))
+			req.Header.Set("Content-Type", ct)
+			res := httptest.NewRecorder()
+
+			h.ServeHTTP(res, req)
+			assert.Equal(t, tc.wantStatus, res.Code)
+		})
+	}
 }
 
 func BenchmarkIngestJFR(b *testing.B) {


### PR DESCRIPTION
A tenant over its ingestion limit is rejected with `ResourceExhausted`, but each
ingest path translated that differently — so expected client-side throttling was
surfaced as server errors (OTLP HTTP 500s, logged at `error`) or the wrong 4xx.

This maps `ResourceExhausted` consistently across the OTLP (HTTP + gRPC) and legacy
`/ingest` handlers, matching the Connect push path. Other errors are unchanged.

| Path | Before | After |
|---|---|---|
| `/ingest` | 422 | 429 |
| OTLP HTTP | 500 | 429 |
| OTLP gRPC | `Unknown` | `ResourceExhausted` |
