### PR TITLE
feat(profilecli): add replay dump/push commands

### DIFF
--- a/cmd/profilecli/main.go
+++ b/cmd/profilecli/main.go
@@ -145,6 +145,12 @@ func main() {
 	recordingRulesDeleteId := recordingRulesDeleteCmd.Arg("rule_id", "Recording rule Id to delete").Required().String()
 	recordingRulesParams := addRecordingRulesListParams(recordingRulesCmd)
 
+	replayCmd := app.Command("replay", "Dump profile data from a source cell and replay it into a destination cell.")
+	replayDumpCmd := replayCmd.Command("dump", "Query a source cell's metastore and bucket, and write the matching profiles to a standalone dump file.")
+	replayDumpParams := addReplayDumpParams(replayDumpCmd)
+	replayPushCmd := replayCmd.Command("push", "Continuously push profiles from a dump file into a destination cell, looping over the recorded time window.")
+	replayPushParams := addReplayPushParams(replayPushCmd)
+
 	debuginfoCmd := app.Command("debuginfo", "Operations on debuginfo (experimental).")
 	debuginfoUploadCmd := debuginfoCmd.Command("upload", "Upload debuginfo.")
 	debuginfoUploadParams := addDebuginfoUploadParams(debuginfoUploadCmd)
@@ -278,6 +284,14 @@ func main() {
 		}
 	case recordingRulesDeleteCmd.FullCommand():
 		if err := deleteRecordingRule(ctx, recordingRulesDeleteId, recordingRulesParams); err != nil {
+			os.Exit(checkError(err))
+		}
+	case replayDumpCmd.FullCommand():
+		if err := replayDump(ctx, replayDumpParams); err != nil {
+			os.Exit(checkError(err))
+		}
+	case replayPushCmd.FullCommand():
+		if err := replayPush(ctx, replayPushParams); err != nil {
 			os.Exit(checkError(err))
 		}
 	case debuginfoUploadCmd.FullCommand():

--- a/cmd/profilecli/replay_dump.go
+++ b/cmd/profilecli/replay_dump.go
@@ -1,0 +1,321 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/grpcclient"
+	"github.com/grafana/dskit/services"
+	"github.com/parquet-go/parquet-go"
+	"github.com/prometheus/prometheus/model/labels"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	"github.com/grafana/pyroscope/v2/pkg/block"
+	metastoreclient "github.com/grafana/pyroscope/v2/pkg/metastore/client"
+	"github.com/grafana/pyroscope/v2/pkg/metastore/discovery"
+	phlaremodel "github.com/grafana/pyroscope/v2/pkg/model"
+	phlareobj "github.com/grafana/pyroscope/v2/pkg/objstore"
+	"github.com/grafana/pyroscope/v2/pkg/operations"
+	"github.com/grafana/pyroscope/v2/pkg/phlaredb/symdb"
+	"github.com/grafana/pyroscope/v2/pkg/pprof"
+)
+
+type replayDumpParams struct {
+	*bucketParams
+
+	MetastoreAddress string
+	Tenant           string
+	Query            string
+	From             string
+	To               string
+	Output           string
+	Force            bool
+}
+
+func addReplayDumpParams(cmd commander) *replayDumpParams {
+	params := &replayDumpParams{}
+	params.bucketParams = addBucketParams(cmd)
+
+	cmd.Flag("metastore.address", "Address of the source cell's metastore (host:port). Accepts a comma-separated list of peers.").
+		Default("localhost:9095").StringVar(&params.MetastoreAddress)
+	// NOTE: only a single tenant is supported for now. The replay push side
+	// sends everything to one destination tenant (X-Scope-OrgID), so dumping
+	// multiple tenants at once would silently merge them into one on replay.
+	cmd.Flag("tenant-id", "Tenant ID to dump from the source cell. Only a single tenant is supported for now.").
+		Required().StringVar(&params.Tenant)
+	cmd.Flag("query", "Label selector to query.").Default("{}").StringVar(&params.Query)
+	cmd.Flag("from", "Beginning of the dump window.").Default("now-1h").StringVar(&params.From)
+	cmd.Flag("to", "End of the dump window.").Default("now").StringVar(&params.To)
+	cmd.Flag("output", "Path to write the replay dump file to.").Short('o').Required().StringVar(&params.Output)
+	cmd.Flag("force", "Overwrite the output file if it already exists.").Short('f').Default("false").BoolVar(&params.Force)
+	return params
+}
+
+func (p *replayDumpParams) parseFromTo() (from, to time.Time, err error) {
+	from, err = operations.ParseTime(p.From)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("failed to parse from: %w", err)
+	}
+	to, err = operations.ParseTime(p.To)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("failed to parse to: %w", err)
+	}
+	if to.Before(from) {
+		return time.Time{}, time.Time{}, fmt.Errorf("from (%s) cannot be after to (%s)", from, to)
+	}
+	return from, to, nil
+}
+
+// newMetastoreClient builds a metastore client from a comma-separated list of
+// addresses. It relies on plaintext (non-TLS) gRPC, matching the default
+// configuration of the metastore.
+func newMetastoreClient(ctx context.Context, address string) (*metastoreclient.Client, error) {
+	disc, err := discovery.NewDiscovery(logger, address, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metastore discovery: %w", err)
+	}
+
+	// Populate default gRPC client settings (e.g. max message sizes), as the
+	// zero-value grpcclient.Config has them disabled (set to 0).
+	var grpcClientConfig grpcclient.Config
+	grpcClientConfig.RegisterFlags(flag.NewFlagSet("", flag.ContinueOnError))
+
+	client := metastoreclient.New(logger, grpcClientConfig, disc)
+	if err := services.StartAndAwaitRunning(ctx, client.Service()); err != nil {
+		return nil, fmt.Errorf("failed to start metastore client: %w", err)
+	}
+	return client, nil
+}
+
+func replayDump(ctx context.Context, params *replayDumpParams) (err error) {
+	from, to, err := params.parseFromTo()
+	if err != nil {
+		return err
+	}
+
+	matchers, err := phlaremodel.ParseMetricSelector(params.Query)
+	if err != nil {
+		return fmt.Errorf("failed to parse query: %w", err)
+	}
+
+	level.Info(logger).Log("msg", "starting replay dump",
+		"metastore", params.MetastoreAddress, "tenant", params.Tenant,
+		"query", params.Query, "from", from, "to", to, "output", params.Output)
+
+	bucket, err := params.initClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create bucket client: %w", err)
+	}
+
+	mc, err := newMetastoreClient(ctx, params.MetastoreAddress)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = services.StopAndAwaitTerminated(context.Background(), mc.Service())
+	}()
+
+	resp, err := mc.QueryMetadata(ctx, &metastorev1.QueryMetadataRequest{
+		TenantId:  []string{params.Tenant},
+		StartTime: from.UnixMilli(),
+		EndTime:   to.UnixMilli(),
+		Query:     params.Query,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to query metastore: %w", err)
+	}
+	level.Info(logger).Log("msg", "found blocks matching query", "count", len(resp.Blocks))
+
+	// Fail early if the destination exists and we are not overwriting, before
+	// doing the (potentially expensive) dump work.
+	if !params.Force {
+		if _, statErr := os.Stat(params.Output); statErr == nil {
+			return fmt.Errorf("output file %s already exists (use --force to overwrite)", params.Output)
+		} else if !errors.Is(statErr, os.ErrNotExist) {
+			return fmt.Errorf("failed to stat output file: %w", statErr)
+		}
+	}
+
+	// Write to a temporary file alongside the destination and atomically
+	// rename it into place only on success, so a failed or interrupted dump
+	// never leaves a partial/corrupt file at the destination path.
+	f, err := os.CreateTemp(filepath.Dir(params.Output), filepath.Base(params.Output)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary output file: %w", err)
+	}
+	tmpName := f.Name()
+	renamed := false
+	defer func() {
+		_ = f.Close()
+		if !renamed {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	rw, err := newReplayWriter(f, replayHeader{
+		SourceQuery: params.Query,
+		Tenants:     []string{params.Tenant},
+		From:        from.UnixMilli(),
+		To:          to.UnixMilli(),
+		CreatedAt:   time.Now().UnixMilli(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to write replay header: %w", err)
+	}
+
+	startNanos := from.UnixNano()
+	endNanos := to.UnixNano()
+
+	var totalProfiles int
+	for _, md := range resp.Blocks {
+		n, dErr := dumpBlock(ctx, bucket, md, matchers, startNanos, endNanos, rw)
+		if dErr != nil {
+			return fmt.Errorf("failed to dump block %s: %w", md.Id, dErr)
+		}
+		totalProfiles += n
+		level.Debug(logger).Log("msg", "dumped block", "block", md.Id, "profiles", n)
+	}
+
+	if err := rw.Flush(); err != nil {
+		return fmt.Errorf("failed to flush replay dump: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("failed to close temporary output file: %w", err)
+	}
+	if err := os.Rename(tmpName, params.Output); err != nil {
+		return fmt.Errorf("failed to move dump into place: %w", err)
+	}
+	renamed = true
+
+	level.Info(logger).Log("msg", "replay dump complete",
+		"blocks", len(resp.Blocks), "profiles", totalProfiles, "output", params.Output)
+	return nil
+}
+
+func dumpBlock(
+	ctx context.Context,
+	bucket phlareobj.Bucket,
+	md *metastorev1.BlockMeta,
+	matchers []*labels.Matcher,
+	startNanos, endNanos int64,
+	rw *replayWriter,
+) (int, error) {
+	obj := block.NewObject(bucket, md)
+
+	var count int
+	for _, dsMeta := range md.Datasets {
+		if block.DatasetFormat(dsMeta.Format) != block.DatasetFormat0 {
+			// Skip tenant-wide dataset index entries: they do not carry
+			// profile/tsdb/symbol sections of their own.
+			continue
+		}
+		n, err := dumpDataset(ctx, obj, dsMeta, matchers, startNanos, endNanos, rw)
+		if err != nil {
+			return count, err
+		}
+		count += n
+	}
+	return count, nil
+}
+
+func dumpDataset(
+	ctx context.Context,
+	obj *block.Object,
+	dsMeta *metastorev1.Dataset,
+	matchers []*labels.Matcher,
+	startNanos, endNanos int64,
+	rw *replayWriter,
+) (int, error) {
+	ds := block.NewDataset(dsMeta, obj)
+	if err := ds.Open(ctx, block.SectionTSDB, block.SectionProfiles, block.SectionSymbols); err != nil {
+		return 0, fmt.Errorf("failed to open dataset: %w", err)
+	}
+	defer ds.Close()
+
+	it, err := block.NewProfileRowIterator(ds)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create profile row iterator: %w", err)
+	}
+	defer it.Close()
+
+	var count int
+	for it.Next() {
+		entry := it.At()
+
+		if entry.Timestamp < startNanos || entry.Timestamp > endNanos {
+			continue
+		}
+		if !matchesAll(matchers, entry.Labels) {
+			continue
+		}
+
+		pprofBytes, err := buildPprofForRow(ctx, ds, entry)
+		if err != nil {
+			// Skip individual profiles that fail to reconstruct/marshal rather
+			// than aborting the whole dump: a best-effort dump of the
+			// remaining profiles is more useful than none.
+			level.Warn(logger).Log("msg", "skipping profile that failed to reconstruct",
+				"timestamp", entry.Timestamp, "labels", entry.Labels.ToPrometheusLabels().String(), "err", err)
+			continue
+		}
+
+		if err := rw.WriteRecord(replayRecord{
+			Labels:         entry.Labels,
+			TimestampNanos: entry.Timestamp,
+			Pprof:          pprofBytes,
+		}); err != nil {
+			return count, fmt.Errorf("failed to write replay record: %w", err)
+		}
+		count++
+	}
+	if err := it.Err(); err != nil {
+		return count, fmt.Errorf("failed to iterate profiles: %w", err)
+	}
+	return count, nil
+}
+
+func matchesAll(matchers []*labels.Matcher, ls phlaremodel.Labels) bool {
+	for _, m := range matchers {
+		if !m.Matches(ls.Get(m.Name)) {
+			return false
+		}
+	}
+	return true
+}
+
+// buildPprofForRow reconstructs a standalone pprof profile (gzip-compressed
+// bytes) from a single profile row, resolving its stack traces via the
+// dataset's symbol table. A new symdb.Resolver is used per profile, as
+// documented on symdb.Resolver.
+func buildPprofForRow(ctx context.Context, ds *block.Dataset, entry block.ProfileEntry) ([]byte, error) {
+	resolver := symdb.NewResolver(ctx, ds.Symbols())
+	defer resolver.Release()
+
+	entry.Row.ForStacktraceIdsAndValues(func(stacktraceIDs, values []parquet.Value) {
+		resolver.AddSamplesFromParquetRow(entry.Row.StacktracePartitionID(), stacktraceIDs, values)
+	})
+
+	profile, err := resolver.Pprof()
+	if err != nil {
+		return nil, err
+	}
+
+	if profileType := entry.Labels.Get(phlaremodel.LabelNameProfileType); profileType != "" {
+		if t, err := phlaremodel.ParseProfileTypeSelector(profileType); err == nil {
+			pprof.SetProfileMetadata(profile, t, entry.Timestamp, 0)
+		}
+	}
+	profile.TimeNanos = entry.Timestamp
+
+	data, err := pprof.Marshal(profile, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal reconstructed pprof: %w", err)
+	}
+	return data, nil
+}

--- a/cmd/profilecli/replay_format.go
+++ b/cmd/profilecli/replay_format.go
@@ -1,0 +1,273 @@
+package main
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+)
+
+// The replay dump file is a simple, self-contained, streamable archive of
+// individually reconstructed pprof profiles, together with their original
+// series labels and timestamps. It is produced by `profilecli replay dump`
+// and consumed by `profilecli replay push`.
+//
+// File layout:
+//
+//	magic (8 bytes) "PYRPLAY1"
+//	varint headerLen
+//	header (JSON, see replayHeader)
+//	record*
+//
+// Each record is framed as:
+//
+//	varint recordLen
+//	record body:
+//	  varint timestampNanos (zigzag)
+//	  varint numLabels
+//	  (varint nameLen, name bytes, varint valueLen, value bytes){numLabels}
+//	  varint pprofLen
+//	  pprof bytes (gzip-compressed pprof, as produced by pkg/pprof.MustMarshal)
+const (
+	replayMagic        = "PYRPLAY1"
+	replayMaxRecordLen = 512 << 20 // 512MiB safety limit for a single profile record
+)
+
+// replayHeader carries metadata about the dump, written once at the
+// beginning of the file. It intentionally does not carry the min/max
+// timestamp of the dump: that is derived by the reader from the records
+// themselves, so the writer can stream records without buffering.
+type replayHeader struct {
+	Version     int      `json:"version"`
+	SourceQuery string   `json:"source_query"`
+	Tenants     []string `json:"tenants"`
+	From        int64    `json:"from_unix_milli"`
+	To          int64    `json:"to_unix_milli"`
+	CreatedAt   int64    `json:"created_at_unix_milli"`
+}
+
+const replayFormatVersion = 1
+
+// replayRecord is a single reconstructed profile: its original series
+// labels, the timestamp it was recorded at (nanoseconds since epoch), and
+// the gzip-compressed pprof bytes.
+type replayRecord struct {
+	Labels         []*typesv1.LabelPair
+	TimestampNanos int64
+	Pprof          []byte
+}
+
+// replayWriter buffers and frames replay records onto an io.Writer. It does
+// not own or close the underlying writer: callers remain responsible for
+// closing the destination (e.g. an *os.File) themselves.
+type replayWriter struct {
+	w       *bufio.Writer
+	scratch [binary.MaxVarintLen64]byte
+}
+
+func newReplayWriter(w io.Writer, header replayHeader) (*replayWriter, error) {
+	header.Version = replayFormatVersion
+	bw := bufio.NewWriter(w)
+	if _, err := bw.WriteString(replayMagic); err != nil {
+		return nil, err
+	}
+	headerBytes, err := json.Marshal(header)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal replay header: %w", err)
+	}
+	rw := &replayWriter{w: bw}
+	rw.writeUvarint(uint64(len(headerBytes)))
+	if _, err := bw.Write(headerBytes); err != nil {
+		return nil, err
+	}
+	return rw, nil
+}
+
+func (rw *replayWriter) writeUvarint(v uint64) {
+	n := binary.PutUvarint(rw.scratch[:], v)
+	_, _ = rw.w.Write(rw.scratch[:n])
+}
+
+func (rw *replayWriter) WriteRecord(rec replayRecord) error {
+	var body bufferedRecord
+	body.writeVarint(rec.TimestampNanos)
+	body.writeUvarint(uint64(len(rec.Labels)))
+	for _, l := range rec.Labels {
+		body.writeString(l.Name)
+		body.writeString(l.Value)
+	}
+	body.writeUvarint(uint64(len(rec.Pprof)))
+	body.buf = append(body.buf, rec.Pprof...)
+
+	rw.writeUvarint(uint64(len(body.buf)))
+	_, err := rw.w.Write(body.buf)
+	return err
+}
+
+// Flush writes any buffered data to the underlying writer. It does not close
+// the underlying writer.
+func (rw *replayWriter) Flush() error {
+	return rw.w.Flush()
+}
+
+// bufferedRecord is a small helper to build a record body in memory before
+// writing its length prefix.
+type bufferedRecord struct {
+	buf     []byte
+	scratch [binary.MaxVarintLen64]byte
+}
+
+func (b *bufferedRecord) writeUvarint(v uint64) {
+	n := binary.PutUvarint(b.scratch[:], v)
+	b.buf = append(b.buf, b.scratch[:n]...)
+}
+
+func (b *bufferedRecord) writeVarint(v int64) {
+	n := binary.PutVarint(b.scratch[:], v)
+	b.buf = append(b.buf, b.scratch[:n]...)
+}
+
+func (b *bufferedRecord) writeString(s string) {
+	b.writeUvarint(uint64(len(s)))
+	b.buf = append(b.buf, s...)
+}
+
+type replayReader struct {
+	r      *bufio.Reader
+	Header replayHeader
+}
+
+func newReplayReader(r io.Reader) (*replayReader, error) {
+	br := bufio.NewReader(r)
+	magic := make([]byte, len(replayMagic))
+	if _, err := io.ReadFull(br, magic); err != nil {
+		return nil, fmt.Errorf("failed to read replay file magic: %w", err)
+	}
+	if string(magic) != replayMagic {
+		return nil, fmt.Errorf("not a profilecli replay dump file (bad magic %q)", magic)
+	}
+	headerLen, err := binary.ReadUvarint(br)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read replay header length: %w", err)
+	}
+	headerBytes := make([]byte, headerLen)
+	if _, err := io.ReadFull(br, headerBytes); err != nil {
+		return nil, fmt.Errorf("failed to read replay header: %w", err)
+	}
+	var header replayHeader
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal replay header: %w", err)
+	}
+	if header.Version != replayFormatVersion {
+		return nil, fmt.Errorf("unsupported replay dump file version %d (expected %d)", header.Version, replayFormatVersion)
+	}
+	return &replayReader{r: br, Header: header}, nil
+}
+
+// ReadRecord reads the next record, returning io.EOF when the file is
+// exhausted.
+func (rr *replayReader) ReadRecord() (replayRecord, error) {
+	recordLen, err := binary.ReadUvarint(rr.r)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return replayRecord{}, io.EOF
+		}
+		return replayRecord{}, fmt.Errorf("failed to read record length: %w", err)
+	}
+	if recordLen > replayMaxRecordLen {
+		return replayRecord{}, fmt.Errorf("record length %d exceeds maximum %d", recordLen, replayMaxRecordLen)
+	}
+	body := make([]byte, recordLen)
+	if _, err := io.ReadFull(rr.r, body); err != nil {
+		return replayRecord{}, fmt.Errorf("failed to read record body: %w", err)
+	}
+	return decodeRecordBody(body)
+}
+
+func decodeRecordBody(body []byte) (replayRecord, error) {
+	br := &byteReader{b: body}
+
+	ts, err := br.readVarint()
+	if err != nil {
+		return replayRecord{}, fmt.Errorf("failed to read record timestamp: %w", err)
+	}
+	numLabels, err := br.readUvarint()
+	if err != nil {
+		return replayRecord{}, fmt.Errorf("failed to read record label count: %w", err)
+	}
+	labels := make([]*typesv1.LabelPair, 0, numLabels)
+	for i := uint64(0); i < numLabels; i++ {
+		name, err := br.readString()
+		if err != nil {
+			return replayRecord{}, fmt.Errorf("failed to read label name: %w", err)
+		}
+		value, err := br.readString()
+		if err != nil {
+			return replayRecord{}, fmt.Errorf("failed to read label value: %w", err)
+		}
+		labels = append(labels, &typesv1.LabelPair{Name: name, Value: value})
+	}
+	pprofLen, err := br.readUvarint()
+	if err != nil {
+		return replayRecord{}, fmt.Errorf("failed to read pprof length: %w", err)
+	}
+	pprofBytes, err := br.readBytes(int(pprofLen))
+	if err != nil {
+		return replayRecord{}, fmt.Errorf("failed to read pprof bytes: %w", err)
+	}
+	return replayRecord{
+		Labels:         labels,
+		TimestampNanos: ts,
+		Pprof:          pprofBytes,
+	}, nil
+}
+
+// byteReader is a minimal varint/bytes reader over an in-memory buffer,
+// used to decode a single record body.
+type byteReader struct {
+	b   []byte
+	off int
+}
+
+func (r *byteReader) readUvarint() (uint64, error) {
+	v, n := binary.Uvarint(r.b[r.off:])
+	if n <= 0 {
+		return 0, errors.New("invalid uvarint")
+	}
+	r.off += n
+	return v, nil
+}
+
+func (r *byteReader) readVarint() (int64, error) {
+	v, n := binary.Varint(r.b[r.off:])
+	if n <= 0 {
+		return 0, errors.New("invalid varint")
+	}
+	r.off += n
+	return v, nil
+}
+
+func (r *byteReader) readBytes(n int) ([]byte, error) {
+	if n < 0 || r.off+n > len(r.b) {
+		return nil, errors.New("unexpected end of record body")
+	}
+	out := r.b[r.off : r.off+n]
+	r.off += n
+	return out, nil
+}
+
+func (r *byteReader) readString() (string, error) {
+	n, err := r.readUvarint()
+	if err != nil {
+		return "", err
+	}
+	b, err := r.readBytes(int(n))
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/cmd/profilecli/replay_format_test.go
+++ b/cmd/profilecli/replay_format_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+)
+
+func TestReplayFormat_WriteReadRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	header := replayHeader{
+		SourceQuery: `{service_name="foo"}`,
+		Tenants:     []string{"tenant-a"},
+		From:        1000,
+		To:          2000,
+		CreatedAt:   1234,
+	}
+
+	records := []replayRecord{
+		{
+			Labels: []*typesv1.LabelPair{
+				{Name: "service_name", Value: "foo"},
+				{Name: "__profile_type__", Value: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"},
+			},
+			TimestampNanos: 1_700_000_000_000_000_000,
+			Pprof:          []byte{0x1f, 0x8b, 0x08, 0x00, 0x01, 0x02, 0x03},
+		},
+		{
+			Labels: []*typesv1.LabelPair{
+				{Name: "service_name", Value: "foo"},
+			},
+			TimestampNanos: -42, // negative timestamps must round-trip correctly (varint zigzag)
+			Pprof:          []byte{},
+		},
+		{
+			Labels:         nil,
+			TimestampNanos: 0,
+			Pprof:          bytes.Repeat([]byte{0xAB}, 4096),
+		},
+	}
+
+	var buf bytes.Buffer
+	rw, err := newReplayWriter(&buf, header)
+	require.NoError(t, err)
+	for _, rec := range records {
+		require.NoError(t, rw.WriteRecord(rec))
+	}
+	require.NoError(t, rw.Flush())
+
+	rr, err := newReplayReader(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+
+	assert.Equal(t, replayFormatVersion, rr.Header.Version)
+	assert.Equal(t, header.SourceQuery, rr.Header.SourceQuery)
+	assert.Equal(t, header.Tenants, rr.Header.Tenants)
+	assert.Equal(t, header.From, rr.Header.From)
+	assert.Equal(t, header.To, rr.Header.To)
+	assert.Equal(t, header.CreatedAt, rr.Header.CreatedAt)
+
+	var got []replayRecord
+	for {
+		rec, err := rr.ReadRecord()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		got = append(got, rec)
+	}
+
+	require.Len(t, got, len(records))
+	for i, want := range records {
+		assert.Equal(t, want.TimestampNanos, got[i].TimestampNanos)
+		assert.Equal(t, want.Pprof, got[i].Pprof)
+		require.Len(t, got[i].Labels, len(want.Labels))
+		for j, wl := range want.Labels {
+			assert.Equal(t, wl.Name, got[i].Labels[j].Name)
+			assert.Equal(t, wl.Value, got[i].Labels[j].Value)
+		}
+	}
+}
+
+func TestReplayFormat_BadMagic(t *testing.T) {
+	t.Parallel()
+
+	_, err := newReplayReader(bytes.NewReader([]byte("NOTAREPLAYFILE")))
+	require.Error(t, err)
+}
+
+func TestReplayFormat_EmptyFile(t *testing.T) {
+	t.Parallel()
+
+	_, err := newReplayReader(bytes.NewReader(nil))
+	require.Error(t, err)
+}

--- a/cmd/profilecli/replay_push.go
+++ b/cmd/profilecli/replay_push.go
@@ -1,0 +1,322 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/go-kit/log/level"
+	"github.com/google/uuid"
+	"github.com/grafana/dskit/runutil"
+
+	pushv1 "github.com/grafana/pyroscope/api/gen/proto/go/push/v1"
+	"github.com/grafana/pyroscope/api/gen/proto/go/push/v1/pushv1connect"
+	"github.com/grafana/pyroscope/v2/pkg/pprof"
+)
+
+// progressLogInterval bounds how often "replay progress" is logged while
+// pushing a (potentially long-running) cycle, so long replays don't look
+// stuck between "starting replay cycle" and "replay cycle complete".
+const progressLogInterval = 5 * time.Second
+
+type replayPushParams struct {
+	*phlareClient
+
+	Input     string
+	Loop      bool
+	Speed     float64
+	BatchSize int
+	BatchWait time.Duration
+}
+
+func addReplayPushParams(cmd commander) *replayPushParams {
+	params := &replayPushParams{}
+	params.phlareClient = addPhlareClient(cmd)
+
+	cmd.Flag("input", "Path to the replay dump file produced by `replay dump`. Accepts a local file path or an http(s) URL.").Short('i').Required().StringVar(&params.Input)
+	cmd.Flag("loop", "Continuously repeat the dump, looping every recorded window duration, so the destination cell keeps receiving data that looks like the original recording.").Default("true").BoolVar(&params.Loop)
+	cmd.Flag("speed", "Time-scale multiplier for replay speed (2 replays twice as fast, 0.5 half as fast).").Default("1").Float64Var(&params.Speed)
+	cmd.Flag("batch-size", "Maximum number of profiles to send in a single push request.").Default("100").IntVar(&params.BatchSize)
+	cmd.Flag("batch-wait", "Maximum time to accumulate a batch before flushing it, once the first profile in the batch becomes due.").Default("500ms").DurationVar(&params.BatchWait)
+	return params
+}
+
+// loadReplayRecords reads the entire dump file into memory, sorted by
+// timestamp. Dump files are expected to be bounded in size (a debug/backup
+// tool, not a bulk data-transfer mechanism), so loading them fully allows
+// the replay loop to schedule pushes precisely without re-reading the file.
+//
+// input may be a local file path or an http(s) URL.
+func loadReplayRecords(ctx context.Context, input string) (replayHeader, []replayRecord, error) {
+	r, err := openReplayInput(ctx, input)
+	if err != nil {
+		return replayHeader{}, nil, err
+	}
+	defer runutil.CloseWithLogOnErr(logger, r, "failed to close replay dump input")
+
+	rr, err := newReplayReader(r)
+	if err != nil {
+		return replayHeader{}, nil, err
+	}
+
+	var records []replayRecord
+	for {
+		rec, err := rr.ReadRecord()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return replayHeader{}, nil, err
+		}
+		records = append(records, rec)
+	}
+
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].TimestampNanos < records[j].TimestampNanos
+	})
+
+	return rr.Header, records, nil
+}
+
+// openReplayInput opens input for reading, transparently supporting either a
+// local file path or an http(s) URL (e.g. a signed object storage URL, or a
+// dump file served over HTTP). The returned io.ReadCloser must always be
+// closed once the reader is no longer needed.
+func openReplayInput(ctx context.Context, input string) (io.ReadCloser, error) {
+	if strings.HasPrefix(input, "http://") || strings.HasPrefix(input, "https://") {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, input, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build request for replay dump file: %w", err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch replay dump file: %w", err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("failed to fetch replay dump file: unexpected status %s: %s", resp.Status, string(body))
+		}
+		return resp.Body, nil
+	}
+
+	f, err := os.Open(input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open replay dump file: %w", err)
+	}
+	return f, nil
+}
+
+func replayPush(ctx context.Context, params *replayPushParams) error {
+	if params.Speed <= 0 {
+		return errors.New("--speed must be greater than 0")
+	}
+	if params.BatchSize < 1 {
+		return errors.New("--batch-size must be at least 1")
+	}
+	if params.BatchWait < 0 {
+		return errors.New("--batch-wait must not be negative")
+	}
+
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	level.Info(logger).Log("msg", "loading replay dump file", "input", params.Input)
+	header, records, err := loadReplayRecords(ctx, params.Input)
+	if err != nil {
+		return err
+	}
+	if len(records) == 0 {
+		return errors.New("replay dump file contains no profiles")
+	}
+	// Only a single tenant is supported for now: push sends everything to one
+	// destination tenant (X-Scope-OrgID), so a multi-tenant dump would
+	// silently merge tenants on replay.
+	if len(header.Tenants) > 1 {
+		return fmt.Errorf("replay dump file contains %d tenants (%s); only single-tenant dumps are supported", len(header.Tenants), strings.Join(header.Tenants, ", "))
+	}
+
+	minTs := records[0].TimestampNanos
+	maxTs := records[len(records)-1].TimestampNanos
+	cycleDuration := time.Duration(maxTs - minTs)
+	if cycleDuration <= 0 {
+		level.Warn(logger).Log("msg", "dump window has no measurable duration (single timestamp); replaying once per second", "profiles", len(records))
+		cycleDuration = time.Second
+	}
+
+	level.Info(logger).Log("msg", "starting replay push",
+		"input", params.Input, "profiles", len(records), "cycle_duration", cycleDuration,
+		"source_query", header.SourceQuery, "loop", params.Loop, "speed", params.Speed,
+		"batch_size", params.BatchSize, "batch_wait", params.BatchWait, "destination", params.URL)
+
+	pc := params.pusherClient()
+
+	startWall := time.Now()
+	for cycle := 0; ; cycle++ {
+		if ctx.Err() != nil {
+			break
+		}
+		cycleOffset := time.Duration(float64(cycle) * float64(cycleDuration) / params.Speed)
+		cycleStart := startWall.Add(cycleOffset)
+		level.Info(logger).Log("msg", "starting replay cycle", "cycle", cycle, "scheduled_start", cycleStart)
+
+		pushed, failed, interrupted := runReplayCycle(ctx, pc, records, minTs, cycleStart, params)
+
+		if interrupted {
+			level.Info(logger).Log("msg", "replay interrupted", "cycle", cycle, "pushed", pushed, "failed", failed)
+			return nil
+		}
+		level.Info(logger).Log("msg", "replay cycle complete", "cycle", cycle, "pushed", pushed, "failed", failed)
+
+		if !params.Loop {
+			break
+		}
+	}
+
+	return nil
+}
+
+// runReplayCycle pushes every record once, grouping consecutive due records
+// into batches of up to params.BatchSize, flushed as soon as either the
+// batch is full or params.BatchWait has elapsed since the first profile in
+// the batch became due. Batching a whole cycle's worth of profiles into far
+// fewer push requests keeps up with schedules that would otherwise require
+// hundreds of individual round-trips per second.
+func runReplayCycle(
+	ctx context.Context,
+	pc pushv1connect.PusherServiceClient,
+	records []replayRecord,
+	minTs int64,
+	cycleStart time.Time,
+	params *replayPushParams,
+) (pushed, failed int, interrupted bool) {
+	scheduledTarget := func(rec replayRecord) time.Time {
+		offset := time.Duration(float64(rec.TimestampNanos-minTs) / params.Speed)
+		return cycleStart.Add(offset)
+	}
+
+	lastProgressLog := time.Now()
+	total := len(records)
+
+	i := 0
+	for i < total {
+		if ctx.Err() != nil {
+			interrupted = true
+			break
+		}
+
+		first := records[i]
+		firstTarget := scheduledTarget(first)
+		if !waitUntil(ctx, firstTarget) {
+			interrupted = true
+			break
+		}
+
+		batch := make([]*pushv1.RawProfileSeries, 0, params.BatchSize)
+		series, err := buildSeries(first, firstTarget)
+		if err != nil {
+			failed++
+			level.Error(logger).Log("msg", "failed to prepare replayed profile", "err", err)
+		} else {
+			batch = append(batch, series)
+		}
+		i++
+
+		deadline := time.Now().Add(params.BatchWait)
+		for i < total && len(batch) < params.BatchSize {
+			next := records[i]
+			nextTarget := scheduledTarget(next)
+			if nextTarget.After(deadline) {
+				break
+			}
+			if !waitUntil(ctx, nextTarget) {
+				interrupted = true
+				break
+			}
+			if series, err := buildSeries(next, nextTarget); err != nil {
+				failed++
+				level.Error(logger).Log("msg", "failed to prepare replayed profile", "err", err)
+			} else {
+				batch = append(batch, series)
+			}
+			i++
+		}
+
+		if len(batch) > 0 {
+			if err := pushBatch(ctx, pc, batch); err != nil {
+				failed += len(batch)
+				level.Error(logger).Log("msg", "failed to push replayed profile batch", "batch_size", len(batch), "err", err)
+			} else {
+				pushed += len(batch)
+				level.Debug(logger).Log("msg", "pushed replayed profile batch", "batch_size", len(batch))
+			}
+		}
+
+		if interrupted {
+			break
+		}
+
+		if now := time.Now(); now.Sub(lastProgressLog) >= progressLogInterval {
+			level.Info(logger).Log("msg", "replay progress", "pushed", pushed, "failed", failed, "total", total)
+			lastProgressLog = now
+		}
+	}
+
+	return pushed, failed, interrupted
+}
+
+// waitUntil blocks until target, or returns false immediately if ctx is
+// cancelled first.
+func waitUntil(ctx context.Context, target time.Time) bool {
+	d := time.Until(target)
+	if d <= 0 {
+		return ctx.Err() == nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// buildSeries reconstructs the pprof profile with its timestamp rewritten to
+// target (the scheduled wall-clock replay time), ready to be included in a
+// push request.
+func buildSeries(rec replayRecord, target time.Time) (*pushv1.RawProfileSeries, error) {
+	profile, err := pprof.RawFromBytes(rec.Pprof)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse pprof: %w", err)
+	}
+	profile.TimeNanos = target.UnixNano()
+	data, err := pprof.Marshal(profile.Profile, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal pprof: %w", err)
+	}
+
+	return &pushv1.RawProfileSeries{
+		Labels: rec.Labels,
+		Samples: []*pushv1.RawSample{{
+			ID:         uuid.New().String(),
+			RawProfile: data,
+		}},
+	}, nil
+}
+
+func pushBatch(ctx context.Context, pc pushv1connect.PusherServiceClient, batch []*pushv1.RawProfileSeries) error {
+	_, err := pc.Push(ctx, connect.NewRequest(&pushv1.PushRequest{
+		Series: batch,
+	}))
+	return err
+}

--- a/cmd/profilecli/replay_push_test.go
+++ b/cmd/profilecli/replay_push_test.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	googlev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	pushv1 "github.com/grafana/pyroscope/api/gen/proto/go/push/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	"github.com/grafana/pyroscope/v2/pkg/pprof"
+)
+
+// fakePusherClient records every push request it receives.
+type fakePusherClient struct {
+	mu       sync.Mutex
+	requests []*pushv1.PushRequest
+}
+
+func (f *fakePusherClient) Push(_ context.Context, req *connect.Request[pushv1.PushRequest]) (*connect.Response[pushv1.PushResponse], error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.requests = append(f.requests, req.Msg)
+	return connect.NewResponse(&pushv1.PushResponse{}), nil
+}
+
+func (f *fakePusherClient) totalSeries() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for _, r := range f.requests {
+		n += len(r.Series)
+	}
+	return n
+}
+
+func (f *fakePusherClient) requestCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.requests)
+}
+
+func (f *fakePusherClient) maxBatchSize() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	max := 0
+	for _, r := range f.requests {
+		if len(r.Series) > max {
+			max = len(r.Series)
+		}
+	}
+	return max
+}
+
+func testPprofBytes(t *testing.T) []byte {
+	t.Helper()
+	p := &googlev1.Profile{
+		SampleType:  []*googlev1.ValueType{{Type: 1, Unit: 2}},
+		PeriodType:  &googlev1.ValueType{Type: 1, Unit: 2},
+		StringTable: []string{"", "samples", "count"},
+		TimeNanos:   1,
+	}
+	data, err := pprof.Marshal(p, true)
+	require.NoError(t, err)
+	return data
+}
+
+// TestRunReplayCycle_Batching verifies that many densely-scheduled records
+// are coalesced into few push requests (bounded by batch size and batch
+// wait), rather than one push request per profile.
+func TestRunReplayCycle_Batching(t *testing.T) {
+	t.Parallel()
+
+	pprofBytes := testPprofBytes(t)
+
+	const n = 500
+	records := make([]replayRecord, n)
+	for i := 0; i < n; i++ {
+		records[i] = replayRecord{
+			Labels: []*typesv1.LabelPair{
+				{Name: "service_name", Value: "checkoutservice"},
+			},
+			// Densely packed: 1ms apart, well within the batch-wait window.
+			TimestampNanos: int64(i) * int64(time.Millisecond),
+			Pprof:          pprofBytes,
+		}
+	}
+
+	fake := &fakePusherClient{}
+	params := &replayPushParams{
+		Speed:     1,
+		BatchSize: 50,
+		BatchWait: 500 * time.Millisecond,
+	}
+
+	cycleStart := time.Now()
+	pushed, failed, interrupted := runReplayCycle(context.Background(), fake, records, records[0].TimestampNanos, cycleStart, params)
+
+	require.False(t, interrupted)
+	assert.Equal(t, 0, failed)
+	assert.Equal(t, n, pushed)
+	assert.Equal(t, n, fake.totalSeries())
+
+	// 500 records batched at up to 50 per request should take far fewer
+	// than 500 push RPCs.
+	assert.LessOrEqual(t, fake.requestCount(), n/10)
+	assert.LessOrEqual(t, fake.maxBatchSize(), params.BatchSize)
+}
+
+// TestRunReplayCycle_SparseRecordsAreNotOverBatched verifies that records
+// scheduled far apart in time (further apart than --batch-wait) are not
+// held back waiting for a full batch: each due record is pushed promptly.
+func TestRunReplayCycle_SparseRecordsAreNotOverBatched(t *testing.T) {
+	t.Parallel()
+
+	pprofBytes := testPprofBytes(t)
+
+	records := []replayRecord{
+		{Labels: []*typesv1.LabelPair{{Name: "service_name", Value: "svc"}}, TimestampNanos: 0, Pprof: pprofBytes},
+		{Labels: []*typesv1.LabelPair{{Name: "service_name", Value: "svc"}}, TimestampNanos: int64(2 * time.Second), Pprof: pprofBytes},
+	}
+
+	fake := &fakePusherClient{}
+	params := &replayPushParams{
+		Speed:     50, // 2s apart in recorded time -> 40ms apart in wall time, still > batch-wait
+		BatchSize: 50,
+		BatchWait: 10 * time.Millisecond,
+	}
+
+	cycleStart := time.Now()
+	pushed, failed, interrupted := runReplayCycle(context.Background(), fake, records, records[0].TimestampNanos, cycleStart, params)
+
+	require.False(t, interrupted)
+	assert.Equal(t, 0, failed)
+	assert.Equal(t, 2, pushed)
+	// Each record should have been flushed in its own batch since they are
+	// scheduled further apart than --batch-wait.
+	assert.Equal(t, 2, fake.requestCount())
+}
+
+func TestRunReplayCycle_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	pprofBytes := testPprofBytes(t)
+	records := []replayRecord{
+		{Labels: []*typesv1.LabelPair{{Name: "service_name", Value: "svc"}}, TimestampNanos: 0, Pprof: pprofBytes},
+		{Labels: []*typesv1.LabelPair{{Name: "service_name", Value: "svc"}}, TimestampNanos: int64(10 * time.Second), Pprof: pprofBytes},
+	}
+
+	fake := &fakePusherClient{}
+	params := &replayPushParams{
+		Speed:     1,
+		BatchSize: 50,
+		BatchWait: 500 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately, before the first record's wait
+
+	_, _, interrupted := runReplayCycle(ctx, fake, records, records[0].TimestampNanos, time.Now().Add(20*time.Second), params)
+	assert.True(t, interrupted)
+}
+
+func TestBuildSeries_RewritesTimestamp(t *testing.T) {
+	t.Parallel()
+
+	pprofBytes := testPprofBytes(t)
+	rec := replayRecord{
+		Labels:         []*typesv1.LabelPair{{Name: "service_name", Value: "svc"}},
+		TimestampNanos: 123,
+		Pprof:          pprofBytes,
+	}
+	target := time.Unix(0, 987654321)
+
+	series, err := buildSeries(rec, target)
+	require.NoError(t, err)
+	require.Len(t, series.Samples, 1)
+
+	profile, err := pprof.RawFromBytes(series.Samples[0].RawProfile)
+	require.NoError(t, err)
+	assert.Equal(t, target.UnixNano(), profile.TimeNanos)
+	assert.NotEqual(t, rec.TimestampNanos, profile.TimeNanos)
+}
+
+func TestReplayFormat_RoundtripWithRealPprof(t *testing.T) {
+	t.Parallel()
+
+	pprofBytes := testPprofBytes(t)
+	var buf bytes.Buffer
+	rw, err := newReplayWriter(&buf, replayHeader{SourceQuery: "{}", Tenants: []string{"t"}})
+	require.NoError(t, err)
+	require.NoError(t, rw.WriteRecord(replayRecord{
+		Labels:         []*typesv1.LabelPair{{Name: "service_name", Value: "svc"}},
+		TimestampNanos: 42,
+		Pprof:          pprofBytes,
+	}))
+	require.NoError(t, rw.Flush())
+
+	rr, err := newReplayReader(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	rec, err := rr.ReadRecord()
+	require.NoError(t, err)
+	assert.Equal(t, pprofBytes, rec.Pprof)
+}
+
+// buildTestDump writes a minimal, valid replay dump file to disk and
+// returns its bytes and path.
+func buildTestDump(t *testing.T) (path string, data []byte) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	rw, err := newReplayWriter(&buf, replayHeader{SourceQuery: `{service_name="svc"}`, Tenants: []string{"t"}})
+	require.NoError(t, err)
+	require.NoError(t, rw.WriteRecord(replayRecord{
+		Labels:         []*typesv1.LabelPair{{Name: "service_name", Value: "svc"}},
+		TimestampNanos: 1,
+		Pprof:          testPprofBytes(t),
+	}))
+	require.NoError(t, rw.Flush())
+
+	path = filepath.Join(t.TempDir(), "dump.replay")
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0o644))
+	return path, buf.Bytes()
+}
+
+func TestLoadReplayRecords_LocalFile(t *testing.T) {
+	t.Parallel()
+
+	path, _ := buildTestDump(t)
+	header, records, err := loadReplayRecords(context.Background(), path)
+	require.NoError(t, err)
+	assert.Equal(t, `{service_name="svc"}`, header.SourceQuery)
+	require.Len(t, records, 1)
+}
+
+func TestLoadReplayRecords_HTTPURL(t *testing.T) {
+	t.Parallel()
+
+	_, data := buildTestDump(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(data)
+	}))
+	t.Cleanup(srv.Close)
+
+	header, records, err := loadReplayRecords(context.Background(), srv.URL+"/dump.replay")
+	require.NoError(t, err)
+	assert.Equal(t, `{service_name="svc"}`, header.SourceQuery)
+	require.Len(t, records, 1)
+}
+
+func TestLoadReplayRecords_HTTPURL_NotFound(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, _, err := loadReplayRecords(context.Background(), srv.URL+"/missing.replay")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestLoadReplayRecords_LocalFile_NotFound(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := loadReplayRecords(context.Background(), filepath.Join(t.TempDir(), "does-not-exist.replay"))
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Adds a two-command workflow for capturing profile data from a source cell and replaying it into a destination cell:

- `profilecli replay dump` queries the source cell's metastore for blocks matching a query/time range, reads the matching blocks directly from object storage, reconstructs individual pprof profiles (preserving original series labels and timestamps), and writes them to a standalone framed dump file.
- `profilecli replay push` reads the dump file and continuously pushes profiles to a destination cell via the pushv1 Push API, rescheduling timestamps so the recorded window repeats seamlessly in a loop (with optional speed scaling and single-pass mode).

Includes a roundtrip test for the dump file format.

## Test plan

- [x] `replay_format_test.go` roundtrip test
- [x] `replay_push_test.go` covers push scheduling/looping behavior