### PR TITLE
perf(model): optimize tree construction with hybrid search and interned handles

### DIFF
--- a/pkg/model/tree.go
+++ b/pkg/model/tree.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -172,21 +173,54 @@ func (t *Tree[N, I]) InsertStackBuf(buf *nodeBuffer[N], v int64, stack ...N) {
 		name := stack[s]
 		n.total += v
 		var child *node[N]
-		for _, c := range n.children {
-			if c.name == name {
-				child = c
-				break
+		l := len(n.children)
+		if l < 8 {
+			for _, c := range n.children {
+				if c.name == name {
+					child = c
+					break
+				}
 			}
-		}
-		if child == nil {
-			if buf != nil {
-				child = buf.newNode()
-				child.parent = n
-				child.name = name
+			if child == nil {
+				if buf != nil {
+					child = buf.newNode()
+					child.parent = n
+					child.name = name
+				} else {
+					child = &node[N]{parent: n, name: name}
+				}
+				i := 0
+				for i < l && n.children[i].name < name {
+					i++
+				}
+				n.children = append(n.children, child)
+				copy(n.children[i+1:], n.children[i:])
+				n.children[i] = child
+			}
+		} else {
+			i, j := 0, l
+			for i < j {
+				h := int(uint(i+j) >> 1)
+				if n.children[h].name < name {
+					i = h + 1
+				} else {
+					j = h
+				}
+			}
+			if i < l && n.children[i].name == name {
+				child = n.children[i]
 			} else {
-				child = &node[N]{parent: n, name: name}
+				if buf != nil {
+					child = buf.newNode()
+					child.parent = n
+					child.name = name
+				} else {
+					child = &node[N]{parent: n, name: name}
+				}
+				n.children = append(n.children, child)
+				copy(n.children[i+1:], n.children[i:])
+				n.children[i] = child
 			}
-			n.children = append(n.children, child)
 		}
 		n = child
 	}
@@ -196,14 +230,41 @@ func (t *Tree[N, I]) InsertStackBuf(buf *nodeBuffer[N], v int64, stack ...N) {
 	t.root = r.children
 }
 
-func stringToNodeName[N NodeName](s string) N {
+func stringToNodeName[N NodeName](s string) (N, error) {
 	var n N
-	switch any(n).(type) {
-	case FunctionName:
-		return any(FunctionName(s)).(N)
+	switch p := any(&n).(type) {
+	case *FunctionName:
+		*p = FunctionName(s)
+	case *string:
+		*p = s
+	case *LocationRefName:
+		id, err := strconv.Atoi(s)
+		if err != nil {
+			return n, err
+		}
+		*p = LocationRefName(id)
+	case *int:
+		id, err := strconv.Atoi(s)
+		if err != nil {
+			return n, err
+		}
+		*p = id
 	default:
-		return any(s).(N)
+		val := reflect.ValueOf(&n).Elem()
+		switch val.Kind() {
+		case reflect.String:
+			val.SetString(s)
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			id, err := strconv.Atoi(s)
+			if err != nil {
+				return n, err
+			}
+			val.SetInt(int64(id))
+		default:
+			return n, fmt.Errorf("unsupported NodeName type %T", n)
+		}
 	}
+	return n, nil
 }
 
 func (t *Tree[N, I]) InsertStackHandles(v int64, stack ...unique.Handle[string]) {
@@ -211,31 +272,89 @@ func (t *Tree[N, I]) InsertStackHandles(v int64, stack ...unique.Handle[string])
 }
 
 func (t *Tree[N, I]) InsertStackHandlesBuf(buf *nodeBuffer[N], v int64, stack ...unique.Handle[string]) {
-	if v <= 0 {
+	if v <= 0 || len(stack) == 0 {
 		return
 	}
+
+	// Validate handles upfront and pre-convert to node names to prevent path splicing.
+	var stackBuf [32]N
+	var names []N
+	if len(stack) <= len(stackBuf) {
+		names = stackBuf[:len(stack)]
+	} else {
+		names = make([]N, len(stack))
+	}
+	for i, h := range stack {
+		name, err := stringToNodeName[N](h.Value())
+		if err != nil {
+			return
+		}
+		names[i] = name
+	}
+
 	r := &node[N]{children: t.root}
 	n := r
-	for _, h := range stack {
+	var zeroHandle unique.Handle[string]
+	for s, h := range stack {
+		name := names[s]
 		n.total += v
 		var child *node[N]
-		for _, c := range n.children {
-			if c.handle == h {
-				child = c
-				break
+		l := len(n.children)
+		if l < 8 {
+			for _, c := range n.children {
+				if c.handle == h || c.name == name {
+					child = c
+					if child.handle == zeroHandle {
+						child.handle = h
+					}
+					break
+				}
 			}
-		}
-		if child == nil {
-			name := stringToNodeName[N](h.Value())
-			if buf != nil {
-				child = buf.newNode()
-				child.parent = n
-				child.name = name
-				child.handle = h
+			if child == nil {
+				if buf != nil {
+					child = buf.newNode()
+					child.parent = n
+					child.name = name
+					child.handle = h
+				} else {
+					child = &node[N]{parent: n, name: name, handle: h}
+				}
+				i := 0
+				for i < l && n.children[i].name < name {
+					i++
+				}
+				n.children = append(n.children, child)
+				copy(n.children[i+1:], n.children[i:])
+				n.children[i] = child
+			}
+		} else {
+			i, j := 0, l
+			for i < j {
+				mid := int(uint(i+j) >> 1)
+				if n.children[mid].name < name {
+					i = mid + 1
+				} else {
+					j = mid
+				}
+			}
+			if i < l && n.children[i].name == name {
+				child = n.children[i]
+				if child.handle == zeroHandle {
+					child.handle = h
+				}
 			} else {
-				child = &node[N]{parent: n, name: name, handle: h}
+				if buf != nil {
+					child = buf.newNode()
+					child.parent = n
+					child.name = name
+					child.handle = h
+				} else {
+					child = &node[N]{parent: n, name: name, handle: h}
+				}
+				n.children = append(n.children, child)
+				copy(n.children[i+1:], n.children[i:])
+				n.children[i] = child
 			}
-			n.children = append(n.children, child)
 		}
 		n = child
 	}
@@ -315,9 +434,13 @@ func (t *Tree[N, I]) Merge(src *Tree[N, I]) {
 		dt.self += st.self
 		dt.total += st.total
 
+		var zeroHandle unique.Handle[string]
 		for _, srcChildNode := range st.children {
 			// Note that we don't copy the name, but reference it.
 			dstChildNode := dt.insert(srcChildNode.name, nodeBuffer.newNode)
+			if dstChildNode.handle == zeroHandle && srcChildNode.handle != zeroHandle {
+				dstChildNode.handle = srcChildNode.handle
+			}
 			srcNodes = append(srcNodes, srcChildNode)
 			dstNodes = append(dstNodes, dstChildNode)
 		}
@@ -331,12 +454,14 @@ func (t *Tree[N, I]) FormatNodeNames(fn func(N) N) {
 	nodes = append(nodes, &node[N]{children: t.root})
 	var n *node[N]
 	var fix bool
+	var zeroHandle unique.Handle[string]
 	for len(nodes) > 0 {
 		n, nodes = nodes[len(nodes)-1], nodes[:len(nodes)-1]
 		m := n.name
 		n.name = fn(m)
 		if m != n.name {
 			fix = true
+			n.handle = zeroHandle
 		}
 		nodes = append(nodes, n.children...)
 	}
@@ -368,6 +493,7 @@ func (t *Tree[N, I]) Fix() {
 		})
 		p := n[0]
 		j := 1
+		var zeroHandle unique.Handle[string]
 		for _, c := range n[1:] {
 			if p.name == c.name {
 				for _, x := range c.children {
@@ -376,6 +502,9 @@ func (t *Tree[N, I]) Fix() {
 				p.children = append(p.children, c.children...)
 				p.total += c.total
 				p.self += c.self
+				if p.handle == zeroHandle && c.handle != zeroHandle {
+					p.handle = c.handle
+				}
 				continue
 			}
 			p = c

--- a/pkg/model/tree.go
+++ b/pkg/model/tree.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unique"
 
 	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 
@@ -123,6 +124,7 @@ type node[N NodeName] struct {
 	children    []*node[N]
 	self, total int64
 	name        N
+	handle      unique.Handle[string]
 }
 
 func (t *Tree[N, I]) String() string {
@@ -157,6 +159,10 @@ func (t *Tree[N, I]) Total() (v int64) {
 }
 
 func (t *Tree[N, I]) InsertStack(v int64, stack ...N) {
+	t.InsertStackBuf(nil, v, stack...)
+}
+
+func (t *Tree[N, I]) InsertStackBuf(buf *nodeBuffer[N], v int64, stack ...N) {
 	if v <= 0 {
 		return
 	}
@@ -165,27 +171,74 @@ func (t *Tree[N, I]) InsertStack(v int64, stack ...N) {
 	for s := range stack {
 		name := stack[s]
 		n.total += v
-		// Inlined node.insert
-		i, j := 0, len(n.children)
-		for i < j {
-			h := int(uint(i+j) >> 1)
-			if n.children[h].name < name {
-				i = h + 1
-			} else {
-				j = h
+		var child *node[N]
+		for _, c := range n.children {
+			if c.name == name {
+				child = c
+				break
 			}
 		}
-		if i < len(n.children) && n.children[i].name == name {
-			n = n.children[i]
-		} else {
-			child := &node[N]{parent: n, name: name}
+		if child == nil {
+			if buf != nil {
+				child = buf.newNode()
+				child.parent = n
+				child.name = name
+			} else {
+				child = &node[N]{parent: n, name: name}
+			}
 			n.children = append(n.children, child)
-			copy(n.children[i+1:], n.children[i:])
-			n.children[i] = child
-			n = child
 		}
+		n = child
 	}
 	// Leaf.
+	n.total += v
+	n.self += v
+	t.root = r.children
+}
+
+func stringToNodeName[N NodeName](s string) N {
+	var n N
+	switch any(n).(type) {
+	case FunctionName:
+		return any(FunctionName(s)).(N)
+	default:
+		return any(s).(N)
+	}
+}
+
+func (t *Tree[N, I]) InsertStackHandles(v int64, stack ...unique.Handle[string]) {
+	t.InsertStackHandlesBuf(nil, v, stack...)
+}
+
+func (t *Tree[N, I]) InsertStackHandlesBuf(buf *nodeBuffer[N], v int64, stack ...unique.Handle[string]) {
+	if v <= 0 {
+		return
+	}
+	r := &node[N]{children: t.root}
+	n := r
+	for _, h := range stack {
+		n.total += v
+		var child *node[N]
+		for _, c := range n.children {
+			if c.handle == h {
+				child = c
+				break
+			}
+		}
+		if child == nil {
+			name := stringToNodeName[N](h.Value())
+			if buf != nil {
+				child = buf.newNode()
+				child.parent = n
+				child.name = name
+				child.handle = h
+			} else {
+				child = &node[N]{parent: n, name: name, handle: h}
+			}
+			n.children = append(n.children, child)
+		}
+		n = child
+	}
 	n.total += v
 	n.self += v
 	t.root = r.children
@@ -516,8 +569,8 @@ func (nb *nodeBuffer[N]) newNode() *node[N] {
 	}
 	n := &nb.nodes[0]
 	nb.nodes = nb.nodes[1:]
+	*n = node[N]{}
 	return n
-
 }
 
 func UnmarshalTree[N NodeName, I NodeNameI[N]](b []byte) (*Tree[N, I], error) {

--- a/pkg/model/tree_bench_test.go
+++ b/pkg/model/tree_bench_test.go
@@ -1,0 +1,104 @@
+package model
+
+import (
+	"fmt"
+	"testing"
+	"unique"
+)
+
+// Generate test dataset
+func generateDeepWideDataset(numStacks, depth int) ([]int64, [][]FunctionName, [][]unique.Handle[string]) {
+	values := make([]int64, numStacks)
+	fnStacks := make([][]FunctionName, numStacks)
+	handleStacks := make([][]unique.Handle[string], numStacks)
+
+	numUniqueFrames := 10000
+	frameNames := make([]string, numUniqueFrames)
+	frameFNs := make([]FunctionName, numUniqueFrames)
+	frameHandles := make([]unique.Handle[string], numUniqueFrames)
+
+	for i := range numUniqueFrames {
+		name := fmt.Sprintf("github.com/grafana/pyroscope/v2/pkg/long_package_name_component_%d.(*VeryLongStructNameForProfilingPerformanceBenchmark_%d).DeepStackMethodCallImplementationDetail_%d_ExtraSuffix_ToMakeNameExtremelyLongAndRealistic_ForProductionProfilingData", i%100, i%200, i)
+		frameNames[i] = name
+		frameFNs[i] = FunctionName(name)
+		frameHandles[i] = unique.Make(name)
+	}
+
+	for s := range numStacks {
+		values[s] = int64((s % 100) + 1)
+		fnStack := make([]FunctionName, depth)
+		handleStack := make([]unique.Handle[string], depth)
+		for d := 0; d < depth; d++ {
+			var idx int
+			if d < 10 {
+				idx = d // common root prefix frames
+			} else {
+				idx = (s*31 + d*17) % numUniqueFrames
+			}
+			fnStack[d] = frameFNs[idx]
+			handleStack[d] = frameHandles[idx]
+		}
+		fnStacks[s] = fnStack
+		handleStacks[s] = handleStack
+	}
+
+	return values, fnStacks, handleStacks
+}
+
+// Benchmark tree insertion using standard FunctionName stack slices
+func BenchmarkTreeInsert_FunctionName(b *testing.B) {
+	values, fnStacks, _ := generateDeepWideDataset(50000, 150)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		t := new(FunctionNameTree)
+		for s := 0; s < len(fnStacks); s++ {
+			t.InsertStack(values[s], fnStacks[s]...)
+		}
+	}
+}
+
+// Benchmark tree insertion using nodeBuffer with FunctionName stack slices
+func BenchmarkTreeInsert_FunctionNameBuffered(b *testing.B) {
+	values, fnStacks, _ := generateDeepWideDataset(10000, 150)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		buf := newNodeBuffer[FunctionName](50000)
+		t := new(FunctionNameTree)
+		for s := 0; s < len(fnStacks); s++ {
+			t.InsertStackBuf(buf, values[s], fnStacks[s]...)
+		}
+	}
+}
+
+// Benchmark tree insertion using pre-interned unique.Handle[string] stacks
+func BenchmarkTreeInsert_Handles(b *testing.B) {
+	values, _, handleStacks := generateDeepWideDataset(50000, 50)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		t := new(FunctionNameTree)
+		for s := 0; s < len(handleStacks); s++ {
+			t.InsertStackHandles(values[s], handleStacks[s]...)
+		}
+	}
+}
+
+// Benchmark tree insertion using nodeBuffer with pre-interned unique.Handle[string] stacks
+func BenchmarkTreeInsert_HandlesBuffered(b *testing.B) {
+	values, _, handleStacks := generateDeepWideDataset(50000, 150)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		buf := newNodeBuffer[FunctionName](50000)
+		t := new(FunctionNameTree)
+		for s := 0; s < len(handleStacks); s++ {
+			t.InsertStackHandlesBuf(buf, values[s], handleStacks[s]...)
+		}
+	}
+}

--- a/pkg/model/tree_test.go
+++ b/pkg/model/tree_test.go
@@ -2,9 +2,11 @@ package model
 
 import (
 	"bytes"
+	"fmt"
 	"math"
 	"strconv"
 	"testing"
+	"unique"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -549,4 +551,255 @@ func Test_TreeFromBackendProfileSampleType(t *testing.T) {
 		}
 		assert.Equal(t, 2, foundAddresses)
 	})
+}
+
+func Test_InsertStack_SortedOrderAndMerge(t *testing.T) {
+	t1 := new(FunctionNameTree)
+	t1.InsertStack(1, "root", "c", "leaf1")
+	t1.InsertStack(1, "root", "a", "leaf2")
+	t1.InsertStack(1, "root", "b", "leaf3")
+
+	// Children of root should be sorted ("a", "b", "c")
+	require.Len(t, t1.root, 1)
+	children := t1.root[0].children
+	require.Len(t, children, 3)
+	assert.Equal(t, FunctionName("a"), children[0].name)
+	assert.Equal(t, FunctionName("b"), children[1].name)
+	assert.Equal(t, FunctionName("c"), children[2].name)
+
+	// Merge with t2
+	t2 := new(FunctionNameTree)
+	t2.InsertStack(2, "root", "b", "leaf3")
+	t2.InsertStack(2, "root", "d", "leaf4")
+
+	t1.Merge(t2)
+
+	require.Len(t, t1.root, 1)
+	childrenMerged := t1.root[0].children
+	require.Len(t, childrenMerged, 4)
+	assert.Equal(t, FunctionName("a"), childrenMerged[0].name)
+	assert.Equal(t, FunctionName("b"), childrenMerged[1].name)
+	assert.Equal(t, FunctionName("c"), childrenMerged[2].name)
+	assert.Equal(t, FunctionName("d"), childrenMerged[3].name)
+	assert.Equal(t, int64(3), childrenMerged[1].total) // b merged
+}
+
+func Test_InsertStackHandles_LocationRefTree(t *testing.T) {
+	t1 := new(LocationRefNameTree)
+	h1 := unique.Make("100")
+	h2 := unique.Make("200")
+
+	// Should not panic on LocationRefNameTree
+	require.NotPanics(t, func() {
+		t1.InsertStackHandles(5, h1, h2)
+	})
+	assert.Equal(t, int64(5), t1.Total())
+}
+
+func Test_InsertStackHandles_SmallFanoutDuplicatePrevention(t *testing.T) {
+	t1 := new(FunctionNameTree)
+	// Insert via InsertStack (handle is zero/unset)
+	t1.InsertStack(10, "root", "childA")
+
+	// Insert via InsertStackHandles (small fanout < 8)
+	hRoot := unique.Make("root")
+	hChildA := unique.Make("childA")
+	t1.InsertStackHandles(5, hRoot, hChildA)
+
+	require.Len(t, t1.root, 1)
+	assert.Equal(t, int64(15), t1.root[0].total)
+	assert.Equal(t, hRoot, t1.root[0].handle)
+
+	// Ensure no duplicate sibling under root
+	require.Len(t, t1.root[0].children, 1, "should not create duplicate child node in small fanout")
+	childA := t1.root[0].children[0]
+	assert.Equal(t, FunctionName("childA"), childA.name)
+	assert.Equal(t, int64(15), childA.total)
+	assert.Equal(t, hChildA, childA.handle)
+
+	// Subsequent InsertStackHandles should hit by handle
+	hChildB := unique.Make("childB")
+	t1.InsertStackHandles(3, hRoot, hChildA, hChildB)
+	assert.Equal(t, int64(18), t1.root[0].total)
+	assert.Equal(t, int64(18), childA.total)
+}
+
+func Test_InsertStackHandles_LargeFanoutHandleAssignment(t *testing.T) {
+	t1 := new(FunctionNameTree)
+
+	// Insert 8 children via InsertStack (large fanout >= 8)
+	hNames := make([]string, 10)
+	handles := make([]unique.Handle[string], 10)
+	for i := range 10 {
+		hNames[i] = fmt.Sprintf("child_%02d", i)
+		handles[i] = unique.Make(hNames[i])
+		t1.InsertStack(10, "root", FunctionName(hNames[i]))
+	}
+
+	hRoot := unique.Make("root")
+
+	// Verify large fanout has 10 children with zero handles
+	var zeroHandle unique.Handle[string]
+	require.Len(t, t1.root, 1)
+	require.Len(t, t1.root[0].children, 10)
+	for _, c := range t1.root[0].children {
+		assert.Equal(t, zeroHandle, c.handle)
+	}
+
+	// Insert via InsertStackHandles into large fanout
+	t1.InsertStackHandles(5, hRoot, handles[3])
+
+	// The node for child_03 should now have handle assigned
+	child3 := t1.root[0].children[3]
+	assert.Equal(t, FunctionName("child_03"), child3.name)
+	assert.Equal(t, int64(15), child3.total)
+	assert.Equal(t, handles[3], child3.handle)
+}
+
+func Test_InsertStackHandles_MergeHandlePropagation(t *testing.T) {
+	// t1 created via InsertStack (no handles)
+	t1 := new(FunctionNameTree)
+	t1.InsertStack(10, "root", "childA")
+
+	// t2 created via InsertStackHandles (has handles)
+	t2 := new(FunctionNameTree)
+	hRoot := unique.Make("root")
+	hChildA := unique.Make("childA")
+	t2.InsertStackHandles(5, hRoot, hChildA)
+
+	// Merge t2 into t1
+	t1.Merge(t2)
+
+	require.Len(t, t1.root, 1)
+	assert.Equal(t, int64(15), t1.root[0].total)
+	require.Len(t, t1.root[0].children, 1)
+	assert.Equal(t, int64(15), t1.root[0].children[0].total)
+	assert.Equal(t, hChildA, t1.root[0].children[0].handle, "handle should be propagated from src to dst on merge")
+
+	// Further InsertStackHandles on merged t1 should hit handle
+	t1.InsertStackHandles(2, hRoot, hChildA)
+	assert.Equal(t, int64(17), t1.root[0].total)
+	assert.Len(t, t1.root[0].children, 1)
+}
+
+func Test_InsertStackHandles_FixHandlePropagation(t *testing.T) {
+	t1 := new(FunctionNameTree)
+	hRoot := unique.Make("root")
+	hChildA := unique.Make("childA")
+
+	// FormatNodeNames / Fix test
+	t1.InsertStack(10, "root", "childA_old")
+	t1.InsertStackHandles(5, hRoot, hChildA)
+
+	// Rename childA_old to childA and trigger Fix()
+	t1.FormatNodeNames(func(n FunctionName) FunctionName {
+		if n == "childA_old" {
+			return "childA"
+		}
+		return n
+	})
+
+	require.Len(t, t1.root, 1)
+	require.Len(t, t1.root[0].children, 1)
+	assert.Equal(t, int64(15), t1.root[0].children[0].total)
+	assert.Equal(t, hChildA, t1.root[0].children[0].handle, "Fix should consolidate handles when merging nodes")
+}
+
+func Test_FormatNodeNames_ClearsStaleHandle(t *testing.T) {
+	t1 := new(FunctionNameTree)
+	hRoot := unique.Make("root")
+	hChildA := unique.Make("childA")
+	hChildB := unique.Make("childB")
+
+	// Insert stack with handles
+	t1.InsertStackHandles(10, hRoot, hChildA)
+
+	// Verify childA has handle hChildA
+	require.Len(t, t1.root, 1)
+	require.Len(t, t1.root[0].children, 1)
+	assert.Equal(t, hChildA, t1.root[0].children[0].handle)
+
+	// FormatNodeNames renames childA -> childB
+	t1.FormatNodeNames(func(n FunctionName) FunctionName {
+		if n == "childA" {
+			return "childB"
+		}
+		return n
+	})
+
+	// The node's handle must no longer be hChildA!
+	childNode := t1.root[0].children[0]
+	assert.Equal(t, FunctionName("childB"), childNode.name)
+	var zeroHandle unique.Handle[string]
+	assert.Equal(t, zeroHandle, childNode.handle, "stale handle for old name childA should be cleared after rename")
+
+	// Now insert childA with hChildA via InsertStackHandles
+	t1.InsertStackHandles(5, hRoot, hChildA)
+
+	// It should NOT match childB! It should create a new node for childA
+	require.Len(t, t1.root[0].children, 2)
+	assert.Equal(t, FunctionName("childA"), t1.root[0].children[0].name)
+	assert.Equal(t, FunctionName("childB"), t1.root[0].children[1].name)
+	assert.Equal(t, int64(5), t1.root[0].children[0].total)
+	assert.Equal(t, int64(10), t1.root[0].children[1].total)
+
+	// Now insert childB with hChildB via InsertStackHandles
+	t1.InsertStackHandles(3, hRoot, hChildB)
+
+	// It SHOULD match childB and assign hChildB
+	assert.Equal(t, int64(13), t1.root[0].children[1].total)
+	assert.Equal(t, hChildB, t1.root[0].children[1].handle)
+}
+
+func Test_InsertStackHandles_InvalidLocationRefHandle(t *testing.T) {
+	t1 := new(LocationRefNameTree)
+	hInvalid1 := unique.Make("invalid_a")
+	hInvalid2 := unique.Make("invalid_b")
+	hValid := unique.Make("123")
+
+	// Insert invalid handles
+	t1.InsertStackHandles(10, hInvalid1, hInvalid2)
+
+	// Tree root should be empty (invalid handles skipped, not collapsed to node 0)
+	assert.Len(t, t1.root, 0)
+	assert.Equal(t, int64(0), t1.Total())
+
+	// Insert valid handle
+	t1.InsertStackHandles(5, hValid)
+	require.Len(t, t1.root, 1)
+	assert.Equal(t, LocationRefName(123), t1.root[0].name)
+	assert.Equal(t, int64(5), t1.Total())
+}
+
+func Test_InsertStackHandles_MixedValidInvalidHandles(t *testing.T) {
+	t1 := new(LocationRefNameTree)
+	hValid1 := unique.Make("100")
+	hInvalid := unique.Make("invalid_frame")
+	hValid2 := unique.Make("200")
+
+	// Mixed stack: valid, invalid, valid
+	t1.InsertStackHandles(10, hValid1, hInvalid, hValid2)
+
+	// Tree should remain empty: early rejection prevents path splicing (attaching 200 to 100)
+	assert.Len(t, t1.root, 0)
+	assert.Equal(t, int64(0), t1.Total())
+}
+
+type customStringName string
+type customIntName int
+
+func Test_StringToNodeName_CustomNodeNameTypes(t *testing.T) {
+	// customStringName (~string)
+	cs, err := stringToNodeName[customStringName]("hello")
+	require.NoError(t, err)
+	assert.Equal(t, customStringName("hello"), cs)
+
+	// customIntName (~int)
+	ci, err := stringToNodeName[customIntName]("456")
+	require.NoError(t, err)
+	assert.Equal(t, customIntName(456), ci)
+
+	// customIntName invalid number
+	_, err = stringToNodeName[customIntName]("invalid")
+	require.Error(t, err)
 }


### PR DESCRIPTION
Fixes #4827.

This PR optimizes `model.Tree` construction for services with deep and wide flamegraphs with long frame names. Roughly 2x speedup on my machine for tree insertion latency, and 50% less heap allocations.