### PR TITLE
fix(helm): move prometheus.io/service-monitor to labels for headless service

### DIFF
--- a/operations/pyroscope/helm/pyroscope/Chart.yaml
+++ b/operations/pyroscope/helm/pyroscope/Chart.yaml
@@ -3,7 +3,7 @@ name: pyroscope
 description: A horizontally scalable, highly available, multi-tenant continuous profiling database.
 home: https://grafana.com/oss/pyroscope/
 type: application
-version: 2.1.2
+version: 2.1.3
 appVersion: 2.1.1
 dependencies:
   - name: grafana-agent

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -27,7 +27,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -48,7 +48,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -69,7 +69,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -90,7 +90,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -111,7 +111,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -132,7 +132,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -176,7 +176,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -523,7 +523,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1396,7 +1396,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1413,7 +1413,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1571,7 +1571,7 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1596,7 +1596,7 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1743,7 +1743,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1770,7 +1770,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1799,7 +1799,7 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1829,7 +1829,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1858,7 +1858,7 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1888,7 +1888,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1917,7 +1917,7 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1947,7 +1947,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1976,7 +1976,7 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2006,7 +2006,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2035,7 +2035,7 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2065,7 +2065,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2094,7 +2094,7 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2124,7 +2124,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2153,7 +2153,7 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2183,7 +2183,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2198,7 +2198,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2293,7 +2293,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2308,7 +2308,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2403,7 +2403,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2418,7 +2418,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2513,7 +2513,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2528,7 +2528,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2623,7 +2623,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2651,7 +2651,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2682,7 +2682,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2710,7 +2710,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2921,7 +2921,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2939,7 +2939,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3039,7 +3039,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3057,7 +3057,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3153,7 +3153,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3171,7 +3171,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -27,7 +27,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -48,7 +48,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -69,7 +69,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -90,7 +90,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -111,7 +111,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -132,7 +132,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -153,7 +153,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -174,7 +174,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -218,7 +218,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -565,7 +565,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1438,7 +1438,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1455,7 +1455,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1613,7 +1613,7 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1638,7 +1638,7 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1785,7 +1785,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1812,7 +1812,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1841,7 +1841,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1871,7 +1871,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1900,7 +1900,7 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1930,7 +1930,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1959,7 +1959,7 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1989,7 +1989,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2018,7 +2018,7 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2048,7 +2048,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2077,7 +2077,7 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2107,7 +2107,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2136,7 +2136,7 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2166,7 +2166,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2195,7 +2195,7 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2225,7 +2225,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2254,7 +2254,7 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2284,7 +2284,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2313,7 +2313,7 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2343,7 +2343,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2359,7 +2359,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2454,7 +2454,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2470,7 +2470,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2565,7 +2565,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2581,7 +2581,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2676,7 +2676,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2692,7 +2692,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2787,7 +2787,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2803,7 +2803,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2898,7 +2898,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2914,7 +2914,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3192,7 +3192,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3210,7 +3210,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3310,7 +3310,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3328,7 +3328,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3424,7 +3424,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3442,7 +3442,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -27,7 +27,7 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -48,7 +48,7 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -69,7 +69,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -90,7 +90,7 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -111,7 +111,7 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -132,7 +132,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -153,7 +153,7 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -174,7 +174,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -218,7 +218,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -565,7 +565,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1438,7 +1438,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1455,7 +1455,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1613,7 +1613,7 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1638,7 +1638,7 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1785,7 +1785,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1812,7 +1812,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1841,7 +1841,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1871,7 +1871,7 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1900,7 +1900,7 @@ metadata:
   name: pyroscope-dev-admin-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1930,7 +1930,7 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1959,7 +1959,7 @@ metadata:
   name: pyroscope-dev-compaction-worker-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1989,7 +1989,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2018,7 +2018,7 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2048,7 +2048,7 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2081,7 +2081,7 @@ metadata:
   name: pyroscope-dev-metastore-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2116,7 +2116,7 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2145,7 +2145,7 @@ metadata:
   name: pyroscope-dev-query-backend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2175,7 +2175,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2204,7 +2204,7 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2234,7 +2234,7 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2263,7 +2263,7 @@ metadata:
   name: pyroscope-dev-segment-writer-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2293,7 +2293,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2322,7 +2322,7 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2352,7 +2352,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2368,7 +2368,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2462,7 +2462,7 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2478,7 +2478,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2572,7 +2572,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2588,7 +2588,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2682,7 +2682,7 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2698,7 +2698,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2792,7 +2792,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2808,7 +2808,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2902,7 +2902,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2918,7 +2918,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3195,7 +3195,7 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3213,7 +3213,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3308,7 +3308,7 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3326,7 +3326,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3437,7 +3437,7 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3455,7 +3455,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -27,7 +27,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -48,7 +48,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -69,7 +69,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -90,7 +90,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -111,7 +111,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -132,7 +132,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -153,7 +153,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -174,7 +174,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -218,7 +218,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -565,7 +565,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1438,7 +1438,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1455,7 +1455,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1740,7 +1740,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1767,7 +1767,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1792,7 +1792,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1818,7 +1818,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1843,7 +1843,7 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1869,7 +1869,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1894,7 +1894,7 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1920,7 +1920,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1945,7 +1945,7 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1971,7 +1971,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1996,7 +1996,7 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2022,7 +2022,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2047,7 +2047,7 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2073,7 +2073,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2098,7 +2098,7 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2124,7 +2124,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2149,7 +2149,7 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2175,7 +2175,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2200,7 +2200,7 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2226,7 +2226,7 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2242,7 +2242,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2330,7 +2330,7 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2346,7 +2346,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2434,7 +2434,7 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2450,7 +2450,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2539,7 +2539,7 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2555,7 +2555,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2643,7 +2643,7 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2659,7 +2659,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -2747,7 +2747,7 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -2763,7 +2763,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3034,7 +3034,7 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3052,7 +3052,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3145,7 +3145,7 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3163,7 +3163,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2
@@ -3252,7 +3252,7 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -3270,7 +3270,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c01be4ab23338b3d9e0ce8fdcfb568d26b4c22b263b0431f779adf86f16fa1e
+        checksum/config: 97740897a5c3de4b7c0efb5552b9fe70980be3c3e7e85ed067b1d362f6f8f208
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -43,7 +43,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -56,7 +56,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -929,7 +929,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -946,7 +946,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1097,7 +1097,7 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1122,7 +1122,7 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1201,7 +1201,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1228,7 +1228,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1261,7 +1261,7 @@ metadata:
   name: pyroscope-dev-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1386,7 +1386,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1404,7 +1404,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7e08f7bdb4b975597fff0044d0b49682d96bf1d45146fcfad98342d3bf791f20
+        checksum/config: ab1d0d4eeb468e84fd72e90f37a3189b50716bf8ff60e70bbc1f478f93300460
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
@@ -6,7 +6,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -43,7 +43,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -56,7 +56,7 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -929,7 +929,7 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -946,7 +946,7 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1156,7 +1156,7 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1183,7 +1183,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1208,7 +1208,7 @@ metadata:
   name: pyroscope-dev-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1324,7 +1324,7 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.1.2
+    helm.sh/chart: pyroscope-2.1.3
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
     app.kubernetes.io/version: "2.1.1"
@@ -1342,7 +1342,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7e08f7bdb4b975597fff0044d0b49682d96bf1d45146fcfad98342d3bf791f20
+        checksum/config: ab1d0d4eeb468e84fd72e90f37a3189b50716bf8ff60e70bbc1f478f93300460
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         profiles.grafana.com/service_git_ref: "v2.1.1"
         profiles.grafana.com/cpu.port_name: http2

--- a/operations/pyroscope/helm/pyroscope/templates/services.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/services.yaml
@@ -52,11 +52,11 @@ metadata:
   labels:
     {{- include "pyroscope.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ $component | quote }}
-  {{- if or .Values.serviceMonitor.enabled $values.service.headlessAnnotations }}
-  annotations:
     {{- if .Values.serviceMonitor.enabled }}
     prometheus.io/service-monitor: "false"
     {{- end }}
+  {{- if $values.service.headlessAnnotations }}
+  annotations:
     {{- with $values.service.headlessAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
Fixes #5215

### What does this PR do?
This PR fixes an issue where the `pyroscope-headless` service is incorrectly scraped by Prometheus when `serviceMonitor.enabled` is `true`.

### Why was it needed?
As reported in #5215, the `ServiceMonitor` uses a `matchExpression` to exclude the headless service from being scraped:
```yaml
matchExpressions:
  - key: prometheus.io/service-monitor
    operator: NotIn
    values:
      - "false"
```
However, in commit `90eceaa` (from PR #4451), the `prometheus.io/service-monitor: "false"` key in `services.yaml` was accidentally moved from `labels` to `annotations` due to a YAML nesting change when adding `headlessAnnotations`. Because `ServiceMonitors` select targets based on labels, the exclusion failed, resulting in duplicated metrics (e.g., both `job="pyroscope"` and `job="pyroscope-headless"` appearing and pointing to the same pod IP).

### How does it fix the problem?
This PR properly isolates the `prometheus.io/service-monitor: "false"` block so it correctly renders under `metadata.labels` instead of `metadata.annotations`. It also preserves the functionality to add custom `headlessAnnotations` introduced in #4451.

Additionally, this PR bumps the chart version from `2.1.2` to `2.1.3` and updates the rendered golden fixtures via `make helm/check`.

### Testing instructions
Rendered locally to verify the output:
`helm template . -s templates/services.yaml --set serviceMonitor.enabled=true`
Confirmed that `prometheus.io/service-monitor: "false"` is now present under `metadata.labels` for the headless service.
