### PR TITLE
perf(compaction): Avoid deep label clones when building block indexes

### DIFF
--- a/pkg/block/compaction.go
+++ b/pkg/block/compaction.go
@@ -510,7 +510,7 @@ type seriesLabels struct {
 
 func (rw *indexRewriter) rewriteRow(e ProfileEntry) {
 	if rw.previousFp != e.Fingerprint || len(rw.series) == 0 {
-		series := e.Labels.Clone()
+		series := slices.Clone(e.Labels)
 		for _, l := range series {
 			rw.symbols[l.Name] = struct{}{}
 			rw.symbols[l.Value] = struct{}{}

--- a/pkg/block/compaction_test.go
+++ b/pkg/block/compaction_test.go
@@ -21,7 +21,9 @@ import (
 	"github.com/grafana/pyroscope/v2/pkg/block"
 	"github.com/grafana/pyroscope/v2/pkg/metrics"
 	phlaremodel "github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/objstore"
 	"github.com/grafana/pyroscope/v2/pkg/objstore/testutil"
+	"github.com/grafana/pyroscope/v2/pkg/phlaredb/tsdb/index"
 	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockmetrics"
 )
 
@@ -340,4 +342,73 @@ func (*stringExporter) Flush() {}
 
 func (e *stringExporter) String() string {
 	return e.output
+}
+
+// collectSeriesLabels reads the TSDB index of every named dataset in the
+// given blocks and returns the labels of each series, keyed by
+// (tenant, dataset, fingerprint). Anonymous datasets (the per-tenant
+// dataset-index pseudo-dataset) are skipped: they aggregate series of the
+// tenant's real datasets and would double-count them.
+func collectSeriesLabels(ctx context.Context, t *testing.T, storage objstore.Bucket, metas []*metastorev1.BlockMeta) map[string]string {
+	out := make(map[string]string)
+	for _, md := range metas {
+		obj := block.NewObject(storage, md)
+		require.NoError(t, obj.Open(ctx))
+		for _, dsMeta := range md.Datasets {
+			ds := block.NewDataset(dsMeta, obj)
+			if ds.Name() == "" {
+				continue
+			}
+			require.NoError(t, ds.Open(ctx, block.SectionTSDB))
+			k, v := index.AllPostingsKey()
+			postings, err := ds.Index().Postings(k, nil, v)
+			require.NoError(t, err)
+			var lbls phlaremodel.Labels
+			var chks []index.ChunkMeta
+			for postings.Next() {
+				fp, err := ds.Index().Series(postings.At(), &lbls, &chks)
+				require.NoError(t, err)
+				key := fmt.Sprintf("%s/%s/%016x", ds.TenantID(), ds.Name(), fp)
+				val := phlaremodel.LabelPairsString(lbls)
+				if prev, ok := out[key]; ok {
+					require.Equal(t, prev, val, "same series with diverging labels: %s", key)
+				}
+				out[key] = val
+			}
+			require.NoError(t, postings.Err())
+		}
+		require.NoError(t, obj.Close())
+	}
+	return out
+}
+
+// Test_Compact_PreservesSeriesLabels verifies, end to end, that compaction
+// writes every input series' labels to the output block unmodified: the
+// (tenant, dataset, fingerprint) -> labels mapping of the compacted block
+// must equal the union of the source blocks'. This exercises the expectation
+// that ProfileEntry.Labels are not mutated.
+func Test_Compact_PreservesSeriesLabels(t *testing.T) {
+	ctx := context.Background()
+	bucket, _ := testutil.NewFilesystemBucket(t, ctx, "testdata")
+
+	var resp metastorev1.GetBlockMetadataResponse
+	raw, err := os.ReadFile("testdata/block-metas.json")
+	require.NoError(t, err)
+	require.NoError(t, protojson.Unmarshal(raw, &resp))
+
+	expected := collectSeriesLabels(ctx, t, bucket, resp.Blocks)
+	require.NotEmpty(t, expected)
+
+	dst, tempdir := testutil.NewFilesystemBucket(t, ctx, t.TempDir())
+	compacted, err := block.Compact(ctx, resp.Blocks, bucket,
+		block.WithCompactionDestination(dst),
+		block.WithCompactionTempDir(tempdir),
+		block.WithCompactionObjectOptions(
+			block.WithObjectDownload(filepath.Join(tempdir, "source")),
+			block.WithObjectMaxSizeLoadInMemory(0)),
+	)
+	require.NoError(t, err)
+
+	actual := collectSeriesLabels(ctx, t, dst, compacted)
+	require.Equal(t, expected, actual)
 }

--- a/pkg/block/dataset_index.go
+++ b/pkg/block/dataset_index.go
@@ -3,6 +3,7 @@ package block
 import (
 	"context"
 	"io"
+	"slices"
 	"sort"
 	"sync"
 
@@ -71,7 +72,7 @@ func (rw *DatasetIndexWriter) reset() {
 // writer (e.g. by deduplicating consecutive rows with the same
 // fingerprint at compaction time).
 func (rw *DatasetIndexWriter) AddSeries(idx uint32, labels phlaremodel.Labels, fp model.Fingerprint) {
-	cloned := labels.Clone()
+	cloned := slices.Clone(labels)
 	for _, l := range cloned {
 		rw.symbols[l.Name] = struct{}{}
 		rw.symbols[l.Value] = struct{}{}

--- a/pkg/block/section_profiles.go
+++ b/pkg/block/section_profiles.go
@@ -254,8 +254,12 @@ type ProfileEntry struct {
 
 	Timestamp   int64
 	Fingerprint model.Fingerprint
-	Labels      phlaremodel.Labels
-	Row         schemav1.ProfileRow
+	// Labels' backing array is reused by the row iterator on advance, but
+	// the label pairs themselves are immutable: consumers that retain
+	// labels beyond the current row must copy the slice (shallow copy is
+	// sufficient), and must never modify the pairs.
+	Labels phlaremodel.Labels
+	Row    schemav1.ProfileRow
 }
 
 func NewMergeRowProfileIterator(src []*Dataset) (iter.Iterator[ProfileEntry], error) {


### PR DESCRIPTION
Label pairs produced by the TSDB index reader are immutable; only the slice backing array is reused as the row iterator advances. A shallow copy is therefore sufficient for retention, halving resident label memory during compaction. Label cloning the largest in-use heap consumer (~28%) in a recent compaction-worker OOM.

BenchmarkDatasetIndexWriter_WriteTo: -60% allocs/op, -46% B/op.