### PR TITLE
docs: add v2.2 release notes

### DIFF
--- a/docs/sources/release-notes/v2-2.md
+++ b/docs/sources/release-notes/v2-2.md
@@ -9,7 +9,7 @@ weight: 660
 
 The Pyroscope team is excited to present Grafana Pyroscope 2.2.0.
 
-This release adds experimental asynchronous query execution, trace ID filtering in the v2 read path, new symbol resolution APIs, and stability and performance fixes across the write and read paths.
+This release adds experimental asynchronous query execution, trace ID filtering in the v2 read path, and stability and performance fixes across the write and read paths.
 
 Notable changes are listed below. For the full diff, check out the [2.2.0 changelog](https://github.com/grafana/pyroscope/compare/v2.1.0...v2.2.0).
 

--- a/docs/sources/release-notes/v2-2.md
+++ b/docs/sources/release-notes/v2-2.md
@@ -1,0 +1,59 @@
+---
+title: Version 2.2 release notes
+menuTitle: V2.2
+description: Release notes for Grafana Pyroscope 2.2
+weight: 660
+---
+
+## Version 2.2.0 release notes
+
+The Pyroscope team is excited to present Grafana Pyroscope 2.2.0.
+
+This release adds experimental asynchronous query execution, trace ID filtering in the v2 read path, new symbol resolution APIs, and stability and performance fixes across the write and read paths.
+
+Notable changes are listed below. For the full diff, check out the [2.2.0 changelog](https://github.com/grafana/pyroscope/compare/v2.1.0...v2.2.0).
+
+### Enhancements
+
+* Add experimental support for asynchronous query execution ([#4995](https://github.com/grafana/pyroscope/pull/4995))
+* **read path**: Support `trace_id_selector` in the v2 read path ([#5284](https://github.com/grafana/pyroscope/pull/5284))
+* **profilecli**: Add a `--trace-id` flag to filter query profile samples by trace ([#5300](https://github.com/grafana/pyroscope/pull/5300))
+* **query API**: Add `SymbolRefTable` and `symbol_refs` tree fields ([#5318](https://github.com/grafana/pyroscope/pull/5318))
+* **symbolizer**: Expose address-level symbol resolution as a public API ([#5317](https://github.com/grafana/pyroscope/pull/5317))
+* Add an optional admin HTTP server on a separate port ([#5191](https://github.com/grafana/pyroscope/pull/5191))
+* Keep totals and labels of sampled-out profiles ([#5354](https://github.com/grafana/pyroscope/pull/5354))
+* **ui**: Add autocomplete to the v2 embedded UI query bar ([#5172](https://github.com/grafana/pyroscope/pull/5172))
+* **querier**: Unify merged profile query formats ([#5358](https://github.com/grafana/pyroscope/pull/5358))
+* **distributor**: Add a `push_batch_series` histogram ([#5305](https://github.com/grafana/pyroscope/pull/5305))
+* **pprof**: Make language detection deterministic and ~40% faster ([#5309](https://github.com/grafana/pyroscope/pull/5309))
+* Improve label validation performance ([#5313](https://github.com/grafana/pyroscope/pull/5313))
+* Helm: Add a `service_name` relabel rule to the Alloy scrape config ([#5262](https://github.com/grafana/pyroscope/pull/5262))
+
+### Fixes
+
+* **ingester**: Return HTTP 429 for ingestion-limit rejections on the OTLP and `/ingest` paths ([#5372](https://github.com/grafana/pyroscope/pull/5372))
+* **otlp**: Send all converted profiles in a single `PushBatch` per export ([#5339](https://github.com/grafana/pyroscope/pull/5339))
+* **distributor**: Bound `PushBatch` series fan-out with a per-tenant limit ([#5306](https://github.com/grafana/pyroscope/pull/5306))
+* Enforce tenant header extraction in the auth interceptor ([#5251](https://github.com/grafana/pyroscope/pull/5251))
+* Reject non-positive ingest sample rates and improve sample rate errors ([#5253](https://github.com/grafana/pyroscope/pull/5253), [#5276](https://github.com/grafana/pyroscope/pull/5276))
+* **metastore**: Enable retention cleanup by default ([#5280](https://github.com/grafana/pyroscope/pull/5280))
+* **metastore**: Retain shards with recent data ([#5360](https://github.com/grafana/pyroscope/pull/5360))
+* **query-backend**: Forward and apply span selectors in pprof and tree query paths ([#5273](https://github.com/grafana/pyroscope/pull/5273))
+* Return trace IDs in span heatmaps ([#5353](https://github.com/grafana/pyroscope/pull/5353))
+* **pprof**: Treat two nil value types as compatible in `ProfileMerge` ([#5315](https://github.com/grafana/pyroscope/pull/5315))
+* **symdb**: Preserve line-less locations when rewriting partitions without functions ([#5337](https://github.com/grafana/pyroscope/pull/5337))
+* Add bounds checks to tree deserialization ([#5145](https://github.com/grafana/pyroscope/pull/5145))
+* Fix a data race in usage stats counters ([#5303](https://github.com/grafana/pyroscope/pull/5303))
+* **debuginfo**: Decline empty build IDs during upload initiation ([#5302](https://github.com/grafana/pyroscope/pull/5302))
+* **debuginfo**: Improve `ListDebugInfo` performance for large tenants ([#5286](https://github.com/grafana/pyroscope/pull/5286))
+* Helm: Respect metastore raft `extraArgs` overrides ([#5275](https://github.com/grafana/pyroscope/pull/5275))
+
+### Security fixes
+
+* Update Go toolchain to 1.25.12, addressing CVE-2026-42505 and CVE-2026-39822 ([#5338](https://github.com/grafana/pyroscope/pull/5338))
+
+### Documentation
+
+* Clarify which flags are v1-exclusive ([#5308](https://github.com/grafana/pyroscope/pull/5308))
+* Add supported platforms documentation ([#5316](https://github.com/grafana/pyroscope/pull/5316))
+* Document Python SDK fork safety ([#5364](https://github.com/grafana/pyroscope/pull/5364))


### PR DESCRIPTION
Adds public Grafana Pyroscope v2.2.0 release notes based on the curated GitHub release changelog.