### PR TITLE
refactor(compaction): isolate retained labels

### DIFF
--- a/pkg/block/compaction.go
+++ b/pkg/block/compaction.go
@@ -71,8 +71,7 @@ type SampleObserver interface {
 
 	// Evaluate is called before the compactor rewrites any symbols.
 	// An "observe" callback function is returned to be called after writing the resulting blocks.
-	// This method must not modify the entry.
-	Evaluate(ProfileEntry) (observe func())
+	Evaluate(ProfileEntryView) (observe func())
 }
 
 func Compact(
@@ -255,7 +254,7 @@ func (b *CompactionPlan) Compact(
 // matching fingerprints belong to the same series.
 func (b *CompactionPlan) addRowToDatasetIndex(r ProfileEntry) {
 	if b.lastDatasetIndexFP != r.Fingerprint || b.datasetIndex.Empty() {
-		b.datasetIndex.AddSeries(b.currentDatasetIdx, r.Labels, r.Fingerprint)
+		b.datasetIndex.addSeries(b.currentDatasetIdx, r.labels, r.Fingerprint)
 		b.lastDatasetIndexFP = r.Fingerprint
 	}
 }
@@ -455,7 +454,7 @@ func (m *datasetCompaction) merge(ctx context.Context) (err error) {
 
 func (m *datasetCompaction) writeRow(r ProfileEntry) (err error) {
 	if m.observer != nil {
-		observe := m.observer.Evaluate(r)
+		observe := m.observer.Evaluate(r.View())
 		defer observe()
 	}
 	m.parent.addRowToDatasetIndex(r)
@@ -504,19 +503,39 @@ type indexRewriter struct {
 }
 
 type seriesLabels struct {
-	labels      phlaremodel.Labels
+	labels      immutableLabels
 	fingerprint model.Fingerprint
+}
+
+type immutableLabel struct {
+	name  string
+	value string
+}
+
+type immutableLabels []immutableLabel
+
+func newImmutableLabels(labels phlaremodel.Labels) immutableLabels {
+	snapshot := make(immutableLabels, len(labels))
+	for i, label := range labels {
+		snapshot[i] = immutableLabel{name: label.Name, value: label.Value}
+	}
+	return snapshot
+}
+
+func (labels immutableLabels) Len() int { return len(labels) }
+
+func (labels immutableLabels) At(i int) (name, value string) {
+	return labels[i].name, labels[i].value
 }
 
 func (rw *indexRewriter) rewriteRow(e ProfileEntry) {
 	if rw.previousFp != e.Fingerprint || len(rw.series) == 0 {
-		series := slices.Clone(e.Labels)
-		for _, l := range series {
-			rw.symbols[l.Name] = struct{}{}
-			rw.symbols[l.Value] = struct{}{}
+		for _, label := range e.labels {
+			rw.symbols[label.name] = struct{}{}
+			rw.symbols[label.value] = struct{}{}
 		}
 		rw.series = append(rw.series, seriesLabels{
-			labels:      series,
+			labels:      e.labels,
 			fingerprint: e.Fingerprint,
 		})
 		rw.chunks = append(rw.chunks, index.ChunkMeta{

--- a/pkg/block/dataset_index.go
+++ b/pkg/block/dataset_index.go
@@ -3,7 +3,6 @@ package block
 import (
 	"context"
 	"io"
-	"slices"
 	"sort"
 	"sync"
 
@@ -39,6 +38,7 @@ type DatasetIndexWriter struct {
 	series  []seriesLabels
 	chunks  []index.ChunkMeta
 	symbols map[string]struct{}
+	labels  immutableLabels
 }
 
 var datasetIndexWriterPool = sync.Pool{
@@ -62,8 +62,11 @@ func (rw *DatasetIndexWriter) Close() {
 }
 
 func (rw *DatasetIndexWriter) reset() {
+	clear(rw.series)
 	rw.series = rw.series[:0]
 	rw.chunks = rw.chunks[:0]
+	clear(rw.labels)
+	rw.labels = rw.labels[:0]
 	clear(rw.symbols)
 }
 
@@ -72,13 +75,24 @@ func (rw *DatasetIndexWriter) reset() {
 // writer (e.g. by deduplicating consecutive rows with the same
 // fingerprint at compaction time).
 func (rw *DatasetIndexWriter) AddSeries(idx uint32, labels phlaremodel.Labels, fp model.Fingerprint) {
-	cloned := slices.Clone(labels)
-	for _, l := range cloned {
-		rw.symbols[l.Name] = struct{}{}
-		rw.symbols[l.Value] = struct{}{}
+	rw.addSeries(idx, rw.snapshotLabels(labels), fp)
+}
+
+func (rw *DatasetIndexWriter) snapshotLabels(labels phlaremodel.Labels) immutableLabels {
+	start := len(rw.labels)
+	for _, label := range labels {
+		rw.labels = append(rw.labels, immutableLabel{name: label.Name, value: label.Value})
+	}
+	return rw.labels[start:]
+}
+
+func (rw *DatasetIndexWriter) addSeries(idx uint32, labels immutableLabels, fp model.Fingerprint) {
+	for _, label := range labels {
+		rw.symbols[label.name] = struct{}{}
+		rw.symbols[label.value] = struct{}{}
 	}
 	rw.series = append(rw.series, seriesLabels{
-		labels:      cloned,
+		labels:      labels,
 		fingerprint: fp,
 	})
 	rw.chunks = append(rw.chunks, index.ChunkMeta{

--- a/pkg/block/dataset_index_test.go
+++ b/pkg/block/dataset_index_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 
 	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
 
 	phlaremodel "github.com/grafana/pyroscope/v2/pkg/model"
+	schemav1 "github.com/grafana/pyroscope/v2/pkg/phlaredb/schemas/v1"
 )
 
 func benchSeries(n int) []phlaremodel.Labels {
@@ -20,6 +22,36 @@ func benchSeries(n int) []phlaremodel.Labels {
 		)
 	}
 	return out
+}
+
+func TestDatasetIndexWriterSnapshotsLabels(t *testing.T) {
+	labels := phlaremodel.LabelsFromStrings("service_name", "original")
+	w := NewDatasetIndexWriter()
+	t.Cleanup(w.Close)
+	w.AddSeries(0, labels, 1)
+
+	labels[0].Value = "mutated"
+	require.Equal(t, "original", w.series[0].labels[0].value)
+}
+
+func TestCompactionIndexWritersShareImmutableLabels(t *testing.T) {
+	source := phlaremodel.LabelsFromStrings("service_name", "original")
+	entry := ProfileEntry{
+		Fingerprint: 1,
+		Row:         make(schemav1.ProfileRow, 4),
+		labels:      newImmutableLabels(source),
+	}
+	index := newIndexRewriter()
+	index.rewriteRow(entry)
+
+	datasetIndex := NewDatasetIndexWriter()
+	t.Cleanup(datasetIndex.Close)
+	datasetIndex.addSeries(0, entry.labels, entry.Fingerprint)
+
+	source[0].Value = "mutated"
+	require.Equal(t, "original", index.series[0].labels[0].value)
+	require.Equal(t, "original", datasetIndex.series[0].labels[0].value)
+	require.Same(t, &index.series[0].labels[0], &datasetIndex.series[0].labels[0])
 }
 
 func BenchmarkDatasetIndexWriter_WriteTo(b *testing.B) {

--- a/pkg/block/section_profiles.go
+++ b/pkg/block/section_profiles.go
@@ -254,12 +254,54 @@ type ProfileEntry struct {
 
 	Timestamp   int64
 	Fingerprint model.Fingerprint
-	// Labels' backing array is reused by the row iterator on advance, but
-	// the label pairs themselves are immutable: consumers that retain
-	// labels beyond the current row must copy the slice (shallow copy is
-	// sufficient), and must never modify the pairs.
-	Labels phlaremodel.Labels
-	Row    schemav1.ProfileRow
+	Labels      phlaremodel.Labels
+	Row         schemav1.ProfileRow
+
+	labels immutableLabels
+}
+
+// ProfileEntryView exposes a compaction row to observers without granting
+// access to the mutable label pairs used by the iterator.
+type ProfileEntryView struct {
+	Dataset     *Dataset
+	Timestamp   int64
+	Fingerprint model.Fingerprint
+	Labels      LabelsView
+	Row         schemav1.ProfileRow
+}
+
+// LabelsView is an immutable view of a profile's labels.
+type LabelsView struct{ labels immutableLabels }
+
+func (v LabelsView) Len() int { return len(v.labels) }
+
+func (v LabelsView) Get(name string) string {
+	for _, label := range v.labels {
+		if label.name == name {
+			return label.value
+		}
+	}
+	return ""
+}
+
+func (v LabelsView) Range(f func(name, value string)) {
+	for _, label := range v.labels {
+		f(label.name, label.value)
+	}
+}
+
+func (e ProfileEntry) View() ProfileEntryView {
+	labels := e.labels
+	if labels == nil {
+		labels = newImmutableLabels(e.Labels)
+	}
+	return ProfileEntryView{
+		Dataset:     e.Dataset,
+		Timestamp:   e.Timestamp,
+		Fingerprint: e.Fingerprint,
+		Labels:      LabelsView{labels: labels},
+		Row:         e.Row,
+	}
 }
 
 func NewMergeRowProfileIterator(src []*Dataset) (iter.Iterator[ProfileEntry], error) {
@@ -333,6 +375,7 @@ type profileRowIterator struct {
 	currentRow       ProfileEntry
 	currentSeriesIdx uint32
 	chunks           []index.ChunkMeta
+	labels           immutableLabels
 }
 
 func NewProfileRowIterator(s *Dataset) (iter.Iterator[ProfileEntry], error) {
@@ -384,7 +427,16 @@ func (p *profileRowIterator) Next() bool {
 		return false
 	}
 	p.currentRow.Fingerprint = model.Fingerprint(fp)
+	p.currentRow.labels = p.snapshotLabels(p.currentRow.Labels)
 	return true
+}
+
+func (p *profileRowIterator) snapshotLabels(labels phlaremodel.Labels) immutableLabels {
+	start := len(p.labels)
+	for _, label := range labels {
+		p.labels = append(p.labels, immutableLabel{name: label.Name, value: label.Value})
+	}
+	return p.labels[start:]
 }
 
 func (p *profileRowIterator) Err() error {

--- a/pkg/metrics/observer.go
+++ b/pkg/metrics/observer.go
@@ -134,7 +134,7 @@ func (o *SampleObserver) initDatasetState(dataset string) {
 //     depending on the rule.GroupBy space. More info in initState).
 //
 // This call is not thread-safe
-func (o *SampleObserver) Evaluate(row block.ProfileEntry) func() {
+func (o *SampleObserver) Evaluate(row block.ProfileEntryView) func() {
 	// Detect a tenant switch
 	tenant := row.Dataset.TenantID()
 	if o.state.tenant != row.Dataset.TenantID() {
@@ -158,14 +158,12 @@ func (o *SampleObserver) Evaluate(row block.ProfileEntry) func() {
 	}
 }
 
-func (o *SampleObserver) initSeriesState(row block.ProfileEntry) {
+func (o *SampleObserver) initSeriesState(row block.ProfileEntryView) {
 	o.state.fingerprint = row.Fingerprint
 	o.state.recordSymbols = false
 
-	sb := labels.NewScratchBuilder(len(row.Labels))
-	for _, label := range row.Labels {
-		sb.Add(label.Name, label.Value)
-	}
+	sb := labels.NewScratchBuilder(row.Labels.Len())
+	row.Labels.Range(sb.Add)
 	sb.Sort()
 	blockLabels := sb.Labels()
 	lb := labels.NewBuilder(labels.EmptyLabels())
@@ -223,7 +221,7 @@ func (o *SampleObserver) ObserveSymbols(strings []string, functions []schemav1.I
 	}
 }
 
-func (o *SampleObserver) observe(row block.ProfileEntry) {
+func (o *SampleObserver) observe(row block.ProfileEntryView) {
 	// Totals are computed as follows: for every rule that matches the series, we add the TotalValue
 	for _, rec := range o.state.targetRecordings {
 		if rec.state.matches && rec.rule.FunctionName == "" {

--- a/pkg/metrics/observer_test.go
+++ b/pkg/metrics/observer_test.go
@@ -87,7 +87,7 @@ func Test_Observer_observe(t *testing.T) {
 	).Return(nil).Once()
 
 	for _, entry := range entries {
-		observe := observer.Evaluate(entry)
+		observe := observer.Evaluate(entry.View())
 		// TODO(alsoba13): Test observeSymbols
 		observe()
 	}

--- a/pkg/model/labels.go
+++ b/pkg/model/labels.go
@@ -70,9 +70,18 @@ const (
 // instantiation.
 type Labels []*typesv1.LabelPair
 
+// LabelSet is the read-only label representation accepted by index writers.
+type LabelSet interface {
+	Len() int
+	At(int) (name, value string)
+}
+
 func (ls Labels) Len() int           { return len(ls) }
 func (ls Labels) Swap(i, j int)      { ls[i], ls[j] = ls[j], ls[i] }
 func (ls Labels) Less(i, j int) bool { return ls[i].Name < ls[j].Name }
+func (ls Labels) At(i int) (name, value string) {
+	return ls[i].Name, ls[i].Value
+}
 
 // Range calls f on each label.
 func (ls Labels) Range(f func(l *typesv1.LabelPair)) {

--- a/pkg/segmentwriter/memdb/index/index.go
+++ b/pkg/segmentwriter/memdb/index/index.go
@@ -133,7 +133,7 @@ type Writer struct {
 	fingerprintOffsets index.FingerprintOffsets
 
 	// Hold last series to validate that clients insert new series in order.
-	lastSeries     phlaremodel.Labels
+	lastSeriesLen  int
 	lastSeriesHash uint64
 	lastRef        storage.SeriesRef
 
@@ -293,7 +293,7 @@ func (w *Writer) writeMeta() error {
 // fingerprint differs from what labels.Hash() produces. For example,
 // multitenant TSDBs embed a tenant label, but the actual series has no such
 // label and so the derived fingerprint differs.
-func (w *Writer) AddSeries(ref storage.SeriesRef, lset phlaremodel.Labels, fp model.Fingerprint, chunks ...index.ChunkMeta) error {
+func (w *Writer) AddSeries(ref storage.SeriesRef, lset phlaremodel.LabelSet, fp model.Fingerprint, chunks ...index.ChunkMeta) error {
 	if err := w.ensureStage(idxStageSeries); err != nil {
 		return err
 	}
@@ -304,7 +304,7 @@ func (w *Writer) AddSeries(ref storage.SeriesRef, lset phlaremodel.Labels, fp mo
 	// without this label in storage.
 	labelHash := uint64(fp)
 
-	if ref < w.lastRef && len(w.lastSeries) != 0 {
+	if ref < w.lastRef && w.lastSeriesLen != 0 {
 		return fmt.Errorf("series with reference greater than %d already added", ref)
 	}
 	// We add padding to 16 bytes to increase the addressable space we get through 4 byte
@@ -319,30 +319,31 @@ func (w *Writer) AddSeries(ref storage.SeriesRef, lset phlaremodel.Labels, fp mo
 
 	w.buf2.Reset()
 	w.buf2.PutBE64(labelHash)
-	w.buf2.PutUvarint(len(lset))
+	w.buf2.PutUvarint(lset.Len())
 
-	for _, l := range lset {
+	for i := range lset.Len() {
+		name, value := lset.At(i)
 		var err error
-		cacheEntry, ok := w.symbolCache[l.Name]
+		cacheEntry, ok := w.symbolCache[name]
 		nameIndex := cacheEntry.index
 		if !ok {
-			nameIndex, err = w.symbols.ReverseLookup(l.Name)
+			nameIndex, err = w.symbols.ReverseLookup(name)
 			if err != nil {
-				return fmt.Errorf("symbol entry for %q does not exist, %v", l.Name, err)
+				return fmt.Errorf("symbol entry for %q does not exist, %v", name, err)
 			}
 		}
-		w.labelNames[l.Name]++
+		w.labelNames[name]++
 		w.buf2.PutUvarint32(nameIndex)
 
 		valueIndex := cacheEntry.lastValueIndex
-		if !ok || cacheEntry.lastValue != l.Value {
-			valueIndex, err = w.symbols.ReverseLookup(l.Value)
+		if !ok || cacheEntry.lastValue != value {
+			valueIndex, err = w.symbols.ReverseLookup(value)
 			if err != nil {
-				return fmt.Errorf("symbol entry for %q does not exist, %v", l.Value, err)
+				return fmt.Errorf("symbol entry for %q does not exist, %v", value, err)
 			}
-			w.symbolCache[l.Name] = symbolCacheEntry{
+			w.symbolCache[name] = symbolCacheEntry{
 				index:          nameIndex,
-				lastValue:      l.Value,
+				lastValue:      value,
 				lastValueIndex: valueIndex,
 			}
 		}
@@ -381,7 +382,7 @@ func (w *Writer) AddSeries(ref storage.SeriesRef, lset phlaremodel.Labels, fp mo
 
 	w.buf2.PutHash(w.crc32)
 
-	w.lastSeries = append(w.lastSeries[:0], lset...)
+	w.lastSeriesLen = lset.Len()
 	w.lastSeriesHash = labelHash
 	w.lastRef = ref
 


### PR DESCRIPTION
Stacked on #5398

This isolates the shared state, so it can't be accidentally alterted by consumers.

## Benchmark
Compared with `main` using ten 1-second samples of `BenchmarkDatasetIndexWriter_WriteTo`:
- time/op: 340.5us -> 312.1us (-8.33%, p=0.000)
- bytes/op: 205.3 KiB -> 110.9 KiB (-45.99%, p=0.000)
- allocs/op: 1991 -> 790 (-60.32%, p=0.000)