### PR TITLE
perf(metastore): scan block bounds before decoding

### DIFF
--- a/pkg/metastore/index/query.go
+++ b/pkg/metastore/index/query.go
@@ -140,7 +140,11 @@ func (q *blockMetadataQuerier) collectBlockMetadata(s *store.Shard) error {
 		return nil
 	}
 	for blocks.Next() {
-		md := q.shards.index.blocks.getOrCreate(s, blocks.At())
+		kv := blocks.At()
+		if minTime, maxTime, err := blockMetaTimeBounds(kv.Value); err == nil && !q.query.overlapsUnixMilli(minTime, maxTime) {
+			continue
+		}
+		md := q.shards.index.blocks.getOrCreate(s, kv)
 		if m := q.collectMatched(s.StringTable, matcher, md); m != nil {
 			q.metas = append(q.metas, m)
 		}
@@ -256,15 +260,20 @@ func (q *metadataLabelQuerier) collectLabels(s *store.Shard) error {
 		return nil
 	}
 	for blocks.Next() {
-		md := q.shards.index.blocks.getOrCreate(s, blocks.At())
-		if q.query.overlapsUnixMilli(md.MinTime, md.MaxTime) {
-			for _, ds := range md.Datasets {
-				if _, ok := q.query.tenantMap[s.StringTable.Lookup(ds.Tenant)]; !ok {
-					continue
-				}
-				if q.query.overlapsUnixMilli(ds.MinTime, ds.MaxTime) {
-					matcher.Matches(ds.Labels)
-				}
+		kv := blocks.At()
+		if minTime, maxTime, err := blockMetaTimeBounds(kv.Value); err == nil && !q.query.overlapsUnixMilli(minTime, maxTime) {
+			continue
+		}
+		md := q.shards.index.blocks.getOrCreate(s, kv)
+		if !q.query.overlapsUnixMilli(md.MinTime, md.MaxTime) {
+			continue
+		}
+		for _, ds := range md.Datasets {
+			if _, ok := q.query.tenantMap[s.StringTable.Lookup(ds.Tenant)]; !ok {
+				continue
+			}
+			if q.query.overlapsUnixMilli(ds.MinTime, ds.MaxTime) {
+				matcher.Matches(ds.Labels)
 			}
 		}
 	}

--- a/pkg/metastore/index/query.go
+++ b/pkg/metastore/index/query.go
@@ -265,9 +265,6 @@ func (q *metadataLabelQuerier) collectLabels(s *store.Shard) error {
 			continue
 		}
 		md := q.shards.index.blocks.getOrCreate(s, kv)
-		if !q.query.overlapsUnixMilli(md.MinTime, md.MaxTime) {
-			continue
-		}
 		for _, ds := range md.Datasets {
 			if _, ok := q.query.tenantMap[s.StringTable.Lookup(ds.Tenant)]; !ok {
 				continue

--- a/pkg/metastore/index/query_bench_test.go
+++ b/pkg/metastore/index/query_bench_test.go
@@ -1,0 +1,127 @@
+package index
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"go.etcd.io/bbolt"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	"github.com/grafana/pyroscope/v2/pkg/test"
+	"github.com/grafana/pyroscope/v2/pkg/util"
+)
+
+const benchmarkOutOfRangeBlocks = 1000
+
+func BenchmarkQueryMetadataLargeOutOfRange(b *testing.B) {
+	benchmarkLargeOutOfRangeQuery(b, func(idx *Index, tx *bbolt.Tx, query MetadataQuery) error {
+		blocks, err := idx.QueryMetadata(tx, context.Background(), query)
+		if err != nil {
+			return err
+		}
+		if len(blocks) != 1 {
+			return fmt.Errorf("got %d blocks, want 1", len(blocks))
+		}
+		return nil
+	})
+}
+
+func BenchmarkQueryMetadataLabelsLargeOutOfRange(b *testing.B) {
+	benchmarkLargeOutOfRangeQuery(b, func(idx *Index, tx *bbolt.Tx, query MetadataQuery) error {
+		labels, err := idx.QueryMetadataLabels(tx, context.Background(), query)
+		if err != nil {
+			return err
+		}
+		if len(labels) == 0 {
+			return fmt.Errorf("got no label sets")
+		}
+		return nil
+	})
+}
+
+func benchmarkLargeOutOfRangeQuery(b *testing.B, query func(*Index, *bbolt.Tx, MetadataQuery) error) {
+	b.Helper()
+
+	db := test.BoltDB(b)
+	config := DefaultConfig
+	config.BlockReadCacheSize = benchmarkOutOfRangeBlocks + 1
+	config.BlockWriteCacheSize = benchmarkOutOfRangeBlocks + 1
+	writer := NewIndex(util.Logger, NewStore(), config, nil)
+	requireNoError(b, db.Update(writer.Init))
+
+	queryStart := time.Date(2024, 9, 23, 8, 0, 0, 0, time.UTC)
+	requireNoError(b, db.Update(func(tx *bbolt.Tx) error {
+		if err := writer.InsertBlock(tx, benchmarkBlock(queryStart)); err != nil {
+			return err
+		}
+		for range benchmarkOutOfRangeBlocks {
+			if err := writer.InsertBlock(tx, benchmarkBlock(queryStart.Add(2*time.Hour))); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+
+	metadataQuery := MetadataQuery{
+		Expr:      `{}`,
+		StartTime: queryStart,
+		EndTime:   queryStart.Add(15 * time.Minute),
+		Tenant:    []string{"tenant-a"},
+		Labels:    []string{"service_name"},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		b.StopTimer()
+		// Recreate the index to measure a cold block cache every iteration.
+		reader := NewIndex(util.Logger, NewStore(), config, nil)
+		requireNoError(b, db.Update(reader.Init))
+		b.StartTimer()
+		requireNoError(b, db.View(func(tx *bbolt.Tx) error {
+			return query(reader, tx, metadataQuery)
+		}))
+	}
+}
+
+func benchmarkBlock(timestamp time.Time) *metastorev1.BlockMeta {
+	const (
+		datasetsPerBlock = 10
+		labelPairsPerSet = 50
+	)
+
+	labels := make([]int32, 0, labelPairsPerSet*2)
+	for range labelPairsPerSet {
+		labels = append(labels, 3, 4)
+	}
+	block := &metastorev1.BlockMeta{
+		Id:      ulid.MustNew(ulid.Timestamp(timestamp), rand.Reader).String(),
+		Tenant:  1,
+		MinTime: timestamp.UnixMilli(),
+		MaxTime: timestamp.Add(15 * time.Minute).UnixMilli(),
+		StringTable: []string{
+			"", "tenant-a", "dataset-a", "service_name", "service-a",
+		},
+	}
+	for range datasetsPerBlock {
+		block.Datasets = append(block.Datasets, &metastorev1.Dataset{
+			Tenant:  1,
+			Name:    2,
+			MinTime: block.MinTime,
+			MaxTime: block.MaxTime,
+			Labels:  labels,
+		})
+	}
+	return block
+}
+
+func requireNoError(b *testing.B, err error) {
+	b.Helper()
+	if err != nil {
+		b.Fatal(err)
+	}
+}

--- a/pkg/metastore/index/query_time_bounds.go
+++ b/pkg/metastore/index/query_time_bounds.go
@@ -1,0 +1,57 @@
+package index
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+const (
+	blockMetaMinTimeField = 6
+	blockMetaMaxTimeField = 7
+)
+
+// blockMetaTimeBounds reads min_time and max_time from an encoded BlockMeta
+// without materializing the message, so that queries can discard blocks
+// outside their time range before paying for a full decode.
+func blockMetaTimeBounds(b []byte) (minTime, maxTime int64, err error) {
+	for len(b) > 0 {
+		field, wireType, n := protowire.ConsumeTag(b)
+		if n < 0 {
+			return 0, 0, protowire.ParseError(n)
+		}
+		b = b[n:]
+		if wireType == protowire.EndGroupType {
+			return 0, 0, fmt.Errorf("unexpected end group for BlockMeta field %d", field)
+		}
+
+		switch field {
+		case blockMetaMinTimeField, blockMetaMaxTimeField:
+			if wireType != protowire.VarintType {
+				return 0, 0, fmt.Errorf("invalid wire type %d for BlockMeta field %d", wireType, field)
+			}
+			value, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return 0, 0, protowire.ParseError(n)
+			}
+			if field == blockMetaMinTimeField {
+				minTime = int64(value)
+			} else {
+				maxTime = int64(value)
+			}
+			b = b[n:]
+		default:
+			// BlockMeta values are written by MarshalVT in ascending field order,
+			// so min_time and max_time cannot appear after a larger field number.
+			if field > blockMetaMaxTimeField {
+				return minTime, maxTime, nil
+			}
+			n = protowire.ConsumeFieldValue(field, wireType, b)
+			if n < 0 {
+				return 0, 0, protowire.ParseError(n)
+			}
+			b = b[n:]
+		}
+	}
+	return minTime, maxTime, nil
+}

--- a/pkg/metastore/index/query_time_bounds_test.go
+++ b/pkg/metastore/index/query_time_bounds_test.go
@@ -1,0 +1,229 @@
+package index
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	"github.com/grafana/pyroscope/v2/pkg/test"
+	"github.com/grafana/pyroscope/v2/pkg/util"
+)
+
+func TestBlockMetaTimeBounds_FieldNumbers(t *testing.T) {
+	fields := (&metastorev1.BlockMeta{}).ProtoReflect().Descriptor().Fields()
+	for _, tc := range []struct {
+		name   string
+		number protowire.Number
+	}{
+		{name: "min_time", number: blockMetaMinTimeField},
+		{name: "max_time", number: blockMetaMaxTimeField},
+	} {
+		field := fields.ByName(protoreflect.Name(tc.name))
+		require.NotNil(t, field)
+		assert.Equal(t, tc.number, field.Number())
+		assert.Equal(t, protoreflect.Int64Kind, field.Kind())
+	}
+}
+
+func TestBlockMetaTimeBounds(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		meta *metastorev1.BlockMeta
+	}{
+		{name: "empty", meta: &metastorev1.BlockMeta{}},
+		{name: "zero times", meta: &metastorev1.BlockMeta{Id: "x", Tenant: 1, Shard: 2}},
+		{name: "min time only", meta: &metastorev1.BlockMeta{MinTime: 1}},
+		{name: "max time only", meta: &metastorev1.BlockMeta{MaxTime: 1}},
+		{name: "negative times", meta: &metastorev1.BlockMeta{MinTime: -2, MaxTime: -1}},
+		{
+			name: "all fields",
+			meta: &metastorev1.BlockMeta{
+				FormatVersion:   1,
+				Id:              "01J9E3ZXCA1QNSSZY8Z7A09VGX",
+				Tenant:          3,
+				Shard:           7,
+				CompactionLevel: 2,
+				MinTime:         1727080000000,
+				MaxTime:         1727083600000,
+				CreatedBy:       4,
+				MetadataOffset:  1024,
+				Size:            1 << 20,
+				Datasets: []*metastorev1.Dataset{
+					{Tenant: 1, Name: 2, MinTime: 1727080000000, MaxTime: 1727083600000, Labels: []int32{2, 3, 4, 5, 6}},
+					{Tenant: 1, Name: 5, MinTime: 1727081000000, MaxTime: 1727082600000, Labels: []int32{2, 3, 4, 5, 6}},
+				},
+				StringTable: []string{"", "a", "b", "service_name", "svc", "__profile_type__", "cpu"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := tc.meta.MarshalVT()
+			require.NoError(t, err)
+			minTime, maxTime, err := blockMetaTimeBounds(b)
+			require.NoError(t, err)
+			assert.Equal(t, tc.meta.MinTime, minTime)
+			assert.Equal(t, tc.meta.MaxTime, maxTime)
+		})
+	}
+}
+
+func TestBlockMetaTimeBounds_Randomized(t *testing.T) {
+	r := rand.New(rand.NewSource(1))
+	for range 1000 {
+		meta := &metastorev1.BlockMeta{
+			FormatVersion:   r.Uint32(),
+			Id:              test.ULID(time.UnixMilli(r.Int63n(1e13)).Format(time.RFC3339)),
+			Tenant:          r.Int31(),
+			Shard:           r.Uint32(),
+			CompactionLevel: r.Uint32() % 3,
+			MinTime:         r.Int63() - r.Int63(),
+			MaxTime:         r.Int63() - r.Int63(),
+			CreatedBy:       r.Int31(),
+			MetadataOffset:  r.Uint64(),
+			Size:            r.Uint64(),
+		}
+		for d := 0; d < r.Intn(20); d++ {
+			meta.Datasets = append(meta.Datasets, &metastorev1.Dataset{
+				Tenant:          r.Int31(),
+				Name:            r.Int31(),
+				MinTime:         r.Int63(),
+				MaxTime:         r.Int63(),
+				TableOfContents: []uint64{r.Uint64(), r.Uint64()},
+				Size:            r.Uint64(),
+				Labels:          []int32{r.Int31n(64), r.Int31n(64), r.Int31n(64)},
+				Format:          r.Uint32() % 2,
+			})
+		}
+		for s := 0; s < r.Intn(10); s++ {
+			meta.StringTable = append(meta.StringTable, test.ULID(time.UnixMilli(r.Int63n(1e13)).Format(time.RFC3339)))
+		}
+		b, err := meta.MarshalVT()
+		require.NoError(t, err)
+
+		var full metastorev1.BlockMeta
+		require.NoError(t, full.UnmarshalVT(b))
+		minTime, maxTime, err := blockMetaTimeBounds(b)
+		require.NoError(t, err)
+		require.Equal(t, full.MinTime, minTime)
+		require.Equal(t, full.MaxTime, maxTime)
+	}
+}
+
+func TestBlockMetaTimeBounds_MalformedInput(t *testing.T) {
+	meta := &metastorev1.BlockMeta{MinTime: 100, MaxTime: 200}
+	b, err := meta.MarshalVT()
+	require.NoError(t, err)
+	for i := 0; i <= len(b); i++ {
+		var full metastorev1.BlockMeta
+		fullErr := full.UnmarshalVT(b[:i])
+		_, _, boundsErr := blockMetaTimeBounds(b[:i])
+		if fullErr != nil {
+			require.Error(t, boundsErr)
+		} else {
+			require.NoError(t, boundsErr)
+		}
+	}
+	for _, malformed := range [][]byte{
+		{0xff, 0xff, 0xff, 0xff},
+		{0},    // Field number zero.
+		{0x0c}, // Unexpected end group.
+	} {
+		_, _, err = blockMetaTimeBounds(malformed)
+		require.Error(t, err)
+	}
+}
+
+// Blocks outside the query time range must not be decoded into the block cache.
+func TestQueryMetadata_TimeFilterSkipsDecode(t *testing.T) {
+	db := test.BoltDB(t)
+
+	// Two blocks in the same 6h partition, hours apart.
+	inRange := &metastorev1.BlockMeta{
+		Id:      test.ULID("2024-09-23T08:00:00.001Z"),
+		Tenant:  1,
+		MinTime: test.UnixMilli("2024-09-23T08:00:00.000Z"),
+		MaxTime: test.UnixMilli("2024-09-23T08:15:00.000Z"),
+		Datasets: []*metastorev1.Dataset{{
+			Tenant:  1,
+			Name:    2,
+			MinTime: test.UnixMilli("2024-09-23T08:00:00.000Z"),
+			MaxTime: test.UnixMilli("2024-09-23T08:15:00.000Z"),
+			Labels:  []int32{1, 3, 4},
+		}},
+		StringTable: []string{"", "tenant-a", "dataset-a", "service_name", "svc-a"},
+	}
+	outOfRange := &metastorev1.BlockMeta{
+		Id:      test.ULID("2024-09-23T10:30:00.002Z"),
+		Tenant:  1,
+		MinTime: test.UnixMilli("2024-09-23T10:30:00.000Z"),
+		MaxTime: test.UnixMilli("2024-09-23T10:45:00.000Z"),
+		Datasets: []*metastorev1.Dataset{{
+			Tenant:  1,
+			Name:    2,
+			MinTime: test.UnixMilli("2024-09-23T10:30:00.000Z"),
+			MaxTime: test.UnixMilli("2024-09-23T10:45:00.000Z"),
+			Labels:  []int32{1, 3, 4},
+		}},
+		StringTable: []string{"", "tenant-a", "dataset-a", "service_name", "svc-a"},
+	}
+
+	idx := NewIndex(util.Logger, NewStore(), DefaultConfig, nil)
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		if err := idx.Init(tx); err != nil {
+			return err
+		}
+		if err := idx.InsertBlock(tx, inRange.CloneVT()); err != nil {
+			return err
+		}
+		return idx.InsertBlock(tx, outOfRange.CloneVT())
+	}))
+
+	// A fresh index observes only the persisted state, with cold caches.
+	idx = NewIndex(util.Logger, NewStore(), DefaultConfig, nil)
+	require.NoError(t, db.Update(idx.Init))
+
+	require.NoError(t, db.View(func(tx *bbolt.Tx) error {
+		found, err := idx.QueryMetadata(tx, t.Context(), MetadataQuery{
+			Expr:      `{}`,
+			StartTime: time.UnixMilli(test.UnixMilli("2024-09-23T08:00:00.000Z")),
+			EndTime:   time.UnixMilli(test.UnixMilli("2024-09-23T09:00:00.000Z")),
+			Tenant:    []string{"tenant-a"},
+		})
+		require.NoError(t, err)
+		require.Len(t, found, 1)
+		require.Equal(t, inRange.Id, found[0].Id)
+		return nil
+	}))
+
+	cached := func(md *metastorev1.BlockMeta) bool {
+		return idx.blocks.read.Contains(blockCacheKey{tenant: "tenant-a", shard: 0, block: md.Id})
+	}
+	assert.True(t, cached(inRange))
+	assert.False(t, cached(outOfRange))
+
+	// Labels queries use the same prefilter and must also avoid caching the
+	// out-of-range block.
+	idx = NewIndex(util.Logger, NewStore(), DefaultConfig, nil)
+	require.NoError(t, db.Update(idx.Init))
+	require.NoError(t, db.View(func(tx *bbolt.Tx) error {
+		labels, err := idx.QueryMetadataLabels(tx, t.Context(), MetadataQuery{
+			Expr:      `{}`,
+			StartTime: time.UnixMilli(test.UnixMilli("2024-09-23T08:00:00.000Z")),
+			EndTime:   time.UnixMilli(test.UnixMilli("2024-09-23T09:00:00.000Z")),
+			Tenant:    []string{"tenant-a"},
+			Labels:    []string{"service_name"},
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, labels)
+		return nil
+	}))
+	assert.True(t, cached(inRange))
+	assert.False(t, cached(outOfRange))
+}


### PR DESCRIPTION
This builds on the excellent idea of #5402 but solves it more elegantly: use protowire instead of an error-prone duplicate proto specification.

## Benchmark

Cold-cache query over 1,000 large out-of-range blocks plus one matching block. Measured with 12 runs each on Apple M2 Max.

| Benchmark | `main` | PR #5402 (duplicate spec) | #5407 (protowire) | Difference vs `main` | p-value |
|---|---:|---:|---:|---:|---:|
| Metadata query | 4.20 ms | 255.15 us | 76.19 us | -98.19% | <0.0005 |
| Labels query | 4.27 ms | 252.97 us | 72.95 us | -98.29% | <0.0005 |
| Metadata B/op | 6.00 MiB | 18.22 KiB | 18.50 KiB | -99.70% | <0.0005 |
| Labels B/op | 6.00 MiB | 14.15 KiB | 14.41 KiB | -99.77% | <0.0005 |

## Test

- `go test ./pkg/metastore/index/... -count=1`
- `golangci-lint run ./pkg/metastore/index/...`
