### PR TITLE
fix(distributor): do not alias sample labels in stripped profiles

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -962,7 +962,10 @@ func stripProfileToTotals(p *profilev1.Profile) {
 	groups := pprof.GroupSamplesByLabels(p)
 	totals := make([]*profilev1.Sample, len(groups))
 	for i, g := range groups {
-		total := &profilev1.Sample{Value: make([]int64, len(p.SampleType)), Label: g.Labels}
+		// The pprof split reads label slices beyond len(): do not alias g.Labels.
+		labels := make([]*profilev1.Label, len(g.Labels))
+		copy(labels, g.Labels)
+		total := &profilev1.Sample{Value: make([]int64, len(p.SampleType)), Label: labels}
 		for _, s := range g.Samples {
 			for j, v := range s.Value {
 				total.Value[j] += v

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2864,3 +2864,59 @@ func TestStripProfileToTotals_SampleLabels(t *testing.T) {
 	assert.Empty(t, p.Mapping)
 	assert.Equal(t, []string{"", "samples", "count", "cpu", "nanoseconds", "span_id", "abc", "def"}, p.StringTable)
 }
+
+func TestPushSeries_KeepStrippedProfiles_SampleSeries(t *testing.T) {
+	d, ing := newStripTestDistributor(t, true)
+
+	prof := stripTestProfile()
+	// Indices into the extended string table: user_id=9, u1=10, u2=11, bytes=12.
+	prof.StringTable = append(prof.StringTable, "user_id", "u1", "u2", "bytes")
+	prof.Sample = []*profilev1.Sample{
+		{LocationId: []uint64{1}, Value: []int64{10, 1000}, Label: []*profilev1.Label{
+			{Key: 9, Str: 10},
+			{Key: 12, Num: 42},
+		}},
+		{LocationId: []uint64{2}, Value: []int64{5, 500}, Label: []*profilev1.Label{
+			{Key: 9, Str: 11},
+		}},
+	}
+
+	req := &distributormodel.ProfileSeries{
+		Labels: []*typesv1.LabelPair{
+			{Name: "__name__", Value: "cpu"},
+			{Name: phlaremodel.LabelNameServiceName, Value: "svc"},
+		},
+		Profile: pprof2.RawFromProto(prof),
+	}
+
+	err := d.pushSeries(context.Background(), req, distributormodel.RawProfileTypePPROF, "user-1", 0)
+	require.NoError(t, err)
+
+	ing.mtx.Lock()
+	defer ing.mtx.Unlock()
+	byUser := make(map[string]*pushv1.RawProfileSeries)
+	for _, r := range ing.requests {
+		for _, s := range r.Series {
+			byUser[phlaremodel.Labels(s.Labels).Get("user_id")] = s
+		}
+	}
+	require.Len(t, byUser, 2)
+
+	wantValues := map[string][]int64{
+		"u1": {10, 1000},
+		"u2": {5, 500},
+	}
+	for user, want := range wantValues {
+		series := byUser[user]
+		require.NotNil(t, series, "missing series for user_id=%s", user)
+		assert.Equal(t, "true", phlaremodel.Labels(series.Labels).Get(phlaremodel.LabelNameSampled))
+
+		received, err := pprof2.RawFromBytes(series.Samples[0].RawProfile)
+		require.NoError(t, err)
+		require.Len(t, received.Sample, 1)
+		assert.Equal(t, want, received.Sample[0].Value)
+		assert.Empty(t, received.Sample[0].LocationId)
+		assert.Empty(t, received.Sample[0].Label)
+		assert.NotContains(t, received.StringTable, "bytes")
+	}
+}


### PR DESCRIPTION
## Problem

With `keep_stripped_profiles` enabled (#5354), pushing some sampled-out profiles fails with `runtime error: index out of range` raised in `pprof.(*SampleExporter).ExportSamples`. The panic is recovered by the write path and surfaces as a push error.

## Cause

`stripProfileToTotals` reuses the label slices of the source samples for the aggregated totals. `dropNonStringLabels` compacts those slices in place, so the backing arrays can still hold dropped labels beyond `len()`, referencing the pre-strip string table.

The pprof split reads label slices beyond `len()` to restore the labels it hides during grouping (`restoreRemovedLabels`), and picks those stale labels back up. The sample exporter then indexes the rebuilt — much smaller — string table with pre-strip indices and panics.

## Fix

Give each total its own label slice, so there is nothing past `len()` for the split to pick up.

Added a regression test that reproduces the panic without the fix.