### PR TITLE
fix(distributor): collapse stripped profiles to a single sample

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -332,7 +332,7 @@ Usage of ./pyroscope:
   -distributor.sample-type-relabeling-rules value
     	List of sample type relabel configurations. Rules are applied to sample types with __type__ and __unit__ labels, along with all series labels.
   -distributor.sampling.keep-stripped-profiles
-    	When a profile is sampled out, retain its totals and labels with stacktraces stripped (marked __sampled__) instead of dropping it.
+    	When a profile is sampled out, retain its totals as a single sample with stacktraces and sample labels stripped (marked __sampled__) instead of dropping it.
   -distributor.zone-awareness-enabled
     	True to enable the zone-awareness and replicate ingested samples across different availability zones.
   -embedded-grafana.data-path string

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -86,7 +86,7 @@ Usage of ./pyroscope:
   -distributor.ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
   -distributor.sampling.keep-stripped-profiles
-    	When a profile is sampled out, retain its totals and labels with stacktraces stripped (marked __sampled__) instead of dropping it.
+    	When a profile is sampled out, retain its totals as a single sample with stacktraces and sample labels stripped (marked __sampled__) instead of dropping it.
   -distributor.zone-awareness-enabled
     	True to enable the zone-awareness and replicate ingested samples across different availability zones.
   -embedded-grafana.data-path string

--- a/cmd/pyroscope/pyroscope.yaml
+++ b/cmd/pyroscope/pyroscope.yaml
@@ -305,8 +305,9 @@ limits:
   # set at least to the maximum profile size expected in a single push request.
   # ingestion_burst_size_mb: 2
 
-  # When a profile is sampled out, retain its totals and labels with stacktraces
-  # stripped (marked __sampled__) instead of dropping it.
+  # When a profile is sampled out, retain its totals as a single sample with
+  # stacktraces and sample labels stripped (marked __sampled__) instead of
+  # dropping it.
   # keep_stripped_profiles: false
 
   # Maximum length accepted for label names.

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -3112,8 +3112,9 @@ The `limits` block configures default and per-tenant limits imposed by component
 # CLI flag: -distributor.ingestion-burst-size-mb
 [ingestion_burst_size_mb: <float> | default = 2]
 
-# When a profile is sampled out, retain its totals and labels with stacktraces
-# stripped (marked __sampled__) instead of dropping it.
+# When a profile is sampled out, retain its totals as a single sample with
+# stacktraces and sample labels stripped (marked __sampled__) instead of
+# dropping it.
 # CLI flag: -distributor.sampling.keep-stripped-profiles
 [keep_stripped_profiles: <boolean> | default = false]
 

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -604,7 +604,7 @@ func (d *Distributor) pushSeries(ctx context.Context, req *distributormodel.Prof
 			groups.CountDiscardedBytes(string(validation.SkippedBySamplingRules), req.TotalBytesUncompressed)
 			return nil
 		}
-		finalLog.msg = "stripping profile stacktraces, keeping samples and labels"
+		finalLog.msg = "stripping profile stacktraces, keeping totals"
 
 		// Language detection reads the string table, which is about to be
 		// stripped; the result is cached in the request.
@@ -953,39 +953,24 @@ func (d *Distributor) sendRequestsToSegmentWriter(ctx context.Context, req *dist
 	return connect.NewResponse(&pushv1.PushResponse{}), nil
 }
 
-// stripProfileToTotals reduces the profile to one sample per distinct
-// sample label set, each holding the summed values of its group:
-// stacktraces and symbols are dropped, only the totals are kept.
-// Sample labels survive so that span- and trace-attributed totals
-// remain distinguishable.
+// stripProfileToTotals reduces the profile to a single sample holding the
+// sum of all sample values: stacktraces, symbols, and sample labels are
+// dropped, only the series totals are kept.
 func stripProfileToTotals(p *profilev1.Profile) {
-	kept := p.Sample[:0]
-	for _, s := range p.Sample {
-		// Mirror Normalize: non-string labels are unsupported, and samples
-		// it would drop (value length mismatch, negative values) must not
-		// contribute to the totals.
-		if len(s.Value) != len(p.SampleType) || hasNegativeValue(s) {
-			continue
-		}
-		s.Label = dropNonStringLabels(s.Label)
-		sort.Sort(pprof.LabelsByKeyValue(s.Label))
-		kept = append(kept, s)
-	}
-	p.Sample = kept
-	sort.Sort(pprof.SamplesByLabels(p.Sample))
-	groups := pprof.GroupSamplesByLabels(p)
-	totals := make([]*profilev1.Sample, len(groups))
-	for i, g := range groups {
-		total := &profilev1.Sample{Value: make([]int64, len(p.SampleType)), Label: g.Labels}
-		for _, s := range g.Samples {
-			for j, v := range s.Value {
-				total.Value[j] += v
+	if len(p.Sample) > 0 {
+		total := &profilev1.Sample{Value: make([]int64, len(p.SampleType))}
+		for _, s := range p.Sample {
+			// Samples that Normalize would drop (value length mismatch,
+			// negative values) must not contribute to the totals.
+			if len(s.Value) != len(total.Value) || hasNegativeValue(s) {
+				continue
+			}
+			for i, v := range s.Value {
+				total.Value[i] += v
 			}
 		}
-		totals[i] = total
+		p.Sample = []*profilev1.Sample{total}
 	}
-	p.Sample = totals
-
 	p.Location = nil
 	p.Function = nil
 	p.Mapping = nil
@@ -1016,24 +1001,7 @@ func stripProfileToTotals(p *profilev1.Profile) {
 	for i, c := range p.Comment {
 		p.Comment[i] = intern(c)
 	}
-	for _, s := range p.Sample {
-		for _, l := range s.Label {
-			l.Key = intern(l.Key)
-			l.Str = intern(l.Str)
-			l.NumUnit = intern(l.NumUnit)
-		}
-	}
 	p.StringTable = newStrings
-}
-
-func dropNonStringLabels(labels []*profilev1.Label) []*profilev1.Label {
-	kept := labels[:0]
-	for _, l := range labels {
-		if l.Str != 0 {
-			kept = append(kept, l)
-		}
-	}
-	return kept
 }
 
 func hasNegativeValue(s *profilev1.Sample) bool {

--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -957,18 +957,22 @@ func (d *Distributor) sendRequestsToSegmentWriter(ctx context.Context, req *dist
 // sum of all sample values: stacktraces, symbols, and sample labels are
 // dropped, only the series totals are kept.
 func stripProfileToTotals(p *profilev1.Profile) {
-	if len(p.Sample) > 0 {
-		total := &profilev1.Sample{Value: make([]int64, len(p.SampleType))}
-		for _, s := range p.Sample {
-			// Samples that Normalize would drop (value length mismatch,
-			// negative values) must not contribute to the totals.
-			if len(s.Value) != len(total.Value) || hasNegativeValue(s) {
-				continue
-			}
-			for i, v := range s.Value {
-				total.Value[i] += v
-			}
+	var total *profilev1.Sample
+	for _, s := range p.Sample {
+		// Samples that Normalize would drop (value length mismatch,
+		// negative values) must not contribute to the totals.
+		if len(s.Value) != len(p.SampleType) || hasNegativeValue(s) {
+			continue
 		}
+		if total == nil {
+			total = &profilev1.Sample{Value: make([]int64, len(p.SampleType))}
+		}
+		for i, v := range s.Value {
+			total.Value[i] += v
+		}
+	}
+	p.Sample = nil
+	if total != nil {
 		p.Sample = []*profilev1.Sample{total}
 	}
 	p.Location = nil

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2722,6 +2722,17 @@ func TestStripProfileToTotals_NoSamples(t *testing.T) {
 	assert.Empty(t, p.Location)
 }
 
+func TestStripProfileToTotals_AllSamplesInvalid(t *testing.T) {
+	p := stripTestProfile()
+	p.Sample = []*profilev1.Sample{
+		{LocationId: []uint64{1}, Value: []int64{-1, 100}},
+		{LocationId: []uint64{1}, Value: []int64{7}},
+	}
+	stripProfileToTotals(p)
+	assert.Empty(t, p.Sample)
+	assert.Empty(t, p.Location)
+}
+
 func newStripTestDistributor(t *testing.T, keepStrippedProfiles bool) (*Distributor, *fakeIngester) {
 	t.Helper()
 	overrides := validation.MockOverrides(func(defaults *validation.Limits, tenantLimits map[string]*validation.Limits) {

--- a/pkg/distributor/distributor_test.go
+++ b/pkg/distributor/distributor_test.go
@@ -2839,28 +2839,17 @@ func TestStripProfileToTotals_SampleLabels(t *testing.T) {
 		{LocationId: []uint64{2}, Value: []int64{2, 20}, Label: []*profilev1.Label{{Key: 9, Str: 10}}},
 		{LocationId: []uint64{1}, Value: []int64{4, 40}, Label: []*profilev1.Label{{Key: 9, Str: 11}}},
 		{LocationId: []uint64{2}, Value: []int64{8, 80}},
-		// Numeric labels are dropped (as Normalize would do), so this
-		// sample must aggregate with the unlabeled one.
 		{LocationId: []uint64{1}, Value: []int64{16, 160}, Label: []*profilev1.Label{{Key: 9, Num: 42}}},
 	}
 
 	stripProfileToTotals(p)
 
-	require.Len(t, p.Sample, 3)
-	assert.Equal(t, []int64{24, 240}, p.Sample[0].Value)
+	require.Len(t, p.Sample, 1)
+	assert.Equal(t, []int64{31, 310}, p.Sample[0].Value)
 	assert.Empty(t, p.Sample[0].Label)
-	assert.Equal(t, []int64{3, 30}, p.Sample[1].Value)
-	require.Len(t, p.Sample[1].Label, 1)
-	assert.Equal(t, "span_id", p.StringTable[p.Sample[1].Label[0].Key])
-	assert.Equal(t, "abc", p.StringTable[p.Sample[1].Label[0].Str])
-	assert.Equal(t, []int64{4, 40}, p.Sample[2].Value)
-	require.Len(t, p.Sample[2].Label, 1)
-	assert.Equal(t, "def", p.StringTable[p.Sample[2].Label[0].Str])
-	for _, s := range p.Sample {
-		assert.Empty(t, s.LocationId)
-	}
+	assert.Empty(t, p.Sample[0].LocationId)
 	assert.Empty(t, p.Location)
 	assert.Empty(t, p.Function)
 	assert.Empty(t, p.Mapping)
-	assert.Equal(t, []string{"", "samples", "count", "cpu", "nanoseconds", "span_id", "abc", "def"}, p.StringTable)
+	assert.Equal(t, []string{"", "samples", "count", "cpu", "nanoseconds"}, p.StringTable)
 }

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -197,7 +197,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&l.MaxFlameGraphNodesMax, "querier.max-flamegraph-nodes-max", 1<<20, "Maximum number of flame graph nodes allowed. 0 to disable.")
 	f.BoolVar(&l.MaxFlameGraphNodesOnSelectMergeProfile, "querier.max-flamegraph-nodes-on-select-merge-profile", false, "Enforce the max nodes limits and defaults on SelectMergeProfile API. Historically this limit was not enforced to enable to gather full pprof profiles without truncation.")
 
-	f.BoolVar(&l.KeepStrippedProfiles, "distributor.sampling.keep-stripped-profiles", false, "When a profile is sampled out, retain its totals and labels with stacktraces stripped (marked __sampled__) instead of dropping it.")
+	f.BoolVar(&l.KeepStrippedProfiles, "distributor.sampling.keep-stripped-profiles", false, "When a profile is sampled out, retain its totals as a single sample with stacktraces and sample labels stripped (marked __sampled__) instead of dropping it.")
 	f.BoolVar(&l.IncludeStrippedProfiles, "query-backend.include-stripped-profiles", false, "Include profiles that were sampled out and stored with stacktraces stripped (marked __sampled__) in query results.")
 	f.Var(&l.DistributorAggregationWindow, "distributor.aggregation-window", "Duration of the distributor aggregation window. Requires aggregation period to be specified. 0 to disable.")
 	f.Var(&l.DistributorAggregationPeriod, "distributor.aggregation-period", "Duration of the distributor aggregation period. Requires aggregation window to be specified. 0 to disable.")


### PR DESCRIPTION
Keeping one aggregated sample per distinct sample label set for sampled-out profiles caused panics: the totals samples alias the label slices of the original samples, and the pprof sample grouping reads labels hidden beyond `len()` (via [`restoreRemovedLabels`](https://github.com/grafana/pyroscope/blob/main/pkg/pprof/pprof.go#L828-L837)), picking up stale labels that index into the rebuilt, smaller string table. Retaining high-cardinality sample labels also increases the resource requirements on the write path.

Collapse a sampled-out profile to a single unlabeled totals sample instead, as previously suggested in [#5354](https://github.com/grafana/pyroscope/pull/5354#discussion_r3612957527): no sample labels survive the strip, so there is nothing to alias, and each stripped profile stores one sample per series. Per-label-set (span/trace-attributed) totals can be revisited later.

Supersedes #5408.