### PR TITLE
feat(metastore): bound compaction job size by bytes, not just block count

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -533,6 +533,8 @@ Usage of ./pyroscope:
     	 (default 15s)
   -metastore.compaction-max-failures uint
     	 (default 3)
+  -metastore.compaction-max-job-bytes uint
+    	Maximum estimated total input size, in bytes, of a compaction job for levels above 0. A job completes once either the block count or this byte limit is reached, whichever happens first; a single block already larger than this limit still forms a valid, single-block job. Does not apply to level 0. 0 disables the size-based limit. (default 2147483648)
   -metastore.compaction-max-job-queue-size uint
     	 (default 10000)
   -metastore.data-dir string

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -1334,6 +1334,14 @@ index:
 
 [levels: <list of LevelConfigs> | default = ]
 
+# (advanced) Maximum estimated total input size, in bytes, of a compaction job
+# for levels above 0. A job completes once either the block count or this byte
+# limit is reached, whichever happens first; a single block already larger than
+# this limit still forms a valid, single-block job. Does not apply to level 0. 0
+# disables the size-based limit.
+# CLI flag: -metastore.compaction-max-job-bytes
+[compaction_max_job_bytes: <int> | default = 2147483648]
+
 [cleanupbatchsize: <int> | default = ]
 
 [cleanupdelay: <duration> | default = ]

--- a/pkg/metastore/compaction/README.md
+++ b/pkg/metastore/compaction/README.md
@@ -107,9 +107,17 @@ sequenceDiagram
 # Job Planner
 
 The compactor is responsible for maintaining a queue of source blocks eligible for compaction. Currently, this queue
-is a simple doubly-linked FIFO structure, populated with new block batches as they are added to the index. In the
-current implementation, a new compaction job is created once the sufficient number of blocks have been enqueued.
+is a simple doubly-linked FIFO structure, populated with new block batches as they are added to the index.
 Compaction jobs are planned on demand when requests are received from the compaction service.
+
+A job is complete once any of the following is reached:
+
+1. Block count: the level's `MaxBlocks` threshold.
+2. Total input size: the accumulated on-disk size (`BlockMeta.Size`) of the job's source blocks reaches
+   `-metastore.compaction-max-job-bytes` (default 2 GiB, levels above 0 only, 0 disables). Compaction worker
+   memory scales with job input size rather than block count; this bounds it. A single block larger than the
+   limit still forms a valid single-block job, and blocks with no recorded size count as 0 bytes.
+3. Age: the level's `MaxAge` threshold forces completion of a partial job.
 
 The queue is segmented by the `Tenant`, `Shard`, and `Level` attributes of the block metadata entries, meaning that
 a block compaction never crosses these boundaries. This segmentation helps avoid unnecessary compactions of unrelated

--- a/pkg/metastore/compaction/compaction.go
+++ b/pkg/metastore/compaction/compaction.go
@@ -71,6 +71,7 @@ type BlockEntry struct {
 	Tenant     string
 	Shard      uint32
 	Level      uint32
+	Size       uint64
 }
 
 func NewBlockEntry(cmd *raft.Log, md *metastorev1.BlockMeta) BlockEntry {
@@ -81,5 +82,6 @@ func NewBlockEntry(cmd *raft.Log, md *metastorev1.BlockMeta) BlockEntry {
 		Tenant:     metadata.Tenant(md),
 		Shard:      md.Shard,
 		Level:      md.CompactionLevel,
+		Size:       md.Size,
 	}
 }

--- a/pkg/metastore/compaction/compaction_test.go
+++ b/pkg/metastore/compaction/compaction_test.go
@@ -1,0 +1,51 @@
+package compaction
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/require"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+)
+
+func TestNewBlockEntry(t *testing.T) {
+	tests := []struct {
+		name string
+		md   *metastorev1.BlockMeta
+		want BlockEntry
+	}{
+		{
+			name: "populates size, tenant, shard, level from BlockMeta",
+			md: &metastorev1.BlockMeta{
+				Id:              "block-1",
+				Shard:           3,
+				CompactionLevel: 2,
+				Size:            123456,
+				Tenant:          1,
+				StringTable:     []string{"", "tenant-a"},
+			},
+			want: BlockEntry{ID: "block-1", Tenant: "tenant-a", Shard: 3, Level: 2, Size: 123456},
+		},
+		{
+			name: "zero size is preserved, not treated as missing",
+			md:   &metastorev1.BlockMeta{Id: "block-2", Size: 0},
+			want: BlockEntry{ID: "block-2", Size: 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &raft.Log{Index: 7, AppendedAt: time.Unix(0, 1000)}
+			got := NewBlockEntry(cmd, tt.md)
+			require.Equal(t, tt.want.ID, got.ID)
+			require.Equal(t, tt.want.Tenant, got.Tenant)
+			require.Equal(t, tt.want.Shard, got.Shard)
+			require.Equal(t, tt.want.Level, got.Level)
+			require.Equal(t, tt.want.Size, got.Size)
+			require.Equal(t, cmd.Index, got.Index)
+			require.Equal(t, cmd.AppendedAt.UnixNano(), got.AppendedAt)
+		})
+	}
+}

--- a/pkg/metastore/compaction/compactor/compaction_queue.go
+++ b/pkg/metastore/compaction/compactor/compaction_queue.go
@@ -88,6 +88,7 @@ type blockRef struct {
 type blockEntry struct {
 	id    string // Block ID.
 	index uint64 // Index of the command in the raft log.
+	size  uint64 // Estimated on-disk size of the block, in bytes.
 }
 
 type batch struct {
@@ -142,6 +143,7 @@ func (q *compactionQueue) push(e compaction.BlockEntry) bool {
 	pushed := staged.push(blockEntry{
 		id:    e.ID,
 		index: e.Index,
+		size:  e.Size,
 	})
 	heap.Fix(level.updates, staged.heapIndex)
 	level.flushOldest(e.AppendedAt)
@@ -479,6 +481,13 @@ func (it *blockIter) more() bool {
 }
 
 func (it *blockIter) peek() (string, bool) {
+	entry, ok := it.peekEntry()
+	return entry.id, ok
+}
+
+// peekEntry returns the next unvisited block entry without advancing the
+// iterator.
+func (it *blockIter) peekEntry() (blockEntry, bool) {
 	for it.batch != nil {
 		if it.i >= len(it.batch.blocks) {
 			it.setBatch(it.batch.next)
@@ -489,9 +498,9 @@ func (it *blockIter) peek() (string, bool) {
 			it.i++
 			continue
 		}
-		return entry.id, true
+		return entry, true
 	}
-	return "", false
+	return blockEntry{}, false
 }
 
 func (it *blockIter) advance() {

--- a/pkg/metastore/compaction/compactor/compaction_queue_test.go
+++ b/pkg/metastore/compaction/compactor/compaction_queue_test.go
@@ -229,7 +229,9 @@ func TestBlockQueue_FlushByAge(t *testing.T) {
 		batches = append(batches, b.blocks...)
 	}
 
-	expected := []blockEntry{{"1", 1}, {"2", 2}, {"3", 3}, {"4", 4}}
+	expected := []blockEntry{
+		{id: "1", index: 1}, {id: "2", index: 2}, {id: "3", index: 3}, {id: "4", index: 4},
+	}
 	// "5" remains staged as we need another push to evict it.
 	assert.Equal(t, expected, batches)
 
@@ -293,6 +295,15 @@ func TestBlockQueue_BatchIterator(t *testing.T) {
 
 	_, ok := iter.next()
 	assert.False(t, ok)
+}
+
+func TestBlockQueue_Push_PropagatesSize(t *testing.T) {
+	q := newCompactionQueue(Config{Levels: []LevelConfig{{MaxBlocks: 10}}}, nil)
+	q.push(compaction.BlockEntry{Tenant: "A", Shard: 1, Level: 0, Index: 1, ID: "1", Size: 42})
+
+	staged := q.blockQueue(0).stagedBlocks(compactionKey{tenant: "A", shard: 1, level: 0})
+	require.Len(t, staged.batch.blocks, 1)
+	require.Equal(t, uint64(42), staged.batch.blocks[0].size)
 }
 
 func remove(q *blockQueue, key compactionKey, block ...string) {

--- a/pkg/metastore/compaction/compactor/compactor_config.go
+++ b/pkg/metastore/compaction/compactor/compactor_config.go
@@ -8,6 +8,13 @@ import (
 type Config struct {
 	Levels []LevelConfig
 
+	// MaxJobBytes bounds the total estimated input size (bytes) of a
+	// compaction job, for levels above 0. A job completes once either
+	// MaxBlocks or MaxJobBytes is reached, whichever happens first.
+	// Level 0 is always exempt - see (*Config).maxBytes. 0 disables the
+	// size-based limit.
+	MaxJobBytes uint64 `yaml:"compaction_max_job_bytes" category:"advanced" doc:""`
+
 	CleanupBatchSize   int32
 	CleanupDelay       time.Duration
 	CleanupJobMinLevel int32
@@ -26,6 +33,7 @@ func DefaultConfig() Config {
 			{MaxBlocks: 10, MaxAge: int64(2 * 360 * time.Second)},
 			{MaxBlocks: 10, MaxAge: int64(3 * 3600 * time.Second)},
 		},
+		MaxJobBytes: 2 << 30,
 
 		CleanupBatchSize:   2,
 		CleanupDelay:       15 * time.Minute,
@@ -34,11 +42,16 @@ func DefaultConfig() Config {
 	}
 }
 
-func (c *Config) RegisterFlagsWithPrefix(string, *flag.FlagSet) {
+func (c *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	// NOTE(kolesnikovae): I'm not sure if making this configurable
 	// is a good idea; however, we might want to add a flag to tune
 	// the parameters based on e.g., segment size or max duration.
 	*c = DefaultConfig()
+	f.Uint64Var(&c.MaxJobBytes, prefix+"compaction-max-job-bytes", c.MaxJobBytes,
+		"Maximum estimated total input size, in bytes, of a compaction job for levels above 0. "+
+			"A job completes once either the block count or this byte limit is reached, whichever happens "+
+			"first; a single block already larger than this limit still forms a valid, single-block job. "+
+			"Does not apply to level 0. 0 disables the size-based limit.")
 }
 
 // exceedsSize is called after the block has been added to the batch.
@@ -78,4 +91,13 @@ func (c *Config) maxAge(l uint32) int64 {
 func (c *Config) maxLevel() uint32 {
 	// Assuming that there is at least one level.
 	return uint32(len(c.Levels) - 1)
+}
+
+// maxBytes returns the job byte limit for level l;
+// level 0 and unconfigured levels return 0 (no limit).
+func (c *Config) maxBytes(l uint32) uint64 {
+	if l == 0 || l >= uint32(len(c.Levels)) {
+		return 0
+	}
+	return c.MaxJobBytes
 }

--- a/pkg/metastore/compaction/compactor/compactor_config_test.go
+++ b/pkg/metastore/compaction/compactor/compactor_config_test.go
@@ -1,0 +1,26 @@
+package compactor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_maxBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   Config
+		level    uint32
+		expected uint64
+	}{
+		{"level 0 is always exempt", Config{Levels: []LevelConfig{{}, {}}, MaxJobBytes: 500}, 0, 0},
+		{"level 1 uses configured MaxJobBytes", Config{Levels: []LevelConfig{{}, {}}, MaxJobBytes: 500}, 1, 500},
+		{"MaxJobBytes 0 disables the limit everywhere", Config{Levels: []LevelConfig{{}, {}}, MaxJobBytes: 0}, 1, 0},
+		{"level beyond configured Levels returns 0", Config{Levels: []LevelConfig{{}}, MaxJobBytes: 500}, 5, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, tt.config.maxBytes(tt.level))
+		})
+	}
+}

--- a/pkg/metastore/compaction/compactor/plan.go
+++ b/pkg/metastore/compaction/compactor/plan.go
@@ -49,6 +49,7 @@ type jobPlan struct {
 	name       string
 	minT       int64
 	maxT       int64
+	bytes      uint64
 	tombstones []*metastorev1.Tombstones
 	blocks     []string
 }
@@ -95,7 +96,7 @@ func (p *plan) nextJob() *jobPlan {
 			// previously, the iterator will proceed to the next batch with
 			// this compaction key. The call to peek() will return false, if
 			// only no blocks eligible for compaction are left in the queue.
-			block, found := p.blocks.peek()
+			entry, found := p.blocks.peekEntry()
 			if !found {
 				// No more blocks with this compaction key at the level.
 				// We may want to force compaction even if the current job
@@ -107,7 +108,7 @@ func (p *plan) nextJob() *jobPlan {
 				force = p.compactor.config.exceedsMaxAge(b, p.now)
 				break
 			}
-			if !job.tryAdd(block) {
+			if !job.tryAdd(entry) {
 				// We may not want to add a bock to the job if it extends the
 				// compacted block time range beyond the desired limit.
 				// In this case, we need to force compaction of incomplete job.
@@ -128,7 +129,7 @@ func (p *plan) nextJob() *jobPlan {
 			// but if the batch is not empty (i.e., we could not put all
 			// the blocks into the job), we must finish it first.
 			if p.blocks.more() {
-				// There are more blocks in the current batch: p.blocks.peek()
+				// There are more blocks in the current batch: p.blocks.peekEntry()
 				// reported a block is found, but we could not add it to the job.
 				//
 				// We need to reset the batch iterator to continue from the oldest
@@ -139,7 +140,7 @@ func (p *plan) nextJob() *jobPlan {
 				// Block iterator ensures that each block is only accessed once.
 				//
 				// If the queue that b points to has any unvisited blocks,
-				// p.blocks.peek() will return them. Otherwise, we continue
+				// p.blocks.peekEntry() will return them. Otherwise, we continue
 				// iterating over the in-order queue of batches (different
 				// compaction queues have distinct compaction keys).
 				//
@@ -187,14 +188,16 @@ func (job *jobPlan) reset(k compactionKey) {
 	job.blocks = job.blocks[:0]
 	job.minT = math.MaxInt64
 	job.maxT = math.MinInt64
+	job.bytes = 0
 }
 
-func (job *jobPlan) tryAdd(block string) bool {
-	t := util.ULIDStringUnixNano(block)
+func (job *jobPlan) tryAdd(entry blockEntry) bool {
+	t := util.ULIDStringUnixNano(entry.id)
 	if len(job.blocks) > 0 && !job.isInAllowedTimeRange(t) {
 		return false
 	}
-	job.blocks = append(job.blocks, block)
+	job.blocks = append(job.blocks, entry.id)
+	job.bytes += entry.size
 	job.maxT = max(job.maxT, t)
 	job.minT = min(job.minT, t)
 	return true
@@ -216,13 +219,18 @@ func (job *jobPlan) isInAllowedTimeRange(t int64) bool {
 }
 
 func (job *jobPlan) isComplete() bool {
-	return uint(len(job.blocks)) >= job.config.maxBlocks(job.level)
+	if uint(len(job.blocks)) >= job.config.maxBlocks(job.level) {
+		return true
+	}
+	maxBytes := job.config.maxBytes(job.level)
+	return maxBytes > 0 && job.bytes >= maxBytes
 }
 
 func (job *jobPlan) finalize() {
 	nameJob(job)
 	job.minT = 0
 	job.maxT = 0
+	job.bytes = 0
 	job.config = nil
 }
 

--- a/pkg/metastore/compaction/compactor/plan_test.go
+++ b/pkg/metastore/compaction/compactor/plan_test.go
@@ -366,6 +366,159 @@ func TestPlan_time_split(t *testing.T) {
 	assert.Equal(t, 15, n)
 }
 
+func TestJobPlan_isComplete(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   Config
+		level    uint32
+		blocks   int
+		bytes    uint64
+		expected bool
+	}{
+		{
+			name:   "below both thresholds",
+			config: Config{Levels: []LevelConfig{{}, {MaxBlocks: 10}}, MaxJobBytes: 100},
+			level:  1, blocks: 3, bytes: 10, expected: false,
+		},
+		{
+			name:   "count threshold reached, bytes below",
+			config: Config{Levels: []LevelConfig{{}, {MaxBlocks: 5}}, MaxJobBytes: 1000},
+			level:  1, blocks: 5, bytes: 10, expected: true,
+		},
+		{
+			name:   "bytes threshold reached, count below",
+			config: Config{Levels: []LevelConfig{{}, {MaxBlocks: 100}}, MaxJobBytes: 100},
+			level:  1, blocks: 2, bytes: 150, expected: true,
+		},
+		{
+			name:   "byte cap disabled at level 0 regardless of MaxJobBytes",
+			config: Config{Levels: []LevelConfig{{MaxBlocks: 100}}, MaxJobBytes: 10},
+			blocks: 1, bytes: 1_000_000, expected: false,
+		},
+		{
+			name:   "byte cap disabled globally when MaxJobBytes is 0",
+			config: Config{Levels: []LevelConfig{{}, {MaxBlocks: 100}}, MaxJobBytes: 0},
+			level:  1, blocks: 1, bytes: 1_000_000, expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := &jobPlan{config: &tt.config, blocks: make([]string, tt.blocks), bytes: tt.bytes}
+			job.level = tt.level
+			require.Equal(t, tt.expected, job.isComplete())
+		})
+	}
+}
+
+// TestPlan_compact_by_size enqueues 4 blocks sharing a compaction key, with
+// MaxBlocks set to the batch size (4) so the whole batch is flushed to the
+// queue atomically (batches only become visible to the planner once
+// flushed - see (*Config).exceedsMaxSize). The byte cap (100) is
+// deliberately reached (at 120 bytes) before the block-count limit (4) is,
+// so completing after 3 blocks is attributable to the byte cap alone, not
+// to MaxBlocks.
+func TestPlan_compact_by_size(t *testing.T) {
+	c := NewCompactor(Config{
+		Levels:      []LevelConfig{{MaxBlocks: 10}, {MaxBlocks: 4}}, // L0 (unused), L1
+		MaxJobBytes: 100,
+	}, nil, nil, nil)
+
+	for _, e := range []compaction.BlockEntry{
+		{Tenant: "A", Shard: 1, Level: 1, Index: 1, ID: "1", Size: 40},
+		{Tenant: "A", Shard: 1, Level: 1, Index: 2, ID: "2", Size: 40},
+		{Tenant: "A", Shard: 1, Level: 1, Index: 3, ID: "3", Size: 40}, // 120 >= 100: completes here.
+		{Tenant: "A", Shard: 1, Level: 1, Index: 4, ID: "4", Size: 10}, // remains in the batch, alone.
+	} {
+		c.enqueue(e)
+	}
+
+	p := &plan{compactor: c, blocks: newBlockIter()}
+	job := p.nextJob()
+	require.NotNil(t, job)
+	assert.Equal(t, []string{"1", "2", "3"}, job.blocks)
+	require.Nil(t, p.nextJob()) // "4" alone hasn't completed the next job yet.
+}
+
+// TestPlan_compact_by_size_oversized_block enqueues 2 blocks (MaxBlocks: 2,
+// so the batch flushes once both have arrived), the first of which alone
+// already exceeds MaxJobBytes. isComplete() must trip immediately after
+// this single block is added (len(blocks) == 1 < MaxBlocks == 2, so this is
+// attributable to the byte cap, not the block count), proving a single
+// oversized block always forms a valid job on its own.
+func TestPlan_compact_by_size_oversized_block(t *testing.T) {
+	c := NewCompactor(Config{
+		Levels:      []LevelConfig{{MaxBlocks: 10}, {MaxBlocks: 2}},
+		MaxJobBytes: 100,
+	}, nil, nil, nil)
+
+	c.enqueue(compaction.BlockEntry{Tenant: "A", Shard: 1, Level: 1, Index: 1, ID: "1", Size: 500})
+	c.enqueue(compaction.BlockEntry{Tenant: "A", Shard: 1, Level: 1, Index: 2, ID: "2", Size: 10})
+
+	p := &plan{compactor: c, blocks: newBlockIter()}
+	job := p.nextJob()
+	require.NotNil(t, job, "a single oversized block must still form a valid job, never a stuck/empty plan")
+	assert.Equal(t, []string{"1"}, job.blocks)
+	require.Nil(t, p.nextJob())
+}
+
+// TestPlan_compact_by_size_excludes_level_zero enqueues 2 L0 blocks
+// (MaxBlocks: 2, so the batch flushes once both arrive) whose combined size
+// vastly exceeds MaxJobBytes. If the byte cap applied at level 0, the job
+// would complete after just the first block (500 >= 10); instead both
+// blocks must be included, proving the byte cap is exempted at level 0.
+func TestPlan_compact_by_size_excludes_level_zero(t *testing.T) {
+	c := NewCompactor(Config{
+		Levels:      []LevelConfig{{MaxBlocks: 2}},
+		MaxJobBytes: 10, // would trip after a single block at any other level.
+	}, nil, nil, nil)
+
+	for _, e := range []compaction.BlockEntry{
+		{Tenant: "A", Shard: 1, Level: 0, Index: 1, ID: "1", Size: 1000},
+		{Tenant: "A", Shard: 1, Level: 0, Index: 2, ID: "2", Size: 1000},
+	} {
+		c.enqueue(e)
+	}
+
+	p := &plan{compactor: c, blocks: newBlockIter()}
+	job := p.nextJob()
+	require.NotNil(t, job)
+	assert.Equal(t, []string{"1", "2"}, job.blocks)
+}
+
+// TestPlan_compact_by_size_mixed_with_legacy_zero_size_block enqueues a
+// Size:0 block (as a queue snapshot restored before size tracking existed
+// would produce, see README.md's "Job Planner" section) alongside sized
+// blocks in the same job. MaxBlocks (6) is kept above the number of blocks
+// needed to trip the byte cap (4), so completion after 4 blocks is
+// attributable to the byte cap, not the block count. The zero-size block
+// must be included in the job like any other block, contributing nothing
+// to the byte accumulator (not causing early completion, and not being
+// skipped or excluded).
+func TestPlan_compact_by_size_mixed_with_legacy_zero_size_block(t *testing.T) {
+	c := NewCompactor(Config{
+		Levels:      []LevelConfig{{MaxBlocks: 10}, {MaxBlocks: 6}}, // L0 (unused), L1
+		MaxJobBytes: 100,
+	}, nil, nil, nil)
+
+	for _, e := range []compaction.BlockEntry{
+		{Tenant: "A", Shard: 1, Level: 1, Index: 1, ID: "1", Size: 0}, // legacy-restored: no recorded size.
+		{Tenant: "A", Shard: 1, Level: 1, Index: 2, ID: "2", Size: 40},
+		{Tenant: "A", Shard: 1, Level: 1, Index: 3, ID: "3", Size: 40},
+		{Tenant: "A", Shard: 1, Level: 1, Index: 4, ID: "4", Size: 40}, // 120 >= 100: completes here (4 < MaxBlocks 6).
+		{Tenant: "A", Shard: 1, Level: 1, Index: 5, ID: "5", Size: 10}, // remains in the batch.
+		{Tenant: "A", Shard: 1, Level: 1, Index: 6, ID: "6", Size: 10}, // flushes the batch (size == MaxBlocks).
+	} {
+		c.enqueue(e)
+	}
+
+	p := &plan{compactor: c, blocks: newBlockIter()}
+	job := p.nextJob()
+	require.NotNil(t, job)
+	assert.Equal(t, []string{"1", "2", "3", "4"}, job.blocks,
+		"the zero-size block is included in the job like any other block")
+	require.Nil(t, p.nextJob(), "the remaining two blocks (20 bytes, 2 < MaxBlocks) haven't completed a job yet")
+}
+
 func TestPlan_remove_staged_batch_corrupts_queue(t *testing.T) {
 	c := NewCompactor(testConfig, nil, nil, nil)
 

--- a/pkg/metastore/compaction/compactor/store/block_queue_store.go
+++ b/pkg/metastore/compaction/compactor/store/block_queue_store.go
@@ -13,7 +13,12 @@ import (
 
 var ErrInvalidBlockEntry = errors.New("invalid block entry")
 
-var blockQueueBucketName = []byte("compaction_block_queue")
+var (
+	blockQueueBucketName = []byte("compaction_block_queue")
+	// Block sizes are stored separately, keyed identically to the block
+	// entries; an entry without a size record loads with Size 0.
+	blockQueueSizeBucketName = []byte("compaction_block_queue_size")
+)
 
 // BlockQueueStore provides methods to store and retrieve block queues.
 // The store is optimized for two cases: load the entire queue (preserving
@@ -26,45 +31,66 @@ var blockQueueBucketName = []byte("compaction_block_queue")
 // always ordered in ascending order by index and use the same cursor when
 // removing entries from the database:
 // DeleteEntry(*bbolt.Tx, ...store.BlockEntry) error
-type BlockQueueStore struct{ bucketName []byte }
+type BlockQueueStore struct {
+	bucketName     []byte
+	sizeBucketName []byte
+}
 
 func NewBlockQueueStore() *BlockQueueStore {
-	return &BlockQueueStore{bucketName: blockQueueBucketName}
+	return &BlockQueueStore{
+		bucketName:     blockQueueBucketName,
+		sizeBucketName: blockQueueSizeBucketName,
+	}
 }
 
 func (s BlockQueueStore) CreateBuckets(tx *bbolt.Tx) error {
-	_, err := tx.CreateBucketIfNotExists(s.bucketName)
+	if _, err := tx.CreateBucketIfNotExists(s.bucketName); err != nil {
+		return err
+	}
+	_, err := tx.CreateBucketIfNotExists(s.sizeBucketName)
 	return err
 }
 
 func (s BlockQueueStore) StoreEntry(tx *bbolt.Tx, entry compaction.BlockEntry) error {
 	e := marshalBlockEntry(entry)
-	return tx.Bucket(s.bucketName).Put(e.Key, e.Value)
+	if err := tx.Bucket(s.bucketName).Put(e.Key, e.Value); err != nil {
+		return err
+	}
+	return tx.Bucket(s.sizeBucketName).Put(e.Key, marshalBlockEntrySize(entry.Size))
 }
 
 func (s BlockQueueStore) DeleteEntry(tx *bbolt.Tx, index uint64, id string) error {
-	return tx.Bucket(s.bucketName).Delete(marshalBlockEntryKey(index, id))
+	k := marshalBlockEntryKey(index, id)
+	if err := tx.Bucket(s.bucketName).Delete(k); err != nil {
+		return err
+	}
+	return tx.Bucket(s.sizeBucketName).Delete(k)
 }
 
 func (s BlockQueueStore) ListEntries(tx *bbolt.Tx) iter.Iterator[compaction.BlockEntry] {
-	return newBlockEntriesIterator(tx.Bucket(s.bucketName))
+	return newBlockEntriesIterator(tx.Bucket(s.bucketName), tx.Bucket(s.sizeBucketName))
 }
 
 type blockEntriesIterator struct {
-	iter *store.CursorIterator
-	cur  compaction.BlockEntry
-	err  error
+	iter  *store.CursorIterator
+	sizes *bbolt.Bucket
+	cur   compaction.BlockEntry
+	err   error
 }
 
-func newBlockEntriesIterator(bucket *bbolt.Bucket) *blockEntriesIterator {
-	return &blockEntriesIterator{iter: store.NewCursorIter(bucket.Cursor())}
+func newBlockEntriesIterator(bucket, sizes *bbolt.Bucket) *blockEntriesIterator {
+	return &blockEntriesIterator{iter: store.NewCursorIter(bucket.Cursor()), sizes: sizes}
 }
 
 func (x *blockEntriesIterator) Next() bool {
 	if x.err != nil || !x.iter.Next() {
 		return false
 	}
-	x.err = unmarshalBlockEntry(&x.cur, x.iter.At())
+	kv := x.iter.At()
+	if x.err = unmarshalBlockEntry(&x.cur, kv); x.err != nil {
+		return false
+	}
+	x.cur.Size, x.err = unmarshalBlockEntrySize(x.sizes, kv.Key)
 	return x.err == nil
 }
 
@@ -107,4 +133,30 @@ func unmarshalBlockEntry(dst *compaction.BlockEntry, e store.KV) error {
 	dst.Shard = binary.BigEndian.Uint32(e.Value[12:16])
 	dst.Tenant = string(e.Value[16:])
 	return nil
+}
+
+// blockEntrySizeValueLen is the fixed length of a size bucket value: an
+// 8-byte big-endian Size.
+const blockEntrySizeValueLen = 8
+
+func marshalBlockEntrySize(size uint64) []byte {
+	b := make([]byte, blockEntrySizeValueLen)
+	binary.BigEndian.PutUint64(b, size)
+	return b
+}
+
+// unmarshalBlockEntrySize decodes the size bucket value for key;
+// a missing record loads as size 0.
+func unmarshalBlockEntrySize(sizes *bbolt.Bucket, key []byte) (uint64, error) {
+	if sizes == nil {
+		return 0, nil
+	}
+	v := sizes.Get(key)
+	if v == nil {
+		return 0, nil
+	}
+	if len(v) != blockEntrySizeValueLen {
+		return 0, ErrInvalidBlockEntry
+	}
+	return binary.BigEndian.Uint64(v), nil
 }

--- a/pkg/metastore/compaction/compactor/store/block_queue_store_test.go
+++ b/pkg/metastore/compaction/compactor/store/block_queue_store_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"encoding/binary"
 	"strconv"
 	"testing"
 	"time"
@@ -29,6 +30,7 @@ func TestBlockQueueStore_StoreEntry(t *testing.T) {
 			Level:      uint32(i % 3),
 			Shard:      uint32(i % 8),
 			Tenant:     strconv.Itoa(i % 4),
+			Size:       uint64(i) * 997,
 		}
 	}
 	for i := range entries {
@@ -68,6 +70,7 @@ func TestBlockQueueStore_DeleteEntry(t *testing.T) {
 			Level:      uint32(i % 3),
 			Shard:      uint32(i % 8),
 			Tenant:     strconv.Itoa(i % 4),
+			Size:       uint64(i) * 997,
 		}
 	}
 	for i := range entries {
@@ -100,5 +103,147 @@ func TestBlockQueueStore_DeleteEntry(t *testing.T) {
 	}
 	assert.Nil(t, iter.Err())
 	assert.Nil(t, iter.Close())
+	require.NoError(t, tx.Rollback())
+}
+
+func TestBlockQueueStore_DecodeLegacyFormat(t *testing.T) {
+	db := test.BoltDB(t)
+	s := NewBlockQueueStore()
+	tx, err := db.Begin(true)
+	require.NoError(t, err)
+	require.NoError(t, s.CreateBuckets(tx))
+
+	// Hand-construct an entry exactly as the pre-Size marshalBlockEntry produced it:
+	// Key = [Index:8][ID], Value = [AppendedAt:8][Level:4][Shard:4][Tenant].
+	const (
+		index      = uint64(42)
+		id         = "01J000000000000000000LEGACY"
+		appendedAt = int64(1_700_000_000_000_000_000) // a realistic wall-clock nanosecond timestamp
+		level      = uint32(2)
+		shard      = uint32(7)
+		tenant     = "legacy-tenant"
+	)
+	key := make([]byte, 8+len(id))
+	binary.BigEndian.PutUint64(key, index)
+	copy(key[8:], id)
+
+	value := make([]byte, 8+4+4+len(tenant))
+	binary.BigEndian.PutUint64(value[0:8], uint64(appendedAt))
+	binary.BigEndian.PutUint32(value[8:12], level)
+	binary.BigEndian.PutUint32(value[12:16], shard)
+	copy(value[16:], tenant)
+
+	require.NoError(t, tx.Bucket(blockQueueBucketName).Put(key, value))
+	require.NoError(t, tx.Commit())
+
+	tx, err = db.Begin(false)
+	require.NoError(t, err)
+
+	it := s.ListEntries(tx)
+	require.True(t, it.Next())
+	entry := it.At()
+	assert.Equal(t, index, entry.Index)
+	assert.Equal(t, id, entry.ID)
+	assert.Equal(t, appendedAt, entry.AppendedAt)
+	assert.Equal(t, level, entry.Level)
+	assert.Equal(t, shard, entry.Shard)
+	assert.Equal(t, tenant, entry.Tenant)
+	assert.Equal(t, uint64(0), entry.Size) // fallback: legacy entries carry no size data.
+	assert.False(t, it.Next())
+	require.NoError(t, it.Err())
+	require.NoError(t, tx.Rollback())
+}
+
+// TestBlockQueueStore_ListEntries_MissingSizeRecord verifies that ListEntries
+// joins the main bucket against the size bucket by key, and falls back to
+// Size == 0 for an entry whose size record is missing - the same situation a
+// downgrade-then-reupgrade, or a pre-Size-tracking legacy entry, produces -
+// without affecting the Size of any other, unrelated entry.
+func TestBlockQueueStore_ListEntries_MissingSizeRecord(t *testing.T) {
+	db := test.BoltDB(t)
+	s := NewBlockQueueStore()
+	tx, err := db.Begin(true)
+	require.NoError(t, err)
+	require.NoError(t, s.CreateBuckets(tx))
+
+	entries := []compaction.BlockEntry{
+		{Index: 1, ID: "block-1", Tenant: "A", Level: 1, Shard: 0, Size: 111},
+		{Index: 2, ID: "block-2", Tenant: "A", Level: 1, Shard: 0, Size: 222},
+	}
+	for _, e := range entries {
+		require.NoError(t, s.StoreEntry(tx, e))
+	}
+	// Simulate a missing size record for the first entry (e.g., one
+	// written by a binary that never wrote to the size bucket) by
+	// deleting only its size record directly, leaving the main entry
+	// intact.
+	require.NoError(t, tx.Bucket(blockQueueSizeBucketName).Delete(marshalBlockEntryKey(1, "block-1")))
+	require.NoError(t, tx.Commit())
+
+	tx, err = db.Begin(false)
+	require.NoError(t, err)
+	it := s.ListEntries(tx)
+
+	require.True(t, it.Next())
+	first := it.At()
+	assert.Equal(t, "block-1", first.ID)
+	assert.Equal(t, uint64(0), first.Size, "missing size record falls back to 0")
+
+	require.True(t, it.Next())
+	second := it.At()
+	assert.Equal(t, "block-2", second.ID)
+	assert.Equal(t, uint64(222), second.Size, "unrelated entry's size is unaffected")
+
+	require.False(t, it.Next())
+	require.NoError(t, it.Err())
+	require.NoError(t, tx.Rollback())
+}
+
+// TestBlockQueueStore_DeleteEntry_RemovesSizeRecord verifies DeleteEntry
+// removes the size record symmetrically with the main entry, so deleted
+// entries never accumulate as orphaned records in the size bucket.
+func TestBlockQueueStore_DeleteEntry_RemovesSizeRecord(t *testing.T) {
+	db := test.BoltDB(t)
+	s := NewBlockQueueStore()
+	tx, err := db.Begin(true)
+	require.NoError(t, err)
+	require.NoError(t, s.CreateBuckets(tx))
+
+	entry := compaction.BlockEntry{Index: 1, ID: "block-1", Tenant: "A", Level: 1, Shard: 0, Size: 555}
+	require.NoError(t, s.StoreEntry(tx, entry))
+	require.NoError(t, tx.Commit())
+
+	tx, err = db.Begin(true)
+	require.NoError(t, err)
+	key := marshalBlockEntryKey(entry.Index, entry.ID)
+	require.NotNil(t, tx.Bucket(blockQueueSizeBucketName).Get(key), "size record should exist before delete")
+
+	require.NoError(t, s.DeleteEntry(tx, entry.Index, entry.ID))
+	assert.Nil(t, tx.Bucket(blockQueueBucketName).Get(key), "main entry should be gone")
+	assert.Nil(t, tx.Bucket(blockQueueSizeBucketName).Get(key), "size record should be gone too, not orphaned")
+	require.NoError(t, tx.Commit())
+}
+
+func TestBlockQueueStore_EmptyTenant(t *testing.T) {
+	db := test.BoltDB(t)
+	s := NewBlockQueueStore()
+	tx, err := db.Begin(true)
+	require.NoError(t, err)
+	require.NoError(t, s.CreateBuckets(tx))
+
+	entry := compaction.BlockEntry{
+		Index: 1, ID: "block-1", AppendedAt: time.Now().UnixNano(),
+		Level: 1, Shard: 0, Tenant: "", Size: 9999,
+	}
+	require.NoError(t, s.StoreEntry(tx, entry))
+	require.NoError(t, tx.Commit())
+
+	tx, err = db.Begin(false)
+	require.NoError(t, err)
+
+	it := s.ListEntries(tx)
+	require.True(t, it.Next())
+	require.Equal(t, entry, it.At())
+	require.False(t, it.Next())
 	require.NoError(t, tx.Rollback())
 }


### PR DESCRIPTION
## What

Compaction job planning previously used a fixed block-count limit per level as the sole completion criterion. This PR adds a second, independent completion criterion: accumulated input size in bytes. A job now completes once either the block count limit **or** the new byte limit is reached, whichever happens first.

- New flag `-metastore.compaction-max-job-bytes` (config key `compaction_max_job_bytes`), default 2GiB. Applies to levels 1 and above only; level 0 is exempt (level-0 blocks are segment-writer flush outputs, already small and tightly bounded by the block-count limit alone). A value of 0 disables the size-based limit entirely.
- Block size is not re-estimated at planning time — it uses the exact on-disk size recorded in `BlockMeta.Size` at block creation (segment flush or a prior compaction).
- A single block that is already larger than the configured byte limit still forms a valid, single-block job; oversized blocks are never excluded and the planner never gets stuck.
- Sizes are persisted in a new, parallel bbolt bucket (`compaction_block_queue_size`), keyed identically to the existing block-queue bucket. The existing bucket's entry format is completely unchanged.

## Why

Compaction workers process a job's input blocks in memory, and worker memory usage scales with total job input size, not block count. A recent production incident saw a 10-block, ~2.8GiB level-2 compaction job cause a compaction worker to require more than 32GiB of memory — nearly 12x the sum of its input blocks' on-disk sizes. As per-block sizes grow (e.g., high-cardinality tenants, larger segment flush intervals), a fixed block-count limit no longer bounds worker memory, and workers OOM.

Bounding job size directly by accumulated input bytes closes this gap while leaving the block-count limit in place as a floor (so small numbers of oversized blocks are still forced into a job promptly, and level 0 keeps its existing behavior unchanged).

### Upgrade / downgrade compatibility

Keeping size in a separate bucket, rather than extending the existing entry's encoded value, means the change is safe in both directions:

- **Upgrade** (pre-existing queue data, new binary): the main bucket decodes exactly as before. Entries have no corresponding record in the new size bucket, so they fall back to `Size == 0` and behave under the pre-existing count-only planning logic until they are compacted or replaced.
- **Downgrade** (queue data written by the new binary, old binary running): an old binary addresses bbolt buckets purely by name and never enumerates or rejects unknown buckets (true both at normal startup and at Raft snapshot restore, which is a byte-for-byte copy of the whole database file), so it simply never touches the size bucket. The main bucket it does read is in the unchanged pre-existing format, so it decodes correctly.

`StoreEntry`/`DeleteEntry` keep both buckets in sync during normal operation. The only caveat: if an old binary runs for a while after a downgrade (deleting entries without knowing about the size bucket) and is later upgraded again, the deleted entries' size records are left behind as harmless orphans (a stale record is indistinguishable from one never written, since Index/ID keys are never reused). This only happens across an actual downgrade window; the two buckets never diverge during normal operation.

## Testing

- Unit tests, race detector, lint, and the full test suite all pass.
- New test coverage added for:
  - Byte-cap completion scenarios, including a single block already larger than the configured limit forming its own job.
  - Level-0 exemption from the byte-based limit.
  - Mixed legacy (zero-size) and new (sized) entries within the same job/queue.
  - Store-level round-trip of the size bucket, decoding of legacy entries with no size record, and symmetric delete behavior between the main and size buckets.

## Follow-ups (deliberately deferred)

- Per-level byte-limit tuning (currently one global `MaxJobBytes` value applied uniformly across levels >= 1).
- Metrics exposing queue byte totals (currently only block counts are exported).
