### PR TITLE
fix(deps): bump tar, js-yaml, brace-expansion in /ui [security]

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -46,7 +46,9 @@
     "node": ">=24"
   },
   "resolutions": {
-    "brace-expansion@npm:^1.1.7": "npm:1.1.13",
-    "brace-expansion@npm:^5.0.2": "npm:5.0.6"
+    "brace-expansion@npm:^1.1.7": "npm:1.1.16",
+    "brace-expansion@npm:^5.0.2": "npm:5.0.7",
+    "js-yaml@npm:^4.1.1": "npm:4.3.0",
+    "tar@npm:^7.5.4": "npm:7.5.21"
   }
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -986,22 +986,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:1.1.13":
-  version: 1.1.13
-  resolution: "brace-expansion@npm:1.1.13"
+"brace-expansion@npm:1.1.16":
+  version: 1.1.16
+  resolution: "brace-expansion@npm:1.1.16"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/384c61bb329b6adfdcc0cbbdd108dc19fb5f3e84ae15a02a74f94c6c791b5a9b035aae73b2a51929a8a478e2f0f212a771eb6a8b5b514cccfb8d0c9f2ce8cbd8
+  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:5.0.6":
-  version: 5.0.6
-  resolution: "brace-expansion@npm:5.0.6"
+"brace-expansion@npm:5.0.7":
+  version: 5.0.7
+  resolution: "brace-expansion@npm:5.0.7"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
+  checksum: 10c0/4769109c3c082de178e449a371bcad50d51ab468f644bce2dd9188efe0cf0a080ed102105d7fc8577382cedc45bad7e6443a91bf3d8102264ee8cf927dbaf205
   languageName: node
   linkType: hard
 
@@ -1723,14 +1723,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.1":
-  version: 4.2.0
-  resolution: "js-yaml@npm:4.2.0"
+"js-yaml@npm:4.3.0":
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/1916456c118746603b067d74bbcbb0445d9a1d5e474ad4ae775e7b20525bed902e01d9d97dd0c81fcd8d4f596162309d0eb057f4aa38f3e9647f14075e9dea45
+  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
   languageName: node
   linkType: hard
 
@@ -2468,16 +2468,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.5.4":
-  version: 7.5.16
-  resolution: "tar@npm:7.5.16"
+"tar@npm:7.5.21":
+  version: 7.5.21
+  resolution: "tar@npm:7.5.21"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/4f37f3c4bd2ca2755fd736a5df1d573c1a868ec1b1e893346aeafa95ac510f9e2fd1469420bd866cc7904799e5bd4ac62b5d4f03fe27747d6e1e373b44505c5c
+  checksum: 10c0/bce0e51692356078e6f6a909d5c93f5b4c099c097ffea19b1b1bf10385539a429baba26bca59aabbace68c4519d16f2f1c07afe7eaab55876a449a032480fabc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What this PR does

Bumps vulnerable transitive dependencies in `ui/` via `resolutions` in `ui/package.json`:

- `tar` 7.5.16 -> 7.5.21
  - CVE-2026-59874 (infinite loop via negative entry size, fixed in 7.5.18)
  - CVE-2026-59873 (gzip bomb DoS, fixed in 7.5.19)
  - CVE-2026-59871 (crash via invalid path-to-number conversion, fixed in 7.5.18)
  - CVE-2026-59875 (crash via NUL bytes in metadata, fixed in 7.5.17)
- `js-yaml` 4.2.0 -> 4.3.0 (CVE-2026-59869, DoS via crafted YAML documents)
- `brace-expansion` 1.1.13 -> 1.1.16 and 5.0.6 -> 5.0.7 (CVE-2026-13149, exponential-time complexity DoS)

All three are dev-only transitive dependencies (`tar` via `node-gyp`, `js-yaml` via `@eslint/eslintrc`, `brace-expansion` via `minimatch`), not direct runtime dependencies of the UI bundle.
