### PR TITLE
examples: enable Python memory profiling

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -432,9 +432,7 @@ func labelValue(labels []labelPair, name string) string {
 	return ""
 }
 
-// seriesData maps a service name to its ingested CPU/wall profile types. Those
-// are the types span profiles are attached to; other types (memory, lock, etc.)
-// are not useful for these checks and are dropped.
+// seriesData maps a service name to its ingested profile types.
 type seriesData map[string][]string
 
 func sortedKeys(d seriesData) []string {
@@ -456,10 +454,27 @@ func isCPUOrWallType(profileType string) bool {
 	return strings.HasPrefix(profileType, "process_cpu:") || strings.HasPrefix(profileType, "wall:")
 }
 
-// discoverSeries queries the Series API and returns the application services and
-// their ingested CPU/wall profile types. Self-profiling series and non-CPU/wall
-// types are excluded.
-func (e *env) discoverSeries(ctx context.Context, host string) (seriesData, error) {
+var pythonMemoryProfileTypes = []string{
+	"memory:alloc_objects:count:space:bytes",
+	"memory:alloc_space:bytes:space:bytes",
+	"memory:inuse_objects:count:space:bytes",
+	"memory:inuse_space:bytes:space:bytes",
+}
+
+func (e *env) requiresPythonMemoryProfiles() bool {
+	dir := e.repoDir()
+	return dir == filepath.Join("examples", "tracing", "python") ||
+		strings.HasPrefix(dir, filepath.Join("examples", "language-sdk-instrumentation", "python")+string(filepath.Separator))
+}
+
+func includeAllProfileTypes(string) bool {
+	return true
+}
+
+// discoverSeries queries the Series API and returns the application services
+// and profile types accepted by includeProfileType. Self-profiling series are
+// excluded.
+func (e *env) discoverSeries(ctx context.Context, host string, includeProfileType func(string) bool) (seriesData, error) {
 	start, end := nowWindowMillis()
 	var resp seriesResponse
 	err := e.pyroscopePost(ctx, host, "querier.v1.QuerierService/Series", map[string]any{
@@ -475,13 +490,13 @@ func (e *env) discoverSeries(ctx context.Context, host string) (seriesData, erro
 	for _, ls := range resp.LabelsSet {
 		svc := labelValue(ls.Labels, "service_name")
 		pt := labelValue(ls.Labels, "__profile_type__")
-		if svc == "" || svc == selfProfilingService || !isCPUOrWallType(pt) {
+		if svc == "" || svc == selfProfilingService || !includeProfileType(pt) {
 			continue
 		}
 		data[svc] = append(data[svc], pt)
 	}
 	if len(data) == 0 {
-		return nil, errors.New("no CPU or wall profile series ingested yet")
+		return nil, errors.New("no matching profile series ingested yet")
 	}
 	return data, nil
 }
@@ -811,6 +826,28 @@ func TestCompletedSuccessfullyServices(t *testing.T) {
 	require.Equal(t, map[string]struct{}{"migrate": {}}, completedSuccessfullyServices(services))
 }
 
+func TestRequiresPythonMemoryProfiles(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		dir  string
+		want bool
+	}{
+		{dir: "language-sdk-instrumentation/python/simple", want: true},
+		{dir: "language-sdk-instrumentation/python/rideshare/flask", want: true},
+		{dir: "tracing/python", want: true},
+		{dir: "language-sdk-instrumentation/golang-push/simple", want: false},
+		{dir: "tracing/golang-push", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.dir, func(t *testing.T) {
+			e := &env{dir: tt.dir}
+			require.Equal(t, tt.want, e.requiresPythonMemoryProfiles())
+		})
+	}
+}
+
 // TestExamples brings each selected example up once and verifies it: profiles
 // are always checked (Series + SelectSeries); tracing examples additionally get
 // the trace-to-profile link checked (SelectMergeSpanProfile).
@@ -857,26 +894,63 @@ func TestExamples(t *testing.T) {
 func (e *env) checkProfilesQueryable(t *testing.T, ctx context.Context, host string) {
 	dir := e.repoDir()
 	var summary string
+	requiredTypes := map[string]struct{}{}
+	if e.requiresPythonMemoryProfiles() {
+		for _, profileType := range pythonMemoryProfileTypes {
+			requiredTypes[profileType] = struct{}{}
+		}
+	}
 	poll(t, ctx, profilesQueryTimeout, func(progress func(string, ...any)) error {
 		progress("[%s] querying Series for ingested profiles...", dir)
-		data, err := e.discoverSeries(ctx, host)
+		data, err := e.discoverSeries(ctx, host, includeAllProfileTypes)
 		if err != nil {
 			return err
 		}
 		progress("[%s] Series found %d service(s): %s; querying SelectSeries...", dir, len(data), strings.Join(sortedKeys(data), ", "))
+		foundTypes := map[string]string{}
 		for svc, types := range data {
 			for _, pt := range types {
+				if len(requiredTypes) > 0 {
+					if _, required := requiredTypes[pt]; !required {
+						continue
+					}
+				}
 				nSeries, nPoints, err := e.selectSeries(ctx, host, svc, pt)
 				if err != nil {
 					return err
 				}
 				if nPoints > 0 {
-					summary = fmt.Sprintf("service=%q profileType=%q -> %d series, %d points (%d service(s) ingesting)",
-						svc, pt, nSeries, nPoints, len(data))
-					return nil
+					foundTypes[pt] = fmt.Sprintf("service=%q profileType=%q -> %d series, %d points",
+						svc, pt, nSeries, nPoints)
+					if len(requiredTypes) == 0 {
+						summary = foundTypes[pt]
+						return nil
+					}
+					continue
 				}
 				progress("[%s] SelectSeries service=%q type=%q -> 0 points (waiting for data)", dir, svc, pt)
 			}
+		}
+
+		var missing []string
+		var found []string
+		for _, profileType := range pythonMemoryProfileTypes {
+			if _, required := requiredTypes[profileType]; !required {
+				continue
+			}
+			detail, ok := foundTypes[profileType]
+			if !ok {
+				missing = append(missing, profileType)
+				continue
+			}
+			found = append(found, detail)
+		}
+		if len(missing) > 0 {
+			return fmt.Errorf("memory profile types have no data points yet: %s", strings.Join(missing, ", "))
+		}
+		if len(requiredTypes) > 0 {
+			summary = strings.Join(found, "; ")
+			return nil
 		}
 		return fmt.Errorf("no data points for any of %d discovered series yet", len(data))
 	})
@@ -891,7 +965,7 @@ func (e *env) checkSpanProfilesQueryable(t *testing.T, ctx context.Context, pyro
 	var summary string
 	poll(t, ctx, tracesQueryTimeout, func(progress func(string, ...any)) error {
 		progress("[%s] querying Series for ingested profiles...", dir)
-		data, err := e.discoverSeries(ctx, pyroHost)
+		data, err := e.discoverSeries(ctx, pyroHost, isCPUOrWallType)
 		if err != nil {
 			return err
 		}

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -894,51 +894,62 @@ func TestExamples(t *testing.T) {
 func (e *env) checkProfilesQueryable(t *testing.T, ctx context.Context, host string) {
 	dir := e.repoDir()
 	var summary string
-	requiredTypes := map[string]struct{}{}
-	if e.requiresPythonMemoryProfiles() {
+	requireMemoryProfiles := e.requiresPythonMemoryProfiles()
+	requiredMemoryTypes := map[string]struct{}{}
+	if requireMemoryProfiles {
 		for _, profileType := range pythonMemoryProfileTypes {
-			requiredTypes[profileType] = struct{}{}
+			requiredMemoryTypes[profileType] = struct{}{}
 		}
 	}
 	poll(t, ctx, profilesQueryTimeout, func(progress func(string, ...any)) error {
 		progress("[%s] querying Series for ingested profiles...", dir)
-		data, err := e.discoverSeries(ctx, host, includeAllProfileTypes)
+		includeProfileType := isCPUOrWallType
+		if requireMemoryProfiles {
+			includeProfileType = includeAllProfileTypes
+		}
+		data, err := e.discoverSeries(ctx, host, includeProfileType)
 		if err != nil {
 			return err
 		}
 		progress("[%s] Series found %d service(s): %s; querying SelectSeries...", dir, len(data), strings.Join(sortedKeys(data), ", "))
-		foundTypes := map[string]string{}
+		var cpuOrWallSummary string
+		foundMemoryTypes := map[string]string{}
 		for svc, types := range data {
 			for _, pt := range types {
-				if len(requiredTypes) > 0 {
-					if _, required := requiredTypes[pt]; !required {
-						continue
-					}
+				_, requiredMemoryType := requiredMemoryTypes[pt]
+				if !isCPUOrWallType(pt) && !requiredMemoryType {
+					continue
 				}
 				nSeries, nPoints, err := e.selectSeries(ctx, host, svc, pt)
 				if err != nil {
 					return err
 				}
 				if nPoints > 0 {
-					foundTypes[pt] = fmt.Sprintf("service=%q profileType=%q -> %d series, %d points",
+					detail := fmt.Sprintf("service=%q profileType=%q -> %d series, %d points",
 						svc, pt, nSeries, nPoints)
-					if len(requiredTypes) == 0 {
-						summary = foundTypes[pt]
-						return nil
+					if isCPUOrWallType(pt) {
+						cpuOrWallSummary = detail
+						continue
 					}
+					foundMemoryTypes[pt] = detail
 					continue
 				}
 				progress("[%s] SelectSeries service=%q type=%q -> 0 points (waiting for data)", dir, svc, pt)
 			}
 		}
 
+		if cpuOrWallSummary == "" {
+			return errors.New("no CPU or wall profile data points yet")
+		}
+		if !requireMemoryProfiles {
+			summary = cpuOrWallSummary
+			return nil
+		}
+
 		var missing []string
-		var found []string
+		found := []string{cpuOrWallSummary}
 		for _, profileType := range pythonMemoryProfileTypes {
-			if _, required := requiredTypes[profileType]; !required {
-				continue
-			}
-			detail, ok := foundTypes[profileType]
+			detail, ok := foundMemoryTypes[profileType]
 			if !ok {
 				missing = append(missing, profileType)
 				continue
@@ -948,11 +959,8 @@ func (e *env) checkProfilesQueryable(t *testing.T, ctx context.Context, host str
 		if len(missing) > 0 {
 			return fmt.Errorf("memory profile types have no data points yet: %s", strings.Join(missing, ", "))
 		}
-		if len(requiredTypes) > 0 {
-			summary = strings.Join(found, "; ")
-			return nil
-		}
-		return fmt.Errorf("no data points for any of %d discovered series yet", len(data))
+		summary = strings.Join(found, "; ")
+		return nil
 	})
 	t.Logf("[%s] PASS profiles queryable via Series+SelectSeries: %s", dir, summary)
 }

--- a/examples/language-sdk-instrumentation/python/README.md
+++ b/examples/language-sdk-instrumentation/python/README.md
@@ -45,11 +45,17 @@ Tagging something static, like the `region`, can be done in the initialization c
 pyroscope.configure(
     application_name       = "ride-sharing-app",
     server_address         = "http://pyroscope:4040",
+    mem_enabled            = True,
     tags                   = {
         "region":   f'{os.getenv("REGION")}', # Tags the region based off the environment variable
     }
 )
 ```
+
+Memory profiling runs alongside CPU profiling and emits allocated objects,
+allocated space, objects in use, and space in use profiles. The rideshare
+workload retains a bounded rotating window of allocations so both cumulative
+and live-memory profiles contain useful data.
 
 ## Tagging dynamically within functions
 
@@ -134,4 +140,4 @@ We have been beta testing this feature with several different companies and some
 
 We would love for you to try out this example and see what ways you can adapt this to your python application. Continuous profiling has become an increasingly popular tool for the monitoring and debugging of performance issues (arguably the fourth pillar of observability).
 
-We'd love to continue to improve this pip package by adding things like integrations with popular tools, memory profiling, etc. and we would love to hear what features _you would like to see_.
+We'd love to continue to improve this pip package with integrations for popular tools, and we would love to hear what features _you would like to see_.

--- a/examples/language-sdk-instrumentation/python/README_zh.md
+++ b/examples/language-sdk-instrumentation/python/README_zh.md
@@ -26,13 +26,16 @@ Pyroscope最有用的功能之一是能够以对你有意义的方式来标记�
 标记一些静态的东西，如`reigon`，可以在初始化代码中的`config.tags`变量中完成:
 ```
 pyroscope.configure(
-    app_name       = "ride-sharing-app",
-    server_address = "http://pyroscope:4040",
-    tags           = {
+    application_name = "ride-sharing-app",
+    server_address   = "http://pyroscope:4040",
+    mem_enabled      = True,
+    tags             = {
         "region":   f'{os.getenv("REGION")}', # 根据环境变量标记该区域
     }
 )
 ```
+
+内存分析与 CPU 分析同时运行，并生成累计分配对象、累计分配空间、当前使用对象和当前使用空间四种分析数据。示例会保留一个有上限的滚动分配窗口，从而生成有意义的累计和实时内存分析数据，而不会无限增加内存使用量。
 
 ## 在函数中动态地添加标签
 像我们对 `vehicle` 标签所做的那样，可以在我们的实用程序 `find_nearest_vehicle()` 函数中使用 `with pyroscope.tag_wrapper()` 上下文区块来完成更动态的标记
@@ -107,4 +110,4 @@ docker-compose up --build
 ### 未来路线图
 我们希望你能尝试一下这个例子，看看你能用什么方式来适配你的 python 应用。持续剖析已经成为监测和调试性能问题的一个越来越流行的工具（可以说是可观察性的第四个支柱）。
 
-我们希望通过增加与流行工具的集成、内存分析等内容来继续改进这个pip包，我们很想听听 _你希望看到的功能_。
+我们希望通过增加与流行工具的集成来继续改进这个pip包，我们很想听听 _你希望看到的功能_。

--- a/examples/language-sdk-instrumentation/python/rideshare/django/README.md
+++ b/examples/language-sdk-instrumentation/python/rideshare/django/README.md
@@ -20,4 +20,13 @@ docker compose up --build
 docker compose down
 ```
 
-Navigate to [Grafana](http://localhost:3000/a/grafana-pyroscope-app/explore?explorationType=flame-graph&var-serviceName=ride-sharing-app&var-profileMetricId=process_cpu:cpu:nanoseconds:cpu:nanoseconds) to explore profiles.
+Navigate to Grafana to explore the generated profiles:
+
+- [CPU](http://localhost:3000/a/grafana-pyroscope-app/explore?explorationType=flame-graph&var-serviceName=ride-sharing-app&var-profileMetricId=process_cpu:cpu:nanoseconds:cpu:nanoseconds)
+- [Allocated space](http://localhost:3000/a/grafana-pyroscope-app/explore?explorationType=flame-graph&var-serviceName=ride-sharing-app&var-profileMetricId=memory:alloc_space:bytes:space:bytes)
+- [Space in use](http://localhost:3000/a/grafana-pyroscope-app/explore?explorationType=flame-graph&var-serviceName=ride-sharing-app&var-profileMetricId=memory:inuse_space:bytes:space:bytes)
+
+The rideshare workload retains a bounded window of allocations. Filter by the
+`vehicle` label to compare memory behavior across the bike, scooter, and car
+endpoints. Memory profiling remains initialized in the `post_fork` hook so each
+Gunicorn worker owns its profiler state.

--- a/examples/language-sdk-instrumentation/python/rideshare/django/app/gunicorn.conf.py
+++ b/examples/language-sdk-instrumentation/python/rideshare/django/app/gunicorn.conf.py
@@ -18,6 +18,7 @@ def post_fork(server, worker):
         server_address=os.getenv("PYROSCOPE_SERVER_ADDRESS", "http://pyroscope:4040"),
         basic_auth_username=os.getenv("PYROSCOPE_BASIC_AUTH_USER", ""),
         basic_auth_password=os.getenv("PYROSCOPE_BASIC_AUTH_PASSWORD", ""),
+        mem_enabled=True,
         tags={
             "region": os.getenv("REGION", ""),
         },

--- a/examples/language-sdk-instrumentation/python/rideshare/django/app/requirements.txt
+++ b/examples/language-sdk-instrumentation/python/rideshare/django/app/requirements.txt
@@ -6,7 +6,7 @@ gunicorn==23.0.0
 psycopg==3.2.9
 psycopg-binary==3.2.9
 pycparser==3.0
-pyroscope-io==1.0.5
+pyroscope-io==1.2.0
 setuptools==82.0.1
 sqlparse==0.5.5
 typing_extensions==4.15.0

--- a/examples/language-sdk-instrumentation/python/rideshare/django/app/ride_share/utility/utility.py
+++ b/examples/language-sdk-instrumentation/python/rideshare/django/app/ride_share/utility/utility.py
@@ -3,6 +3,17 @@ import pyroscope
 import os
 from datetime import datetime
 
+ALLOCATION_SIZE = 64 * 1024
+MAX_RETAINED_ALLOCATIONS = 256
+RETAINED_ALLOCATIONS_AFTER_TRIM = 128
+ALLOCATION_CHUNKS_BY_VEHICLE = {
+    "bike": 1,
+    "scooter": 2,
+    "car": 4,
+}
+retained_allocations = []
+
+
 def mutex_lock(n):
     i = 0
     start_time = time.time()
@@ -24,6 +35,13 @@ def check_driver_availability(n):
         mutex_lock(n)
 
 
+def allocate_vehicle_memory(vehicle):
+    for _ in range(ALLOCATION_CHUNKS_BY_VEHICLE[vehicle]):
+        retained_allocations.append(bytearray(ALLOCATION_SIZE))
+    if len(retained_allocations) >= MAX_RETAINED_ALLOCATIONS:
+        del retained_allocations[:-RETAINED_ALLOCATIONS_AFTER_TRIM]
+
+
 def find_nearest_vehicle(n, vehicle):
     print(f"finding nearest {vehicle}")
     with pyroscope.tag_wrapper({ "vehicle": vehicle}):
@@ -31,5 +49,6 @@ def find_nearest_vehicle(n, vehicle):
         start_time = time.time()
         while time.time() - start_time < n:
             i += 1
+        allocate_vehicle_memory(vehicle)
         if vehicle == "car":
             check_driver_availability(n)

--- a/examples/language-sdk-instrumentation/python/rideshare/fastapi/README.md
+++ b/examples/language-sdk-instrumentation/python/rideshare/fastapi/README.md
@@ -13,4 +13,12 @@ docker compose up --build
 docker compose down
 ```
 
-Navigate to [Grafana](http://localhost:3000/a/grafana-pyroscope-app/explore?explorationType=flame-graph&var-serviceName=ride-sharing-app&var-profileMetricId=process_cpu:cpu:nanoseconds:cpu:nanoseconds) to explore profiles.
+Navigate to Grafana to explore the generated profiles:
+
+- [CPU](http://localhost:3000/a/grafana-pyroscope-app/explore?explorationType=flame-graph&var-serviceName=ride-sharing-app&var-profileMetricId=process_cpu:cpu:nanoseconds:cpu:nanoseconds)
+- [Allocated space](http://localhost:3000/a/grafana-pyroscope-app/explore?explorationType=flame-graph&var-serviceName=ride-sharing-app&var-profileMetricId=memory:alloc_space:bytes:space:bytes)
+- [Space in use](http://localhost:3000/a/grafana-pyroscope-app/explore?explorationType=flame-graph&var-serviceName=ride-sharing-app&var-profileMetricId=memory:inuse_space:bytes:space:bytes)
+
+The rideshare workload retains a bounded window of allocations. Filter by the
+`vehicle` label to compare memory behavior across the bike, scooter, and car
+endpoints.

--- a/examples/language-sdk-instrumentation/python/rideshare/fastapi/lib/server.py
+++ b/examples/language-sdk-instrumentation/python/rideshare/fastapi/lib/server.py
@@ -9,6 +9,7 @@ from lib.scooter.scooter import order_scooter
 pyroscope.configure(
 	application_name = "ride-sharing-app",
 	server_address   = "http://pyroscope:4040",
+    mem_enabled = True,
 	tags             = {
         "region":   f'{os.getenv("REGION")}',
 	}

--- a/examples/language-sdk-instrumentation/python/rideshare/fastapi/lib/utility/utility.py
+++ b/examples/language-sdk-instrumentation/python/rideshare/fastapi/lib/utility/utility.py
@@ -9,6 +9,16 @@ MUTEX_LOCK_MULTIPLIER = 2
 # How much time check_driver_availability() takes relative to search_radius()
 DRIVER_AVAILABILITY_MULTIPLIER = 0.5
 
+ALLOCATION_SIZE = 64 * 1024
+MAX_RETAINED_ALLOCATIONS = 256
+RETAINED_ALLOCATIONS_AFTER_TRIM = 128
+ALLOCATION_CHUNKS_BY_VEHICLE = {
+    "bike": 1,
+    "scooter": 2,
+    "car": 4,
+}
+retained_allocations = []
+
 def mutex_lock(n):
     i = 0
     start_time = time.time()
@@ -30,11 +40,19 @@ def check_driver_availability(n):
         mutex_lock(n)
 
 
+def allocate_vehicle_memory(vehicle):
+    for _ in range(ALLOCATION_CHUNKS_BY_VEHICLE[vehicle]):
+        retained_allocations.append(bytearray(ALLOCATION_SIZE))
+    if len(retained_allocations) >= MAX_RETAINED_ALLOCATIONS:
+        del retained_allocations[:-RETAINED_ALLOCATIONS_AFTER_TRIM]
+
+
 def find_nearest_vehicle(n, vehicle):
     with pyroscope.tag_wrapper({ "vehicle": vehicle}):
         i = 0
         start_time = time.time()
         while time.time() - start_time < n:
             i += 1
+        allocate_vehicle_memory(vehicle)
         if vehicle == "car":
             check_driver_availability(n)

--- a/examples/language-sdk-instrumentation/python/rideshare/fastapi/requirements.txt
+++ b/examples/language-sdk-instrumentation/python/rideshare/fastapi/requirements.txt
@@ -10,7 +10,7 @@ idna==3.18
 pycparser==3.0
 pydantic==2.13.4
 pydantic_core==2.46.4
-pyroscope-io==1.0.4
+pyroscope-io==1.2.0
 python-dotenv==1.2.2
 PyYAML==6.0.3
 starlette==1.2.1

--- a/examples/language-sdk-instrumentation/python/rideshare/flask/README.md
+++ b/examples/language-sdk-instrumentation/python/rideshare/flask/README.md
@@ -13,4 +13,12 @@ docker compose up --build
 docker compose down
 ```
 
-Navigate to [Grafana](http://localhost:3000/a/grafana-pyroscope-app/explore?explorationType=flame-graph&var-serviceName=ride-sharing-app&var-profileMetricId=process_cpu:cpu:nanoseconds:cpu:nanoseconds) to explore profiles.
+Navigate to Grafana to explore the generated profiles:
+
+- [CPU](http://localhost:3000/a/grafana-pyroscope-app/explore?explorationType=flame-graph&var-serviceName=ride-sharing-app&var-profileMetricId=process_cpu:cpu:nanoseconds:cpu:nanoseconds)
+- [Allocated space](http://localhost:3000/a/grafana-pyroscope-app/explore?explorationType=flame-graph&var-serviceName=ride-sharing-app&var-profileMetricId=memory:alloc_space:bytes:space:bytes)
+- [Space in use](http://localhost:3000/a/grafana-pyroscope-app/explore?explorationType=flame-graph&var-serviceName=ride-sharing-app&var-profileMetricId=memory:inuse_space:bytes:space:bytes)
+
+The rideshare workload retains a bounded window of allocations. Filter by the
+`vehicle` label to compare memory behavior across the bike, scooter, and car
+endpoints.

--- a/examples/language-sdk-instrumentation/python/rideshare/flask/lib/server.py
+++ b/examples/language-sdk-instrumentation/python/rideshare/flask/lib/server.py
@@ -33,6 +33,7 @@ pyroscope.configure(
 	server_address   = server_addr,
     basic_auth_username = basic_auth_username, # for grafana cloud
     basic_auth_password = basic_auth_password, # for grafana cloud
+    mem_enabled = True,
 	tags             = {
         "region":   f'{os.getenv("REGION")}',
 	}

--- a/examples/language-sdk-instrumentation/python/rideshare/flask/lib/utility/utility.py
+++ b/examples/language-sdk-instrumentation/python/rideshare/flask/lib/utility/utility.py
@@ -3,6 +3,16 @@ import pyroscope
 import os
 from datetime import datetime
 
+ALLOCATION_SIZE = 64 * 1024
+MAX_RETAINED_ALLOCATIONS = 256
+RETAINED_ALLOCATIONS_AFTER_TRIM = 128
+ALLOCATION_CHUNKS_BY_VEHICLE = {
+    "bike": 1,
+    "scooter": 2,
+    "car": 4,
+}
+retained_allocations = []
+
 
 def mutex_lock(n):
     i = 0
@@ -25,11 +35,19 @@ def check_driver_availability(n):
         mutex_lock(n)
 
 
+def allocate_vehicle_memory(vehicle):
+    for _ in range(ALLOCATION_CHUNKS_BY_VEHICLE[vehicle]):
+        retained_allocations.append(bytearray(ALLOCATION_SIZE))
+    if len(retained_allocations) >= MAX_RETAINED_ALLOCATIONS:
+        del retained_allocations[:-RETAINED_ALLOCATIONS_AFTER_TRIM]
+
+
 def find_nearest_vehicle(n, vehicle):
     with pyroscope.tag_wrapper({ "vehicle": vehicle}):
         i = 0
         start_time = time.time()
         while time.time() - start_time < n:
             i += 1
+        allocate_vehicle_memory(vehicle)
         if vehicle == "car":
             check_driver_availability(n)

--- a/examples/language-sdk-instrumentation/python/rideshare/flask/requirements.txt
+++ b/examples/language-sdk-instrumentation/python/rideshare/flask/requirements.txt
@@ -20,7 +20,7 @@ opentelemetry-util-http==0.63b1
 packaging==26.2
 protobuf==6.33.6
 pycparser==3.0
-pyroscope-io==1.0.11
+pyroscope-io==1.2.0
 pyroscope-otel==1.0.1
 typing_extensions==4.15.0
 Werkzeug==3.1.8

--- a/examples/language-sdk-instrumentation/python/simple/README.md
+++ b/examples/language-sdk-instrumentation/python/simple/README.md
@@ -13,4 +13,12 @@ docker compose up --build
 docker compose down
 ```
 
-Navigate to [Grafana](http://localhost:3000/a/grafana-pyroscope-app/explore?explorationType=flame-graph&var-serviceName=simple.python.app&var-profileMetricId=process_cpu:cpu:nanoseconds:cpu:nanoseconds) to explore profiles.
+Navigate to Grafana to explore the generated profiles:
+
+- [CPU](http://localhost:3000/a/grafana-pyroscope-app/explore?explorationType=flame-graph&var-serviceName=simple.python.app&var-profileMetricId=process_cpu:cpu:nanoseconds:cpu:nanoseconds)
+- [Allocated space](http://localhost:3000/a/grafana-pyroscope-app/explore?explorationType=flame-graph&var-serviceName=simple.python.app&var-profileMetricId=memory:alloc_space:bytes:space:bytes)
+- [Space in use](http://localhost:3000/a/grafana-pyroscope-app/explore?explorationType=flame-graph&var-serviceName=simple.python.app&var-profileMetricId=memory:inuse_space:bytes:space:bytes)
+
+The application continuously allocates 64 KiB chunks and retains a bounded
+rotating window. This produces useful allocation and in-use profiles without
+allowing the example's memory use to grow indefinitely.

--- a/examples/language-sdk-instrumentation/python/simple/main.py
+++ b/examples/language-sdk-instrumentation/python/simple/main.py
@@ -7,6 +7,11 @@ import pyroscope
 l = logging.getLogger()
 l.setLevel(logging.DEBUG)
 
+ALLOCATION_SIZE = 64 * 1024
+MAX_RETAINED_ALLOCATIONS = 256
+RETAINED_ALLOCATIONS_AFTER_TRIM = 128
+retained_allocations = []
+
 addr = os.getenv("PYROSCOPE_SERVER_ADDRESS") or "http://pyroscope:4040"
 print(addr)
 
@@ -14,6 +19,7 @@ pyroscope.configure(
 	application_name = "simple.python.app",
 	server_address = addr,
 	enable_logging = True,
+	mem_enabled = True,
 )
 
 def work(n):
@@ -21,13 +27,21 @@ def work(n):
 	while i < n:
 		i += 1
 
+def allocate_memory(chunks):
+	for _ in range(chunks):
+		retained_allocations.append(bytearray(ALLOCATION_SIZE))
+	if len(retained_allocations) >= MAX_RETAINED_ALLOCATIONS:
+		del retained_allocations[:-RETAINED_ALLOCATIONS_AFTER_TRIM]
+
 def fast_function():
 	with pyroscope.tag_wrapper({ "function": "fast" }):
 		work(20000)
+		allocate_memory(1)
 
 def slow_function():
 	with pyroscope.tag_wrapper({ "function": "slow" }):
 	    work(80000)
+	    allocate_memory(4)
 
 if __name__ == "__main__":
 	while True:

--- a/examples/language-sdk-instrumentation/python/simple/requirements.txt
+++ b/examples/language-sdk-instrumentation/python/simple/requirements.txt
@@ -1,1 +1,1 @@
-pyroscope-io==1.0.4
+pyroscope-io==1.2.0

--- a/examples/tracing/python/Dockerfile
+++ b/examples/tracing/python/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.9
+FROM python:3.12
 
-RUN pip3 install flask pyroscope-io==0.8.8 pyroscope-otel==0.4.0
+RUN pip3 install flask pyroscope-io==1.2.0 pyroscope-otel==1.0.1
 RUN pip3 install opentelemetry-api opentelemetry-sdk opentelemetry-instrumentation-flask opentelemetry-exporter-otlp-proto-grpc
 
 ENV FLASK_ENV=development

--- a/examples/tracing/python/README.md
+++ b/examples/tracing/python/README.md
@@ -27,6 +27,15 @@ The load generator will automatically start sending requests to all regional ins
 
 ### Viewing Traces and Profiles
 
+The application emits CPU and memory profiles while preserving CPU span
+profiles. Open the following views to inspect the memory workload:
+
+- [Allocated space](http://localhost:3000/a/grafana-pyroscope-app/explore?explorationType=flame-graph&var-serviceName=rideshare.python.push.app&var-profileMetricId=memory:alloc_space:bytes:space:bytes)
+- [Space in use](http://localhost:3000/a/grafana-pyroscope-app/explore?explorationType=flame-graph&var-serviceName=rideshare.python.push.app&var-profileMetricId=memory:inuse_space:bytes:space:bytes)
+
+The workload retains a bounded window of allocations. Filter by the `vehicle`
+label to compare the bike, scooter, and car endpoints.
+
 Navigate to the [Explore page](http://localhost:3000/explore?schemaVersion=1&panes=%7B%22yM9%22:%7B%22datasource%22:%22tempo%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22tempo%22,%22uid%22:%22tempo%22%7D,%22queryType%22:%22traceqlSearch%22,%22limit%22:20,%22tableType%22:%22traces%22,%22filters%22:%5B%7B%22id%22:%22e73a615e%22,%22operator%22:%22%3D%22,%22scope%22:%22span%22%7D,%7B%22id%22:%22service-name%22,%22tag%22:%22service.name%22,%22operator%22:%22%3D%22,%22scope%22:%22resource%22,%22value%22:%5B%22rideshare.python.push.app%22%5D,%22valueType%22:%22string%22%7D%5D%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1), select a trace and click on a span that has a linked profile:
 
 ![image](https://github.com/grafana/otel-profiling-go/assets/12090599/31e33cd1-818b-4116-b952-c9ec7b1fb593)

--- a/examples/tracing/python/lib/server.py
+++ b/examples/tracing/python/lib/server.py
@@ -33,6 +33,7 @@ pyroscope.configure(
 	server_address   = server_addr,
     basic_auth_username = basic_auth_username, # for grafana cloud
     basic_auth_password = basic_auth_password, # for grafana cloud
+    mem_enabled = True,
 	tags             = {
         "region":   f'{os.getenv("REGION")}',
 	}

--- a/examples/tracing/python/lib/utility/utility.py
+++ b/examples/tracing/python/lib/utility/utility.py
@@ -3,6 +3,16 @@ import pyroscope
 import os
 from datetime import datetime
 
+ALLOCATION_SIZE = 64 * 1024
+MAX_RETAINED_ALLOCATIONS = 256
+RETAINED_ALLOCATIONS_AFTER_TRIM = 128
+ALLOCATION_CHUNKS_BY_VEHICLE = {
+    "bike": 1,
+    "scooter": 2,
+    "car": 4,
+}
+retained_allocations = []
+
 
 def mutex_lock(n):
     i = 0
@@ -25,11 +35,19 @@ def check_driver_availability(n):
         mutex_lock(n)
 
 
+def allocate_vehicle_memory(vehicle):
+    for _ in range(ALLOCATION_CHUNKS_BY_VEHICLE[vehicle]):
+        retained_allocations.append(bytearray(ALLOCATION_SIZE))
+    if len(retained_allocations) >= MAX_RETAINED_ALLOCATIONS:
+        del retained_allocations[:-RETAINED_ALLOCATIONS_AFTER_TRIM]
+
+
 def find_nearest_vehicle(n, vehicle):
     with pyroscope.tag_wrapper({ "vehicle": vehicle}):
         i = 0
         start_time = time.time()
         while time.time() - start_time < n:
             i += 1
+        allocate_vehicle_memory(vehicle)
         if vehicle == "car":
             check_driver_availability(n)


### PR DESCRIPTION
## Summary
- upgrade every Python example to the memory-capable SDK and enable memory profiling alongside CPU profiling
- add bounded allocation workloads and documentation for allocation and in-use profiles
- require all four Python memory profile types in the example integration harness while preserving CPU span-profile checks

## Test plan
- [x] validate modified Python source syntax
- [x] `go test -tags=examples ./examples -run 'Test(ContainerStatusesReady|CompletedSuccessfullyServices|RequiresPythonMemoryProfiles)$'`
- [x] `make examples/check-templates`
- [x] `PYROSCOPE_TEST_EXAMPLES=\"examples/language-sdk-instrumentation/python examples/tracing/python\" make examples/test`