### PR TITLE
chore(deps): update parquet-go to v0.30.1

### DIFF
--- a/api/gen/proto/go/google/v1/profile.pb.go
+++ b/api/gen/proto/go/google/v1/profile.pb.go
@@ -73,19 +73,19 @@ type Profile struct {
 	// If one of the values represents the number of events represented
 	// by the sample, by convention it should be at index 0 and use
 	// sample_type.unit == "count".
-	SampleType []*ValueType `protobuf:"bytes,1,rep,name=sample_type,json=sampleType,proto3" json:"sample_type,omitempty" parquet:","`
+	SampleType []*ValueType `protobuf:"bytes,1,rep,name=sample_type,json=sampleType,proto3" json:"sample_type,omitempty" parquet:"SampleType,"`
 	// The set of samples recorded in this profile.
-	Sample []*Sample `protobuf:"bytes,2,rep,name=sample,proto3" json:"sample,omitempty" parquet:","`
+	Sample []*Sample `protobuf:"bytes,2,rep,name=sample,proto3" json:"sample,omitempty" parquet:"Sample,"`
 	// Mapping from address ranges to the image/binary/library mapped
 	// into that address range.  mapping[0] will be the main binary.
-	Mapping []*Mapping `protobuf:"bytes,3,rep,name=mapping,proto3" json:"mapping,omitempty" parquet:","`
+	Mapping []*Mapping `protobuf:"bytes,3,rep,name=mapping,proto3" json:"mapping,omitempty" parquet:"Mapping,"`
 	// Useful program location
-	Location []*Location `protobuf:"bytes,4,rep,name=location,proto3" json:"location,omitempty" parquet:","`
+	Location []*Location `protobuf:"bytes,4,rep,name=location,proto3" json:"location,omitempty" parquet:"Location,"`
 	// Functions referenced by locations
-	Function []*Function `protobuf:"bytes,5,rep,name=function,proto3" json:"function,omitempty" parquet:","`
+	Function []*Function `protobuf:"bytes,5,rep,name=function,proto3" json:"function,omitempty" parquet:"Function,"`
 	// A common table for strings referenced by various messages.
 	// string_table[0] must always be "".
-	StringTable []string `protobuf:"bytes,6,rep,name=string_table,json=stringTable,proto3" json:"string_table,omitempty" parquet:","`
+	StringTable []string `protobuf:"bytes,6,rep,name=string_table,json=stringTable,proto3" json:"string_table,omitempty" parquet:"StringTable,"`
 	// frames with Function.function_name fully matching the following
 	// regexp will be dropped from the samples, along with their successors.
 	DropFrames int64 `protobuf:"varint,7,opt,name=drop_frames,json=dropFrames,proto3" json:"drop_frames,omitempty" parquet:"-"` // Index into string table.
@@ -93,7 +93,7 @@ type Profile struct {
 	// regexp will be kept, even if it matches drop_frames.
 	KeepFrames int64 `protobuf:"varint,8,opt,name=keep_frames,json=keepFrames,proto3" json:"keep_frames,omitempty" parquet:"-"` // Index into string table.
 	// Time of collection (UTC) represented as nanoseconds past the epoch.
-	TimeNanos int64 `protobuf:"varint,9,opt,name=time_nanos,json=timeNanos,proto3" json:"time_nanos,omitempty" parquet:",delta"`
+	TimeNanos int64 `protobuf:"varint,9,opt,name=time_nanos,json=timeNanos,proto3" json:"time_nanos,omitempty" parquet:"TimeNanos,delta"`
 	// Duration of the profile, if a duration makes sense.
 	DurationNanos int64 `protobuf:"varint,10,opt,name=duration_nanos,json=durationNanos,proto3" json:"duration_nanos,omitempty" parquet:"-"`
 	// The kind of events between sampled ocurrences.
@@ -241,8 +241,8 @@ func (x *Profile) GetDefaultSampleType() int64 {
 // ValueType describes the semantics and measurement units of a value.
 type ValueType struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Type          int64                  `protobuf:"varint,1,opt,name=type,proto3" json:"type,omitempty" parquet:","` // Index into string table.
-	Unit          int64                  `protobuf:"varint,2,opt,name=unit,proto3" json:"unit,omitempty" parquet:","` // Index into string table.
+	Type          int64                  `protobuf:"varint,1,opt,name=type,proto3" json:"type,omitempty" parquet:"Type,"` // Index into string table.
+	Unit          int64                  `protobuf:"varint,2,opt,name=unit,proto3" json:"unit,omitempty" parquet:"Unit,"` // Index into string table.
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -299,14 +299,14 @@ type Sample struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The ids recorded here correspond to a Profile.location.id.
 	// The leaf is at location_id[0].
-	LocationId []uint64 `protobuf:"varint,1,rep,packed,name=location_id,json=locationId,proto3" json:"location_id,omitempty" parquet:","`
+	LocationId []uint64 `protobuf:"varint,1,rep,packed,name=location_id,json=locationId,proto3" json:"location_id,omitempty" parquet:"LocationId,"`
 	// The type and unit of each value is defined by the corresponding
 	// entry in Profile.sample_type. All samples must have the same
 	// number of values, the same as the length of Profile.sample_type.
 	// When aggregating multiple samples into a single sample, the
 	// result has a list of values that is the element-wise sum of the
 	// lists of the originals.
-	Value []int64 `protobuf:"varint,2,rep,packed,name=value,proto3" json:"value,omitempty" parquet:","`
+	Value []int64 `protobuf:"varint,2,rep,packed,name=value,proto3" json:"value,omitempty" parquet:"Value,"`
 	// label includes additional context for this sample. It can include
 	// things like a thread id, allocation size, etc
 	Label         []*Label `protobuf:"bytes,3,rep,name=label,proto3" json:"label,omitempty"`
@@ -367,10 +367,10 @@ func (x *Sample) GetLabel() []*Label {
 
 type Label struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	Key   int64                  `protobuf:"varint,1,opt,name=key,proto3" json:"key,omitempty"` // Index into string table
+	Key   int64                  `protobuf:"varint,1,opt,name=key,proto3" json:"key,omitempty" parquet:"Key,"` // Index into string table
 	// At most one of the following must be present
-	Str int64 `protobuf:"varint,2,opt,name=str,proto3" json:"str,omitempty" parquet:",optional"` // Index into string table
-	Num int64 `protobuf:"varint,3,opt,name=num,proto3" json:"num,omitempty" parquet:",optional"`
+	Str int64 `protobuf:"varint,2,opt,name=str,proto3" json:"str,omitempty" parquet:"Str,optional"` // Index into string table
+	Num int64 `protobuf:"varint,3,opt,name=num,proto3" json:"num,omitempty" parquet:"Num,optional"`
 	// Should only be present when num is present.
 	// Specifies the units of num.
 	// Use arbitrary string (for example, "requests") as a custom count unit.
@@ -378,7 +378,7 @@ type Label struct {
 	// Consumers may also  interpret units like "bytes" and "kilobytes" as memory
 	// units and units like "seconds" and "nanoseconds" as time units,
 	// and apply appropriate unit conversions to these.
-	NumUnit       int64 `protobuf:"varint,4,opt,name=num_unit,json=numUnit,proto3" json:"num_unit,omitempty" parquet:",optional"` // Index into string table
+	NumUnit       int64 `protobuf:"varint,4,opt,name=num_unit,json=numUnit,proto3" json:"num_unit,omitempty" parquet:"NumUnit,optional"` // Index into string table
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -444,26 +444,26 @@ func (x *Label) GetNumUnit() int64 {
 type Mapping struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Unique nonzero id for the mapping.
-	Id uint64 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id uint64 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty" parquet:"Id,"`
 	// Address at which the binary (or DLL) is loaded into memory.
-	MemoryStart uint64 `protobuf:"varint,2,opt,name=memory_start,json=memoryStart,proto3" json:"memory_start,omitempty"`
+	MemoryStart uint64 `protobuf:"varint,2,opt,name=memory_start,json=memoryStart,proto3" json:"memory_start,omitempty" parquet:"MemoryStart,"`
 	// The limit of the address range occupied by this mapping.
-	MemoryLimit uint64 `protobuf:"varint,3,opt,name=memory_limit,json=memoryLimit,proto3" json:"memory_limit,omitempty"`
+	MemoryLimit uint64 `protobuf:"varint,3,opt,name=memory_limit,json=memoryLimit,proto3" json:"memory_limit,omitempty" parquet:"MemoryLimit,"`
 	// Offset in the binary that corresponds to the first mapped address.
-	FileOffset uint64 `protobuf:"varint,4,opt,name=file_offset,json=fileOffset,proto3" json:"file_offset,omitempty"`
+	FileOffset uint64 `protobuf:"varint,4,opt,name=file_offset,json=fileOffset,proto3" json:"file_offset,omitempty" parquet:"FileOffset,"`
 	// The object this entry is loaded from.  This can be a filename on
 	// disk for the main binary and shared libraries, or virtual
 	// abstractions like "[vdso]".
-	Filename int64 `protobuf:"varint,5,opt,name=filename,proto3" json:"filename,omitempty"` // Index into string table
+	Filename int64 `protobuf:"varint,5,opt,name=filename,proto3" json:"filename,omitempty" parquet:"Filename,"` // Index into string table
 	// A string that uniquely identifies a particular program version
 	// with high probability. E.g., for binaries generated by GNU tools,
 	// it could be the contents of the .note.gnu.build-id field.
-	BuildId int64 `protobuf:"varint,6,opt,name=build_id,json=buildId,proto3" json:"build_id,omitempty"` // Index into string table
+	BuildId int64 `protobuf:"varint,6,opt,name=build_id,json=buildId,proto3" json:"build_id,omitempty" parquet:"BuildId,"` // Index into string table
 	// The following fields indicate the resolution of symbolic info.
-	HasFunctions    bool `protobuf:"varint,7,opt,name=has_functions,json=hasFunctions,proto3" json:"has_functions,omitempty"`
-	HasFilenames    bool `protobuf:"varint,8,opt,name=has_filenames,json=hasFilenames,proto3" json:"has_filenames,omitempty"`
-	HasLineNumbers  bool `protobuf:"varint,9,opt,name=has_line_numbers,json=hasLineNumbers,proto3" json:"has_line_numbers,omitempty"`
-	HasInlineFrames bool `protobuf:"varint,10,opt,name=has_inline_frames,json=hasInlineFrames,proto3" json:"has_inline_frames,omitempty"`
+	HasFunctions    bool `protobuf:"varint,7,opt,name=has_functions,json=hasFunctions,proto3" json:"has_functions,omitempty" parquet:"HasFunctions,"`
+	HasFilenames    bool `protobuf:"varint,8,opt,name=has_filenames,json=hasFilenames,proto3" json:"has_filenames,omitempty" parquet:"HasFilenames,"`
+	HasLineNumbers  bool `protobuf:"varint,9,opt,name=has_line_numbers,json=hasLineNumbers,proto3" json:"has_line_numbers,omitempty" parquet:"HasLineNumbers,"`
+	HasInlineFrames bool `protobuf:"varint,10,opt,name=has_inline_frames,json=hasInlineFrames,proto3" json:"has_inline_frames,omitempty" parquet:"HasInlineFrames,"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -573,17 +573,17 @@ type Location struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Unique nonzero id for the location.  A profile could use
 	// instruction addresses or any integer sequence as ids.
-	Id uint64 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id uint64 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty" parquet:"Id,"`
 	// The id of the corresponding profile.Mapping for this location.
 	// It can be unset if the mapping is unknown or not applicable for
 	// this profile type.
-	MappingId uint64 `protobuf:"varint,2,opt,name=mapping_id,json=mappingId,proto3" json:"mapping_id,omitempty"`
+	MappingId uint64 `protobuf:"varint,2,opt,name=mapping_id,json=mappingId,proto3" json:"mapping_id,omitempty" parquet:"MappingId,"`
 	// The instruction address for this location, if available.  It
 	// should be within [Mapping.memory_start...Mapping.memory_limit]
 	// for the corresponding mapping. A non-leaf address may be in the
 	// middle of a call instruction. It is up to display tools to find
 	// the beginning of the instruction if necessary.
-	Address uint64 `protobuf:"varint,3,opt,name=address,proto3" json:"address,omitempty"`
+	Address uint64 `protobuf:"varint,3,opt,name=address,proto3" json:"address,omitempty" parquet:"Address,"`
 	// Multiple line indicates this location has inlined functions,
 	// where the last entry represents the caller into which the
 	// preceding entries were inlined.
@@ -592,13 +592,13 @@ type Location struct {
 	//
 	//	line[0].function_name == "memcpy"
 	//	line[1].function_name == "printf"
-	Line []*Line `protobuf:"bytes,4,rep,name=line,proto3" json:"line,omitempty"`
+	Line []*Line `protobuf:"bytes,4,rep,name=line,proto3" json:"line,omitempty" parquet:"Line,"`
 	// Provides an indication that multiple symbols map to this location's
 	// address, for example due to identical code folding by the linker. In that
 	// case the line information above represents one of the multiple
 	// symbols. This field must be recomputed when the symbolization state of the
 	// profile changes.
-	IsFolded      bool `protobuf:"varint,5,opt,name=is_folded,json=isFolded,proto3" json:"is_folded,omitempty"`
+	IsFolded      bool `protobuf:"varint,5,opt,name=is_folded,json=isFolded,proto3" json:"is_folded,omitempty" parquet:"IsFolded,"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -671,9 +671,9 @@ func (x *Location) GetIsFolded() bool {
 type Line struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The id of the corresponding profile.Function for this line.
-	FunctionId uint64 `protobuf:"varint,1,opt,name=function_id,json=functionId,proto3" json:"function_id,omitempty"`
+	FunctionId uint64 `protobuf:"varint,1,opt,name=function_id,json=functionId,proto3" json:"function_id,omitempty" parquet:"FunctionId,"`
 	// Line number in source code.
-	Line          int64 `protobuf:"varint,2,opt,name=line,proto3" json:"line,omitempty"`
+	Line          int64 `protobuf:"varint,2,opt,name=line,proto3" json:"line,omitempty" parquet:"Line,"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -725,16 +725,16 @@ func (x *Line) GetLine() int64 {
 type Function struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Unique nonzero id for the function.
-	Id uint64 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Id uint64 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty" parquet:"Id,"`
 	// Name of the function, in human-readable form if available.
-	Name int64 `protobuf:"varint,2,opt,name=name,proto3" json:"name,omitempty"` // Index into string table
+	Name int64 `protobuf:"varint,2,opt,name=name,proto3" json:"name,omitempty" parquet:"Name,"` // Index into string table
 	// Name of the function, as identified by the system.
 	// For instance, it can be a C++ mangled name.
-	SystemName int64 `protobuf:"varint,3,opt,name=system_name,json=systemName,proto3" json:"system_name,omitempty"` // Index into string table
+	SystemName int64 `protobuf:"varint,3,opt,name=system_name,json=systemName,proto3" json:"system_name,omitempty" parquet:"SystemName,"` // Index into string table
 	// Source file containing the function.
-	Filename int64 `protobuf:"varint,4,opt,name=filename,proto3" json:"filename,omitempty"` // Index into string table
+	Filename int64 `protobuf:"varint,4,opt,name=filename,proto3" json:"filename,omitempty" parquet:"Filename,"` // Index into string table
 	// Line number in source file.
-	StartLine     int64 `protobuf:"varint,5,opt,name=start_line,json=startLine,proto3" json:"start_line,omitempty"`
+	StartLine     int64 `protobuf:"varint,5,opt,name=start_line,json=startLine,proto3" json:"start_line,omitempty" parquet:"StartLine,"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/api/gen/proto/go/google/v1/profile.pb.go
+++ b/api/gen/proto/go/google/v1/profile.pb.go
@@ -309,7 +309,7 @@ type Sample struct {
 	Value []int64 `protobuf:"varint,2,rep,packed,name=value,proto3" json:"value,omitempty" parquet:"Value,"`
 	// label includes additional context for this sample. It can include
 	// things like a thread id, allocation size, etc
-	Label         []*Label `protobuf:"bytes,3,rep,name=label,proto3" json:"label,omitempty"`
+	Label         []*Label `protobuf:"bytes,3,rep,name=label,proto3" json:"label,omitempty" parquet:"Label,"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/parquet-go/parquet-go v0.26.4
+	github.com/parquet-go/parquet-go v0.30.1
 	github.com/planetscale/vtprotobuf v0.6.1-0.20250313105119-ba97887b0a25
 	github.com/platinummonkey/go-concurrency-limits v0.10.0
 	github.com/prometheus/client_golang v1.23.2
@@ -120,6 +120,7 @@ require (
 	github.com/prometheus/client_golang/exp v0.0.0-20260325093428-d8591d0db856 // indirect
 	github.com/puzpuzpuz/xsync/v4 v4.4.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	github.com/twpayne/go-geom v1.6.1 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Code-Hex/go-generics-cache v1.5.1 h1:6vhZGc5M7Y/YD8cIUcY8kcuQLB4cHR7U+0KMqAA0KcU=
 github.com/Code-Hex/go-generics-cache v1.5.1/go.mod h1:qxcC9kRVrct9rHeiYpFWSoW1vxyillCVzX13KZG8dl4=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0/go.mod h1:RD2SsorTmYhF6HkTmDw7KmPYQk8OBYwTkuasChwv7R4=
@@ -65,8 +67,12 @@ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA
 github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO8RIBo=
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
 github.com/QcloudApi/qcloud_sign_golang v0.0.0-20141224014652-e4130a326409/go.mod h1:1pk82RBxDY/JZnPQrtqHlUFfCctgdorsd9M06fMynOM=
+github.com/alecthomas/assert/v2 v2.10.0 h1:jjRCHsj6hBJhkmhznrCzoNpbA3zqy0fYiUcYZP/GkPY=
+github.com/alecthomas/assert/v2 v2.10.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjHpqDjYY=
 github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
+github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
+github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -629,8 +635,8 @@ github.com/parquet-go/bitpack v1.0.0 h1:AUqzlKzPPXf2bCdjfj4sTeacrUwsT7NlcYDMUQxP
 github.com/parquet-go/bitpack v1.0.0/go.mod h1:XnVk9TH+O40eOOmvpAVZ7K2ocQFrQwysLMnc6M/8lgs=
 github.com/parquet-go/jsonlite v1.0.0 h1:87QNdi56wOfsE5bdgas0vRzHPxfJgzrXGml1zZdd7VU=
 github.com/parquet-go/jsonlite v1.0.0/go.mod h1:nDjpkpL4EOtqs6NQugUsi0Rleq9sW/OtC1NnZEnxzF0=
-github.com/parquet-go/parquet-go v0.26.4 h1:zJ3l8ef5WJZE2m63pKwyEJ2BhyDlgS0PfOEhuCQQU2A=
-github.com/parquet-go/parquet-go v0.26.4/go.mod h1:h9GcSt41Knf5qXI1tp1TfR8bDBUtvdUMzSKe26aZcHk=
+github.com/parquet-go/parquet-go v0.30.1 h1:Oy6ganNrAdFiVwy7wNmWagfPTWA2X9Z3tVHBc7JtuX8=
+github.com/parquet-go/parquet-go v0.30.1/go.mod h1:navtkAYr2LGoJVp141oXPlO/sxLvaOe3la2JEoD8+rg=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pb33f/jsonpath v0.8.1 h1:84C6QRyx6HcSm6PZnsMpcqYot3IsZ+m0n95+0NbBbvs=
@@ -765,6 +771,8 @@ github.com/thanos-io/objstore v0.0.0-20250813080715-4e5fd4289b50/go.mod h1:47A17
 github.com/tinylib/msgp v1.6.1 h1:ESRv8eL3u+DNHUoSAAQRE50Hm162zqAnBoGv9PzScPY=
 github.com/tinylib/msgp v1.6.1/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
+github.com/twpayne/go-geom v1.6.1 h1:iLE+Opv0Ihm/ABIcvQFGIiFBXd76oBIar9drAwHFhR4=
+github.com/twpayne/go-geom v1.6.1/go.mod h1:Kr+Nly6BswFsKM5sd31YaoWS5PeDDH2NftJTK7Gd028=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=

--- a/pkg/phlaredb/schemas/v1/schema_test.go
+++ b/pkg/phlaredb/schemas/v1/schema_test.go
@@ -20,11 +20,14 @@ func TestSchemaMatch(t *testing.T) {
 	// schema of a List of a struct pointer. This replaces this in the schema
 	// comparison, because this has no affect to our construct/reconstruct code
 	// we can simply replace the string in the schema.
-	profilesStructSchema := strings.ReplaceAll(
-		parquet.SchemaOf(&Profile{}).String(),
-		"optional group element",
-		"required group element",
-	)
+	profilesStructSchema := strings.NewReplacer(
+		"optional group element", "required group element",
+		// The manual schema preserves the historic protobuf field names.
+		"int64 key", "int64 Key",
+		"int64 str", "int64 Str",
+		"int64 num_unit", "int64 NumUnit",
+	).Replace(parquet.SchemaOf(&Profile{}).String())
+	profilesStructSchema = strings.ReplaceAll(profilesStructSchema, "int64 num", "int64 Num")
 	// []byte produces "optional binary TraceID" but our schema uses
 	// fixed_len_byte_array(16). We use []byte because parquet-go panics
 	// with [16]byte on null optional FixedLenByteArray values.

--- a/pkg/phlaredb/schemas/v1/schema_test.go
+++ b/pkg/phlaredb/schemas/v1/schema_test.go
@@ -20,14 +20,11 @@ func TestSchemaMatch(t *testing.T) {
 	// schema of a List of a struct pointer. This replaces this in the schema
 	// comparison, because this has no affect to our construct/reconstruct code
 	// we can simply replace the string in the schema.
-	profilesStructSchema := strings.NewReplacer(
-		"optional group element", "required group element",
-		// The manual schema preserves the historic protobuf field names.
-		"int64 key", "int64 Key",
-		"int64 str", "int64 Str",
-		"int64 num_unit", "int64 NumUnit",
-	).Replace(parquet.SchemaOf(&Profile{}).String())
-	profilesStructSchema = strings.ReplaceAll(profilesStructSchema, "int64 num", "int64 Num")
+	profilesStructSchema := strings.ReplaceAll(
+		parquet.SchemaOf(&Profile{}).String(),
+		"optional group element",
+		"required group element",
+	)
 	// []byte produces "optional binary TraceID" but our schema uses
 	// fixed_len_byte_array(16). We use []byte because parquet-go panics
 	// with [16]byte on null optional FixedLenByteArray values.
@@ -42,6 +39,38 @@ func TestSchemaMatch(t *testing.T) {
 
 	stacktracesStructSchema := parquet.SchemaOf(&storedStacktrace{})
 	require.Equal(t, strings.Replace(stacktracesStructSchema.String(), "message storedStacktrace", "message Stacktrace", 1), stacktracesSchema.String())
+
+	require.Equal(t, `message Location {
+	required int64 Id (INT(64,false));
+	required int64 MappingId (INT(64,false));
+	required int64 Address (INT(64,false));
+	repeated group Line {
+		required int64 FunctionId (INT(64,false));
+		required int64 Line (INT(64,true));
+	}
+	required boolean IsFolded;
+}`, locationsSchema.String())
+
+	require.Equal(t, `message Function {
+	required int64 Id (INT(64,false));
+	required int64 Name (INT(64,true));
+	required int64 SystemName (INT(64,true));
+	required int64 Filename (INT(64,true));
+	required int64 StartLine (INT(64,true));
+}`, functionsSchema.String())
+
+	require.Equal(t, `message Mapping {
+	required int64 Id (INT(64,false));
+	required int64 MemoryStart (INT(64,false));
+	required int64 MemoryLimit (INT(64,false));
+	required int64 FileOffset (INT(64,false));
+	required int64 Filename (INT(64,true));
+	required int64 BuildId (INT(64,true));
+	required boolean HasFunctions;
+	required boolean HasFilenames;
+	required boolean HasLineNumbers;
+	required boolean HasInlineFrames;
+}`, mappingsSchema.String())
 }
 
 func newStacktraces() []*Stacktrace {

--- a/tools/add-parquet-tags.sh
+++ b/tools/add-parquet-tags.sh
@@ -22,7 +22,7 @@ for f in Type Unit; do
 done
 
 # Sample
-for f in LocationId Value; do
+for f in LocationId Value Label; do
   gomodifytags -file "${ROOT}/api/gen/proto/go/google/v1/profile.pb.go" -struct Sample -field "${f}" -add-tags parquet -template "${f}," -w -quiet -override
 done
 

--- a/tools/add-parquet-tags.sh
+++ b/tools/add-parquet-tags.sh
@@ -10,23 +10,41 @@ set -x
 gomodifytags -file "${ROOT}/api/gen/proto/go/google/v1/profile.pb.go" -struct Profile -add-tags parquet -template "-" -w -quiet
 
 # Profile
-gomodifytags -file "${ROOT}/api/gen/proto/go/google/v1/profile.pb.go" -override -struct Profile -field TimeNanos -add-tags parquet -template ",delta" -w -quiet
+gomodifytags -file "${ROOT}/api/gen/proto/go/google/v1/profile.pb.go" -override -struct Profile -field TimeNanos -add-tags parquet -template "TimeNanos,delta" -w -quiet
 
 for f in SampleType Sample Mapping Location Function StringTable; do
-  gomodifytags -file "${ROOT}/api/gen/proto/go/google/v1/profile.pb.go" -struct Profile -field "${f}" -add-tags parquet -template "," -w -quiet -override
+  gomodifytags -file "${ROOT}/api/gen/proto/go/google/v1/profile.pb.go" -struct Profile -field "${f}" -add-tags parquet -template "${f}," -w -quiet -override
 done
 
 # SampleType
 for f in Type Unit; do
-  gomodifytags -file "${ROOT}/api/gen/proto/go/google/v1/profile.pb.go" -struct ValueType -field "${f}" -add-tags parquet -template "," -w -quiet -override
+  gomodifytags -file "${ROOT}/api/gen/proto/go/google/v1/profile.pb.go" -struct ValueType -field "${f}" -add-tags parquet -template "${f}," -w -quiet -override
 done
 
 # Sample
 for f in LocationId Value; do
-  gomodifytags -file "${ROOT}/api/gen/proto/go/google/v1/profile.pb.go" -struct Sample -field "${f}" -add-tags parquet -template "," -w -quiet -override
+  gomodifytags -file "${ROOT}/api/gen/proto/go/google/v1/profile.pb.go" -struct Sample -field "${f}" -add-tags parquet -template "${f}," -w -quiet -override
 done
 
 # Label
+gomodifytags -file "${ROOT}/api/gen/proto/go/google/v1/profile.pb.go" -override -struct Label -field Key -add-tags parquet -template "Key," -w -quiet
 for f in Str NumUnit Num; do
-  gomodifytags -file "${ROOT}/api/gen/proto/go/google/v1/profile.pb.go" -override -struct Label -field "${f}" -add-tags parquet -template ",optional" -w -quiet
+  gomodifytags -file "${ROOT}/api/gen/proto/go/google/v1/profile.pb.go" -override -struct Label -field "${f}" -add-tags parquet -template "${f},optional" -w -quiet
+done
+
+# Symbol tables
+for f in Id MemoryStart MemoryLimit FileOffset Filename BuildId HasFunctions HasFilenames HasLineNumbers HasInlineFrames; do
+  gomodifytags -file "${ROOT}/api/gen/proto/go/google/v1/profile.pb.go" -override -struct Mapping -field "${f}" -add-tags parquet -template "${f}," -w -quiet
+done
+
+for f in Id MappingId Address Line IsFolded; do
+  gomodifytags -file "${ROOT}/api/gen/proto/go/google/v1/profile.pb.go" -override -struct Location -field "${f}" -add-tags parquet -template "${f}," -w -quiet
+done
+
+for f in FunctionId Line; do
+  gomodifytags -file "${ROOT}/api/gen/proto/go/google/v1/profile.pb.go" -override -struct Line -field "${f}" -add-tags parquet -template "${f}," -w -quiet
+done
+
+for f in Id Name SystemName Filename StartLine; do
+  gomodifytags -file "${ROOT}/api/gen/proto/go/google/v1/profile.pb.go" -override -struct Function -field "${f}" -add-tags parquet -template "${f}," -w -quiet
 done


### PR DESCRIPTION
## Summary

- Update github.com/parquet-go/parquet-go from v0.26.4 to v0.30.1.
- Record parquet-go's new indirect dependencies after running go mod tidy.
- Normalize the schema compatibility assertion for parquet-go's updated protobuf field-name inference, preserving the existing on-disk profile schema.

## Upstream Changes

This update includes [136 upstream commits](https://github.com/parquet-go/parquet-go/compare/v0.26.4...v0.30.1).

- [v0.27.0](https://github.com/parquet-go/parquet-go/compare/v0.26.4...v0.27.0): faster schema conversion and GenericWriter, protobuf tag names as default column names, geometry/geography logical types, plus merge and Thrift fixes. This release changes ConcurrentRowGroupWriter from an interface to a concrete type.
- [v0.28.0](https://github.com/parquet-go/parquet-go/compare/v0.27.0...v0.28.0): nested-list, optional-value, decimal, boolean, DataPageV2, sorting, statistics, and corruption-handling fixes; reduced writer allocations.
- [v0.29.0](https://github.com/parquet-go/parquet-go/compare/v0.28.0...v0.29.0): zero-allocation Thrift decoding, configurable page statistics, writer sizing, explicit integer-width tags, and LIST/MAP, optional-column, and merged-row-group fixes.
- [v0.30.0](https://github.com/parquet-go/parquet-go/compare/v0.29.0...v0.30.0): VARIANT, INTERVAL, column encryption, bloom-filter, geospatial-statistics, GZip bloom-filter compression, BYTE_STREAM_SPLIT, NULL-column, and additional encoding support and fixes.
- [v0.30.1](https://github.com/parquet-go/parquet-go/compare/v0.30.0...v0.30.1): fixes optional value-type null handling and reconstructing optional fields.

### Our Upstream Contribution

- [#489](https://github.com/parquet-go/parquet-go/pull/489), authored by @simonswine and included in v0.30.0, ensures an explicit parquet field name takes precedence over a protobuf field name. This is directly relevant to Pyroscope's profile schema compatibility check.

## Testing

- go test ./pkg/parquet ./pkg/phlaredb/... ./pkg/block ./pkg/objstore/parquet ./pkg/segmentwriter/memdb ./pkg/querybackend ./cmd/profilecli
- go test ./pkg/metrics ./pkg/operations/v2/blocks