### PR TITLE
feat(compaction): optionally read block metadata from object storage

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -63,6 +63,8 @@ Usage of ./pyroscope:
     	Number of concurrent jobs compaction worker will run. Defaults to the number of CPU cores.
   -compaction-worker.job-poll-interval duration
     	Interval between job requests (default 5s)
+  -compaction-worker.metadata-fetch-timeout duration
+    	Timeout for reading the metadata of a single block from object storage. Only effective when metadata-source is object-storage. 0 disables the timeout. (default 30s)
   -compaction-worker.metadata-source string
     	Source of the compaction job source block metadata. Supported values: metastore, object-storage. (default "metastore")
   -compaction-worker.metrics-exporter.enabled

--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -63,6 +63,8 @@ Usage of ./pyroscope:
     	Number of concurrent jobs compaction worker will run. Defaults to the number of CPU cores.
   -compaction-worker.job-poll-interval duration
     	Interval between job requests (default 5s)
+  -compaction-worker.metadata-source string
+    	Source of the compaction job source block metadata. Supported values: metastore, object-storage. (default "metastore")
   -compaction-worker.metrics-exporter.enabled
     	This parameter specifies whether the metrics exporter is enabled.
   -compaction-worker.metrics-exporter.remote-write-address string

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -1390,6 +1390,12 @@ The `compaction_worker` block configures the compaction-worker (V2).
 # CLI flag: -compaction-worker.metadata-source
 [metadata_source: <string> | default = "metastore"]
 
+# (advanced) Timeout for reading the metadata of a single block from object
+# storage. Only effective when metadata-source is object-storage. 0 disables the
+# timeout.
+# CLI flag: -compaction-worker.metadata-fetch-timeout
+[metadata_fetch_timeout: <duration> | default = 30s]
+
 metrics_exporter:
   # (advanced) This parameter specifies whether the metrics exporter is enabled.
   # CLI flag: -compaction-worker.metrics-exporter.enabled

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -1385,6 +1385,11 @@ The `compaction_worker` block configures the compaction-worker (V2).
 # CLI flag: -compaction-worker.cleanup-max-duration
 [cleanup_max_duration: <duration> | default = 15s]
 
+# (advanced) Source of the compaction job source block metadata. Supported
+# values: metastore, object-storage.
+# CLI flag: -compaction-worker.metadata-source
+[metadata_source: <string> | default = "metastore"]
+
 metrics_exporter:
   # (advanced) This parameter specifies whether the metrics exporter is enabled.
   # CLI flag: -compaction-worker.metrics-exporter.enabled

--- a/pkg/block/object.go
+++ b/pkg/block/object.go
@@ -75,6 +75,7 @@ func NewObjectFromPath(ctx context.Context, storage objstore.Bucket, path string
 	size := attrs.Size - offset
 
 	buf := bufferpool.GetBuffer(int(size))
+	defer func() { bufferpool.Put(buf) }()
 	if err := objstore.ReadRange(ctx, buf, path, storage, offset, size); err != nil {
 		return nil, err
 	}
@@ -88,11 +89,12 @@ func NewObjectFromPath(ctx context.Context, storage objstore.Bucket, path string
 
 		bufNew := bufferpool.GetBuffer(int(metaSize))
 		if err := objstore.ReadRange(ctx, bufNew, path, storage, offset, metaSize-size); err != nil {
+			bufferpool.Put(bufNew)
 			return nil, err
 		}
 		bufNew.B = append(bufNew.B, buf.B...)
+		bufferpool.Put(buf)
 		buf = bufNew
-
 	}
 
 	var meta metastorev1.BlockMeta

--- a/pkg/compactionworker/metadata_test.go
+++ b/pkg/compactionworker/metadata_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/mock"
@@ -145,6 +146,26 @@ func TestWorker_MetadataFromStorage_SegmentPath(t *testing.T) {
 	require.NoError(t, w.getBlockMetadata(log.NewNopLogger(), job))
 	require.Len(t, job.blocks, 1)
 	require.Equal(t, "", metadata.Tenant(job.blocks[0]))
+}
+
+func TestWorker_MetadataFromStorage_FetchTimeout(t *testing.T) {
+	bucket := mockobjstore.NewMockBucket(t)
+	bucket.EXPECT().Attributes(mock.Anything, mock.Anything).RunAndReturn(
+		func(ctx context.Context, _ string) (thanosstore.ObjectAttributes, error) {
+			<-ctx.Done()
+			return thanosstore.ObjectAttributes{}, ctx.Err()
+		})
+	bucket.EXPECT().IsObjNotFoundErr(mock.Anything).Return(false)
+
+	w := newStorageMetadataWorker(t, bucket)
+	w.config.MetadataFetchTimeout = 20 * time.Millisecond
+	job := testCompactionJob("tenant-a", 1, 1, "01J000000000000000000000F0")
+
+	start := time.Now()
+	err := w.getBlockMetadata(log.NewNopLogger(), job)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	// The read must be bounded by MetadataFetchTimeout, not by the job context.
+	require.Less(t, time.Since(start), 5*time.Second)
 }
 
 func TestWorker_MetadataFromStorage_ReadError(t *testing.T) {

--- a/pkg/compactionworker/metadata_test.go
+++ b/pkg/compactionworker/metadata_test.go
@@ -1,0 +1,198 @@
+package compactionworker
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	thanosstore "github.com/thanos-io/objstore"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	"github.com/grafana/pyroscope/v2/pkg/block"
+	"github.com/grafana/pyroscope/v2/pkg/block/metadata"
+	"github.com/grafana/pyroscope/v2/pkg/objstore"
+	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockmetastorev1"
+	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockobjstore"
+)
+
+// newStorageMetadataWorker creates a worker that reads block metadata from
+// object storage. The metastore mocks carry no expectations: any metastore
+// call on the metadata path fails the test.
+func newStorageMetadataWorker(t *testing.T, bucket objstore.Bucket) *Worker {
+	client := &MetastoreClientMock{
+		MockCompactionServiceClient: mockmetastorev1.NewMockCompactionServiceClient(t),
+		MockIndexServiceClient:      mockmetastorev1.NewMockIndexServiceClient(t),
+	}
+	w := createTestWorker(t, client, nil, bucket)
+	w.config.MetadataSource = MetadataSourceObjectStorage
+	return w
+}
+
+func testBlockMeta(id string, shard uint32, level uint32, tenant string) *metastorev1.BlockMeta {
+	st := metadata.NewStringTable()
+	md := &metastorev1.BlockMeta{
+		FormatVersion:   1,
+		Id:              id,
+		Shard:           shard,
+		CompactionLevel: level,
+		Tenant:          st.Put(tenant),
+		CreatedBy:       st.Put("segment-writer-1"),
+		MinTime:         1,
+		MaxTime:         2,
+	}
+	md.StringTable = st.Strings
+	return md
+}
+
+// writeBlockObject uploads an object of the block layout relevant here:
+// arbitrary data followed by the footer-encoded metadata.
+func writeBlockObject(t *testing.T, bucket objstore.Bucket, md *metastorev1.BlockMeta) string {
+	t.Helper()
+	var body bytes.Buffer
+	body.WriteString(strings.Repeat("x", 64))
+	md.MetadataOffset = uint64(body.Len())
+	require.NoError(t, metadata.Encode(&body, md))
+	path := block.ObjectPath(md)
+	require.NoError(t, bucket.Upload(context.Background(), path, bytes.NewReader(body.Bytes())))
+	return path
+}
+
+func testCompactionJob(tenant string, shard uint32, level uint32, blocks ...string) *compactionJob {
+	return &compactionJob{
+		CompactionJob: &metastorev1.CompactionJob{
+			Name:            "test-job",
+			Tenant:          tenant,
+			Shard:           shard,
+			CompactionLevel: level,
+			SourceBlocks:    blocks,
+		},
+		ctx: context.Background(),
+	}
+}
+
+func TestWorker_MetadataFromStorage(t *testing.T) {
+	bucket := objstore.NewBucket(thanosstore.NewInMemBucket())
+	ids := []string{
+		"01J000000000000000000000A1",
+		"01J000000000000000000000A2",
+		"01J000000000000000000000A3",
+	}
+	for _, id := range ids {
+		writeBlockObject(t, bucket, testBlockMeta(id, 3, 1, "tenant-a"))
+	}
+
+	w := newStorageMetadataWorker(t, bucket)
+	job := testCompactionJob("tenant-a", 3, 1, ids...)
+	require.NoError(t, w.getBlockMetadata(log.NewNopLogger(), job))
+
+	require.Len(t, job.blocks, 3)
+	for i, md := range job.blocks {
+		require.Equal(t, ids[i], md.Id)
+		require.Equal(t, "tenant-a", metadata.Tenant(md))
+		require.NotZero(t, md.Size, "metadata read from storage must carry the object size")
+	}
+	require.Equal(t, ids, job.SourceBlocks)
+}
+
+func TestWorker_MetadataFromStorage_MissingBlocksDropped(t *testing.T) {
+	bucket := objstore.NewBucket(thanosstore.NewInMemBucket())
+	present := []string{
+		"01J000000000000000000000B1",
+		"01J000000000000000000000B3",
+	}
+	for _, id := range present {
+		writeBlockObject(t, bucket, testBlockMeta(id, 1, 2, "tenant-a"))
+	}
+
+	w := newStorageMetadataWorker(t, bucket)
+	job := testCompactionJob("tenant-a", 1, 2,
+		"01J000000000000000000000B1",
+		"01J000000000000000000000B2", // no such object
+		"01J000000000000000000000B3",
+	)
+	require.NoError(t, w.getBlockMetadata(log.NewNopLogger(), job))
+
+	// The missing block is dropped and the job plan is updated,
+	// mirroring the metastore lookup semantics.
+	require.Equal(t, present, job.SourceBlocks)
+	require.Len(t, job.blocks, 2)
+}
+
+func TestWorker_MetadataFromStorage_AllMissing(t *testing.T) {
+	bucket := objstore.NewBucket(thanosstore.NewInMemBucket())
+	w := newStorageMetadataWorker(t, bucket)
+	job := testCompactionJob("tenant-a", 1, 1, "01J000000000000000000000C1")
+	require.NoError(t, w.getBlockMetadata(log.NewNopLogger(), job))
+	require.Empty(t, job.blocks)
+	require.Empty(t, job.SourceBlocks)
+}
+
+func TestWorker_MetadataFromStorage_SegmentPath(t *testing.T) {
+	bucket := objstore.NewBucket(thanosstore.NewInMemBucket())
+	// L0 segments are multi-tenant: the block tenant is anonymous and the
+	// object lives under the segment prefix regardless of the job tenant.
+	md := testBlockMeta("01J000000000000000000000D1", 5, 0, "")
+	path := writeBlockObject(t, bucket, md)
+	require.True(t, strings.HasPrefix(path, block.DirNameSegment+"/"), path)
+
+	w := newStorageMetadataWorker(t, bucket)
+	job := testCompactionJob("", 5, 0, "01J000000000000000000000D1")
+	require.NoError(t, w.getBlockMetadata(log.NewNopLogger(), job))
+	require.Len(t, job.blocks, 1)
+	require.Equal(t, "", metadata.Tenant(job.blocks[0]))
+}
+
+func TestWorker_MetadataFromStorage_ReadError(t *testing.T) {
+	bucket := mockobjstore.NewMockBucket(t)
+	bucket.EXPECT().Attributes(mock.Anything, mock.Anything).
+		Return(thanosstore.ObjectAttributes{}, errors.New("boom"))
+	bucket.EXPECT().IsObjNotFoundErr(mock.Anything).Return(false)
+
+	w := newStorageMetadataWorker(t, bucket)
+	job := testCompactionJob("tenant-a", 1, 1, "01J000000000000000000000E1")
+	require.Error(t, w.getBlockMetadata(log.NewNopLogger(), job))
+}
+
+// TestPyroscopeInstanceHash_MetadataSourceIndependent pins the CreatedBy
+// string table position across the two metadata representations. The
+// pyroscope_instance label of exported metrics hashes the CreatedBy string
+// table index (not the string), so the index must not depend on whether the
+// metadata was read from the block footer or exported by the metastore:
+// series identity would change with the metadata source otherwise.
+func TestPyroscopeInstanceHash_MetadataSourceIndependent(t *testing.T) {
+	// Footer representation: the segment writer interns the hostname first
+	// (see segment.flushBlock), so CreatedBy lands at index 1.
+	st := metadata.NewStringTable()
+	footer := &metastorev1.BlockMeta{
+		FormatVersion: 1,
+		Id:            "01J000000000000000000000F1",
+		Shard:         7,
+		Tenant:        0,
+		CreatedBy:     st.Put("segment-writer-1"),
+	}
+	footer.StringTable = st.Strings
+	require.EqualValues(t, 1, footer.CreatedBy)
+
+	// Metastore representation: blocks are stored against a shared
+	// shard-level string table, where the hostname lands at an arbitrary
+	// index; GetBlockMetadata exports a fresh per-block table.
+	shardTable := metadata.NewStringTable()
+	for _, s := range []string{"svc-a", "svc-b", "tenant-x"} {
+		shardTable.Put(s)
+	}
+	exported := footer.CloneVT()
+	shardTable.Import(exported)
+	require.NotEqual(t, footer.CreatedBy, exported.CreatedBy)
+	shardTable.Export(exported)
+
+	require.Equal(t, footer.CreatedBy, exported.CreatedBy)
+	require.Equal(t,
+		pyroscopeInstanceHash(footer.Shard, uint32(footer.CreatedBy)),
+		pyroscopeInstanceHash(exported.Shard, uint32(exported.CreatedBy)),
+	)
+}

--- a/pkg/compactionworker/worker.go
+++ b/pkg/compactionworker/worker.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -25,6 +26,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	thanosstore "github.com/thanos-io/objstore"
 	_ "go.uber.org/automaxprocs"
+	"golang.org/x/sync/errgroup"
 
 	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
 	"github.com/grafana/pyroscope/v2/pkg/block"
@@ -34,6 +36,16 @@ import (
 	"github.com/grafana/pyroscope/v2/pkg/util"
 )
 
+// Sources of the compaction job source block metadata.
+const (
+	MetadataSourceMetastore     = "metastore"
+	MetadataSourceObjectStorage = "object-storage"
+)
+
+// metadataReadConcurrency bounds the parallel block metadata reads
+// from object storage within a single compaction job.
+const metadataReadConcurrency = 8
+
 type Config struct {
 	JobConcurrency     int            `yaml:"job_capacity" category:"advanced"`
 	JobPollInterval    time.Duration  `yaml:"job_poll_interval" category:"advanced"`
@@ -41,6 +53,7 @@ type Config struct {
 	TempDir            string         `yaml:"temp_dir" category:"advanced" doc:"default=/tmp"`
 	RequestTimeout     time.Duration  `yaml:"request_timeout" category:"advanced"`
 	CleanupMaxDuration time.Duration  `yaml:"cleanup_max_duration" category:"advanced"`
+	MetadataSource     string         `yaml:"metadata_source" category:"advanced"`
 	MetricsExporter    metrics.Config `yaml:"metrics_exporter" category:"advanced"`
 }
 
@@ -52,7 +65,18 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.DurationVar(&cfg.CleanupMaxDuration, prefix+"cleanup-max-duration", 15*time.Second, "Maximum duration of the cleanup operations.")
 	f.IntVar(&cfg.SmallObjectSize, prefix+"small-object-size-bytes", 8<<20, "Size of the object that can be loaded in memory.")
 	f.StringVar(&cfg.TempDir, prefix+"temp-dir", os.TempDir(), "Temporary directory for compaction jobs.")
+	f.StringVar(&cfg.MetadataSource, prefix+"metadata-source", MetadataSourceMetastore, "Source of the compaction job source block metadata. Supported values: metastore, object-storage.")
 	cfg.MetricsExporter.RegisterFlags(f)
+}
+
+func (cfg *Config) Validate() error {
+	switch cfg.MetadataSource {
+	case MetadataSourceMetastore, MetadataSourceObjectStorage:
+		return nil
+	default:
+		return fmt.Errorf("invalid compaction-worker.metadata-source %q: supported values: %s, %s",
+			cfg.MetadataSource, MetadataSourceMetastore, MetadataSourceObjectStorage)
+	}
 }
 
 type Worker struct {
@@ -383,15 +407,6 @@ func (w *Worker) runCompaction(job *compactionJob) {
 	logger := log.With(w.logger, "job", job.Name)
 	level.Info(logger).Log("msg", "starting compaction job", "source_blocks", strings.Join(job.SourceBlocks, " "))
 
-	// FIXME(kolesnikovae): Read metadata from blocks: it's located in the
-	//   blocks footer. The start offest and CRC are the last 8 bytes (BE).
-	//   See metadata.Encode and metadata.Decode.
-	//   We use metadata to download objects: in fact we need to know only
-	//   tenant, shard, level, and ID: the information which we already have
-	//   in the job. We definitely don't need the full metadata entry with
-	//   datasets: this part can be set once we download the block and read
-	//   meta locally. Or, we can just fetch the metadata from the objects
-	//   directly, before downloading them.
 	if err := w.getBlockMetadata(logger, job); err != nil {
 		// The error is likely to be transient, therefore the job is not failed,
 		// but just abandoned – another worker will pick it up and try again.
@@ -521,6 +536,28 @@ func pyroscopeInstanceHash(shard uint32, createdBy uint32) string {
 }
 
 func (w *Worker) getBlockMetadata(logger log.Logger, job *compactionJob) error {
+	var blocks []*metastorev1.BlockMeta
+	var err error
+	if w.config.MetadataSource == MetadataSourceObjectStorage {
+		blocks, err = w.readBlockMetadataFromStorage(logger, job)
+	} else {
+		blocks, err = w.getBlockMetadataFromMetastore(logger, job)
+	}
+	if err != nil {
+		return err
+	}
+
+	job.blocks = blocks
+	// Update the plan to reflect the actual compaction job state.
+	job.SourceBlocks = job.SourceBlocks[:0]
+	for _, b := range job.blocks {
+		job.SourceBlocks = append(job.SourceBlocks, b.Id)
+	}
+
+	return nil
+}
+
+func (w *Worker) getBlockMetadataFromMetastore(logger log.Logger, job *compactionJob) ([]*metastorev1.BlockMeta, error) {
 	ctx, cancel := context.WithTimeout(job.ctx, w.config.RequestTimeout)
 	defer cancel()
 
@@ -533,17 +570,44 @@ func (w *Worker) getBlockMetadata(logger log.Logger, job *compactionJob) error {
 	})
 	if err != nil {
 		level.Error(logger).Log("msg", "failed to get block metadata", "err", err)
-		return err
+		return nil, err
 	}
 
-	job.blocks = resp.GetBlocks()
-	// Update the plan to reflect the actual compaction job state.
-	job.SourceBlocks = job.SourceBlocks[:0]
-	for _, b := range job.blocks {
-		job.SourceBlocks = append(job.SourceBlocks, b.Id)
-	}
+	return resp.GetBlocks(), nil
+}
 
-	return nil
+// readBlockMetadataFromStorage reads the source block metadata from the
+// block object footers, bypassing the metastore. The object paths are
+// derived from the job fields: the compaction queue is keyed by tenant,
+// shard, and level, so they are guaranteed to match the source blocks.
+func (w *Worker) readBlockMetadataFromStorage(logger log.Logger, job *compactionJob) ([]*metastorev1.BlockMeta, error) {
+	blocks := make([]*metastorev1.BlockMeta, len(job.SourceBlocks))
+	g, ctx := errgroup.WithContext(job.ctx)
+	g.SetLimit(metadataReadConcurrency)
+	for i, b := range job.SourceBlocks {
+		g.Go(func() error {
+			ctx, cancel := context.WithTimeout(ctx, w.config.RequestTimeout)
+			defer cancel()
+			path := block.BuildObjectPath(job.Tenant, job.Shard, job.CompactionLevel, b)
+			obj, err := block.NewObjectFromPath(ctx, w.storage, path)
+			switch {
+			case err == nil:
+				blocks[i] = obj.Metadata()
+			case objstore.IsNotExist(w.storage, err):
+				// The block has been deleted: drop it from the job,
+				// mirroring the metastore lookup semantics.
+				level.Warn(logger).Log("msg", "source block object not found", "block", b)
+			default:
+				level.Error(logger).Log("msg", "failed to read block metadata from storage", "block", b, "err", err)
+				return err
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return slices.DeleteFunc(blocks, func(m *metastorev1.BlockMeta) bool { return m == nil }), nil
 }
 
 func (w *Worker) handleTombstones(logger log.Logger, tombstones ...*metastorev1.Tombstones) {

--- a/pkg/compactionworker/worker.go
+++ b/pkg/compactionworker/worker.go
@@ -47,14 +47,15 @@ const (
 const metadataReadConcurrency = 8
 
 type Config struct {
-	JobConcurrency     int            `yaml:"job_capacity" category:"advanced"`
-	JobPollInterval    time.Duration  `yaml:"job_poll_interval" category:"advanced"`
-	SmallObjectSize    int            `yaml:"small_object_size_bytes" category:"advanced"`
-	TempDir            string         `yaml:"temp_dir" category:"advanced" doc:"default=/tmp"`
-	RequestTimeout     time.Duration  `yaml:"request_timeout" category:"advanced"`
-	CleanupMaxDuration time.Duration  `yaml:"cleanup_max_duration" category:"advanced"`
-	MetadataSource     string         `yaml:"metadata_source" category:"advanced"`
-	MetricsExporter    metrics.Config `yaml:"metrics_exporter" category:"advanced"`
+	JobConcurrency       int            `yaml:"job_capacity" category:"advanced"`
+	JobPollInterval      time.Duration  `yaml:"job_poll_interval" category:"advanced"`
+	SmallObjectSize      int            `yaml:"small_object_size_bytes" category:"advanced"`
+	TempDir              string         `yaml:"temp_dir" category:"advanced" doc:"default=/tmp"`
+	RequestTimeout       time.Duration  `yaml:"request_timeout" category:"advanced"`
+	CleanupMaxDuration   time.Duration  `yaml:"cleanup_max_duration" category:"advanced"`
+	MetadataSource       string         `yaml:"metadata_source" category:"advanced"`
+	MetadataFetchTimeout time.Duration  `yaml:"metadata_fetch_timeout" category:"advanced"`
+	MetricsExporter      metrics.Config `yaml:"metrics_exporter" category:"advanced"`
 }
 
 func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
@@ -66,6 +67,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.IntVar(&cfg.SmallObjectSize, prefix+"small-object-size-bytes", 8<<20, "Size of the object that can be loaded in memory.")
 	f.StringVar(&cfg.TempDir, prefix+"temp-dir", os.TempDir(), "Temporary directory for compaction jobs.")
 	f.StringVar(&cfg.MetadataSource, prefix+"metadata-source", MetadataSourceMetastore, "Source of the compaction job source block metadata. Supported values: metastore, object-storage.")
+	f.DurationVar(&cfg.MetadataFetchTimeout, prefix+"metadata-fetch-timeout", 30*time.Second, "Timeout for reading the metadata of a single block from object storage. Only effective when metadata-source is object-storage. 0 disables the timeout.")
 	cfg.MetricsExporter.RegisterFlags(f)
 }
 
@@ -586,10 +588,17 @@ func (w *Worker) readBlockMetadataFromStorage(logger log.Logger, job *compaction
 	g.SetLimit(metadataReadConcurrency)
 	for i, b := range job.SourceBlocks {
 		g.Go(func() error {
-			ctx, cancel := context.WithTimeout(ctx, w.config.RequestTimeout)
-			defer cancel()
+			// Deliberately not RequestTimeout: that one is pinned small by the
+			// job lease renewal (it guards the metastore poll RPC), while a
+			// ranged read against object storage has much heavier tails.
+			readCtx := ctx
+			if w.config.MetadataFetchTimeout > 0 {
+				var cancel context.CancelFunc
+				readCtx, cancel = context.WithTimeout(ctx, w.config.MetadataFetchTimeout)
+				defer cancel()
+			}
 			path := block.BuildObjectPath(job.Tenant, job.Shard, job.CompactionLevel, b)
-			obj, err := block.NewObjectFromPath(ctx, w.storage, path)
+			obj, err := block.NewObjectFromPath(readCtx, w.storage, path)
 			switch {
 			case err == nil:
 				blocks[i] = obj.Metadata()

--- a/pkg/pyroscope/pyroscope.go
+++ b/pkg/pyroscope/pyroscope.go
@@ -421,6 +421,10 @@ func (c *Config) Validate() error {
 		return err
 	}
 
+	if err := c.CompactionWorker.Validate(); err != nil {
+		return err
+	}
+
 	if c.usesV1Storage() {
 		if err := c.Compactor.Validate(c.PhlareDB.MaxBlockDuration); err != nil {
 			return err


### PR DESCRIPTION
The compaction worker fetches full source block metadata from the metastore (`GetBlockMetadata`), even though the same metadata is stored in each block's footer. This keeps the worker coupled to the metastore on a path where the blocks are downloaded from object storage right after anyway - and it stands in the way of shrinking the metastore index.

This PR adds `-compaction-worker.metadata-source` (default `metastore`, opt-in `object-storage`) to read the metadata from the block object footers instead. Object paths are derived from the job fields (tenant, shard, level), which are guaranteed to match the source blocks since the compaction queue is keyed by them. Reads run in parallel with bounded concurrency.

Notes:
- A missing object drops the block from the job, mirroring the metastore lookup filtering; all objects missing lands on the existing `metadata_not_found` path.
- The `pyroscope_instance` label of exported metrics hashes the `CreatedBy` string table index, which happens to be identical in the footer and metastore representations of the metadata - a test pins this so series identity can't silently change with the metadata source.