### PR TITLE
perf(symdb): index stacktrace tree edges

### DIFF
--- a/pkg/phlaredb/metrics_test.go
+++ b/pkg/phlaredb/metrics_test.go
@@ -55,7 +55,7 @@ pyroscope_head_size_bytes{type="functions"} 96
 pyroscope_head_size_bytes{type="locations"} 152
 pyroscope_head_size_bytes{type="mappings"} 96
 pyroscope_head_size_bytes{type="profiles"} 564
-pyroscope_head_size_bytes{type="stacktraces"} 96
+pyroscope_head_size_bytes{type="stacktraces"} 72
 pyroscope_head_size_bytes{type="strings"} 66
 
 `),

--- a/pkg/phlaredb/symdb/partition_memory.go
+++ b/pkg/phlaredb/symdb/partition_memory.go
@@ -54,8 +54,8 @@ type stacktraces struct {
 
 func (p *stacktraces) size() uint64 {
 	p.m.RLock()
-	// TODO: map footprint isn't accounted
-	v := stacktraceTreeNodeSize * cap(p.tree.nodes)
+	// TODO: hashToIdx map footprint isn't accounted.
+	v := stacktraceTreeNodeSize*cap(p.tree.nodes) + stacktraceTreeEdgeSize*cap(p.tree.edges.slots)
 	p.m.RUnlock()
 	return uint64(v)
 }

--- a/pkg/phlaredb/symdb/partition_memory_test.go
+++ b/pkg/phlaredb/symdb/partition_memory_test.go
@@ -45,6 +45,14 @@ func Test_Stacktrace_append_existing(t *testing.T) {
 	assert.Equal(t, []uint32{5, 6}, sids)
 }
 
+func Test_Stacktraces_size(t *testing.T) {
+	p := newStacktraces()
+	p.tree.nodes = make([]node, 1, 5)
+	p.tree.edges.slots = make([]uint32, 8)
+
+	assert.Equal(t, uint64(72), p.size())
+}
+
 func Test_Stacktraces_memory_resolve_pprof(t *testing.T) {
 	p, err := pprof.OpenFile("testdata/profile.pb.gz")
 	require.NoError(t, err)

--- a/pkg/phlaredb/symdb/stacktrace_tree.go
+++ b/pkg/phlaredb/symdb/stacktrace_tree.go
@@ -11,18 +11,24 @@ import (
 const (
 	defaultStacktraceTreeSize = 0
 	stacktraceTreeNodeSize    = int(unsafe.Sizeof(node{}))
+	stacktraceTreeEdgeSize    = int(unsafe.Sizeof(uint32(0)))
 )
 
 type stacktraceTree struct {
 	nodes []node
+	edges edgeTable
 }
 
 type node struct {
 	p int32 // Parent index.
 	r int32 // Reference the to stack frame data.
-	// Auxiliary members only needed for insertion.
-	fc int32 // First child index.
-	ns int32 // Next sibling index.
+}
+
+// edgeTable maps a (parent, location) pair to its child node index. The pair
+// is reconstructed from nodes[child], keeping the insertion-only index compact.
+type edgeTable struct {
+	slots []uint32
+	count uint32
 }
 
 func newStacktraceTree(size int) *stacktraceTree {
@@ -31,10 +37,9 @@ func newStacktraceTree(size int) *stacktraceTree {
 	}
 	t := stacktraceTree{nodes: make([]node, 1, size)}
 	t.nodes[0] = node{
-		p:  sentinel,
-		fc: sentinel,
-		ns: sentinel,
+		p: sentinel,
 	}
+	t.edges.init(size - 1)
 	return &t
 }
 
@@ -43,47 +48,63 @@ const sentinel = -1
 func (t *stacktraceTree) len() uint32 { return uint32(len(t.nodes)) }
 
 func (t *stacktraceTree) insert(refs []uint64) uint32 {
-	var (
-		n = &t.nodes[0]
-		i = n.fc
-		x int32
-	)
-
-	for j := len(refs) - 1; j >= 0; {
-		r := int32(refs[j])
-		if i == sentinel {
-			ni := int32(len(t.nodes))
-			n.fc = ni
-			t.nodes = append(t.nodes, node{
-				r:  r,
-				p:  x,
-				fc: sentinel,
-				ns: sentinel,
-			})
-			x = ni
-			n = &t.nodes[ni]
-		} else {
-			x = i
-			n = &t.nodes[i]
+	parent := int32(0)
+	for j := len(refs) - 1; j >= 0; j-- {
+		location := int32(refs[j])
+		child, slot := t.edges.lookup(t.nodes, parent, location)
+		if child == 0 {
+			t.edges.grow(t.nodes)
+			child, slot = t.edges.lookup(t.nodes, parent, location)
+			child = uint32(len(t.nodes))
+			t.nodes = append(t.nodes, node{p: parent, r: location})
+			t.edges.slots[slot] = child
+			t.edges.count++
 		}
-		if n.r == r {
-			i = n.fc
-			j--
-			continue
-		}
-		if n.ns < 0 {
-			n.ns = int32(len(t.nodes))
-			t.nodes = append(t.nodes, node{
-				r:  r,
-				p:  n.p,
-				fc: sentinel,
-				ns: sentinel,
-			})
-		}
-		i = n.ns
+		parent = int32(child)
 	}
 
-	return uint32(x)
+	return uint32(parent)
+}
+
+func (t *edgeTable) init(entries int) {
+	if entries < 1 {
+		entries = 1
+	}
+	t.slots = make([]uint32, edgeTableCapacity(entries))
+}
+
+func (t *edgeTable) lookup(nodes []node, parent, location int32) (uint32, int) {
+	mask := uint64(len(t.slots) - 1)
+	for slot := int(edgeHash(parent, location) & mask); ; slot = (slot + 1) & int(mask) {
+		child := t.slots[slot]
+		if child == 0 || (nodes[child].p == parent && nodes[child].r == location) {
+			return child, slot
+		}
+	}
+}
+
+func (t *edgeTable) grow(nodes []node) {
+	if (t.count+1)*4 <= uint32(len(t.slots))*3 {
+		return
+	}
+	t.slots = make([]uint32, len(t.slots)*2)
+	for child := uint32(1); child < uint32(len(nodes)); child++ {
+		n := nodes[child]
+		_, slot := t.lookup(nodes, n.p, n.r)
+		t.slots[slot] = child
+	}
+}
+
+func edgeTableCapacity(entries int) int {
+	capacity := 2
+	for capacity*3/4 < entries {
+		capacity <<= 1
+	}
+	return capacity
+}
+
+func edgeHash(parent, location int32) uint64 {
+	return uint64(uint32(parent))*0x9e3779b185ebca87 + uint64(uint32(location))*0xc2b2ae3d27d4eb4f
 }
 
 func (t *stacktraceTree) resolve(dst []int32, id uint32) []int32 {
@@ -186,33 +207,21 @@ func (t *parentPointerTree) Nodes() []Node {
 
 func (t *parentPointerTree) toStacktraceTree() *stacktraceTree {
 	l := int32(len(t.nodes))
-	x := stacktraceTree{nodes: make([]node, l)}
-	x.nodes[0] = node{
-		p:  sentinel,
-		fc: sentinel,
-		ns: sentinel,
-	}
-	lc := make([]int32, len(t.nodes))
-	var s int32
+	x := newStacktraceTree(int(l))
+	x.nodes = make([]node, l)
+	x.nodes[0].p = sentinel
 	for i := int32(1); i < l; i++ {
 		n := t.nodes[i]
 		x.nodes[i] = node{
-			p:  n.p,
-			r:  n.r,
-			fc: sentinel,
-			ns: sentinel,
+			p: n.p,
+			r: n.r,
 		}
-		// Swap the last child of the parent with self.
-		// If this is the first child, update the parent.
-		// Otherwise, update the sibling.
-		s, lc[n.p] = lc[n.p], i
-		if s == 0 {
-			x.nodes[n.p].fc = i
-		} else {
-			x.nodes[s].ns = i
-		}
+		x.edges.grow(x.nodes[:i])
+		_, slot := x.edges.lookup(x.nodes[:i], n.p, n.r)
+		x.edges.slots[slot] = uint32(i)
+		x.edges.count++
 	}
-	return &x
+	return x
 }
 
 // ReadFrom decodes parent pointer tree from the reader.

--- a/pkg/phlaredb/symdb/stacktrace_tree.go
+++ b/pkg/phlaredb/symdb/stacktrace_tree.go
@@ -53,8 +53,9 @@ func (t *stacktraceTree) insert(refs []uint64) uint32 {
 		location := int32(refs[j])
 		child, slot := t.edges.lookup(t.nodes, parent, location)
 		if child == 0 {
-			t.edges.grow(t.nodes)
-			child, slot = t.edges.lookup(t.nodes, parent, location)
+			if t.edges.grow(t.nodes) {
+				_, slot = t.edges.lookup(t.nodes, parent, location)
+			}
 			child = uint32(len(t.nodes))
 			t.nodes = append(t.nodes, node{p: parent, r: location})
 			t.edges.slots[slot] = child
@@ -83,9 +84,9 @@ func (t *edgeTable) lookup(nodes []node, parent, location int32) (uint32, int) {
 	}
 }
 
-func (t *edgeTable) grow(nodes []node) {
+func (t *edgeTable) grow(nodes []node) bool {
 	if (t.count+1)*4 <= uint32(len(t.slots))*3 {
-		return
+		return false
 	}
 	t.slots = make([]uint32, len(t.slots)*2)
 	for child := uint32(1); child < uint32(len(nodes)); child++ {
@@ -93,6 +94,7 @@ func (t *edgeTable) grow(nodes []node) {
 		_, slot := t.lookup(nodes, n.p, n.r)
 		t.slots[slot] = child
 	}
+	return true
 }
 
 func edgeTableCapacity(entries int) int {
@@ -212,10 +214,7 @@ func (t *parentPointerTree) toStacktraceTree() *stacktraceTree {
 	x.nodes[0].p = sentinel
 	for i := int32(1); i < l; i++ {
 		n := t.nodes[i]
-		x.nodes[i] = node{
-			p: n.p,
-			r: n.r,
-		}
+		x.nodes[i] = node(n)
 		x.edges.grow(x.nodes[:i])
 		_, slot := x.edges.lookup(x.nodes[:i], n.p, n.r)
 		x.edges.slots[slot] = uint32(i)

--- a/pkg/phlaredb/symdb/stacktrace_tree_test.go
+++ b/pkg/phlaredb/symdb/stacktrace_tree_test.go
@@ -161,6 +161,17 @@ func Test_stacktrace_tree_insert_grows_edge_table(t *testing.T) {
 	}
 }
 
+func Test_edge_table_grow(t *testing.T) {
+	tree := newStacktraceTree(1)
+	assert.False(t, tree.edges.grow(tree.nodes))
+
+	id := tree.insert([]uint64{1})
+	assert.True(t, tree.edges.grow(tree.nodes))
+	assert.Equal(t, 4, len(tree.edges.slots))
+	child, _ := tree.edges.lookup(tree.nodes, 0, 1)
+	assert.Equal(t, id, child)
+}
+
 func Test_stacktrace_tree_pprof_locations(t *testing.T) {
 	p, err := pprof.OpenFile("testdata/profile.pb.gz")
 	require.NoError(t, err)

--- a/pkg/phlaredb/symdb/stacktrace_tree_test.go
+++ b/pkg/phlaredb/symdb/stacktrace_tree_test.go
@@ -92,10 +92,8 @@ func Test_stacktrace_tree_encoding_rand(t *testing.T) {
 	nodes := make([]node, 1<<20)
 	for i := range nodes {
 		nodes[i] = node{
-			fc: 2,
-			ns: 3,
-			p:  int32(rand.Intn(10 << 10)),
-			r:  int32(rand.Intn(10 << 10)),
+			p: int32(rand.Intn(10 << 10)),
+			r: int32(rand.Intn(10 << 10)),
 		}
 	}
 
@@ -124,6 +122,43 @@ func Test_stacktrace_tree_pprof_locations_(t *testing.T) {
 	p := newParentPointerTree(0)
 	assert.Len(t, p.resolve([]int32{0, 1, 2, 3}, 42), 0)
 	assert.Len(t, p.resolveUint64([]uint64{0, 1, 2, 3}, 42), 0)
+}
+
+func Test_stacktrace_tree_insert_collision(t *testing.T) {
+	tree := newStacktraceTree(1)
+	locations := make([]uint64, 0, 3)
+	slot := edgeHash(0, 1) & uint64(len(tree.edges.slots)-1)
+	for location := int32(1); len(locations) < cap(locations); location++ {
+		if edgeHash(0, location)&uint64(len(tree.edges.slots)-1) == slot {
+			locations = append(locations, uint64(location))
+		}
+	}
+
+	for _, location := range locations {
+		tree.insert([]uint64{location})
+	}
+
+	assert.Len(t, tree.nodes, len(locations)+1)
+	for _, location := range locations {
+		id := tree.insert([]uint64{location})
+		assert.Equal(t, []int32{int32(location)}, tree.resolve(nil, id))
+	}
+}
+
+func Test_stacktrace_tree_insert_grows_edge_table(t *testing.T) {
+	tree := newStacktraceTree(1)
+	const locations = 1024
+	for location := 1; location <= locations; location++ {
+		tree.insert([]uint64{uint64(location)})
+	}
+
+	assert.Len(t, tree.nodes, locations+1)
+	assert.Equal(t, uint32(locations), tree.edges.count)
+	assert.GreaterOrEqual(t, len(tree.edges.slots)*3/4, locations)
+	for location := 1; location <= locations; location++ {
+		id := tree.insert([]uint64{uint64(location)})
+		assert.Equal(t, []int32{int32(location)}, tree.resolve(nil, id))
+	}
 }
 
 func Test_stacktrace_tree_pprof_locations(t *testing.T) {


### PR DESCRIPTION
## What this PR does

Replaces the stacktrace tree child/sibling scan with an open-addressed edge index keyed by `(parent, location)`. The insertion-only index reconstructs keys from child nodes, reducing each tree node from four `int32` fields to two while avoiding linear sibling scans.

The stacktrace memory estimate now includes edge-table slots, and collision/growth tests cover the index behavior.

## Results

The existing `size=2048` insertion benchmark improved from approximately 87.8 us/op to 61.4 us/op (30% faster).

A production comparison showed the targeted stacktrace index:

- CPU: 23.93 s to 12.81 s (46.5% lower)
- Allocated bytes: 8.65 GB to 7.13 GB (17.5% lower)

## Verification

- `go test ./pkg/phlaredb/symdb`
- `go test -race ./pkg/phlaredb/symdb`
- Signed commit verified with `git verify-commit HEAD`