### PR TITLE
fix: clean up stale ring members on shutdown and via auto-forget

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -721,6 +721,8 @@ Usage of ./pyroscope:
     	The prefix for the keys in the store. Should end with a /. (default "collectors/")
   -overrides-exporter.ring.store string
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
+  -overrides-exporter.ring.unregister-on-shutdown
+    	Unregister from the ring upon clean shutdown. Disabling it keeps the instance in the ring in LEAVING state until it is auto-forgotten, which minimises leader changes when the instance is expected to rejoin with the same ID shortly. (default true)
   -overrides-exporter.ring.wait-stability-max-duration duration
     	Maximum time to wait for ring stability at startup. If the overrides-exporter ring keeps changing after this period of time, it will start anyway. (default 5m0s)
   -overrides-exporter.ring.wait-stability-min-duration duration
@@ -1073,6 +1075,8 @@ Usage of ./pyroscope:
     	HTTP client timeout when fetching runtime config from URLs. (default 30s)
   -runtime-config.reload-period duration
     	How often to check runtime config files. (default 10s)
+  -segment-writer.auto-forget-unhealthy-periods int
+    	Number of consecutive heartbeat-timeout periods after which a ring member whose heartbeat has gone stale is automatically removed (forgotten) from the ring. This cleans up entries of instances that have left the ring without unregistering, e.g. after a scale-down. 0 disables auto-forget.
   -segment-writer.availability-zone string
     	The availability zone where this instance is running.
   -segment-writer.bucket-health-check-enabled

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -1170,6 +1170,13 @@ lifecycler:
   # CLI flag: -segment-writer.lifecycler.ID
   [id: <string> | default = "<hostname>"]
 
+# (advanced) Number of consecutive heartbeat-timeout periods after which a ring
+# member whose heartbeat has gone stale is automatically removed (forgotten)
+# from the ring. This cleans up entries of instances that have left the ring
+# without unregistering, e.g. after a scale-down. 0 disables auto-forget.
+# CLI flag: -segment-writer.auto-forget-unhealthy-periods
+[auto_forget_unhealthy_periods: <int> | default = 0]
+
 # (advanced) Timeout when flushing segments to bucket.
 # CLI flag: -segment-writer.segment-duration
 [segment_duration: <duration> | default = 500ms]
@@ -2637,6 +2644,13 @@ ring:
   # start anyway.
   # CLI flag: -overrides-exporter.ring.wait-stability-max-duration
   [wait_stability_max_duration: <duration> | default = 5m]
+
+  # (advanced) Unregister from the ring upon clean shutdown. Disabling it keeps
+  # the instance in the ring in LEAVING state until it is auto-forgotten, which
+  # minimises leader changes when the instance is expected to rejoin with the
+  # same ID shortly.
+  # CLI flag: -overrides-exporter.ring.unregister-on-shutdown
+  [unregister_on_shutdown: <boolean> | default = true]
 ```
 
 ### grpc_client

--- a/pkg/segmentwriter/autoforget.go
+++ b/pkg/segmentwriter/autoforget.go
@@ -61,6 +61,7 @@ func (f *autoForget) iteration(ctx context.Context) error {
 				// the problem is more likely on our side (e.g. a network
 				// partition), so we must not judge the other members.
 				level.Warn(f.logger).Log("msg", "auto-forget sees its own instance as unhealthy, the network may be partitioned, skipping this round", "instance", id)
+				forgotten = forgotten[:0]
 				return nil, false, nil
 			}
 			forgotten = append(forgotten, id)

--- a/pkg/segmentwriter/autoforget.go
+++ b/pkg/segmentwriter/autoforget.go
@@ -1,0 +1,84 @@
+package segmentwriter
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/kv"
+	"github.com/grafana/dskit/ring"
+	"github.com/grafana/dskit/services"
+)
+
+// autoForget periodically removes ring members whose heartbeat has been stale
+// for longer than the forget period. The segment-writer lifecycler keeps its
+// ring entry on shutdown (-segment-writer.unregister-on-shutdown defaults to
+// false) so that restarts do not disturb shard placement, but instances that
+// never come back, e.g. after a scale-down, would otherwise stay in the ring
+// until forgotten manually. This is the classic-lifecycler equivalent of
+// dskit's AutoForgetDelegate.
+type autoForget struct {
+	services.Service
+
+	kv           kv.Client
+	instanceID   string
+	forgetPeriod time.Duration
+	logger       log.Logger
+}
+
+func newAutoForget(kvClient kv.Client, instanceID string, forgetPeriod, interval time.Duration, logger log.Logger) *autoForget {
+	f := &autoForget{
+		kv:           kvClient,
+		instanceID:   instanceID,
+		forgetPeriod: forgetPeriod,
+		logger:       logger,
+	}
+	f.Service = services.NewTimerService(interval, nil, f.iteration, nil)
+	return f
+}
+
+func (f *autoForget) iteration(ctx context.Context) error {
+	var forgotten []string
+	err := f.kv.CAS(ctx, RingKey, func(in any) (out any, retry bool, err error) {
+		forgotten = forgotten[:0]
+		if in == nil {
+			return nil, false, nil
+		}
+		desc, ok := in.(*ring.Desc)
+		if !ok {
+			level.Warn(f.logger).Log("msg", fmt.Sprintf("auto-forget saw a KV store value that was not `ring.Desc`, got `%T`", in))
+			return nil, false, nil
+		}
+		now := time.Now()
+		for id, instance := range desc.Ingesters {
+			if now.Sub(time.Unix(instance.GetTimestamp(), 0)) <= f.forgetPeriod {
+				continue
+			}
+			if id == f.instanceID {
+				// If our own heartbeat looks stale in our view of the ring,
+				// the problem is more likely on our side (e.g. a network
+				// partition), so we must not judge the other members.
+				level.Warn(f.logger).Log("msg", "auto-forget sees its own instance as unhealthy, the network may be partitioned, skipping this round", "instance", id)
+				return nil, false, nil
+			}
+			forgotten = append(forgotten, id)
+		}
+		if len(forgotten) == 0 {
+			return nil, false, nil
+		}
+		for _, id := range forgotten {
+			desc.RemoveIngester(id)
+		}
+		return desc, true, nil
+	})
+	if err != nil {
+		level.Warn(f.logger).Log("msg", "auto-forget failed to update the ring", "err", err)
+		return nil
+	}
+	for _, id := range forgotten {
+		level.Info(f.logger).Log("msg", "auto-forget removed instance from the ring because its heartbeat was stale for too long", "instance", id, "forget_period", f.forgetPeriod)
+	}
+	return nil
+}

--- a/pkg/segmentwriter/autoforget_test.go
+++ b/pkg/segmentwriter/autoforget_test.go
@@ -1,0 +1,85 @@
+package segmentwriter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/kv/consul"
+	"github.com/grafana/dskit/ring"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setInstanceHeartbeat(t *testing.T, kvStore *consul.Client, id string, ts time.Time) {
+	t.Helper()
+	require.NoError(t, kvStore.CAS(context.Background(), RingKey, func(in any) (out any, retry bool, err error) {
+		desc := in.(*ring.Desc)
+		instance := desc.Ingesters[id]
+		instance.Timestamp = ts.Unix()
+		desc.Ingesters[id] = instance
+		return desc, true, nil
+	}))
+}
+
+func newTestRingDesc(t *testing.T, kvStore *consul.Client, ids ...string) {
+	t.Helper()
+	require.NoError(t, kvStore.CAS(context.Background(), RingKey, func(in any) (out any, retry bool, err error) {
+		desc := ring.NewDesc()
+		for i, id := range ids {
+			desc.AddIngester(id, "127.0.0.1", "", []uint32{uint32(i)}, ring.ACTIVE, time.Now(), false, time.Now(), ring.InstanceVersions{})
+		}
+		return desc, true, nil
+	}))
+}
+
+func ringInstanceIDs(t *testing.T, kvStore *consul.Client) []string {
+	t.Helper()
+	v, err := kvStore.Get(context.Background(), RingKey)
+	require.NoError(t, err)
+	desc, ok := v.(*ring.Desc)
+	require.True(t, ok)
+	ids := make([]string, 0, len(desc.Ingesters))
+	for id := range desc.Ingesters {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func TestAutoForget_removesStaleInstances(t *testing.T) {
+	kvStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	const forgetPeriod = 4 * time.Minute
+	newTestRingDesc(t, kvStore, "self", "fresh", "stale")
+	setInstanceHeartbeat(t, kvStore, "stale", time.Now().Add(-forgetPeriod-time.Minute))
+
+	f := newAutoForget(kvStore, "self", forgetPeriod, time.Minute, log.NewNopLogger())
+	require.NoError(t, f.iteration(context.Background()))
+
+	assert.ElementsMatch(t, []string{"self", "fresh"}, ringInstanceIDs(t, kvStore))
+}
+
+func TestAutoForget_skipsRoundWhenOwnHeartbeatIsStale(t *testing.T) {
+	kvStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	const forgetPeriod = 4 * time.Minute
+	newTestRingDesc(t, kvStore, "self", "stale")
+	setInstanceHeartbeat(t, kvStore, "self", time.Now().Add(-forgetPeriod-time.Minute))
+	setInstanceHeartbeat(t, kvStore, "stale", time.Now().Add(-forgetPeriod-time.Minute))
+
+	f := newAutoForget(kvStore, "self", forgetPeriod, time.Minute, log.NewNopLogger())
+	require.NoError(t, f.iteration(context.Background()))
+
+	assert.ElementsMatch(t, []string{"self", "stale"}, ringInstanceIDs(t, kvStore))
+}
+
+func TestAutoForget_noRing(t *testing.T) {
+	kvStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	f := newAutoForget(kvStore, "self", 4*time.Minute, time.Minute, log.NewNopLogger())
+	require.NoError(t, f.iteration(context.Background()))
+}

--- a/pkg/segmentwriter/autoforget_test.go
+++ b/pkg/segmentwriter/autoforget_test.go
@@ -1,6 +1,7 @@
 package segmentwriter
 
 import (
+	"bytes"
 	"context"
 	"testing"
 	"time"
@@ -70,10 +71,12 @@ func TestAutoForget_skipsRoundWhenOwnHeartbeatIsStale(t *testing.T) {
 	setInstanceHeartbeat(t, kvStore, "self", time.Now().Add(-forgetPeriod-time.Minute))
 	setInstanceHeartbeat(t, kvStore, "stale", time.Now().Add(-forgetPeriod-time.Minute))
 
-	f := newAutoForget(kvStore, "self", forgetPeriod, time.Minute, log.NewNopLogger())
+	var logs bytes.Buffer
+	f := newAutoForget(kvStore, "self", forgetPeriod, time.Minute, log.NewLogfmtLogger(&logs))
 	require.NoError(t, f.iteration(context.Background()))
 
 	assert.ElementsMatch(t, []string{"self", "stale"}, ringInstanceIDs(t, kvStore))
+	assert.NotContains(t, logs.String(), "auto-forget removed instance")
 }
 
 func TestAutoForget_noRing(t *testing.T) {

--- a/pkg/segmentwriter/service.go
+++ b/pkg/segmentwriter/service.go
@@ -42,21 +42,22 @@ const (
 )
 
 type Config struct {
-	GRPCClientConfig         grpcclient.Config     `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate with the segment writer."`
-	LifecyclerConfig         ring.LifecyclerConfig `yaml:"lifecycler,omitempty"`
-	SegmentDuration          time.Duration         `yaml:"segment_duration,omitempty" category:"advanced"`
-	FlushConcurrency         uint                  `yaml:"flush_concurrency,omitempty" category:"advanced"`
-	UploadTimeout            time.Duration         `yaml:"upload-timeout,omitempty" category:"advanced"`
-	UploadMaxRetries         int                   `yaml:"upload-retry_max_retries,omitempty" category:"advanced"`
-	UploadMinBackoff         time.Duration         `yaml:"upload-retry_min_period,omitempty" category:"advanced"`
-	UploadMaxBackoff         time.Duration         `yaml:"upload-retry_max_period,omitempty" category:"advanced"`
-	UploadHedgeAfter         time.Duration         `yaml:"upload-hedge_upload_after,omitempty" category:"advanced"`
-	UploadHedgeRateMax       float64               `yaml:"upload-hedge_rate_max,omitempty" category:"advanced"`
-	UploadHedgeRateBurst     uint                  `yaml:"upload-hedge_rate_burst,omitempty" category:"advanced"`
-	MetadataDLQEnabled       bool                  `yaml:"metadata_dlq_enabled,omitempty" category:"advanced"`
-	MetadataUpdateTimeout    time.Duration         `yaml:"metadata_update_timeout,omitempty" category:"advanced"`
-	BucketHealthCheckEnabled bool                  `yaml:"bucket_health_check_enabled,omitempty" category:"advanced"`
-	BucketHealthCheckTimeout time.Duration         `yaml:"bucket_health_check_timeout,omitempty" category:"advanced"`
+	GRPCClientConfig           grpcclient.Config     `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate with the segment writer."`
+	LifecyclerConfig           ring.LifecyclerConfig `yaml:"lifecycler,omitempty"`
+	AutoForgetUnhealthyPeriods int                   `yaml:"auto_forget_unhealthy_periods,omitempty" category:"advanced"`
+	SegmentDuration            time.Duration         `yaml:"segment_duration,omitempty" category:"advanced"`
+	FlushConcurrency           uint                  `yaml:"flush_concurrency,omitempty" category:"advanced"`
+	UploadTimeout              time.Duration         `yaml:"upload-timeout,omitempty" category:"advanced"`
+	UploadMaxRetries           int                   `yaml:"upload-retry_max_retries,omitempty" category:"advanced"`
+	UploadMinBackoff           time.Duration         `yaml:"upload-retry_min_period,omitempty" category:"advanced"`
+	UploadMaxBackoff           time.Duration         `yaml:"upload-retry_max_period,omitempty" category:"advanced"`
+	UploadHedgeAfter           time.Duration         `yaml:"upload-hedge_upload_after,omitempty" category:"advanced"`
+	UploadHedgeRateMax         float64               `yaml:"upload-hedge_rate_max,omitempty" category:"advanced"`
+	UploadHedgeRateBurst       uint                  `yaml:"upload-hedge_rate_burst,omitempty" category:"advanced"`
+	MetadataDLQEnabled         bool                  `yaml:"metadata_dlq_enabled,omitempty" category:"advanced"`
+	MetadataUpdateTimeout      time.Duration         `yaml:"metadata_update_timeout,omitempty" category:"advanced"`
+	BucketHealthCheckEnabled   bool                  `yaml:"bucket_health_check_enabled,omitempty" category:"advanced"`
+	BucketHealthCheckTimeout   time.Duration         `yaml:"bucket_health_check_timeout,omitempty" category:"advanced"`
 }
 
 func (cfg *Config) Validate() error {
@@ -83,6 +84,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 		prefix + ".tokens-file-path":                   fieldcategory.Advanced,
 	})
 	cfg.LifecyclerConfig.RegisterFlagsWithPrefix(prefix+".", f, util.Logger)
+	f.IntVar(&cfg.AutoForgetUnhealthyPeriods, prefix+".auto-forget-unhealthy-periods", 0, "Number of consecutive heartbeat-timeout periods after which a ring member whose heartbeat has gone stale is automatically removed (forgotten) from the ring. This cleans up entries of instances that have left the ring without unregistering, e.g. after a scale-down. 0 disables auto-forget.")
 	cfg.GRPCClientConfig.RegisterFlagsWithPrefix(prefix+".grpc-client-config", f)
 	f.DurationVar(&cfg.SegmentDuration, prefix+".segment-duration", defaultSegmentDuration, "Timeout when flushing segments to bucket.")
 	f.UintVar(&cfg.FlushConcurrency, prefix+".flush-concurrency", 0, "Number of concurrent flushes. Defaults to the number of CPUs, but not less than 8.")
@@ -154,7 +156,23 @@ func New(
 		return nil, err
 	}
 
-	i.subservices, err = services.NewManager(i.lifecycler)
+	subservices := []services.Service{i.lifecycler}
+	if config.AutoForgetUnhealthyPeriods > 0 &&
+		config.LifecyclerConfig.HeartbeatPeriod > 0 &&
+		config.LifecyclerConfig.RingConfig.HeartbeatTimeout > 0 {
+		forgetPeriod := time.Duration(config.AutoForgetUnhealthyPeriods) * config.LifecyclerConfig.RingConfig.HeartbeatTimeout
+		subservices = append(subservices, newAutoForget(
+			i.lifecycler.KVStore,
+			i.lifecycler.ID,
+			forgetPeriod,
+			config.LifecyclerConfig.HeartbeatPeriod,
+			log.With(logger, "component", "segment-writer-auto-forget"),
+		))
+	} else {
+		level.Info(logger).Log("msg", "the segment-writer ring auto-forget is disabled")
+	}
+
+	i.subservices, err = services.NewManager(subservices...)
 	if err != nil {
 		return nil, fmt.Errorf("services manager: %w", err)
 	}

--- a/pkg/validation/exporter/ring.go
+++ b/pkg/validation/exporter/ring.go
@@ -40,9 +40,10 @@ const (
 
 // ringOp is used as an instance state filter when obtaining instances from the
 // ring. Instances in the LEAVING state are included to help minimise the number
-// of leader changes during rollout and scaling operations. These instances will
-// be forgotten after ringAutoForgetUnhealthyPeriods (see
-// `KeepInstanceInTheRingOnShutdown`).
+// of leader changes during rollout and scaling operations. With
+// -overrides-exporter.ring.unregister-on-shutdown=false, instances remain in
+// the ring after shutdown and are forgotten after
+// ringAutoForgetUnhealthyPeriods heartbeat timeouts.
 var ringOp = ring.NewOp([]ring.InstanceState{ring.ACTIVE, ring.LEAVING}, nil)
 
 // RingConfig holds the configuration for the overrides-exporter ring.
@@ -52,6 +53,8 @@ type RingConfig struct {
 	// Ring stability (used to decrease token reshuffling on scale-up).
 	WaitStabilityMinDuration time.Duration `yaml:"wait_stability_min_duration" category:"advanced"`
 	WaitStabilityMaxDuration time.Duration `yaml:"wait_stability_max_duration" category:"advanced"`
+
+	UnregisterOnShutdown bool `yaml:"unregister_on_shutdown" category:"advanced"`
 }
 
 // RegisterFlags configures this RingConfig to the given flag set and sets defaults.
@@ -63,6 +66,7 @@ func (c *RingConfig) RegisterFlags(f *flag.FlagSet, logger log.Logger) {
 	// Ring stability flags.
 	f.DurationVar(&c.WaitStabilityMinDuration, flagNamePrefix+"wait-stability-min-duration", 0, "Minimum time to wait for ring stability at startup, if set to positive value. Set to 0 to disable.")
 	f.DurationVar(&c.WaitStabilityMaxDuration, flagNamePrefix+"wait-stability-max-duration", 5*time.Minute, "Maximum time to wait for ring stability at startup. If the overrides-exporter ring keeps changing after this period of time, it will start anyway.")
+	f.BoolVar(&c.UnregisterOnShutdown, flagNamePrefix+"unregister-on-shutdown", true, "Unregister from the ring upon clean shutdown. Disabling it keeps the instance in the ring in LEAVING state until it is auto-forgotten, which minimises leader changes when the instance is expected to rejoin with the same ID shortly.")
 }
 
 // toBasicLifecyclerConfig transforms a RingConfig into configuration that can be used to create a BasicLifecycler.
@@ -81,7 +85,7 @@ func (c *RingConfig) toBasicLifecyclerConfig(logger log.Logger) (ring.BasicLifec
 		HeartbeatTimeout:                c.Ring.HeartbeatTimeout,
 		TokensObservePeriod:             0,
 		NumTokens:                       ringNumTokens,
-		KeepInstanceInTheRingOnShutdown: true,
+		KeepInstanceInTheRingOnShutdown: !c.UnregisterOnShutdown,
 	}, nil
 }
 

--- a/pkg/validation/exporter/ring_test.go
+++ b/pkg/validation/exporter/ring_test.go
@@ -16,6 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testInstance1ID   = "instance-1"
+	testInstance1Addr = "127.0.0.1"
+)
+
 func TestOverridesExporter_emptyRing(t *testing.T) {
 	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
 	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
@@ -29,8 +34,8 @@ func TestOverridesExporter_emptyRing(t *testing.T) {
 	cfg := RingConfig{}
 	cfg.Ring.KVStore.Mock = ringStore
 
-	cfg.Ring.InstanceID = "instance-1"
-	cfg.Ring.InstanceAddr = "127.0.0.1"
+	cfg.Ring.InstanceID = testInstance1ID
+	cfg.Ring.InstanceAddr = testInstance1Addr
 	i1, err := newRing(cfg, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, i1.client))
@@ -50,9 +55,10 @@ func TestOverridesExporterRing_scaleDown(t *testing.T) {
 	cfg1.Ring.KVStore.Mock = ringStore
 	cfg1.Ring.HeartbeatPeriod = 1 * time.Second
 	cfg1.Ring.HeartbeatTimeout = 15 * time.Second
+	cfg1.UnregisterOnShutdown = false
 
-	cfg1.Ring.InstanceID = "instance-1"
-	cfg1.Ring.InstanceAddr = "127.0.0.1"
+	cfg1.Ring.InstanceID = testInstance1ID
+	cfg1.Ring.InstanceAddr = testInstance1Addr
 	i1, err := newRing(cfg1, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	l1 := i1.lifecycler
@@ -136,4 +142,70 @@ func TestOverridesExporterRing_scaleDown(t *testing.T) {
 		isLeader, _ := i2.isLeader()
 		return isLeader
 	})
+}
+
+// TestOverridesExporterRing_unregisterOnShutdown tests that an instance
+// removes itself from the ring on shutdown, handing leadership over without
+// waiting for the auto-forget period.
+func TestOverridesExporterRing_unregisterOnShutdown(t *testing.T) {
+	ringStore, closer := consul.NewInMemoryClient(ring.GetCodec(), log.NewNopLogger(), nil)
+	t.Cleanup(func() { assert.NoError(t, closer.Close()) })
+
+	cfg1 := RingConfig{}
+	cfg1.Ring.KVStore.Mock = ringStore
+	cfg1.Ring.HeartbeatPeriod = 1 * time.Second
+	cfg1.Ring.HeartbeatTimeout = 15 * time.Second
+	cfg1.UnregisterOnShutdown = true
+
+	cfg1.Ring.InstanceID = testInstance1ID
+	cfg1.Ring.InstanceAddr = testInstance1Addr
+	i1, err := newRing(cfg1, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	l1 := i1.lifecycler
+
+	cfg2 := cfg1
+	cfg2.Ring.InstanceID = "instance-2"
+	cfg2.Ring.InstanceAddr = "127.0.0.2"
+	i2, err := newRing(cfg2, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	l2 := i2.lifecycler
+
+	// Register instances in the ring (manually, to be able to assign tokens).
+	ctx := context.Background()
+	require.NoError(t, ringStore.CAS(ctx, ringKey, func(in any) (out any, retry bool, err error) {
+		desc := ring.NewDesc()
+		desc.AddIngester(l1.GetInstanceID(), l1.GetInstanceAddr(), "", []uint32{leaderToken + 1}, ring.ACTIVE, time.Now(), false, time.Now(), ring.InstanceVersions{})
+		desc.AddIngester(l2.GetInstanceID(), l2.GetInstanceAddr(), "", []uint32{leaderToken + 2}, ring.ACTIVE, time.Now(), false, time.Now(), ring.InstanceVersions{})
+		return desc, true, nil
+	}))
+
+	require.NoError(t, services.StartAndAwaitRunning(ctx, i1))
+	require.NoError(t, services.StartAndAwaitRunning(ctx, i2))
+	t.Cleanup(func() { require.NoError(t, services.StopAndAwaitTerminated(ctx, i2)) })
+
+	// Wait until the clients have received the ring update.
+	test.Poll(t, time.Second, []int{2, 2}, func() any {
+		rs1, _ := i1.client.GetAllHealthy(ringOp)
+		rs2, _ := i2.client.GetAllHealthy(ringOp)
+		return []int{len(rs1.Instances), len(rs2.Instances)}
+	})
+
+	i1IsLeader, err := i1.isLeader()
+	require.NoError(t, err)
+	require.True(t, i1IsLeader)
+
+	// Stop instance-1: it should unregister from the ring right away, and
+	// instance-2 should take over leadership without any waiting period.
+	require.NoError(t, services.StopAndAwaitTerminated(ctx, i1))
+
+	test.Poll(t, 5*time.Second, true, func() any {
+		isLeader, _ := i2.isLeader()
+		return isLeader
+	})
+
+	v, err := ringStore.Get(ctx, ringKey)
+	require.NoError(t, err)
+	desc, ok := v.(*ring.Desc)
+	require.True(t, ok)
+	require.NotContains(t, desc.Ingesters, l1.GetInstanceID())
 }


### PR DESCRIPTION
When an instance shuts down cleanly, both the overrides-exporter and the segment-writer keep their ring entries, leaving unhealthy members behind:

- The overrides-exporter hardcodes `KeepInstanceInTheRingOnShutdown: true`. Query-frontends typically run as Deployments, so a departed pod never comes back to reclaim its entry; it lingers as `Unhealthy` until auto-forget removes it 4 heartbeat timeouts later. Every rollout, node drain or eviction produces a few minutes of unhealthy ring members (and alert noise) with no benefit in return.
- The segment-writer disables `unregister-on-shutdown` on purpose (a restarted pod reclaims its entry, keeping shard placement undisturbed for restarts shorter than the heartbeat timeout), but the classic lifecycler has no auto-forget: entries left behind by a scale-down stay in the ring indefinitely and must be forgotten manually on the ring page. They also block readiness of any segment-writer that starts afterwards, because `readiness-check-ring-health` (enabled by default) requires every ring member to be healthy.

Changes:

- overrides-exporter: new `-overrides-exporter.ring.unregister-on-shutdown` option, `true` by default. Instances now remove themselves from the ring on clean shutdown and hand leadership over immediately. Set it to `false` to restore the previous behavior.
- segment-writer: new opt-in auto-forget janitor (`-segment-writer.auto-forget-unhealthy-periods`, disabled by default) that removes ring members whose heartbeat has been stale for the given number of heartbeat timeouts. This is the classic-lifecycler equivalent of dskit's `AutoForgetDelegate`, modeled on Loki's `-ingester.autoforget-unhealthy`, including the guard that skips a round when the instance's own heartbeat looks stale (its view of the ring is then likely the problem).

Notes:

- Unlike Loki, a round is not skipped when all other members look unhealthy: forgetting a live segment-writer is self-healing (it re-registers on its next heartbeat, and shard placement depends on instance IDs and token counts rather than token values), whereas skipping would leave a scale-down from N to 1 never cleaned up.
- Auto-forget ships disabled to keep upgrades behavior-neutral. We plan to enable it with 4 periods (forget after ~4m at the default 1m heartbeat timeout) in our own deployments, matching what the overrides-exporter ring already does.
