### PR TITLE
fix(ui): adapt to prettier 3.9 and eslint-plugin-react-hooks 7.1

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -33,10 +33,10 @@
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
-    "prettier": "^3.8.1",
+    "prettier": "^3.9.6",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "^8.0.1"

--- a/ui/src/admin/components/QueryForm.tsx
+++ b/ui/src/admin/components/QueryForm.tsx
@@ -57,31 +57,30 @@ export function QueryForm({
     [params, onParamsChange],
   );
 
-  const loadProfileTypes = useCallback(async () => {
-    if (!params.tenantId) {
-      setProfileTypes([]);
-      return;
-    }
-    setProfileTypesLoading(true);
-    setProfileTypesError(null);
-    try {
-      const startMs = parseTimeForApi(params.startTime);
-      const endMs = parseTimeForApi(params.endTime);
-      const types = await fetchProfileTypes(params.tenantId, startMs, endMs);
-      setProfileTypes(types);
-    } catch (err) {
-      setProfileTypesError(
-        err instanceof Error ? err.message : 'Failed to load profile types',
-      );
-      setProfileTypes([]);
-    } finally {
-      setProfileTypesLoading(false);
-    }
-  }, [params.tenantId, params.startTime, params.endTime]);
-
   useEffect(() => {
+    async function loadProfileTypes() {
+      if (!params.tenantId) {
+        setProfileTypes([]);
+        return;
+      }
+      setProfileTypesLoading(true);
+      setProfileTypesError(null);
+      try {
+        const startMs = parseTimeForApi(params.startTime);
+        const endMs = parseTimeForApi(params.endTime);
+        const types = await fetchProfileTypes(params.tenantId, startMs, endMs);
+        setProfileTypes(types);
+      } catch (err) {
+        setProfileTypesError(
+          err instanceof Error ? err.message : 'Failed to load profile types',
+        );
+        setProfileTypes([]);
+      } finally {
+        setProfileTypesLoading(false);
+      }
+    }
     loadProfileTypes();
-  }, [loadProfileTypes]);
+  }, [params.tenantId, params.startTime, params.endTime]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/ui/src/admin/pages/DiagnosticsListPage.tsx
+++ b/ui/src/admin/pages/DiagnosticsListPage.tsx
@@ -16,15 +16,33 @@ import { formatBytes, formatMs, formatTime, getBasePath } from '../utils';
 import type { DiagnosticSummary } from '../types';
 
 type SortField =
-  | 'created_at'
-  | 'method'
-  | 'response_time_ms'
-  | 'response_size_bytes';
+  'created_at' | 'method' | 'response_time_ms' | 'response_size_bytes';
 type SortDirection = 'asc' | 'desc';
+
+function SortIcon({
+  field,
+  sortField,
+  sortDirection,
+}: {
+  field: SortField;
+  sortField: SortField;
+  sortDirection: SortDirection;
+}) {
+  if (sortField !== field) {
+    return <span className="sort-icon text-muted">⇅</span>;
+  }
+  return (
+    <span className="sort-icon active">
+      {sortDirection === 'asc' ? '↑' : '↓'}
+    </span>
+  );
+}
 
 export function DiagnosticsListPage() {
   const [tenants, setTenants] = useState<string[]>([]);
-  const [selectedTenant, setSelectedTenant] = useState<string | null>(null);
+  const [selectedTenant, setSelectedTenant] = useState<string | null>(() =>
+    new URLSearchParams(window.location.search).get('tenant'),
+  );
   const [diagnostics, setDiagnostics] = useState<DiagnosticSummary[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -50,16 +68,9 @@ export function DiagnosticsListPage() {
   }, []);
 
   useEffect(() => {
-    const urlParams = new URLSearchParams(window.location.search);
-    const tenant = urlParams.get('tenant');
-    if (tenant) {
-      setSelectedTenant(tenant);
-    }
-  }, []);
-
-  useEffect(() => {
+    // selectedTenant never goes back to null once set, so there is no stale
+    // diagnostics list to clear here.
     if (!selectedTenant) {
-      setDiagnostics([]);
       return;
     }
 
@@ -189,17 +200,6 @@ export function DiagnosticsListPage() {
     },
     [selectedTenant],
   );
-
-  const SortIcon = ({ field }: { field: SortField }) => {
-    if (sortField !== field) {
-      return <span className="sort-icon text-muted">⇅</span>;
-    }
-    return (
-      <span className="sort-icon active">
-        {sortDirection === 'asc' ? '↑' : '↓'}
-      </span>
-    );
-  };
 
   return (
     <div className="diagnostics-list-page">
@@ -380,26 +380,46 @@ export function DiagnosticsListPage() {
                               className="col-narrow sortable"
                               onClick={() => handleSort('created_at')}
                             >
-                              Created <SortIcon field="created_at" />
+                              Created{' '}
+                              <SortIcon
+                                field="created_at"
+                                sortField={sortField}
+                                sortDirection={sortDirection}
+                              />
                             </th>
                             <th
                               className="col-narrow sortable"
                               onClick={() => handleSort('method')}
                             >
-                              Method <SortIcon field="method" />
+                              Method{' '}
+                              <SortIcon
+                                field="method"
+                                sortField={sortField}
+                                sortDirection={sortDirection}
+                              />
                             </th>
                             <th className="col-payload">Payload</th>
                             <th
                               className="col-narrow sortable"
                               onClick={() => handleSort('response_time_ms')}
                             >
-                              Time <SortIcon field="response_time_ms" />
+                              Time{' '}
+                              <SortIcon
+                                field="response_time_ms"
+                                sortField={sortField}
+                                sortDirection={sortDirection}
+                              />
                             </th>
                             <th
                               className="col-narrow sortable"
                               onClick={() => handleSort('response_size_bytes')}
                             >
-                              Size <SortIcon field="response_size_bytes" />
+                              Size{' '}
+                              <SortIcon
+                                field="response_size_bytes"
+                                sortField={sortField}
+                                sortDirection={sortDirection}
+                              />
                             </th>
                             <th className="col-narrow"></th>
                           </tr>

--- a/ui/src/admin/pages/QueryDiagnosticsPage.tsx
+++ b/ui/src/admin/pages/QueryDiagnosticsPage.tsx
@@ -263,8 +263,16 @@ export function QueryDiagnosticsPage() {
     loadTenants();
   }, []);
 
-  const loadStoredDiagnostic = useCallback(
-    async (tenant: string, id: string) => {
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const loadId = urlParams.get('load');
+    const tenant = urlParams.get('tenant');
+
+    if (!loadId || !tenant) {
+      return;
+    }
+
+    async function loadStoredDiagnostic(tenant: string, id: string) {
       try {
         const diagnostic: RawDiagnostic = await loadDiagnostic(tenant, id);
 
@@ -284,50 +292,34 @@ export function QueryDiagnosticsPage() {
         };
 
         setParams(newParams);
-        populateFromDiagnostic(diagnostic, newParams);
+        setDiagnosticsId(diagnostic.id);
+        setResponseTimeMs(diagnostic.response_time_ms);
+
+        if (diagnostic.plan) {
+          const tree = convertQueryPlanToTree(diagnostic.plan);
+          setPlanTree(tree);
+          setPlanJson(JSON.stringify(diagnostic.plan, null, 2));
+
+          const blocks = extractBlocksFromPlan(diagnostic.plan);
+          const startTime = parseTimeForStats(newParams.startTime);
+          const endTime = parseTimeForStats(newParams.endTime);
+          const stats = buildMetadataStats(blocks, startTime, endTime);
+          setMetadataStats(stats);
+        }
+
+        if (diagnostic.execution) {
+          const tree = convertExecutionNodeToTree(diagnostic.execution);
+          setExecutionTree(tree);
+        }
       } catch (err) {
         setGlobalError(
           err instanceof Error ? err.message : 'Failed to load diagnostic',
         );
       }
-    },
-    [],
-  );
-
-  useEffect(() => {
-    const urlParams = new URLSearchParams(window.location.search);
-    const loadId = urlParams.get('load');
-    const tenant = urlParams.get('tenant');
-
-    if (loadId && tenant) {
-      loadStoredDiagnostic(tenant, loadId);
-    }
-  }, [loadStoredDiagnostic]);
-
-  const populateFromDiagnostic = (
-    diagnostic: RawDiagnostic,
-    currentParams: QueryParams,
-  ) => {
-    setDiagnosticsId(diagnostic.id);
-    setResponseTimeMs(diagnostic.response_time_ms);
-
-    if (diagnostic.plan) {
-      const tree = convertQueryPlanToTree(diagnostic.plan);
-      setPlanTree(tree);
-      setPlanJson(JSON.stringify(diagnostic.plan, null, 2));
-
-      const blocks = extractBlocksFromPlan(diagnostic.plan);
-      const startTime = parseTimeForStats(currentParams.startTime);
-      const endTime = parseTimeForStats(currentParams.endTime);
-      const stats = buildMetadataStats(blocks, startTime, endTime);
-      setMetadataStats(stats);
     }
 
-    if (diagnostic.execution) {
-      const tree = convertExecutionNodeToTree(diagnostic.execution);
-      setExecutionTree(tree);
-    }
-  };
+    loadStoredDiagnostic(tenant, loadId);
+  }, []);
 
   const handleSubmit = useCallback(async () => {
     if (!params.tenantId) {

--- a/ui/src/components/TimeSeries.tsx
+++ b/ui/src/components/TimeSeries.tsx
@@ -35,8 +35,7 @@ export function TimeSeries({
     startFrac: number;
     currentFrac: number;
   } | null>(null);
-  const dragRef = useRef(drag);
-  dragRef.current = drag;
+  const startFracRef = useRef(0);
   const timeRef = useRef({ rangeStart: 0, durationMs: 0, onRangeSelect });
 
   const isDragging = drag !== null;
@@ -53,7 +52,7 @@ export function TimeSeries({
     };
     const onUp = (e: MouseEvent) => {
       const frac = getX(e);
-      const startFrac = dragRef.current!.startFrac;
+      const startFrac = startFracRef.current;
       const { rangeStart, durationMs, onRangeSelect } = timeRef.current;
       const lo = Math.min(startFrac, frac);
       const hi = Math.max(startFrac, frac);
@@ -73,10 +72,6 @@ export function TimeSeries({
     };
   }, [isDragging]);
 
-  if (n === 0) {
-    return <Empty />;
-  }
-
   // eslint-disable-next-line react-hooks/purity
   const rangeEnd = endMs ?? Date.now();
   const durationMs =
@@ -84,7 +79,16 @@ export function TimeSeries({
       ? endMs - startMs
       : parseRangeMs(timeRange);
   const rangeStart = rangeEnd - durationMs;
-  timeRef.current = { rangeStart, durationMs, onRangeSelect };
+
+  // Written in an effect rather than during render (react-hooks/refs); the
+  // window-level mouseup handler reads the latest committed values from it.
+  useEffect(() => {
+    timeRef.current = { rangeStart, durationMs, onRangeSelect };
+  });
+
+  if (n === 0) {
+    return <Empty />;
+  }
 
   const max = Math.max(...data.map((d) => d.value));
   const norm = max === 0 ? data.map(() => 0) : data.map((d) => d.value / max);
@@ -179,6 +183,7 @@ export function TimeSeries({
               0,
               Math.min(1, (e.clientX - rect.left) / rect.width),
             );
+            startFracRef.current = frac;
             setDrag({ startFrac: frac, currentFrac: frac });
           }}
         >

--- a/ui/src/hooks/usePyroscopeQuery.ts
+++ b/ui/src/hooks/usePyroscopeQuery.ts
@@ -57,17 +57,19 @@ export function usePyroscopeQuery(params: QueryParams): QueryResult {
   const { service, profileType, timeRange, absoluteRange, tenantID } = params;
 
   useEffect(() => {
-    setServicesLoading(true);
-    const { start, end } = absoluteRange ?? parseTimeRange(timeRange);
-    fetchServices(start, end)
-      .then((s) => {
-        setServices(s);
+    async function loadServices() {
+      setServicesLoading(true);
+      const { start, end } = absoluteRange ?? parseTimeRange(timeRange);
+      try {
+        setServices(await fetchServices(start, end));
         setError(null);
-      })
-      .catch((e: unknown) =>
-        setError(e instanceof Error ? e.message : String(e)),
-      )
-      .finally(() => setServicesLoading(false));
+      } catch (e: unknown) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setServicesLoading(false);
+      }
+    }
+    loadServices();
   }, [timeRange, absoluteRange, tenantID]);
 
   const execute = useCallback(
@@ -102,36 +104,40 @@ export function usePyroscopeQuery(params: QueryParams): QueryResult {
 
   useEffect(() => {
     if (!service || !profileType) return;
-    const { start, end } = absoluteRange ?? parseTimeRange(timeRange);
-    const labelSelector = `{service_name="${service}"}`;
-    const rangeSeconds = (end - start) / 1000;
-    const step = Math.max(15, Math.ceil(rangeSeconds / 100));
 
-    setLoading(true);
-    Promise.all([
-      fetchFlamegraph({
-        profileTypeID: profileType,
-        labelSelector,
-        start,
-        end,
-      }),
-      fetchTimeline({
-        profileTypeID: profileType,
-        labelSelector,
-        start,
-        end,
-        step,
-      }),
-    ])
-      .then(([fg, tl]) => {
+    async function loadProfile() {
+      const { start, end } = absoluteRange ?? parseTimeRange(timeRange);
+      const labelSelector = `{service_name="${service}"}`;
+      const rangeSeconds = (end - start) / 1000;
+      const step = Math.max(15, Math.ceil(rangeSeconds / 100));
+
+      setLoading(true);
+      try {
+        const [fg, tl] = await Promise.all([
+          fetchFlamegraph({
+            profileTypeID: profileType,
+            labelSelector,
+            start,
+            end,
+          }),
+          fetchTimeline({
+            profileTypeID: profileType,
+            labelSelector,
+            start,
+            end,
+            step,
+          }),
+        ]);
         setFlamegraph(fg);
         setTimeline(tl);
         setError(null);
-      })
-      .catch((e: unknown) =>
-        setError(e instanceof Error ? e.message : String(e)),
-      )
-      .finally(() => setLoading(false));
+      } catch (e: unknown) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadProfile();
   }, [service, profileType, timeRange, absoluteRange, tenantID]);
 
   const run = useCallback(() => {

--- a/ui/src/hooks/useTenant.ts
+++ b/ui/src/hooks/useTenant.ts
@@ -4,10 +4,7 @@ import { checkMultitenancy, setOrgID } from '@api/client';
 const STORAGE_KEY = 'pyroscope:tenantID';
 
 export type TenantStatus =
-  | 'loading'
-  | 'single_tenant'
-  | 'needs_tenant_id'
-  | 'multi_tenant';
+  'loading' | 'single_tenant' | 'needs_tenant_id' | 'multi_tenant';
 
 export function useTenant() {
   const [status, setStatus] = useState<TenantStatus>('loading');

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1271,9 +1271,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "eslint-plugin-react-hooks@npm:7.0.1"
+"eslint-plugin-react-hooks@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "eslint-plugin-react-hooks@npm:7.1.1"
   dependencies:
     "@babel/core": "npm:^7.24.4"
     "@babel/parser": "npm:^7.24.4"
@@ -1281,8 +1281,8 @@ __metadata:
     zod: "npm:^3.25.0 || ^4.0.0"
     zod-validation-error: "npm:^3.5.0 || ^4.0.0"
   peerDependencies:
-    eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
-  checksum: 10c0/1e711d1a9d1fa9cfc51fa1572500656577201199c70c795c6a27adfc1df39e5c598f69aab6aa91117753d23cc1f11388579a2bed14921cf9a4efe60ae8618496
+    eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
+  checksum: 10c0/cee8454915d71ac5d70a0d8f4f260e76eaf45fcd4162747dd4282b792ee5616d187351dabe6cdcff9040c79d0cec625635c4fd0777276be119efa88ebe058525
   languageName: node
   linkType: hard
 
@@ -2254,12 +2254,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.8.1":
-  version: 3.8.1
-  resolution: "prettier@npm:3.8.1"
+"prettier@npm:^3.9.6":
+  version: 3.9.6
+  resolution: "prettier@npm:3.9.6"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 10c0/33169b594009e48f570471271be7eac7cdcf88a209eed39ac3b8d6d78984039bfa9132f82b7e6ba3b06711f3bfe0222a62a1bfb87c43f50c25a83df1b78a2c42
+  checksum: 10c0/9f7ddae234035868f3daab3dc34e6de7e54622185afb017378029f0c09a9c023248ccf6f34def0b17a0538e18c47aa1b3188bab72965d1bf735919baa0747e99
   languageName: node
   linkType: hard
 
@@ -2573,10 +2573,10 @@ __metadata:
     "@xyflow/react": "npm:^12.10.0"
     eslint: "npm:^9.39.4"
     eslint-config-prettier: "npm:^10.1.8"
-    eslint-plugin-react-hooks: "npm:^7.0.1"
+    eslint-plugin-react-hooks: "npm:^7.1.1"
     eslint-plugin-react-refresh: "npm:^0.5.2"
     globals: "npm:^17.4.0"
-    prettier: "npm:^3.8.1"
+    prettier: "npm:^3.9.6"
     react: "npm:^19.2.4"
     react-dom: "npm:^19.2.4"
     tinycolor2: "npm:^1.6.0"


### PR DESCRIPTION
Renovate's lock file maintenance PRs (#5418, #5419, #5420) are stuck: the refreshed `ui/yarn.lock` pulls in prettier 3.9.6 and eslint-plugin-react-hooks 7.1.1, and the new versions fail the `format` and `lint` checks on existing code. Since Renovate can't fix that on its branch, this PR bumps those two tools explicitly and adapts the code to the stricter rules:

- reformat `DiagnosticsListPage.tsx` and `useTenant.ts` for prettier 3.9's union type style
- `TimeSeries.tsx`: stop writing refs during render (`react-hooks/refs`) — capture the drag start fraction in the mousedown handler and update `timeRef` in an effect
- `DiagnosticsListPage.tsx`: hoist `SortIcon` to module level (`react-hooks/component-hook-factories`) and initialize the selected tenant from the URL via a lazy `useState` initializer instead of an effect
- `QueryDiagnosticsPage.tsx`: fold `loadStoredDiagnostic`/`populateFromDiagnostic` into the URL-load effect, fixing both the declaration-order error and `react-hooks/set-state-in-effect`
- `QueryForm.tsx`, `usePyroscopeQuery.ts`: move fetch logic into effect-local async functions so state updates are no longer synchronous in the effect body (`react-hooks/set-state-in-effect`), matching the pattern already used elsewhere in the admin pages

No `eslint-disable` comments were added. Once this merges, #5418 should rebase and go green; #5419/#5420 need the same treatment on the release branches (or can be closed if we don't want lockfile churn there).