### PR TITLE
feat(experimental): make async queries resumable

### DIFF
--- a/pkg/frontend/async/coordinator.go
+++ b/pkg/frontend/async/coordinator.go
@@ -6,13 +6,16 @@ import (
 	"sync"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"google.golang.org/protobuf/proto"
 
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect"
 	"github.com/grafana/pyroscope/v2/pkg/tenant"
 )
 
@@ -20,11 +23,11 @@ type Limits interface {
 	MaxAsyncQueryConcurrency(tenantID string) int
 }
 
-// QueryResult is the result of a query execution sent over a channel.
+// queryResult is the result of a query execution sent over a channel.
 // On success, Response carries the raw SelectMergeStacktracesResponse
 // from the wrapped handler (its Async field is unset); the
 // coordinator/store own request_id and status.
-type QueryResult struct {
+type queryResult struct {
 	Response *querierv1.SelectMergeStacktracesResponse
 	Err      error
 }
@@ -33,6 +36,7 @@ type Coordinator struct {
 	logger log.Logger
 	store  *Store
 	limits Limits
+	next   querierv1connect.QuerierServiceHandler
 
 	mu       sync.Mutex
 	inFlight map[string]int // tenantID -> count
@@ -41,11 +45,12 @@ type Coordinator struct {
 	asyncQueriesMax     *prometheus.GaugeVec
 }
 
-func NewCoordinator(logger log.Logger, store *Store, limits Limits, reg prometheus.Registerer) *Coordinator {
+func NewCoordinator(logger log.Logger, store *Store, limits Limits, next querierv1connect.QuerierServiceHandler, reg prometheus.Registerer) *Coordinator {
 	return &Coordinator{
 		logger:   logger,
 		store:    store,
 		limits:   limits,
+		next:     next,
 		inFlight: make(map[string]int),
 		asyncQueriesCurrent: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "pyroscope_async_queries_in_progress",
@@ -77,30 +82,66 @@ func (c *Coordinator) tryAcquire(tenantID string) error {
 	return nil
 }
 
-// Register reserves the per-tenant concurrency slot, persists the
-// in-progress metadata, and starts watching resultCh. The caller is
-// responsible for dispatching the query and sending its outcome on
-// resultCh; the coordinator owns reads from the channel, store writes,
-// and the heartbeat loop. Returns the assigned request ID, or an error
-// if the slot could not be acquired.
-func (c *Coordinator) Register(ctx context.Context, tenantID string, resultCh <-chan QueryResult) (string, error) {
+// Submit reserves the tenant's concurrency slot, strips the Async marker
+// from req, persists the resulting spec as a new in-progress query, and
+// dispatches it in the background. Returns the assigned request ID.
+func (c *Coordinator) Submit(ctx context.Context, tenantID string, req *querierv1.SelectMergeStacktracesRequest) (string, error) {
 	if err := c.tryAcquire(tenantID); err != nil {
 		return "", err
 	}
 
 	requestID := uuid.New().String()
+	spec := proto.Clone(req).(*querierv1.SelectMergeStacktracesRequest)
+	spec.Async = nil
 
-	if err := c.store.create(ctx, tenantID, requestID); err != nil {
+	if err := c.store.create(ctx, tenantID, requestID, spec); err != nil {
 		c.decrement(tenantID)
 		return "", fmt.Errorf("failed to create async query: %w", err)
 	}
 
-	go c.awaitResult(tenantID, requestID, resultCh)
-
+	c.dispatch(tenantID, requestID, spec)
+	level.Info(c.logger).Log("msg", "async query submitted", "tenant", tenantID, "request_id", requestID)
 	return requestID, nil
 }
 
-func (c *Coordinator) awaitResult(tenantID, requestID string, resultCh <-chan QueryResult) {
+// Dispatch implements Store's Dispatcher interface: it (re-)runs a query
+// whose record and spec are already persisted. A declined dispatch (tenant
+// at its concurrency limit) never rolls back the store's claim on the
+// record; it is simply retried by a later adoption scan once the lease
+// expires again. The context is intentionally unused: like Submit, a
+// dispatched query always runs detached from its caller so it survives
+// independently of whatever triggered it.
+func (c *Coordinator) Dispatch(_ context.Context, tenantID, requestID string, spec *querierv1.SelectMergeStacktracesRequest) {
+	if err := c.tryAcquire(tenantID); err != nil {
+		level.Warn(c.logger).Log("msg", "skipping async query adoption: concurrency limit reached", "tenant", tenantID, "request_id", requestID, "err", err)
+		return
+	}
+	c.dispatch(tenantID, requestID, spec)
+}
+
+// dispatch runs spec against next on a background context, detached from the
+// caller's context, so the query survives client disconnects and outlives
+// the scan tick that triggered an adoption. Submit and Dispatch both share
+// this path once their concurrency slot is reserved.
+func (c *Coordinator) dispatch(tenantID, requestID string, spec *querierv1.SelectMergeStacktracesRequest) {
+	queryCtx := tenant.InjectTenantID(context.Background(), tenantID)
+	resultCh := make(chan queryResult, 1)
+
+	// query goroutine: runs the spec end-to-end.
+	go func() {
+		resp, err := c.next.SelectMergeStacktraces(queryCtx, connect.NewRequest(spec))
+		if err != nil {
+			resultCh <- queryResult{Err: err}
+			return
+		}
+		resultCh <- queryResult{Response: resp.Msg}
+	}()
+
+	// supervisor goroutine: renews the lease and records the outcome.
+	go c.awaitResult(tenantID, requestID, resultCh)
+}
+
+func (c *Coordinator) awaitResult(tenantID, requestID string, resultCh <-chan queryResult) {
 	defer c.decrement(tenantID)
 
 	ctx := tenant.InjectTenantID(context.Background(), tenantID)
@@ -120,6 +161,8 @@ func (c *Coordinator) awaitResult(tenantID, requestID string, resultCh <-chan Qu
 			}
 			if err := c.store.complete(ctx, tenantID, requestID, res.Response); err != nil {
 				level.Error(c.logger).Log("msg", "failed to store async query result", "tenant", tenantID, "request_id", requestID, "err", err)
+			} else {
+				level.Info(c.logger).Log("msg", "async query completed", "tenant", tenantID, "request_id", requestID)
 			}
 			return
 		case <-ticker.C:

--- a/pkg/frontend/async/coordinator.go
+++ b/pkg/frontend/async/coordinator.go
@@ -104,9 +104,9 @@ func (c *Coordinator) Submit(ctx context.Context, tenantID string, req *querierv
 	return requestID, nil
 }
 
-// CanDispatch implements Store's Dispatcher interface: a read-only peek at
+// HasCapacity implements Store's Dispatcher interface: a read-only peek at
 // whether tenantID currently has spare capacity.
-func (c *Coordinator) CanDispatch(tenantID string) bool {
+func (c *Coordinator) HasCapacity(tenantID string) bool {
 	maxConcurrent := c.limits.MaxAsyncQueryConcurrency(tenantID)
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/pkg/frontend/async/coordinator.go
+++ b/pkg/frontend/async/coordinator.go
@@ -108,10 +108,8 @@ func (c *Coordinator) Submit(ctx context.Context, tenantID string, req *querierv
 // whose record and spec are already persisted. A declined dispatch (tenant
 // at its concurrency limit) never rolls back the store's claim on the
 // record; it is simply retried by a later adoption scan once the lease
-// expires again. The context is intentionally unused: like Submit, a
-// dispatched query always runs detached from its caller so it survives
-// independently of whatever triggered it.
-func (c *Coordinator) Dispatch(_ context.Context, tenantID, requestID string, spec *querierv1.SelectMergeStacktracesRequest) {
+// expires again.
+func (c *Coordinator) Dispatch(tenantID, requestID string, spec *querierv1.SelectMergeStacktracesRequest) {
 	if err := c.tryAcquire(tenantID); err != nil {
 		level.Warn(c.logger).Log("msg", "skipping async query adoption: concurrency limit reached", "tenant", tenantID, "request_id", requestID, "err", err)
 		return

--- a/pkg/frontend/async/coordinator.go
+++ b/pkg/frontend/async/coordinator.go
@@ -104,6 +104,15 @@ func (c *Coordinator) Submit(ctx context.Context, tenantID string, req *querierv
 	return requestID, nil
 }
 
+// CanDispatch implements Store's Dispatcher interface: a read-only peek at
+// whether tenantID currently has spare capacity.
+func (c *Coordinator) CanDispatch(tenantID string) bool {
+	maxConcurrent := c.limits.MaxAsyncQueryConcurrency(tenantID)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return maxConcurrent > 0 && c.inFlight[tenantID] < maxConcurrent
+}
+
 // Dispatch implements Store's Dispatcher interface: it (re-)runs a query
 // whose record and spec are already persisted. A declined dispatch (tenant
 // at its concurrency limit) never rolls back the store's claim on the

--- a/pkg/frontend/async/coordinator_test.go
+++ b/pkg/frontend/async/coordinator_test.go
@@ -138,21 +138,21 @@ func TestCoordinatorDispatch_ConcurrencyLimitSkipsExecution(t *testing.T) {
 	require.Empty(t, fakeNext.callsSnapshot())
 }
 
-// TestCoordinatorCanDispatch_ReflectsInFlightWithoutMutating proves
-// CanDispatch is a pure peek: it tracks capacity as tryAcquire consumes it,
+// TestCoordinatorHasCapacity_ReflectsInFlightWithoutMutating proves
+// HasCapacity is a pure peek: it tracks capacity as tryAcquire consumes it,
 // but never itself changes inFlight or the gauge.
-func TestCoordinatorCanDispatch_ReflectsInFlightWithoutMutating(t *testing.T) {
+func TestCoordinatorHasCapacity_ReflectsInFlightWithoutMutating(t *testing.T) {
 	logger := log.NewNopLogger()
 	store := NewStore(logger, objstore.NewInMemBucket(), nil)
 	fakeNext := &fakeQuerierHandler{resp: &querierv1.SelectMergeStacktracesResponse{}}
 	coordinator := NewCoordinator(logger, store, fixedLimits{max: 1}, fakeNext, nil)
 
 	const tenantID = "tenant-a"
-	require.True(t, coordinator.CanDispatch(tenantID))
-	require.True(t, coordinator.CanDispatch(tenantID), "a peek must not itself consume capacity")
+	require.True(t, coordinator.HasCapacity(tenantID))
+	require.True(t, coordinator.HasCapacity(tenantID), "a peek must not itself consume capacity")
 
 	require.NoError(t, coordinator.tryAcquire(tenantID))
-	require.False(t, coordinator.CanDispatch(tenantID))
+	require.False(t, coordinator.HasCapacity(tenantID))
 }
 
 func TestCoordinatorSubmit_TenantIsolation(t *testing.T) {

--- a/pkg/frontend/async/coordinator_test.go
+++ b/pkg/frontend/async/coordinator_test.go
@@ -138,6 +138,23 @@ func TestCoordinatorDispatch_ConcurrencyLimitSkipsExecution(t *testing.T) {
 	require.Empty(t, fakeNext.callsSnapshot())
 }
 
+// TestCoordinatorCanDispatch_ReflectsInFlightWithoutMutating proves
+// CanDispatch is a pure peek: it tracks capacity as tryAcquire consumes it,
+// but never itself changes inFlight or the gauge.
+func TestCoordinatorCanDispatch_ReflectsInFlightWithoutMutating(t *testing.T) {
+	logger := log.NewNopLogger()
+	store := NewStore(logger, objstore.NewInMemBucket(), nil)
+	fakeNext := &fakeQuerierHandler{resp: &querierv1.SelectMergeStacktracesResponse{}}
+	coordinator := NewCoordinator(logger, store, fixedLimits{max: 1}, fakeNext, nil)
+
+	const tenantID = "tenant-a"
+	require.True(t, coordinator.CanDispatch(tenantID))
+	require.True(t, coordinator.CanDispatch(tenantID), "a peek must not itself consume capacity")
+
+	require.NoError(t, coordinator.tryAcquire(tenantID))
+	require.False(t, coordinator.CanDispatch(tenantID))
+}
+
 func TestCoordinatorSubmit_TenantIsolation(t *testing.T) {
 	ctx := context.Background()
 	logger := log.NewNopLogger()

--- a/pkg/frontend/async/coordinator_test.go
+++ b/pkg/frontend/async/coordinator_test.go
@@ -1,0 +1,193 @@
+package async
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+	"google.golang.org/protobuf/proto"
+
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	"github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect"
+)
+
+// fakeQuerierHandler is a QuerierServiceHandler that records every
+// SelectMergeStacktraces call it receives and returns a canned response or
+// error. If block is set, calls wait for it to close before returning,
+// letting tests hold a dispatched query open to exercise concurrency
+// limits.
+type fakeQuerierHandler struct {
+	querierv1connect.UnimplementedQuerierServiceHandler
+
+	resp  *querierv1.SelectMergeStacktracesResponse
+	err   error
+	block <-chan struct{}
+
+	mu    sync.Mutex
+	calls []*querierv1.SelectMergeStacktracesRequest
+}
+
+func (f *fakeQuerierHandler) SelectMergeStacktraces(
+	_ context.Context,
+	req *connect.Request[querierv1.SelectMergeStacktracesRequest],
+) (*connect.Response[querierv1.SelectMergeStacktracesResponse], error) {
+	f.mu.Lock()
+	f.calls = append(f.calls, req.Msg)
+	f.mu.Unlock()
+
+	if f.block != nil {
+		<-f.block
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	return connect.NewResponse(f.resp), nil
+}
+
+func (f *fakeQuerierHandler) callsSnapshot() []*querierv1.SelectMergeStacktracesRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]*querierv1.SelectMergeStacktracesRequest(nil), f.calls...)
+}
+
+// fixedLimits is a Limits fake allowing exactly max concurrent async
+// queries, the same for every tenant.
+type fixedLimits struct {
+	max int
+}
+
+func (l fixedLimits) MaxAsyncQueryConcurrency(string) int { return l.max }
+
+// unlimitedLimits is a Limits fake that never rejects a submit or dispatch.
+type unlimitedLimits struct{}
+
+func (unlimitedLimits) MaxAsyncQueryConcurrency(string) int { return 1 << 30 }
+
+func TestCoordinatorSubmit_PersistsSpecStripsAsyncAndDispatches(t *testing.T) {
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+	store := NewStore(logger, objstore.NewInMemBucket(), nil)
+
+	want := &querierv1.SelectMergeStacktracesResponse{Tree: []byte("tree")}
+	fakeNext := &fakeQuerierHandler{resp: want}
+	coordinator := NewCoordinator(logger, store, fixedLimits{max: 5}, fakeNext, nil)
+
+	const tenantID = "tenant-a"
+	req := &querierv1.SelectMergeStacktracesRequest{
+		ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+		Async:         &querierv1.AsyncQueryRequest{Type: querierv1.AsyncQueryType_ASYNC_QUERY_TYPE_FORCE},
+	}
+
+	requestID, err := coordinator.Submit(ctx, tenantID, req)
+	require.NoError(t, err)
+	require.NotEmpty(t, requestID)
+
+	require.Eventually(t, func() bool {
+		result, err := store.get(ctx, tenantID, requestID)
+		return err == nil && result != nil && result.Metadata.Status == StatusSuccess
+	}, time.Second, 10*time.Millisecond)
+
+	calls := fakeNext.callsSnapshot()
+	require.Len(t, calls, 1)
+	require.Nil(t, calls[0].GetAsync())
+
+	result, err := store.get(ctx, tenantID, requestID)
+	require.NoError(t, err)
+	require.True(t, proto.Equal(want, result.Response))
+}
+
+func TestCoordinatorSubmit_ConcurrencyLimitRejects(t *testing.T) {
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+	store := NewStore(logger, objstore.NewInMemBucket(), nil)
+
+	block := make(chan struct{})
+	defer close(block)
+	fakeNext := &fakeQuerierHandler{resp: &querierv1.SelectMergeStacktracesResponse{}, block: block}
+	coordinator := NewCoordinator(logger, store, fixedLimits{max: 1}, fakeNext, nil)
+
+	const tenantID = "tenant-a"
+	req := &querierv1.SelectMergeStacktracesRequest{}
+
+	firstID, err := coordinator.Submit(ctx, tenantID, req)
+	require.NoError(t, err)
+	require.NotEmpty(t, firstID)
+
+	_, err = coordinator.Submit(ctx, tenantID, req)
+	require.Error(t, err)
+}
+
+func TestCoordinatorDispatch_ConcurrencyLimitSkipsExecution(t *testing.T) {
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+	store := NewStore(logger, objstore.NewInMemBucket(), nil)
+
+	fakeNext := &fakeQuerierHandler{resp: &querierv1.SelectMergeStacktracesResponse{}}
+	coordinator := NewCoordinator(logger, store, fixedLimits{max: 1}, fakeNext, nil)
+
+	const tenantID = "tenant-a"
+	require.NoError(t, coordinator.tryAcquire(tenantID))
+
+	spec := &querierv1.SelectMergeStacktracesRequest{ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"}
+	coordinator.Dispatch(ctx, tenantID, "adopted-request-id", spec)
+
+	require.Empty(t, fakeNext.callsSnapshot())
+}
+
+func TestCoordinatorSubmit_TenantIsolation(t *testing.T) {
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+	store := NewStore(logger, objstore.NewInMemBucket(), nil)
+
+	block := make(chan struct{})
+	defer close(block)
+	fakeNext := &fakeQuerierHandler{resp: &querierv1.SelectMergeStacktracesResponse{}, block: block}
+	coordinator := NewCoordinator(logger, store, fixedLimits{max: 1}, fakeNext, nil)
+
+	req := &querierv1.SelectMergeStacktracesRequest{}
+
+	tenantAID, err := coordinator.Submit(ctx, "tenant-a", req)
+	require.NoError(t, err)
+	require.NotEmpty(t, tenantAID)
+
+	tenantBID, err := coordinator.Submit(ctx, "tenant-b", req)
+	require.NoError(t, err)
+	require.NotEmpty(t, tenantBID)
+}
+
+func TestAdoption_EndToEnd_ResumesOrphanedQuery(t *testing.T) {
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+	bucket := objstore.NewInMemBucket()
+	store := NewStore(logger, bucket, nil)
+
+	fakeNext := &fakeQuerierHandler{resp: &querierv1.SelectMergeStacktracesResponse{Tree: []byte("t")}}
+	coordinator := NewCoordinator(logger, store, unlimitedLimits{}, fakeNext, nil)
+	store.SetDispatcher(coordinator)
+
+	const (
+		tenantID  = "tenant-a"
+		requestID = "550e8400-e29b-41d4-a716-446655440002"
+	)
+	spec := &querierv1.SelectMergeStacktracesRequest{ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"}
+	require.NoError(t, store.create(ctx, tenantID, requestID, spec))
+	backdateHeartbeat(t, ctx, store, tenantID, requestID, time.Now().Add(-time.Hour))
+
+	store.runAdoption(ctx)
+
+	require.Eventually(t, func() bool {
+		r, err := store.get(ctx, tenantID, requestID)
+		return err == nil && r != nil && r.Metadata.Status != StatusInProgress
+	}, time.Second, 10*time.Millisecond)
+
+	result, err := store.get(ctx, tenantID, requestID)
+	require.NoError(t, err)
+	require.Equal(t, StatusSuccess, result.Metadata.Status)
+	require.True(t, proto.Equal(fakeNext.resp, result.Response))
+	require.Len(t, fakeNext.callsSnapshot(), 1)
+}

--- a/pkg/frontend/async/coordinator_test.go
+++ b/pkg/frontend/async/coordinator_test.go
@@ -123,7 +123,6 @@ func TestCoordinatorSubmit_ConcurrencyLimitRejects(t *testing.T) {
 }
 
 func TestCoordinatorDispatch_ConcurrencyLimitSkipsExecution(t *testing.T) {
-	ctx := context.Background()
 	logger := log.NewNopLogger()
 	store := NewStore(logger, objstore.NewInMemBucket(), nil)
 
@@ -134,7 +133,7 @@ func TestCoordinatorDispatch_ConcurrencyLimitSkipsExecution(t *testing.T) {
 	require.NoError(t, coordinator.tryAcquire(tenantID))
 
 	spec := &querierv1.SelectMergeStacktracesRequest{ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"}
-	coordinator.Dispatch(ctx, tenantID, "adopted-request-id", spec)
+	coordinator.Dispatch(tenantID, "adopted-request-id", spec)
 
 	require.Empty(t, fakeNext.callsSnapshot())
 }

--- a/pkg/frontend/async/handler.go
+++ b/pkg/frontend/async/handler.go
@@ -6,11 +6,9 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/grafana/dskit/tenant"
-	"google.golang.org/protobuf/proto"
 
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	"github.com/grafana/pyroscope/api/gen/proto/go/querier/v1/querierv1connect"
-	pyrotenant "github.com/grafana/pyroscope/v2/pkg/tenant"
 )
 
 // Handler decorates a QuerierServiceHandler with async query support for
@@ -67,30 +65,10 @@ func (h *Handler) submit(
 	tenantID string,
 	req *querierv1.SelectMergeStacktracesRequest,
 ) (*connect.Response[querierv1.SelectMergeStacktracesResponse], error) {
-	queryCtx := pyrotenant.InjectTenantID(context.Background(), tenantID)
-	resultCh := make(chan QueryResult, 1)
-
-	// Strip the Async marker before dispatching so the wrapped handler
-	// treats this as an ordinary sync request.
-	inner := proto.Clone(req).(*querierv1.SelectMergeStacktracesRequest)
-	inner.Async = nil
-
-	// Reserve the concurrency slot before dispatching so a rejected
-	// submit never starts background work.
-	requestID, err := h.coordinator.Register(ctx, tenantID, resultCh)
+	requestID, err := h.coordinator.Submit(ctx, tenantID, req)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeResourceExhausted, err)
 	}
-
-	go func() {
-		resp, err := h.QuerierServiceHandler.SelectMergeStacktraces(queryCtx, connect.NewRequest(inner))
-		if err != nil {
-			resultCh <- QueryResult{Err: err}
-			return
-		}
-		resultCh <- QueryResult{Response: resp.Msg}
-	}()
-
 	return connect.NewResponse(&querierv1.SelectMergeStacktracesResponse{
 		Async: &querierv1.AsyncQueryResponse{
 			RequestId: requestID,

--- a/pkg/frontend/async/handler_test.go
+++ b/pkg/frontend/async/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"connectrpc.com/connect"
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
@@ -15,12 +16,12 @@ import (
 
 func TestHandlerPollCopiesPprofResponse(t *testing.T) {
 	ctx := context.Background()
-	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket())
+	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
 	const (
 		tenantID  = "tenant-a"
 		requestID = "550e8400-e29b-41d4-a716-446655440000"
 	)
-	require.NoError(t, store.create(ctx, tenantID, requestID))
+	require.NoError(t, store.create(ctx, tenantID, requestID, &querierv1.SelectMergeStacktracesRequest{}))
 	want := &profilev1.Profile{Sample: []*profilev1.Sample{{Value: []int64{1}}}}
 	require.NoError(t, store.complete(ctx, tenantID, requestID, &querierv1.SelectMergeStacktracesResponse{
 		Pprof: &querierv1.PprofProfile{Profile: want},
@@ -32,4 +33,21 @@ func TestHandlerPollCopiesPprofResponse(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, querierv1.AsyncQueryStatus_ASYNC_QUERY_STATUS_SUCCESS, resp.Msg.GetAsync().GetStatus())
 	require.True(t, proto.Equal(want, resp.Msg.GetPprof().GetProfile()))
+}
+
+func TestHandlerPollTenantIsolation(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+	const (
+		tenantA   = "tenant-a"
+		tenantB   = "tenant-b"
+		requestID = "550e8400-e29b-41d4-a716-446655440001"
+	)
+	require.NoError(t, store.create(ctx, tenantA, requestID, &querierv1.SelectMergeStacktracesRequest{}))
+
+	handler := &Handler{coordinator: &Coordinator{store: store}}
+	_, err := handler.poll(ctx, tenantB, requestID)
+
+	require.Error(t, err)
+	require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
 }

--- a/pkg/frontend/async/store.go
+++ b/pkg/frontend/async/store.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -13,6 +15,8 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/google/uuid"
 	"github.com/grafana/dskit/services"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/thanos-io/objstore"
 	"google.golang.org/protobuf/proto"
 
@@ -20,11 +24,12 @@ import (
 )
 
 const (
-	storagePrefix            = "async-queries/"
-	defaultTTL               = 30 * time.Minute
-	defaultHeartbeatInterval = 15 * time.Second
-	defaultHeartbeatTimeout  = 45 * time.Second
-	cleanupInterval          = 5 * time.Minute
+	storagePrefix               = "async-queries/"
+	defaultTTL                  = 30 * time.Minute
+	defaultHeartbeatInterval    = 15 * time.Second
+	defaultLeaseTimeout         = 45 * time.Second
+	defaultAdoptionScanInterval = 30 * time.Second
+	cleanupInterval             = 5 * time.Minute
 )
 
 // Status represents the lifecycle state of an async query.
@@ -48,6 +53,7 @@ type Metadata struct {
 	CreatedAt     time.Time `json:"created_at"`
 	LastHeartbeat time.Time `json:"last_heartbeat,omitempty"`
 	ErrorMessage  string    `json:"error_message,omitempty"`
+	Owner         string    `json:"owner,omitempty"`
 }
 
 // Result bundles a query's Metadata with its decoded Response. Response is only
@@ -57,38 +63,83 @@ type Result struct {
 	Response *querierv1.SelectMergeStacktracesResponse
 }
 
+// Dispatcher re-runs a query that Store has adopted after its owner's lease
+// expired. Implemented by Coordinator; wired into Store via SetDispatcher.
+type Dispatcher interface {
+	Dispatch(ctx context.Context, tenantID, requestID string, spec *querierv1.SelectMergeStacktracesRequest)
+}
+
 // Store persists async query state and results in object storage. It also runs
-// as a dskit service that periodically removes expired entries.
+// as a dskit service that periodically removes expired entries and adopts
+// queries whose owner's lease has expired.
 type Store struct {
 	services.Service
 	logger            log.Logger
 	bucket            objstore.Bucket
 	ttl               time.Duration
 	heartbeatInterval time.Duration
-	heartbeatTimeout  time.Duration
+	leaseTimeout      time.Duration
+	scanInterval      time.Duration
+	ownerID           string
+	dispatcher        Dispatcher
+
+	adoptionAttempts  *prometheus.CounterVec
+	adoptionSuccesses *prometheus.CounterVec
 }
 
 // NewStore returns a Store backed by the given bucket. The returned Store is a
 // dskit service that, once started, periodically deletes entries older than the
-// configured TTL; callers are responsible for starting and stopping it via its
-// embedded Service.
-func NewStore(logger log.Logger, bucket objstore.Bucket) *Store {
+// configured TTL and scans for adoptable queries; callers are responsible for
+// starting and stopping it via its embedded Service.
+func NewStore(logger log.Logger, bucket objstore.Bucket, reg prometheus.Registerer) *Store {
+	hostname, _ := os.Hostname()
 	s := &Store{
 		logger:            logger,
 		bucket:            bucket,
 		ttl:               defaultTTL,
 		heartbeatInterval: defaultHeartbeatInterval,
-		heartbeatTimeout:  defaultHeartbeatTimeout,
+		leaseTimeout:      defaultLeaseTimeout,
+		scanInterval:      defaultAdoptionScanInterval,
+		ownerID:           hostname,
+		adoptionAttempts: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "pyroscope_async_queries_adoption_attempts_total",
+			Help: "Total number of attempts to adopt an async query whose owner appears to have died.",
+		}, []string{"tenant"}),
+		adoptionSuccesses: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "pyroscope_async_queries_adoption_successes_total",
+			Help: "Total number of async queries successfully claimed by a new owner after adoption.",
+		}, []string{"tenant"}),
 	}
 	s.Service = services.NewBasicService(s.starting, s.running, s.stopping)
 	return s
 }
 
+// SetDispatcher wires the adoption scan to a Dispatcher. Must be called before
+// the Store's Service is started: s.dispatcher is a plain field, never
+// synchronized against running()'s reads of it, so calling this after the
+// Service has started is a genuine data race, not merely a logic error. nil is
+// safe (adoption is then a no-op), e.g. when Store runs standalone or in tests.
+func (s *Store) SetDispatcher(d Dispatcher) { s.dispatcher = d }
+
 func (s *Store) basePath(tenantID, requestID string) string {
 	return storagePrefix + tenantID + "/" + requestID + "/"
 }
 
-func (s *Store) create(ctx context.Context, tenantID, requestID string) error {
+func (s *Store) create(ctx context.Context, tenantID, requestID string, spec *querierv1.SelectMergeStacktracesRequest) error {
+	base := s.basePath(tenantID, requestID)
+
+	data, err := proto.Marshal(spec)
+	if err != nil {
+		return fmt.Errorf("failed to marshal spec: %w", err)
+	}
+	// spec.pb must land before metadata.json: metadata.json existing is what a
+	// poller/scanner treats as "this record is real", so writing spec first means
+	// a crash between the two uploads can never leave a spec-less in_progress
+	// record that this code path created.
+	if err := s.bucket.Upload(ctx, base+"spec.pb", bytes.NewReader(data)); err != nil {
+		return fmt.Errorf("failed to upload spec: %w", err)
+	}
+
 	now := time.Now().UTC()
 	meta := &Metadata{
 		RequestID:     requestID,
@@ -96,8 +147,57 @@ func (s *Store) create(ctx context.Context, tenantID, requestID string) error {
 		Status:        StatusInProgress,
 		CreatedAt:     now,
 		LastHeartbeat: now,
+		Owner:         s.ownerID,
 	}
-	return s.saveJSON(ctx, s.basePath(tenantID, requestID)+"metadata.json", meta)
+	return s.saveJSON(ctx, base+"metadata.json", meta)
+}
+
+// errSpecCorrupt indicates spec.pb exists but its contents don't decode.
+// Unlike a transient read error, retrying can never fix this.
+var errSpecCorrupt = errors.New("spec is present but could not be decoded")
+
+func (s *Store) readSpec(ctx context.Context, tenantID, requestID string) (*querierv1.SelectMergeStacktracesRequest, error) {
+	data, err := s.readRaw(ctx, s.basePath(tenantID, requestID)+"spec.pb")
+	if err != nil {
+		return nil, err
+	}
+	var spec querierv1.SelectMergeStacktracesRequest
+	if err := proto.Unmarshal(data, &spec); err != nil {
+		return nil, fmt.Errorf("%w: %v", errSpecCorrupt, err)
+	}
+	return &spec, nil
+}
+
+// objectExists reports whether the object at path is confirmed present. Any
+// error other than IsObjNotFoundErr is inconclusive (e.g. a transient
+// object-storage error) and must not be treated as either presence or
+// absence.
+func (s *Store) objectExists(ctx context.Context, path string) (bool, error) {
+	_, err := s.bucket.Attributes(ctx, path)
+	if err == nil {
+		return true, nil
+	}
+	if s.bucket.IsObjNotFoundErr(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+// specAbsent reports whether spec.pb is confirmed gone.
+func (s *Store) specAbsent(ctx context.Context, tenantID, requestID string) (bool, error) {
+	exists, err := s.objectExists(ctx, s.basePath(tenantID, requestID)+"spec.pb")
+	if err != nil {
+		return false, err
+	}
+	return !exists, nil
+}
+
+// resultExists reports whether result.pb has been written. Only successful
+// executions write result.pb, so its existence proves success even when
+// metadata.json disagrees. Racing duplicate executions may replace it with
+// another valid result: existence, not content, is the invariant.
+func (s *Store) resultExists(ctx context.Context, tenantID, requestID string) (bool, error) {
+	return s.objectExists(ctx, s.basePath(tenantID, requestID)+"result.pb")
 }
 
 func (s *Store) heartbeat(ctx context.Context, tenantID, requestID string) error {
@@ -106,8 +206,20 @@ func (s *Store) heartbeat(ctx context.Context, tenantID, requestID string) error
 	if err := s.readJSON(ctx, base+"metadata.json", &meta); err != nil {
 		return err
 	}
+	if meta.Status != StatusInProgress {
+		// Already terminal: a lingering heartbeat from a still-alive duplicate
+		// execution (post-adoption) must not resurrect a completed/failed record.
+		return nil
+	}
 	meta.LastHeartbeat = time.Now().UTC()
+	meta.Owner = s.ownerID
 	return s.saveJSON(ctx, base+"metadata.json", &meta)
+}
+
+// leaseExpired reports whether meta describes an in-progress query whose
+// owner has stopped renewing its lease, making it eligible for adoption.
+func (s *Store) leaseExpired(meta *Metadata) bool {
+	return meta.Status == StatusInProgress && !meta.LastHeartbeat.IsZero() && time.Since(meta.LastHeartbeat) > s.leaseTimeout
 }
 
 func (s *Store) complete(ctx context.Context, tenantID, requestID string, resp *querierv1.SelectMergeStacktracesResponse) error {
@@ -125,8 +237,19 @@ func (s *Store) complete(ctx context.Context, tenantID, requestID string, resp *
 	if err := s.readJSON(ctx, base+"metadata.json", &meta); err != nil {
 		return fmt.Errorf("failed to read metadata: %w", err)
 	}
+	if meta.Status == StatusSuccess {
+		// Already recorded success (this execution's own write racing itself,
+		// or a duplicate's); nothing left to do.
+		return nil
+	}
+	// A real success always wins, including over a prior Failure: result.pb
+	// was just durably written above, so at least one execution produced the
+	// correct answer and it must be reported regardless of what any other,
+	// differently-outcome'd execution wrote.
 	meta.Status = StatusSuccess
+	meta.ErrorMessage = ""
 	meta.LastHeartbeat = time.Now().UTC()
+	meta.Owner = s.ownerID
 	return s.saveJSON(ctx, base+"metadata.json", &meta)
 }
 
@@ -136,10 +259,58 @@ func (s *Store) fail(ctx context.Context, tenantID, requestID string, queryErr e
 	if err := s.readJSON(ctx, base+"metadata.json", &meta); err != nil {
 		return fmt.Errorf("failed to read metadata: %w", err)
 	}
+	if meta.Status != StatusInProgress {
+		return nil
+	}
 	meta.Status = StatusFailure
 	meta.ErrorMessage = queryErr.Error()
 	meta.LastHeartbeat = time.Now().UTC()
+	meta.Owner = s.ownerID
 	return s.saveJSON(ctx, base+"metadata.json", &meta)
+}
+
+// errOrphanedNoSpec is the single, shared definition of "unrecoverable" used by
+// both get() and the adoption scan: a stale in-progress record whose spec is
+// gone can never be resumed.
+var errOrphanedNoSpec = errors.New("query orphaned: owner heartbeat expired and no request spec is available for adoption")
+
+func (s *Store) markUnadoptable(ctx context.Context, tenantID, requestID string) error {
+	level.Warn(s.logger).Log("msg", "async query is unrecoverable, marking failed", "tenant", tenantID, "request_id", requestID)
+	return s.fail(ctx, tenantID, requestID, errOrphanedNoSpec)
+}
+
+// buildSuccessResult fetches and unmarshals result.pb, returning a Result
+// with Status forced to Success. Callers only reach this once they've
+// already established (via meta.Status or result.pb's own existence) that
+// the query succeeded.
+func (s *Store) buildSuccessResult(ctx context.Context, tenantID, requestID string, meta Metadata) (*Result, error) {
+	data, err := s.readRaw(ctx, s.basePath(tenantID, requestID)+"result.pb")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read result: %w", err)
+	}
+	var resp querierv1.SelectMergeStacktracesResponse
+	if err := proto.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal result: %w", err)
+	}
+	meta.Status = StatusSuccess
+	return &Result{Metadata: meta, Response: &resp}, nil
+}
+
+// healToSuccess best-effort corrects metadata.json's Status once result.pb's
+// existence has already proven a real success occurred. No guard is needed:
+// this write always converges to the one fixed value the anchor already
+// proved correct, unlike every other write in this file, so it's safe to
+// issue redundantly and to ignore on failure.
+// The caller's snapshot may overwrite a concurrent writer's Owner or
+// LastHeartbeat, but both are advisory once a record is terminal: heartbeats
+// no-op on terminal records, adoption stops at the anchor, and cleanup keys
+// on object timestamps, so neither field drives any further decision.
+func (s *Store) healToSuccess(ctx context.Context, tenantID, requestID string, meta Metadata) {
+	meta.Status = StatusSuccess
+	meta.ErrorMessage = ""
+	if err := s.saveJSON(ctx, s.basePath(tenantID, requestID)+"metadata.json", &meta); err != nil {
+		level.Warn(s.logger).Log("msg", "failed to heal metadata to success", "request_id", requestID, "err", err)
+	}
 }
 
 func (s *Store) get(ctx context.Context, tenantID, requestID string) (*Result, error) {
@@ -162,26 +333,54 @@ func (s *Store) get(ctx context.Context, tenantID, requestID string) (*Result, e
 		return nil, nil
 	}
 
-	if meta.Status == StatusInProgress && !meta.LastHeartbeat.IsZero() && time.Since(meta.LastHeartbeat) > s.heartbeatTimeout {
-		meta.Status = StatusFailure
-		meta.ErrorMessage = "query appears to have been orphaned (heartbeat timed out)"
+	// Object storage has no compare-and-swap, so a stale writer can always
+	// overwrite metadata.json and make its Status lie. result.pb is different:
+	// it is written exactly once, by a successful execution, and never
+	// modified, so once it exists nothing can un-write it. Check for it first
+	// so a poll reports success whenever a result genuinely exists, no matter
+	// what the metadata says.
+	if meta.Status != StatusSuccess {
+		exists, err := s.resultExists(ctx, tenantID, requestID)
+		if err != nil {
+			level.Warn(s.logger).Log("msg", "failed to check result existence; falling back to persisted status", "request_id", requestID, "err", err)
+		} else if exists {
+			result, err := s.buildSuccessResult(ctx, tenantID, requestID, meta)
+			if err != nil {
+				return nil, err
+			}
+			s.healToSuccess(ctx, tenantID, requestID, meta)
+			return result, nil
+		}
 	}
 
-	result := &Result{Metadata: meta}
+	if s.leaseExpired(&meta) {
+		absent, err := s.specAbsent(ctx, tenantID, requestID)
+		if err != nil {
+			// Inconclusive (e.g. a transient object-storage error): leave the
+			// record in progress rather than risk permanently failing a
+			// live, adoptable query. A later poll or the adoption scan will
+			// re-evaluate it.
+			level.Warn(s.logger).Log("msg", "failed to check spec existence; leaving query in progress", "request_id", requestID, "err", err)
+		} else if absent {
+			if err := s.markUnadoptable(ctx, tenantID, requestID); err != nil {
+				level.Warn(s.logger).Log("msg", "failed to persist orphaned query state", "request_id", requestID, "err", err)
+			} else {
+				meta.Status = StatusFailure
+				meta.ErrorMessage = errOrphanedNoSpec.Error()
+			}
+		}
+		// A stale lease with the spec still present means the owner died but
+		// the query is recoverable, so in-progress is the truthful answer.
+		// The poll path deliberately never adopts because many clients can
+		// poll concurrently. Instead, the periodic adoption scan will claim
+		// and re-run it.
+	}
 
 	if meta.Status == StatusSuccess {
-		data, err := s.readRaw(ctx, base+"result.pb")
-		if err != nil {
-			return nil, fmt.Errorf("failed to read result: %w", err)
-		}
-		var resp querierv1.SelectMergeStacktracesResponse
-		if err := proto.Unmarshal(data, &resp); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal result: %w", err)
-		}
-		result.Response = &resp
+		return s.buildSuccessResult(ctx, tenantID, requestID, meta)
 	}
 
-	return result, nil
+	return &Result{Metadata: meta}, nil
 }
 
 func (s *Store) cleanup(ctx context.Context) (int, error) {
@@ -252,17 +451,22 @@ func (s *Store) starting(context.Context) error { return nil }
 func (s *Store) stopping(error) error           { return nil }
 
 func (s *Store) running(ctx context.Context) error {
-	ticker := time.NewTicker(cleanupInterval)
-	defer ticker.Stop()
+	cleanupTicker := time.NewTicker(cleanupInterval)
+	defer cleanupTicker.Stop()
+	adoptionTicker := time.NewTicker(s.scanInterval)
+	defer adoptionTicker.Stop()
 
 	s.runCleanup(ctx)
+	s.runAdoption(ctx)
 
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
-		case <-ticker.C:
+		case <-cleanupTicker.C:
 			s.runCleanup(ctx)
+		case <-adoptionTicker.C:
+			s.runAdoption(ctx)
 		}
 	}
 }
@@ -276,4 +480,106 @@ func (s *Store) runCleanup(ctx context.Context) {
 	if deleted > 0 {
 		level.Info(s.logger).Log("msg", "cleaned up old async query results", "deleted", deleted)
 	}
+}
+
+// runAdoption lists every object under storagePrefix but filters to just
+// metadata.json. The number of listed objects is bounded by cleanup()'s TTL.
+//
+// No cap on adoptions per tick: actual query re-execution is already
+// bounded per tenant by Coordinator.Dispatch's own tryAcquire. This does
+// not protect against the aggregate burst of re-executions summed across
+// many tenants at once, e.g. right after one replica dies while holding
+// queries for many tenants. A claim whose dispatch is declined does no
+// further work.
+//
+// A query that repeatedly kills its owner (e.g. one that OOMs the frontend)
+// is re-adopted at most once per leaseTimeout+scanInterval, and cleanup()
+// bounds the loop: spec.pb is written once and never rewritten, so it ages
+// out after the TTL even while metadata.json stays fresh, at which point the
+// next scan finds no spec and persists a terminal failure. Worst case is
+// roughly ttl/(leaseTimeout+scanInterval) re-executions, each still subject
+// to the tenant's concurrency limit.
+func (s *Store) runAdoption(ctx context.Context) {
+	err := s.bucket.Iter(ctx, storagePrefix, func(name string) error {
+		if !strings.HasSuffix(name, "metadata.json") {
+			return nil
+		}
+		var meta Metadata
+		if err := s.readJSON(ctx, name, &meta); err != nil {
+			level.Warn(s.logger).Log("msg", "failed to read metadata during adoption scan", "object", name, "err", err)
+			return nil
+		}
+		if !s.leaseExpired(&meta) {
+			return nil
+		}
+		s.adopt(ctx, meta)
+		return nil
+	}, objstore.WithRecursiveIter())
+	if err != nil {
+		level.Warn(s.logger).Log("msg", "async query adoption scan failed", "err", err)
+	}
+}
+
+func (s *Store) adopt(ctx context.Context, meta Metadata) {
+	if exists, err := s.resultExists(ctx, meta.TenantID, meta.RequestID); err != nil {
+		level.Warn(s.logger).Log("msg", "failed to check result existence before adoption; proceeding", "request_id", meta.RequestID, "err", err)
+	} else if exists {
+		s.healToSuccess(ctx, meta.TenantID, meta.RequestID, meta)
+		return
+	}
+
+	spec, err := s.readSpec(ctx, meta.TenantID, meta.RequestID)
+	if err != nil {
+		if s.bucket.IsObjNotFoundErr(err) || errors.Is(err, errSpecCorrupt) {
+			if err2 := s.markUnadoptable(ctx, meta.TenantID, meta.RequestID); err2 != nil {
+				level.Warn(s.logger).Log("msg", "failed to mark unadoptable query as failed", "request_id", meta.RequestID, "err", err2)
+			}
+			return
+		}
+		level.Warn(s.logger).Log("msg", "failed to read spec during adoption", "request_id", meta.RequestID, "err", err)
+		return
+	}
+
+	s.adoptionAttempts.WithLabelValues(meta.TenantID).Inc()
+	if s.dispatcher == nil {
+		level.Warn(s.logger).Log("msg", "found adoptable async query but no dispatcher is configured", "request_id", meta.RequestID)
+		return
+	}
+
+	// meta is a snapshot from the scan; readSpec above was a real round trip
+	// during which the true owner could have completed, failed, or already
+	// been re-claimed. Re-read immediately before the claim write so that
+	// window can't revert a now-terminal (or now-fresh) record.
+	//
+	// Two scanners can still both pass this check and both claim; the
+	// consequence is bounded to one duplicate execution, and the result stays
+	// correct because complete()'s terminal guard and the result.pb anchor
+	// make the first success stick.
+	base := s.basePath(meta.TenantID, meta.RequestID)
+	var fresh Metadata
+	if err := s.readJSON(ctx, base+"metadata.json", &fresh); err != nil {
+		level.Warn(s.logger).Log("msg", "failed to re-read metadata before claim", "request_id", meta.RequestID, "err", err)
+		return
+	}
+	if !s.leaseExpired(&fresh) {
+		return
+	}
+	if exists, err := s.resultExists(ctx, meta.TenantID, meta.RequestID); err != nil {
+		level.Warn(s.logger).Log("msg", "failed to check result existence before claim; proceeding", "request_id", meta.RequestID, "err", err)
+	} else if exists {
+		s.healToSuccess(ctx, meta.TenantID, meta.RequestID, fresh)
+		return
+	}
+
+	previousOwner := fresh.Owner
+	leaseAge := time.Since(fresh.LastHeartbeat)
+	fresh.Owner = s.ownerID
+	fresh.LastHeartbeat = time.Now().UTC()
+	if err := s.saveJSON(ctx, base+"metadata.json", &fresh); err != nil {
+		level.Warn(s.logger).Log("msg", "failed to claim orphaned query", "request_id", meta.RequestID, "err", err)
+		return
+	}
+	s.adoptionSuccesses.WithLabelValues(meta.TenantID).Inc()
+	level.Info(s.logger).Log("msg", "adopted orphaned async query", "tenant", meta.TenantID, "request_id", meta.RequestID, "previous_owner", previousOwner, "lease_age", leaseAge)
+	s.dispatcher.Dispatch(ctx, meta.TenantID, meta.RequestID, spec)
 }

--- a/pkg/frontend/async/store.go
+++ b/pkg/frontend/async/store.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"math/rand/v2"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -26,11 +27,25 @@ import (
 
 const (
 	storagePrefix               = "async-queries/"
+	metadataFilename            = "metadata.json"
+	specFilename                = "spec.pb"
+	resultFilename              = "result.pb"
 	defaultTTL                  = 30 * time.Minute
 	defaultHeartbeatInterval    = 15 * time.Second
 	defaultLeaseTimeout         = 45 * time.Second
 	defaultAdoptionScanInterval = 30 * time.Second
 	cleanupInterval             = 5 * time.Minute
+)
+
+var (
+	// errSpecCorrupt indicates spec.pb exists but its contents don't decode.
+	// Unlike a transient read error, retrying can never fix this.
+	errSpecCorrupt = errors.New("spec is present but could not be decoded")
+
+	// errOrphanedNoSpec is the single, shared definition of "unrecoverable" used
+	// by both get() and the adoption scan: a stale in-progress record whose
+	// spec is gone can never be resumed.
+	errOrphanedNoSpec = errors.New("query orphaned: owner heartbeat expired and no request spec is available for adoption")
 )
 
 // Status represents the lifecycle state of an async query.
@@ -67,7 +82,7 @@ type Result struct {
 // Dispatcher re-runs a query that Store has adopted after its owner's lease
 // expired. Implemented by Coordinator; wired into Store via SetDispatcher.
 type Dispatcher interface {
-	Dispatch(ctx context.Context, tenantID, requestID string, spec *querierv1.SelectMergeStacktracesRequest)
+	Dispatch(tenantID, requestID string, spec *querierv1.SelectMergeStacktracesRequest)
 }
 
 // Store persists async query state and results in object storage. It also runs
@@ -122,13 +137,11 @@ func NewStore(logger log.Logger, bucket objstore.Bucket, reg prometheus.Register
 // safe (adoption is then a no-op), e.g. when Store runs standalone or in tests.
 func (s *Store) SetDispatcher(d Dispatcher) { s.dispatcher = d }
 
-func (s *Store) basePath(tenantID, requestID string) string {
-	return storagePrefix + tenantID + "/" + requestID + "/"
+func (s *Store) buildPath(tenantID, requestID, filename string) string {
+	return path.Join(storagePrefix, tenantID, requestID, filename)
 }
 
 func (s *Store) create(ctx context.Context, tenantID, requestID string, spec *querierv1.SelectMergeStacktracesRequest) error {
-	base := s.basePath(tenantID, requestID)
-
 	data, err := proto.Marshal(spec)
 	if err != nil {
 		return fmt.Errorf("failed to marshal spec: %w", err)
@@ -137,7 +150,7 @@ func (s *Store) create(ctx context.Context, tenantID, requestID string, spec *qu
 	// poller/scanner treats as "this record is real", so writing spec first means
 	// a crash between the two uploads can never leave a spec-less in_progress
 	// record that this code path created.
-	if err := s.bucket.Upload(ctx, base+"spec.pb", bytes.NewReader(data)); err != nil {
+	if err := s.bucket.Upload(ctx, s.buildPath(tenantID, requestID, specFilename), bytes.NewReader(data)); err != nil {
 		return fmt.Errorf("failed to upload spec: %w", err)
 	}
 
@@ -150,15 +163,11 @@ func (s *Store) create(ctx context.Context, tenantID, requestID string, spec *qu
 		LastHeartbeat: now,
 		Owner:         s.ownerID,
 	}
-	return s.saveJSON(ctx, base+"metadata.json", meta)
+	return s.saveJSON(ctx, s.buildPath(tenantID, requestID, metadataFilename), meta)
 }
 
-// errSpecCorrupt indicates spec.pb exists but its contents don't decode.
-// Unlike a transient read error, retrying can never fix this.
-var errSpecCorrupt = errors.New("spec is present but could not be decoded")
-
 func (s *Store) readSpec(ctx context.Context, tenantID, requestID string) (*querierv1.SelectMergeStacktracesRequest, error) {
-	data, err := s.readRaw(ctx, s.basePath(tenantID, requestID)+"spec.pb")
+	data, err := s.readRaw(ctx, s.buildPath(tenantID, requestID, specFilename))
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +195,7 @@ func (s *Store) objectExists(ctx context.Context, path string) (bool, error) {
 
 // specAbsent reports whether spec.pb is confirmed gone.
 func (s *Store) specAbsent(ctx context.Context, tenantID, requestID string) (bool, error) {
-	exists, err := s.objectExists(ctx, s.basePath(tenantID, requestID)+"spec.pb")
+	exists, err := s.objectExists(ctx, s.buildPath(tenantID, requestID, specFilename))
 	if err != nil {
 		return false, err
 	}
@@ -198,13 +207,13 @@ func (s *Store) specAbsent(ctx context.Context, tenantID, requestID string) (boo
 // metadata.json disagrees. Racing duplicate executions may replace it with
 // another valid result: existence, not content, is the invariant.
 func (s *Store) resultExists(ctx context.Context, tenantID, requestID string) (bool, error) {
-	return s.objectExists(ctx, s.basePath(tenantID, requestID)+"result.pb")
+	return s.objectExists(ctx, s.buildPath(tenantID, requestID, resultFilename))
 }
 
 func (s *Store) heartbeat(ctx context.Context, tenantID, requestID string) error {
-	base := s.basePath(tenantID, requestID)
+	metaPath := s.buildPath(tenantID, requestID, metadataFilename)
 	var meta Metadata
-	if err := s.readJSON(ctx, base+"metadata.json", &meta); err != nil {
+	if err := s.readJSON(ctx, metaPath, &meta); err != nil {
 		return err
 	}
 	if meta.Status != StatusInProgress {
@@ -214,7 +223,7 @@ func (s *Store) heartbeat(ctx context.Context, tenantID, requestID string) error
 	}
 	meta.LastHeartbeat = time.Now().UTC()
 	meta.Owner = s.ownerID
-	return s.saveJSON(ctx, base+"metadata.json", &meta)
+	return s.saveJSON(ctx, metaPath, &meta)
 }
 
 // leaseExpired reports whether meta describes an in-progress query whose
@@ -224,18 +233,17 @@ func (s *Store) leaseExpired(meta *Metadata) bool {
 }
 
 func (s *Store) complete(ctx context.Context, tenantID, requestID string, resp *querierv1.SelectMergeStacktracesResponse) error {
-	base := s.basePath(tenantID, requestID)
-
 	data, err := proto.Marshal(resp)
 	if err != nil {
 		return fmt.Errorf("failed to marshal response: %w", err)
 	}
-	if err := s.bucket.Upload(ctx, base+"result.pb", bytes.NewReader(data)); err != nil {
+	if err := s.bucket.Upload(ctx, s.buildPath(tenantID, requestID, resultFilename), bytes.NewReader(data)); err != nil {
 		return fmt.Errorf("failed to upload result: %w", err)
 	}
 
+	metaPath := s.buildPath(tenantID, requestID, metadataFilename)
 	var meta Metadata
-	if err := s.readJSON(ctx, base+"metadata.json", &meta); err != nil {
+	if err := s.readJSON(ctx, metaPath, &meta); err != nil {
 		return fmt.Errorf("failed to read metadata: %w", err)
 	}
 	if meta.Status == StatusSuccess {
@@ -251,13 +259,13 @@ func (s *Store) complete(ctx context.Context, tenantID, requestID string, resp *
 	meta.ErrorMessage = ""
 	meta.LastHeartbeat = time.Now().UTC()
 	meta.Owner = s.ownerID
-	return s.saveJSON(ctx, base+"metadata.json", &meta)
+	return s.saveJSON(ctx, metaPath, &meta)
 }
 
 func (s *Store) fail(ctx context.Context, tenantID, requestID string, queryErr error) error {
-	base := s.basePath(tenantID, requestID)
+	metaPath := s.buildPath(tenantID, requestID, metadataFilename)
 	var meta Metadata
-	if err := s.readJSON(ctx, base+"metadata.json", &meta); err != nil {
+	if err := s.readJSON(ctx, metaPath, &meta); err != nil {
 		return fmt.Errorf("failed to read metadata: %w", err)
 	}
 	if meta.Status != StatusInProgress {
@@ -267,13 +275,8 @@ func (s *Store) fail(ctx context.Context, tenantID, requestID string, queryErr e
 	meta.ErrorMessage = queryErr.Error()
 	meta.LastHeartbeat = time.Now().UTC()
 	meta.Owner = s.ownerID
-	return s.saveJSON(ctx, base+"metadata.json", &meta)
+	return s.saveJSON(ctx, metaPath, &meta)
 }
-
-// errOrphanedNoSpec is the single, shared definition of "unrecoverable" used by
-// both get() and the adoption scan: a stale in-progress record whose spec is
-// gone can never be resumed.
-var errOrphanedNoSpec = errors.New("query orphaned: owner heartbeat expired and no request spec is available for adoption")
 
 func (s *Store) markUnadoptable(ctx context.Context, tenantID, requestID string) error {
 	level.Warn(s.logger).Log("msg", "async query is unrecoverable, marking failed", "tenant", tenantID, "request_id", requestID)
@@ -285,7 +288,7 @@ func (s *Store) markUnadoptable(ctx context.Context, tenantID, requestID string)
 // already established (via meta.Status or result.pb's own existence) that
 // the query succeeded.
 func (s *Store) buildSuccessResult(ctx context.Context, tenantID, requestID string, meta Metadata) (*Result, error) {
-	data, err := s.readRaw(ctx, s.basePath(tenantID, requestID)+"result.pb")
+	data, err := s.readRaw(ctx, s.buildPath(tenantID, requestID, resultFilename))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read result: %w", err)
 	}
@@ -309,8 +312,8 @@ func (s *Store) buildSuccessResult(ctx context.Context, tenantID, requestID stri
 func (s *Store) healToSuccess(ctx context.Context, tenantID, requestID string, meta Metadata) {
 	meta.Status = StatusSuccess
 	meta.ErrorMessage = ""
-	if err := s.saveJSON(ctx, s.basePath(tenantID, requestID)+"metadata.json", &meta); err != nil {
-		level.Warn(s.logger).Log("msg", "failed to heal metadata to success", "request_id", requestID, "err", err)
+	if err := s.saveJSON(ctx, s.buildPath(tenantID, requestID, metadataFilename), &meta); err != nil {
+		level.Warn(s.logger).Log("msg", "failed to heal metadata to success", "tenant", tenantID, "request_id", requestID, "err", err)
 	}
 }
 
@@ -319,10 +322,10 @@ func (s *Store) get(ctx context.Context, tenantID, requestID string) (*Result, e
 		return nil, fmt.Errorf("invalid request ID: %w", err)
 	}
 
-	base := s.basePath(tenantID, requestID)
+	metaPath := s.buildPath(tenantID, requestID, metadataFilename)
 
 	var meta Metadata
-	if err := s.readJSON(ctx, base+"metadata.json", &meta); err != nil {
+	if err := s.readJSON(ctx, metaPath, &meta); err != nil {
 		if s.bucket.IsObjNotFoundErr(err) {
 			return nil, nil
 		}
@@ -343,7 +346,7 @@ func (s *Store) get(ctx context.Context, tenantID, requestID string) (*Result, e
 	if meta.Status != StatusSuccess {
 		exists, err := s.resultExists(ctx, tenantID, requestID)
 		if err != nil {
-			level.Warn(s.logger).Log("msg", "failed to check result existence; falling back to persisted status", "request_id", requestID, "err", err)
+			level.Warn(s.logger).Log("msg", "failed to check result existence; falling back to persisted status", "tenant", tenantID, "request_id", requestID, "err", err)
 		} else if exists {
 			result, err := s.buildSuccessResult(ctx, tenantID, requestID, meta)
 			if err != nil {
@@ -361,10 +364,10 @@ func (s *Store) get(ctx context.Context, tenantID, requestID string) (*Result, e
 			// record in progress rather than risk permanently failing a
 			// live, adoptable query. A later poll or the adoption scan will
 			// re-evaluate it.
-			level.Warn(s.logger).Log("msg", "failed to check spec existence; leaving query in progress", "request_id", requestID, "err", err)
+			level.Warn(s.logger).Log("msg", "failed to check spec existence; leaving query in progress", "tenant", tenantID, "request_id", requestID, "err", err)
 		} else if absent {
 			if err := s.markUnadoptable(ctx, tenantID, requestID); err != nil {
-				level.Warn(s.logger).Log("msg", "failed to persist orphaned query state", "request_id", requestID, "err", err)
+				level.Warn(s.logger).Log("msg", "failed to persist orphaned query state", "tenant", tenantID, "request_id", requestID, "err", err)
 			} else {
 				meta.Status = StatusFailure
 				meta.ErrorMessage = errOrphanedNoSpec.Error()
@@ -511,7 +514,7 @@ func (s *Store) runCleanup(ctx context.Context) {
 // to the tenant's concurrency limit.
 func (s *Store) runAdoption(ctx context.Context) {
 	err := s.bucket.Iter(ctx, storagePrefix, func(name string) error {
-		if !strings.HasSuffix(name, "metadata.json") {
+		if path.Base(name) != metadataFilename {
 			return nil
 		}
 		var meta Metadata
@@ -532,7 +535,11 @@ func (s *Store) runAdoption(ctx context.Context) {
 
 func (s *Store) adopt(ctx context.Context, meta Metadata) {
 	if exists, err := s.resultExists(ctx, meta.TenantID, meta.RequestID); err != nil {
-		level.Warn(s.logger).Log("msg", "failed to check result existence before adoption; proceeding", "request_id", meta.RequestID, "err", err)
+		// Inconclusive: skip this candidate rather than risk a duplicate
+		// execution racing a result we can't yet see. The next scan tick
+		// will re-evaluate it.
+		level.Warn(s.logger).Log("msg", "failed to check result existence before adoption; skipping adoption this scan", "tenant", meta.TenantID, "request_id", meta.RequestID, "err", err)
+		return
 	} else if exists {
 		s.healToSuccess(ctx, meta.TenantID, meta.RequestID, meta)
 		return
@@ -542,17 +549,17 @@ func (s *Store) adopt(ctx context.Context, meta Metadata) {
 	if err != nil {
 		if s.bucket.IsObjNotFoundErr(err) || errors.Is(err, errSpecCorrupt) {
 			if err2 := s.markUnadoptable(ctx, meta.TenantID, meta.RequestID); err2 != nil {
-				level.Warn(s.logger).Log("msg", "failed to mark unadoptable query as failed", "request_id", meta.RequestID, "err", err2)
+				level.Warn(s.logger).Log("msg", "failed to mark unadoptable query as failed", "tenant", meta.TenantID, "request_id", meta.RequestID, "err", err2)
 			}
 			return
 		}
-		level.Warn(s.logger).Log("msg", "failed to read spec during adoption", "request_id", meta.RequestID, "err", err)
+		level.Warn(s.logger).Log("msg", "failed to read spec during adoption", "tenant", meta.TenantID, "request_id", meta.RequestID, "err", err)
 		return
 	}
 
 	s.adoptionAttempts.WithLabelValues(meta.TenantID).Inc()
 	if s.dispatcher == nil {
-		level.Warn(s.logger).Log("msg", "found adoptable async query but no dispatcher is configured", "request_id", meta.RequestID)
+		level.Warn(s.logger).Log("msg", "found adoptable async query but no dispatcher is configured", "tenant", meta.TenantID, "request_id", meta.RequestID)
 		return
 	}
 
@@ -565,17 +572,20 @@ func (s *Store) adopt(ctx context.Context, meta Metadata) {
 	// consequence is bounded to one duplicate execution, and the result stays
 	// correct because complete()'s terminal guard and the result.pb anchor
 	// make the first success stick.
-	base := s.basePath(meta.TenantID, meta.RequestID)
+	metaPath := s.buildPath(meta.TenantID, meta.RequestID, metadataFilename)
 	var fresh Metadata
-	if err := s.readJSON(ctx, base+"metadata.json", &fresh); err != nil {
-		level.Warn(s.logger).Log("msg", "failed to re-read metadata before claim", "request_id", meta.RequestID, "err", err)
+	if err := s.readJSON(ctx, metaPath, &fresh); err != nil {
+		level.Warn(s.logger).Log("msg", "failed to re-read metadata before claim", "tenant", meta.TenantID, "request_id", meta.RequestID, "err", err)
 		return
 	}
 	if !s.leaseExpired(&fresh) {
 		return
 	}
 	if exists, err := s.resultExists(ctx, meta.TenantID, meta.RequestID); err != nil {
-		level.Warn(s.logger).Log("msg", "failed to check result existence before claim; proceeding", "request_id", meta.RequestID, "err", err)
+		// Same reasoning as the entry check above: inconclusive means skip,
+		// not proceed, and wait for the next scan tick.
+		level.Warn(s.logger).Log("msg", "failed to check result existence before claim; skipping adoption this scan", "tenant", meta.TenantID, "request_id", meta.RequestID, "err", err)
+		return
 	} else if exists {
 		s.healToSuccess(ctx, meta.TenantID, meta.RequestID, fresh)
 		return
@@ -585,11 +595,11 @@ func (s *Store) adopt(ctx context.Context, meta Metadata) {
 	leaseAge := time.Since(fresh.LastHeartbeat)
 	fresh.Owner = s.ownerID
 	fresh.LastHeartbeat = time.Now().UTC()
-	if err := s.saveJSON(ctx, base+"metadata.json", &fresh); err != nil {
-		level.Warn(s.logger).Log("msg", "failed to claim orphaned query", "request_id", meta.RequestID, "err", err)
+	if err := s.saveJSON(ctx, metaPath, &fresh); err != nil {
+		level.Warn(s.logger).Log("msg", "failed to claim orphaned query", "tenant", meta.TenantID, "request_id", meta.RequestID, "err", err)
 		return
 	}
 	s.adoptionSuccesses.WithLabelValues(meta.TenantID).Inc()
 	level.Info(s.logger).Log("msg", "adopted orphaned async query", "tenant", meta.TenantID, "request_id", meta.RequestID, "previous_owner", previousOwner, "lease_age", leaseAge)
-	s.dispatcher.Dispatch(ctx, meta.TenantID, meta.RequestID, spec)
+	s.dispatcher.Dispatch(meta.TenantID, meta.RequestID, spec)
 }

--- a/pkg/frontend/async/store.go
+++ b/pkg/frontend/async/store.go
@@ -139,10 +139,16 @@ func NewStore(logger log.Logger, bucket objstore.Bucket, reg prometheus.Register
 
 // SetDispatcher wires the adoption scan to a Dispatcher. Must be called before
 // the Store's Service is started: s.dispatcher is a plain field, never
-// synchronized against running()'s reads of it, so calling this after the
-// Service has started is a genuine data race, not merely a logic error. nil is
-// safe (adoption is then a no-op), e.g. when Store runs standalone or in tests.
-func (s *Store) SetDispatcher(d Dispatcher) { s.dispatcher = d }
+// synchronized against running()'s reads of it. A late call is a programming
+// error, so it panics rather than risk an unsynchronized write racing the
+// running service. nil is safe (adoption is then a no-op), e.g. when Store
+// runs standalone or in tests.
+func (s *Store) SetDispatcher(d Dispatcher) {
+	if state := s.State(); state != services.New {
+		panic(fmt.Sprintf("SetDispatcher must be called before the store service starts; service state is %s", state))
+	}
+	s.dispatcher = d
+}
 
 func (s *Store) buildPath(tenantID, requestID, filename string) string {
 	return path.Join(storagePrefix, tenantID, requestID, filename)

--- a/pkg/frontend/async/store.go
+++ b/pkg/frontend/async/store.go
@@ -89,10 +89,10 @@ type Result struct {
 // Dispatcher re-runs a query that Store has adopted after its owner's lease
 // expired. Implemented by Coordinator; wired into Store via SetDispatcher.
 type Dispatcher interface {
-	// CanDispatch is a read-only capacity peek, not a reservation: it makes
+	// HasCapacity is a read-only capacity peek, not a reservation: it makes
 	// no guarantee that a following Dispatch call will actually run the
 	// query (Dispatch has its own gate and may still decline).
-	CanDispatch(tenantID string) bool
+	HasCapacity(tenantID string) bool
 	Dispatch(tenantID, requestID string, spec *querierv1.SelectMergeStacktracesRequest)
 }
 
@@ -577,7 +577,7 @@ func (s *Store) adopt(ctx context.Context, meta Metadata) {
 	// still decline after the claim has reset the lease and spent one unit
 	// of the adoption budget. That wastes at most one claim per race; the
 	// peek prevents the systematic version on a saturated frontend.
-	if !s.dispatcher.CanDispatch(meta.TenantID) {
+	if !s.dispatcher.HasCapacity(meta.TenantID) {
 		return
 	}
 

--- a/pkg/frontend/async/store.go
+++ b/pkg/frontend/async/store.go
@@ -89,6 +89,10 @@ type Result struct {
 // Dispatcher re-runs a query that Store has adopted after its owner's lease
 // expired. Implemented by Coordinator; wired into Store via SetDispatcher.
 type Dispatcher interface {
+	// CanDispatch is a read-only capacity peek, not a reservation: it makes
+	// no guarantee that a following Dispatch call will actually run the
+	// query (Dispatch has its own gate and may still decline).
+	CanDispatch(tenantID string) bool
 	Dispatch(tenantID, requestID string, spec *querierv1.SelectMergeStacktracesRequest)
 }
 
@@ -513,21 +517,9 @@ func (s *Store) runCleanup(ctx context.Context) {
 	}
 }
 
-// runAdoption lists every object under storagePrefix but filters to just
-// metadata.json. The number of listed objects is bounded by cleanup()'s TTL.
-//
-// No cap on adoptions per tick: actual query re-execution is already
-// bounded per tenant by Coordinator.Dispatch's own tryAcquire. This does
-// not protect against the aggregate burst of re-executions summed across
-// many tenants at once, e.g. right after one replica dies while holding
-// queries for many tenants. A claim whose dispatch is declined does no
-// further work.
-//
-// A query that repeatedly kills its owner (e.g. one that OOMs the frontend)
-// is capped at defaultMaxAdoptions re-executions via Metadata.AdoptionCount;
-// once exhausted it's marked failed outright. The TTL remains the backstop
-// for records that never get adopted at all, e.g. because no dispatcher is
-// configured.
+// runAdoption re-dispatches in-progress records whose lease has expired.
+// Re-execution is bounded per tenant by the concurrency limit and per
+// record by defaultMaxAdoptions, but not across tenants in aggregate.
 func (s *Store) runAdoption(ctx context.Context) {
 	err := s.bucket.Iter(ctx, storagePrefix, func(name string) error {
 		if path.Base(name) != metadataFilename {
@@ -576,6 +568,16 @@ func (s *Store) adopt(ctx context.Context, meta Metadata) {
 	s.adoptionAttempts.WithLabelValues(meta.TenantID).Inc()
 	if s.dispatcher == nil {
 		level.Warn(s.logger).Log("msg", "found adoptable async query but no dispatcher is configured", "tenant", meta.TenantID, "request_id", meta.RequestID)
+		return
+	}
+
+	// Best-effort peek; Dispatch's gate is authoritative. The peek and the
+	// dispatch are not atomic: during the reads and the claim write below, a
+	// concurrent Submit can take the tenant's last slot, so Dispatch may
+	// still decline after the claim has reset the lease and spent one unit
+	// of the adoption budget. That wastes at most one claim per race; the
+	// peek prevents the systematic version on a saturated frontend.
+	if !s.dispatcher.CanDispatch(meta.TenantID) {
 		return
 	}
 

--- a/pkg/frontend/async/store.go
+++ b/pkg/frontend/async/store.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"os"
 	"strings"
 	"time"
@@ -450,14 +451,22 @@ func (s *Store) readRaw(ctx context.Context, path string) ([]byte, error) {
 func (s *Store) starting(context.Context) error { return nil }
 func (s *Store) stopping(error) error           { return nil }
 
+// jitteredInterval returns a duration uniformly distributed in
+// [0.8*d, 1.2*d), i.e. d plus or minus 20%.
+func jitteredInterval(d time.Duration) time.Duration {
+	return time.Duration((0.8 + 0.4*rand.Float64()) * float64(d))
+}
+
 func (s *Store) running(ctx context.Context) error {
 	cleanupTicker := time.NewTicker(cleanupInterval)
 	defer cleanupTicker.Stop()
-	adoptionTicker := time.NewTicker(s.scanInterval)
-	defer adoptionTicker.Stop()
+
+	// Randomizing the initial delay breaks the synchronized start across
+	// frontends; re-randomizing the period each tick keeps it broken.
+	adoptionTimer := time.NewTimer(rand.N(s.scanInterval))
+	defer adoptionTimer.Stop()
 
 	s.runCleanup(ctx)
-	s.runAdoption(ctx)
 
 	for {
 		select {
@@ -465,8 +474,9 @@ func (s *Store) running(ctx context.Context) error {
 			return nil
 		case <-cleanupTicker.C:
 			s.runCleanup(ctx)
-		case <-adoptionTicker.C:
+		case <-adoptionTimer.C:
 			s.runAdoption(ctx)
+			adoptionTimer.Reset(jitteredInterval(s.scanInterval))
 		}
 	}
 }

--- a/pkg/frontend/async/store.go
+++ b/pkg/frontend/async/store.go
@@ -34,6 +34,7 @@ const (
 	defaultHeartbeatInterval    = 15 * time.Second
 	defaultLeaseTimeout         = 45 * time.Second
 	defaultAdoptionScanInterval = 30 * time.Second
+	defaultMaxAdoptions         = 3
 	cleanupInterval             = 5 * time.Minute
 )
 
@@ -46,6 +47,11 @@ var (
 	// by both get() and the adoption scan: a stale in-progress record whose
 	// spec is gone can never be resumed.
 	errOrphanedNoSpec = errors.New("query orphaned: owner heartbeat expired and no request spec is available for adoption")
+
+	// errTooManyAdoptions indicates a query has already been adopted
+	// defaultMaxAdoptions times; adoption is refused and the query is marked
+	// failed instead of being claimed again.
+	errTooManyAdoptions = errors.New("query exceeded the maximum number of adoption attempts")
 )
 
 // Status represents the lifecycle state of an async query.
@@ -70,6 +76,7 @@ type Metadata struct {
 	LastHeartbeat time.Time `json:"last_heartbeat,omitempty"`
 	ErrorMessage  string    `json:"error_message,omitempty"`
 	Owner         string    `json:"owner,omitempty"`
+	AdoptionCount int       `json:"adoption_count,omitempty"`
 }
 
 // Result bundles a query's Metadata with its decoded Response. Response is only
@@ -281,6 +288,11 @@ func (s *Store) fail(ctx context.Context, tenantID, requestID string, queryErr e
 func (s *Store) markUnadoptable(ctx context.Context, tenantID, requestID string) error {
 	level.Warn(s.logger).Log("msg", "async query is unrecoverable, marking failed", "tenant", tenantID, "request_id", requestID)
 	return s.fail(ctx, tenantID, requestID, errOrphanedNoSpec)
+}
+
+func (s *Store) markTooManyAdoptions(ctx context.Context, tenantID, requestID string, count int) error {
+	level.Warn(s.logger).Log("msg", "async query exceeded max adoption attempts, marking failed", "tenant", tenantID, "request_id", requestID, "count", count)
+	return s.fail(ctx, tenantID, requestID, errTooManyAdoptions)
 }
 
 // buildSuccessResult fetches and unmarshals result.pb, returning a Result
@@ -506,12 +518,10 @@ func (s *Store) runCleanup(ctx context.Context) {
 // further work.
 //
 // A query that repeatedly kills its owner (e.g. one that OOMs the frontend)
-// is re-adopted at most once per leaseTimeout+scanInterval, and cleanup()
-// bounds the loop: spec.pb is written once and never rewritten, so it ages
-// out after the TTL even while metadata.json stays fresh, at which point the
-// next scan finds no spec and persists a terminal failure. Worst case is
-// roughly ttl/(leaseTimeout+scanInterval) re-executions, each still subject
-// to the tenant's concurrency limit.
+// is capped at defaultMaxAdoptions re-executions via Metadata.AdoptionCount;
+// once exhausted it's marked failed outright. The TTL remains the backstop
+// for records that never get adopted at all, e.g. because no dispatcher is
+// configured.
 func (s *Store) runAdoption(ctx context.Context) {
 	err := s.bucket.Iter(ctx, storagePrefix, func(name string) error {
 		if path.Base(name) != metadataFilename {
@@ -581,6 +591,12 @@ func (s *Store) adopt(ctx context.Context, meta Metadata) {
 	if !s.leaseExpired(&fresh) {
 		return
 	}
+	if fresh.AdoptionCount >= defaultMaxAdoptions {
+		if err := s.markTooManyAdoptions(ctx, meta.TenantID, meta.RequestID, fresh.AdoptionCount); err != nil {
+			level.Warn(s.logger).Log("msg", "failed to persist too-many-adoptions failure", "tenant", meta.TenantID, "request_id", meta.RequestID, "err", err)
+		}
+		return
+	}
 	if exists, err := s.resultExists(ctx, meta.TenantID, meta.RequestID); err != nil {
 		// Same reasoning as the entry check above: inconclusive means skip,
 		// not proceed, and wait for the next scan tick.
@@ -595,6 +611,7 @@ func (s *Store) adopt(ctx context.Context, meta Metadata) {
 	leaseAge := time.Since(fresh.LastHeartbeat)
 	fresh.Owner = s.ownerID
 	fresh.LastHeartbeat = time.Now().UTC()
+	fresh.AdoptionCount++
 	if err := s.saveJSON(ctx, metaPath, &fresh); err != nil {
 		level.Warn(s.logger).Log("msg", "failed to claim orphaned query", "tenant", meta.TenantID, "request_id", meta.RequestID, "err", err)
 		return

--- a/pkg/frontend/async/store_test.go
+++ b/pkg/frontend/async/store_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/google/uuid"
+	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
@@ -341,6 +342,25 @@ func TestStoreAdopt_TransientResultCheckErrorAtPreClaimSkipsCandidate(t *testing
 	require.NoError(t, seed.readJSON(ctx, seed.buildPath(tenantID, requestID, metadataFilename), &got))
 	require.Equal(t, StatusInProgress, got.Status)
 	require.WithinDuration(t, stale, got.LastHeartbeat, time.Second)
+}
+
+func TestSetDispatcher(t *testing.T) {
+	t.Run("succeeds before the service starts", func(t *testing.T) {
+		store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+		dispatcher := &fakeDispatcher{}
+
+		require.NotPanics(t, func() { store.SetDispatcher(dispatcher) })
+		require.Same(t, Dispatcher(dispatcher), store.dispatcher)
+	})
+
+	t.Run("panics once the service has started", func(t *testing.T) {
+		ctx := context.Background()
+		store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+		require.NoError(t, services.StartAndAwaitRunning(ctx, store))
+		defer func() { require.NoError(t, services.StopAndAwaitTerminated(ctx, store)) }()
+
+		require.Panics(t, func() { store.SetDispatcher(&fakeDispatcher{}) })
+	})
 }
 
 func TestStoreAdopt_StaleWithSpecClaimsAndDispatches(t *testing.T) {

--- a/pkg/frontend/async/store_test.go
+++ b/pkg/frontend/async/store_test.go
@@ -88,6 +88,20 @@ func (b *gatedUploadBucket) Upload(ctx context.Context, name string, r io.Reader
 	return b.Bucket.Upload(ctx, name, r, opts...)
 }
 
+func TestJitteredInterval_WithinBoundsAndVaries(t *testing.T) {
+	const base = 30 * time.Second
+	lower, upper := 24*time.Second, 36*time.Second
+
+	seen := make(map[time.Duration]struct{})
+	for i := 0; i < 1000; i++ {
+		got := jitteredInterval(base)
+		require.GreaterOrEqual(t, got, lower)
+		require.Less(t, got, upper)
+		seen[got] = struct{}{}
+	}
+	require.Greater(t, len(seen), 1, "jitteredInterval should not always return the same value")
+}
+
 func TestMetadataUnmarshal_BackwardCompatible(t *testing.T) {
 	raw := []byte(`{
 		"request_id": "550e8400-e29b-41d4-a716-446655440000",

--- a/pkg/frontend/async/store_test.go
+++ b/pkg/frontend/async/store_test.go
@@ -40,25 +40,25 @@ type fakeDispatchCall struct {
 	spec      *querierv1.SelectMergeStacktracesRequest
 }
 
-// fakeDispatcher is a test double for Dispatcher. CanDispatch defaults to
-// true (spare capacity) unless canDispatch is explicitly set to false,
+// fakeDispatcher is a test double for Dispatcher. HasCapacity defaults to
+// true (spare capacity) unless hasCapacity is explicitly set to false,
 // simulating a saturated tenant. Dispatch always records the call;
 // onDispatch, if set, runs synchronously afterward. Leaving onDispatch nil
 // simulates a dispatcher whose execution declines to do anything further
-// once dispatched (distinct from CanDispatch returning false, which never
+// once dispatched (distinct from HasCapacity returning false, which never
 // reaches Dispatch at all).
 type fakeDispatcher struct {
 	mu               sync.Mutex
 	calls            []fakeDispatchCall
-	canDispatchCalls int
-	atCapacity       bool // when true, CanDispatch reports no spare capacity; default (false) has capacity.
+	hasCapacityCalls int
+	atCapacity       bool // when true, HasCapacity reports no spare capacity; default (false) has capacity.
 	onDispatch       func(tenantID, requestID string, spec *querierv1.SelectMergeStacktracesRequest)
 }
 
-func (f *fakeDispatcher) CanDispatch(tenantID string) bool {
+func (f *fakeDispatcher) HasCapacity(tenantID string) bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.canDispatchCalls++
+	f.hasCapacityCalls++
 	return !f.atCapacity
 }
 
@@ -496,7 +496,7 @@ func TestStoreAdopt_NilDispatcherIsNoop(t *testing.T) {
 }
 
 // TestStoreAdopt_AtCapacityLeavesRecordUntouched proves the fix for the
-// claim-before-capacity-check bug: when CanDispatch reports no spare
+// claim-before-capacity-check bug: when HasCapacity reports no spare
 // capacity (e.g. the tenant is at its concurrency limit), adopt() must not
 // touch the record at all -- no Owner/LastHeartbeat change, no AdoptionCount
 // spend, and no claim success recorded -- so the lease stays expired and any
@@ -520,7 +520,7 @@ func TestStoreAdopt_AtCapacityLeavesRecordUntouched(t *testing.T) {
 	store.runAdoption(ctx)
 
 	require.Empty(t, dispatcher.calls)
-	require.Greater(t, dispatcher.canDispatchCalls, 0, "CanDispatch must still be consulted")
+	require.Greater(t, dispatcher.hasCapacityCalls, 0, "HasCapacity must still be consulted")
 
 	var meta Metadata
 	require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &meta))

--- a/pkg/frontend/async/store_test.go
+++ b/pkg/frontend/async/store_test.go
@@ -26,11 +26,11 @@ import (
 // query whose owner stopped renewing its lease some time ago.
 func backdateHeartbeat(t *testing.T, ctx context.Context, store *Store, tenantID, requestID string, when time.Time) {
 	t.Helper()
-	base := store.basePath(tenantID, requestID)
+	metaPath := store.buildPath(tenantID, requestID, metadataFilename)
 	var meta Metadata
-	require.NoError(t, store.readJSON(ctx, base+"metadata.json", &meta))
+	require.NoError(t, store.readJSON(ctx, metaPath, &meta))
 	meta.LastHeartbeat = when
-	require.NoError(t, store.saveJSON(ctx, base+"metadata.json", &meta))
+	require.NoError(t, store.saveJSON(ctx, metaPath, &meta))
 }
 
 type fakeDispatchCall struct {
@@ -49,7 +49,7 @@ type fakeDispatcher struct {
 	onDispatch func(tenantID, requestID string, spec *querierv1.SelectMergeStacktracesRequest)
 }
 
-func (f *fakeDispatcher) Dispatch(_ context.Context, tenantID, requestID string, spec *querierv1.SelectMergeStacktracesRequest) {
+func (f *fakeDispatcher) Dispatch(tenantID, requestID string, spec *querierv1.SelectMergeStacktracesRequest) {
 	f.mu.Lock()
 	f.calls = append(f.calls, fakeDispatchCall{tenantID: tenantID, requestID: requestID, spec: spec})
 	onDispatch := f.onDispatch
@@ -127,10 +127,9 @@ func TestStoreCreate_PersistsSpecBeforeMetadata(t *testing.T) {
 
 	require.NoError(t, store.create(ctx, tenantID, requestID, spec))
 
-	base := store.basePath(tenantID, requestID)
-	_, err := store.bucket.Attributes(ctx, base+"spec.pb")
+	_, err := store.bucket.Attributes(ctx, store.buildPath(tenantID, requestID, specFilename))
 	require.NoError(t, err)
-	_, err = store.bucket.Attributes(ctx, base+"metadata.json")
+	_, err = store.bucket.Attributes(ctx, store.buildPath(tenantID, requestID, metadataFilename))
 	require.NoError(t, err)
 
 	gotSpec, err := store.readSpec(ctx, tenantID, requestID)
@@ -138,7 +137,7 @@ func TestStoreCreate_PersistsSpecBeforeMetadata(t *testing.T) {
 	require.True(t, proto.Equal(spec, gotSpec))
 
 	var meta Metadata
-	require.NoError(t, store.readJSON(ctx, base+"metadata.json", &meta))
+	require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &meta))
 	require.Equal(t, StatusInProgress, meta.Status)
 	require.Equal(t, store.ownerID, meta.Owner)
 }
@@ -159,7 +158,7 @@ func TestStoreGet_StaleWithSpecStaysInProgress(t *testing.T) {
 	require.Empty(t, result.Metadata.ErrorMessage)
 
 	var meta Metadata
-	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &meta))
+	require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &meta))
 	require.Equal(t, StatusInProgress, meta.Status)
 	require.Empty(t, meta.ErrorMessage)
 }
@@ -178,7 +177,7 @@ func TestStoreGet_StaleWithoutSpecPersistsFailure(t *testing.T) {
 		CreatedAt:     past,
 		LastHeartbeat: past,
 	}
-	require.NoError(t, store.saveJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", meta))
+	require.NoError(t, store.saveJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), meta))
 
 	result, err := store.get(ctx, tenantID, requestID)
 	require.NoError(t, err)
@@ -186,7 +185,7 @@ func TestStoreGet_StaleWithoutSpecPersistsFailure(t *testing.T) {
 	require.Equal(t, errOrphanedNoSpec.Error(), result.Metadata.ErrorMessage)
 
 	var got Metadata
-	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &got))
+	require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &got))
 	require.Equal(t, StatusFailure, got.Status)
 
 	// Idempotent: a second get() is a no-op, still StatusFailure, no error.
@@ -225,7 +224,7 @@ func TestStoreGet_TransientSpecCheckErrorLeavesQueryInProgress(t *testing.T) {
 
 	wrapped := &attributesErrBucket{
 		Bucket:   inner,
-		failName: seed.basePath(tenantID, requestID) + "spec.pb",
+		failName: seed.buildPath(tenantID, requestID, specFilename),
 		err:      errors.New("simulated transient storage error"),
 	}
 	store := NewStore(log.NewNopLogger(), wrapped, nil)
@@ -236,8 +235,111 @@ func TestStoreGet_TransientSpecCheckErrorLeavesQueryInProgress(t *testing.T) {
 	require.Empty(t, result.Metadata.ErrorMessage)
 
 	var meta Metadata
-	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &meta))
+	require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &meta))
 	require.Equal(t, StatusInProgress, meta.Status)
+}
+
+// attributesErrAfterNBucket wraps a Bucket, letting the first n Attributes
+// calls for one specific object name succeed normally, then forcing every
+// call after that to return a fixed error. Used to simulate a transient
+// object-storage error that only surfaces on a later, otherwise-identical
+// check (e.g. adopt()'s pre-claim resultExists re-check).
+type attributesErrAfterNBucket struct {
+	objstore.Bucket
+	failName string
+	n        int
+	err      error
+	calls    int
+}
+
+func (b *attributesErrAfterNBucket) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
+	if name == b.failName {
+		b.calls++
+		if b.calls > b.n {
+			return objstore.ObjectAttributes{}, b.err
+		}
+	}
+	return b.Bucket.Attributes(ctx, name)
+}
+
+// TestStoreAdopt_TransientResultCheckErrorAtEntrySkipsCandidate proves that a
+// transient error from adopt()'s entry-point resultExists check causes the
+// candidate to be skipped entirely (no claim, no dispatch, no adoption
+// attempt recorded) rather than proceeding as if no result existed.
+func TestStoreAdopt_TransientResultCheckErrorAtEntrySkipsCandidate(t *testing.T) {
+	ctx := context.Background()
+	inner := objstore.NewInMemBucket()
+
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	seed := NewStore(log.NewNopLogger(), inner, nil)
+	spec := &querierv1.SelectMergeStacktracesRequest{ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"}
+	require.NoError(t, seed.create(ctx, tenantID, requestID, spec))
+	stale := time.Now().Add(-time.Hour).UTC()
+	backdateHeartbeat(t, ctx, seed, tenantID, requestID, stale)
+
+	wrapped := &attributesErrAfterNBucket{
+		Bucket:   inner,
+		failName: seed.buildPath(tenantID, requestID, resultFilename),
+		n:        0, // fail starting on the very first call.
+		err:      errors.New("simulated transient storage error"),
+	}
+	store := NewStore(log.NewNopLogger(), wrapped, nil)
+	dispatcher := &fakeDispatcher{}
+	store.SetDispatcher(dispatcher)
+
+	var meta Metadata
+	require.NoError(t, seed.readJSON(ctx, seed.buildPath(tenantID, requestID, metadataFilename), &meta))
+
+	store.adopt(ctx, meta)
+
+	require.Empty(t, dispatcher.calls)
+	require.Equal(t, float64(0), testutil.ToFloat64(store.adoptionAttempts.WithLabelValues(tenantID)))
+
+	var got Metadata
+	require.NoError(t, seed.readJSON(ctx, seed.buildPath(tenantID, requestID, metadataFilename), &got))
+	require.Equal(t, StatusInProgress, got.Status)
+	require.WithinDuration(t, stale, got.LastHeartbeat, time.Second)
+}
+
+// TestStoreAdopt_TransientResultCheckErrorAtPreClaimSkipsCandidate proves the
+// same skip-on-error behavior for adopt()'s pre-claim resultExists re-check:
+// a transient error there must abort the claim, not proceed with it.
+func TestStoreAdopt_TransientResultCheckErrorAtPreClaimSkipsCandidate(t *testing.T) {
+	ctx := context.Background()
+	inner := objstore.NewInMemBucket()
+
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	seed := NewStore(log.NewNopLogger(), inner, nil)
+	spec := &querierv1.SelectMergeStacktracesRequest{ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"}
+	require.NoError(t, seed.create(ctx, tenantID, requestID, spec))
+	stale := time.Now().Add(-time.Hour).UTC()
+	backdateHeartbeat(t, ctx, seed, tenantID, requestID, stale)
+
+	wrapped := &attributesErrAfterNBucket{
+		Bucket:   inner,
+		failName: seed.buildPath(tenantID, requestID, resultFilename),
+		n:        1, // entry check (call 1) succeeds; pre-claim check (call 2) fails.
+		err:      errors.New("simulated transient storage error"),
+	}
+	store := NewStore(log.NewNopLogger(), wrapped, nil)
+	dispatcher := &fakeDispatcher{}
+	store.SetDispatcher(dispatcher)
+
+	var meta Metadata
+	require.NoError(t, seed.readJSON(ctx, seed.buildPath(tenantID, requestID, metadataFilename), &meta))
+
+	store.adopt(ctx, meta)
+
+	require.Empty(t, dispatcher.calls)
+	require.Equal(t, float64(1), testutil.ToFloat64(store.adoptionAttempts.WithLabelValues(tenantID)))
+	require.Equal(t, float64(0), testutil.ToFloat64(store.adoptionSuccesses.WithLabelValues(tenantID)))
+
+	var got Metadata
+	require.NoError(t, seed.readJSON(ctx, seed.buildPath(tenantID, requestID, metadataFilename), &got))
+	require.Equal(t, StatusInProgress, got.Status)
+	require.WithinDuration(t, stale, got.LastHeartbeat, time.Second)
 }
 
 func TestStoreAdopt_StaleWithSpecClaimsAndDispatches(t *testing.T) {
@@ -260,7 +362,7 @@ func TestStoreAdopt_StaleWithSpecClaimsAndDispatches(t *testing.T) {
 	require.True(t, proto.Equal(spec, dispatcher.calls[0].spec))
 
 	var meta Metadata
-	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &meta))
+	require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &meta))
 	require.Equal(t, StatusInProgress, meta.Status)
 	require.Equal(t, store.ownerID, meta.Owner)
 	require.WithinDuration(t, time.Now(), meta.LastHeartbeat, 5*time.Second)
@@ -285,14 +387,14 @@ func TestStoreAdopt_StaleWithoutSpecMarksFailureNoDispatch(t *testing.T) {
 		CreatedAt:     past,
 		LastHeartbeat: past,
 	}
-	require.NoError(t, store.saveJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", meta))
+	require.NoError(t, store.saveJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), meta))
 
 	store.runAdoption(ctx)
 
 	require.Empty(t, dispatcher.calls)
 
 	var got Metadata
-	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &got))
+	require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &got))
 	require.Equal(t, StatusFailure, got.Status)
 	require.Equal(t, errOrphanedNoSpec.Error(), got.ErrorMessage)
 
@@ -308,10 +410,9 @@ func TestStoreAdopt_CorruptSpecMarksUnadoptable(t *testing.T) {
 
 	const tenantID = "tenant-a"
 	requestID := uuid.New().String()
-	base := store.basePath(tenantID, requestID)
 	// An incomplete varint: guaranteed to fail proto.Unmarshal regardless of
 	// message schema, simulating a torn/truncated spec.pb.
-	require.NoError(t, store.bucket.Upload(ctx, base+"spec.pb", bytes.NewReader([]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF})))
+	require.NoError(t, store.bucket.Upload(ctx, store.buildPath(tenantID, requestID, specFilename), bytes.NewReader([]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF})))
 
 	past := time.Now().Add(-time.Hour).UTC()
 	meta := &Metadata{
@@ -321,14 +422,14 @@ func TestStoreAdopt_CorruptSpecMarksUnadoptable(t *testing.T) {
 		CreatedAt:     past,
 		LastHeartbeat: past,
 	}
-	require.NoError(t, store.saveJSON(ctx, base+"metadata.json", meta))
+	require.NoError(t, store.saveJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), meta))
 
 	store.runAdoption(ctx)
 
 	require.Empty(t, dispatcher.calls)
 
 	var got Metadata
-	require.NoError(t, store.readJSON(ctx, base+"metadata.json", &got))
+	require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &got))
 	require.Equal(t, StatusFailure, got.Status)
 	require.Equal(t, errOrphanedNoSpec.Error(), got.ErrorMessage)
 
@@ -351,7 +452,7 @@ func TestStoreAdopt_NilDispatcherIsNoop(t *testing.T) {
 	require.NotPanics(t, func() { store.runAdoption(ctx) })
 
 	var meta Metadata
-	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &meta))
+	require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &meta))
 	require.Equal(t, StatusInProgress, meta.Status)
 	require.Equal(t, store.ownerID, meta.Owner)
 	require.WithinDuration(t, stale, meta.LastHeartbeat, time.Second)
@@ -376,7 +477,7 @@ func TestStoreAdopt_ClaimSucceedsEvenIfDispatcherDeclines(t *testing.T) {
 	store.runAdoption(ctx)
 
 	var meta Metadata
-	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &meta))
+	require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &meta))
 	require.Equal(t, store.ownerID, meta.Owner)
 	require.WithinDuration(t, time.Now(), meta.LastHeartbeat, 5*time.Second)
 	require.Equal(t, float64(1), testutil.ToFloat64(store.adoptionSuccesses.WithLabelValues(tenantID)))
@@ -453,7 +554,7 @@ func TestStoreComplete_SuccessOverwritesPriorFailure(t *testing.T) {
 	require.NoError(t, store.complete(ctx, tenantID, requestID, &querierv1.SelectMergeStacktracesResponse{Tree: []byte("late-success")}))
 
 	var meta Metadata
-	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &meta))
+	require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &meta))
 	require.Equal(t, StatusSuccess, meta.Status)
 	require.Empty(t, meta.ErrorMessage)
 }
@@ -499,18 +600,18 @@ func TestStoreHeartbeat_CanRevertSoftFailureToInProgress(t *testing.T) {
 	requestID := uuid.New().String()
 	require.NoError(t, store.create(ctx, tenantID, requestID, &querierv1.SelectMergeStacktracesRequest{}))
 
-	base := store.basePath(tenantID, requestID)
+	metaPath := store.buildPath(tenantID, requestID, metadataFilename)
 	var staleRead Metadata
-	require.NoError(t, store.readJSON(ctx, base+"metadata.json", &staleRead))
+	require.NoError(t, store.readJSON(ctx, metaPath, &staleRead))
 
 	require.NoError(t, store.fail(ctx, tenantID, requestID, errors.New("straggler failure")))
 
 	staleRead.LastHeartbeat = time.Now().UTC()
 	staleRead.Owner = store.ownerID
-	require.NoError(t, store.saveJSON(ctx, base+"metadata.json", &staleRead))
+	require.NoError(t, store.saveJSON(ctx, metaPath, &staleRead))
 
 	var meta Metadata
-	require.NoError(t, store.readJSON(ctx, base+"metadata.json", &meta))
+	require.NoError(t, store.readJSON(ctx, metaPath, &meta))
 	require.Equal(t, StatusInProgress, meta.Status)
 }
 
@@ -528,7 +629,7 @@ func TestStoreCompleteFail_SuccessAlwaysWinsOverFailure(t *testing.T) {
 		require.NoError(t, store.fail(ctx, tenantID, requestID, errors.New("late straggler failure")))
 
 		var meta Metadata
-		require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &meta))
+		require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &meta))
 		require.Equal(t, StatusSuccess, meta.Status)
 		require.Empty(t, meta.ErrorMessage)
 
@@ -552,7 +653,7 @@ func TestStoreCompleteFail_SuccessAlwaysWinsOverFailure(t *testing.T) {
 		// execution produced the correct answer, so it must be reported --
 		// regardless of what any differently-outcome'd execution wrote first.
 		var meta Metadata
-		require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &meta))
+		require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &meta))
 		require.Equal(t, StatusSuccess, meta.Status)
 		require.Empty(t, meta.ErrorMessage)
 
@@ -578,7 +679,7 @@ func TestStoreHeartbeat_DoesNotResurrectTerminalRecord(t *testing.T) {
 	require.NoError(t, store.heartbeat(ctx, tenantID, requestID))
 
 	var meta Metadata
-	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &meta))
+	require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &meta))
 	require.Equal(t, StatusSuccess, meta.Status)
 
 	result, err := store.get(ctx, tenantID, requestID)
@@ -599,7 +700,7 @@ func TestStoreGet_AnchorSurvivesHeartbeatGatedRevert(t *testing.T) {
 	seed := NewStore(log.NewNopLogger(), inner, nil)
 	require.NoError(t, seed.create(ctx, tenantID, requestID, &querierv1.SelectMergeStacktracesRequest{}))
 
-	target := seed.basePath(tenantID, requestID) + "metadata.json"
+	target := seed.buildPath(tenantID, requestID, metadataFilename)
 	gated := newGatedUploadBucket(inner, target)
 	heartbeatStore := NewStore(log.NewNopLogger(), gated, nil)
 
@@ -621,7 +722,7 @@ func TestStoreGet_AnchorSurvivesHeartbeatGatedRevert(t *testing.T) {
 	// Informational only: proves the interleaving actually landed -- the raw
 	// record was reverted by the stale heartbeat write.
 	var raw Metadata
-	require.NoError(t, seed.readJSON(ctx, seed.basePath(tenantID, requestID)+"metadata.json", &raw))
+	require.NoError(t, seed.readJSON(ctx, seed.buildPath(tenantID, requestID, metadataFilename), &raw))
 	require.Equal(t, StatusInProgress, raw.Status)
 
 	result, err := seed.get(ctx, tenantID, requestID)
@@ -647,9 +748,9 @@ func TestStoreAdopt_ClaimGatedByConcurrentCompletion(t *testing.T) {
 	backdateHeartbeat(t, ctx, seed, tenantID, requestID, time.Now().Add(-time.Hour).UTC())
 
 	var snapshot Metadata
-	require.NoError(t, seed.readJSON(ctx, seed.basePath(tenantID, requestID)+"metadata.json", &snapshot))
+	require.NoError(t, seed.readJSON(ctx, seed.buildPath(tenantID, requestID, metadataFilename), &snapshot))
 
-	target := seed.basePath(tenantID, requestID) + "metadata.json"
+	target := seed.buildPath(tenantID, requestID, metadataFilename)
 	gated := newGatedUploadBucket(inner, target)
 	adoptStore := NewStore(log.NewNopLogger(), gated, nil)
 	adoptStore.SetDispatcher(&fakeDispatcher{})
@@ -691,7 +792,7 @@ func TestStoreAdopt_ReReadAbortsOnConcurrentCompletion(t *testing.T) {
 	// true owner completing the query while adopt()'s readSpec round trip is
 	// "in flight" -- i.e. after the scan's read but before the claim write.
 	var stale Metadata
-	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &stale))
+	require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &stale))
 	require.NoError(t, store.complete(ctx, tenantID, requestID, &querierv1.SelectMergeStacktracesResponse{Tree: []byte("already-done")}))
 
 	store.adopt(ctx, stale)
@@ -699,7 +800,7 @@ func TestStoreAdopt_ReReadAbortsOnConcurrentCompletion(t *testing.T) {
 	require.Empty(t, dispatcher.calls)
 
 	var final Metadata
-	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &final))
+	require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &final))
 	require.Equal(t, StatusSuccess, final.Status)
 
 	// result.pb already exists by the time adopt() runs, so its entry-point

--- a/pkg/frontend/async/store_test.go
+++ b/pkg/frontend/async/store_test.go
@@ -1,0 +1,771 @@
+package async
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+	"go.uber.org/atomic"
+	"google.golang.org/protobuf/proto"
+
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+)
+
+// backdateHeartbeat rewrites an existing record's LastHeartbeat, simulating a
+// query whose owner stopped renewing its lease some time ago.
+func backdateHeartbeat(t *testing.T, ctx context.Context, store *Store, tenantID, requestID string, when time.Time) {
+	t.Helper()
+	base := store.basePath(tenantID, requestID)
+	var meta Metadata
+	require.NoError(t, store.readJSON(ctx, base+"metadata.json", &meta))
+	meta.LastHeartbeat = when
+	require.NoError(t, store.saveJSON(ctx, base+"metadata.json", &meta))
+}
+
+type fakeDispatchCall struct {
+	tenantID  string
+	requestID string
+	spec      *querierv1.SelectMergeStacktracesRequest
+}
+
+// fakeDispatcher is a test double for Dispatcher. It always records the call;
+// onDispatch, if set, runs synchronously afterward. Leaving onDispatch nil
+// simulates a dispatcher that declines to do anything, e.g. Coordinator's
+// concurrency limit rejecting the adopted query.
+type fakeDispatcher struct {
+	mu         sync.Mutex
+	calls      []fakeDispatchCall
+	onDispatch func(tenantID, requestID string, spec *querierv1.SelectMergeStacktracesRequest)
+}
+
+func (f *fakeDispatcher) Dispatch(_ context.Context, tenantID, requestID string, spec *querierv1.SelectMergeStacktracesRequest) {
+	f.mu.Lock()
+	f.calls = append(f.calls, fakeDispatchCall{tenantID: tenantID, requestID: requestID, spec: spec})
+	onDispatch := f.onDispatch
+	f.mu.Unlock()
+	if onDispatch != nil {
+		onDispatch(tenantID, requestID, spec)
+	}
+}
+
+// gatedUploadBucket wraps a Bucket so a test can pause a writer goroutine
+// deterministically at "about to write" one specific object, inject a real,
+// concurrent write from elsewhere into the gap, then let the paused writer
+// proceed. reached closes once the gate is hit; the wrapped Upload blocks
+// until proceed is closed.
+type gatedUploadBucket struct {
+	objstore.Bucket
+	target  string
+	reached chan struct{}
+	proceed chan struct{}
+}
+
+func newGatedUploadBucket(inner objstore.Bucket, target string) *gatedUploadBucket {
+	return &gatedUploadBucket{
+		Bucket:  inner,
+		target:  target,
+		reached: make(chan struct{}),
+		proceed: make(chan struct{}),
+	}
+}
+
+func (b *gatedUploadBucket) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) error {
+	if name == b.target {
+		close(b.reached)
+		<-b.proceed
+	}
+	return b.Bucket.Upload(ctx, name, r, opts...)
+}
+
+func TestMetadataUnmarshal_BackwardCompatible(t *testing.T) {
+	raw := []byte(`{
+		"request_id": "550e8400-e29b-41d4-a716-446655440000",
+		"tenant_id": "tenant-a",
+		"status": "in_progress",
+		"created_at": "2024-01-01T00:00:00Z",
+		"last_heartbeat": "2024-01-01T00:00:05Z"
+	}`)
+
+	var meta Metadata
+	require.NoError(t, json.Unmarshal(raw, &meta))
+	require.Equal(t, StatusInProgress, meta.Status)
+	require.Equal(t, "", meta.Owner)
+}
+
+func TestStoreCreate_PersistsSpecBeforeMetadata(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	spec := &querierv1.SelectMergeStacktracesRequest{ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"}
+
+	require.NoError(t, store.create(ctx, tenantID, requestID, spec))
+
+	base := store.basePath(tenantID, requestID)
+	_, err := store.bucket.Attributes(ctx, base+"spec.pb")
+	require.NoError(t, err)
+	_, err = store.bucket.Attributes(ctx, base+"metadata.json")
+	require.NoError(t, err)
+
+	gotSpec, err := store.readSpec(ctx, tenantID, requestID)
+	require.NoError(t, err)
+	require.True(t, proto.Equal(spec, gotSpec))
+
+	var meta Metadata
+	require.NoError(t, store.readJSON(ctx, base+"metadata.json", &meta))
+	require.Equal(t, StatusInProgress, meta.Status)
+	require.Equal(t, store.ownerID, meta.Owner)
+}
+
+func TestStoreGet_StaleWithSpecStaysInProgress(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	spec := &querierv1.SelectMergeStacktracesRequest{ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"}
+	require.NoError(t, store.create(ctx, tenantID, requestID, spec))
+	backdateHeartbeat(t, ctx, store, tenantID, requestID, time.Now().Add(-time.Hour).UTC())
+
+	result, err := store.get(ctx, tenantID, requestID)
+	require.NoError(t, err)
+	require.Equal(t, StatusInProgress, result.Metadata.Status)
+	require.Empty(t, result.Metadata.ErrorMessage)
+
+	var meta Metadata
+	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &meta))
+	require.Equal(t, StatusInProgress, meta.Status)
+	require.Empty(t, meta.ErrorMessage)
+}
+
+func TestStoreGet_StaleWithoutSpecPersistsFailure(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	past := time.Now().Add(-time.Hour).UTC()
+	meta := &Metadata{
+		RequestID:     requestID,
+		TenantID:      tenantID,
+		Status:        StatusInProgress,
+		CreatedAt:     past,
+		LastHeartbeat: past,
+	}
+	require.NoError(t, store.saveJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", meta))
+
+	result, err := store.get(ctx, tenantID, requestID)
+	require.NoError(t, err)
+	require.Equal(t, StatusFailure, result.Metadata.Status)
+	require.Equal(t, errOrphanedNoSpec.Error(), result.Metadata.ErrorMessage)
+
+	var got Metadata
+	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &got))
+	require.Equal(t, StatusFailure, got.Status)
+
+	// Idempotent: a second get() is a no-op, still StatusFailure, no error.
+	result2, err := store.get(ctx, tenantID, requestID)
+	require.NoError(t, err)
+	require.Equal(t, StatusFailure, result2.Metadata.Status)
+}
+
+// attributesErrBucket wraps a Bucket, forcing Attributes to return a fixed
+// error for one specific object name; every other call (and every other
+// object name) is delegated unchanged. Used to simulate a transient
+// object-storage error that is distinct from "not found".
+type attributesErrBucket struct {
+	objstore.Bucket
+	failName string
+	err      error
+}
+
+func (b *attributesErrBucket) Attributes(ctx context.Context, name string) (objstore.ObjectAttributes, error) {
+	if name == b.failName {
+		return objstore.ObjectAttributes{}, b.err
+	}
+	return b.Bucket.Attributes(ctx, name)
+}
+
+func TestStoreGet_TransientSpecCheckErrorLeavesQueryInProgress(t *testing.T) {
+	ctx := context.Background()
+	inner := objstore.NewInMemBucket()
+
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	seed := NewStore(log.NewNopLogger(), inner, nil)
+	spec := &querierv1.SelectMergeStacktracesRequest{ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"}
+	require.NoError(t, seed.create(ctx, tenantID, requestID, spec))
+	backdateHeartbeat(t, ctx, seed, tenantID, requestID, time.Now().Add(-time.Hour).UTC())
+
+	wrapped := &attributesErrBucket{
+		Bucket:   inner,
+		failName: seed.basePath(tenantID, requestID) + "spec.pb",
+		err:      errors.New("simulated transient storage error"),
+	}
+	store := NewStore(log.NewNopLogger(), wrapped, nil)
+
+	result, err := store.get(ctx, tenantID, requestID)
+	require.NoError(t, err)
+	require.Equal(t, StatusInProgress, result.Metadata.Status)
+	require.Empty(t, result.Metadata.ErrorMessage)
+
+	var meta Metadata
+	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &meta))
+	require.Equal(t, StatusInProgress, meta.Status)
+}
+
+func TestStoreAdopt_StaleWithSpecClaimsAndDispatches(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+	dispatcher := &fakeDispatcher{}
+	store.SetDispatcher(dispatcher)
+
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	spec := &querierv1.SelectMergeStacktracesRequest{ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"}
+	require.NoError(t, store.create(ctx, tenantID, requestID, spec))
+	backdateHeartbeat(t, ctx, store, tenantID, requestID, time.Now().Add(-time.Hour).UTC())
+
+	store.runAdoption(ctx)
+
+	require.Len(t, dispatcher.calls, 1)
+	require.Equal(t, tenantID, dispatcher.calls[0].tenantID)
+	require.Equal(t, requestID, dispatcher.calls[0].requestID)
+	require.True(t, proto.Equal(spec, dispatcher.calls[0].spec))
+
+	var meta Metadata
+	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &meta))
+	require.Equal(t, StatusInProgress, meta.Status)
+	require.Equal(t, store.ownerID, meta.Owner)
+	require.WithinDuration(t, time.Now(), meta.LastHeartbeat, 5*time.Second)
+
+	require.Equal(t, float64(1), testutil.ToFloat64(store.adoptionAttempts.WithLabelValues(tenantID)))
+	require.Equal(t, float64(1), testutil.ToFloat64(store.adoptionSuccesses.WithLabelValues(tenantID)))
+}
+
+func TestStoreAdopt_StaleWithoutSpecMarksFailureNoDispatch(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+	dispatcher := &fakeDispatcher{}
+	store.SetDispatcher(dispatcher)
+
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	past := time.Now().Add(-time.Hour).UTC()
+	meta := &Metadata{
+		RequestID:     requestID,
+		TenantID:      tenantID,
+		Status:        StatusInProgress,
+		CreatedAt:     past,
+		LastHeartbeat: past,
+	}
+	require.NoError(t, store.saveJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", meta))
+
+	store.runAdoption(ctx)
+
+	require.Empty(t, dispatcher.calls)
+
+	var got Metadata
+	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &got))
+	require.Equal(t, StatusFailure, got.Status)
+	require.Equal(t, errOrphanedNoSpec.Error(), got.ErrorMessage)
+
+	require.Equal(t, float64(0), testutil.ToFloat64(store.adoptionAttempts.WithLabelValues(tenantID)))
+	require.Equal(t, float64(0), testutil.ToFloat64(store.adoptionSuccesses.WithLabelValues(tenantID)))
+}
+
+func TestStoreAdopt_CorruptSpecMarksUnadoptable(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+	dispatcher := &fakeDispatcher{}
+	store.SetDispatcher(dispatcher)
+
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	base := store.basePath(tenantID, requestID)
+	// An incomplete varint: guaranteed to fail proto.Unmarshal regardless of
+	// message schema, simulating a torn/truncated spec.pb.
+	require.NoError(t, store.bucket.Upload(ctx, base+"spec.pb", bytes.NewReader([]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF})))
+
+	past := time.Now().Add(-time.Hour).UTC()
+	meta := &Metadata{
+		RequestID:     requestID,
+		TenantID:      tenantID,
+		Status:        StatusInProgress,
+		CreatedAt:     past,
+		LastHeartbeat: past,
+	}
+	require.NoError(t, store.saveJSON(ctx, base+"metadata.json", meta))
+
+	store.runAdoption(ctx)
+
+	require.Empty(t, dispatcher.calls)
+
+	var got Metadata
+	require.NoError(t, store.readJSON(ctx, base+"metadata.json", &got))
+	require.Equal(t, StatusFailure, got.Status)
+	require.Equal(t, errOrphanedNoSpec.Error(), got.ErrorMessage)
+
+	// A corrupt spec is unreadable, not a genuine adoption candidate.
+	require.Equal(t, float64(0), testutil.ToFloat64(store.adoptionAttempts.WithLabelValues(tenantID)))
+}
+
+func TestStoreAdopt_NilDispatcherIsNoop(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+	// dispatcher intentionally left nil: SetDispatcher is never called.
+
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	spec := &querierv1.SelectMergeStacktracesRequest{ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"}
+	require.NoError(t, store.create(ctx, tenantID, requestID, spec))
+	stale := time.Now().Add(-time.Hour).UTC()
+	backdateHeartbeat(t, ctx, store, tenantID, requestID, stale)
+
+	require.NotPanics(t, func() { store.runAdoption(ctx) })
+
+	var meta Metadata
+	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &meta))
+	require.Equal(t, StatusInProgress, meta.Status)
+	require.Equal(t, store.ownerID, meta.Owner)
+	require.WithinDuration(t, stale, meta.LastHeartbeat, time.Second)
+
+	// A nil dispatcher is still a stale+spec-present candidate found; it
+	// counts as an attempt even though nothing further happens.
+	require.Equal(t, float64(1), testutil.ToFloat64(store.adoptionAttempts.WithLabelValues(tenantID)))
+}
+
+func TestStoreAdopt_ClaimSucceedsEvenIfDispatcherDeclines(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+	dispatcher := &fakeDispatcher{} // no onDispatch hook: declines to run anything further.
+	store.SetDispatcher(dispatcher)
+
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	spec := &querierv1.SelectMergeStacktracesRequest{ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"}
+	require.NoError(t, store.create(ctx, tenantID, requestID, spec))
+	backdateHeartbeat(t, ctx, store, tenantID, requestID, time.Now().Add(-time.Hour).UTC())
+
+	store.runAdoption(ctx)
+
+	var meta Metadata
+	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &meta))
+	require.Equal(t, store.ownerID, meta.Owner)
+	require.WithinDuration(t, time.Now(), meta.LastHeartbeat, 5*time.Second)
+	require.Equal(t, float64(1), testutil.ToFloat64(store.adoptionSuccesses.WithLabelValues(tenantID)))
+}
+
+func TestStoreAdopt_MultiTenantScanIsIsolated(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+	dispatcher := &fakeDispatcher{}
+	store.SetDispatcher(dispatcher)
+
+	const (
+		tenantA = "tenant-a"
+		tenantB = "tenant-b"
+	)
+	requestA, requestB := uuid.New().String(), uuid.New().String()
+	specA := &querierv1.SelectMergeStacktracesRequest{ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds", LabelSelector: `{tenant="a"}`}
+	specB := &querierv1.SelectMergeStacktracesRequest{ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds", LabelSelector: `{tenant="b"}`}
+
+	require.NoError(t, store.create(ctx, tenantA, requestA, specA))
+	require.NoError(t, store.create(ctx, tenantB, requestB, specB))
+	backdateHeartbeat(t, ctx, store, tenantA, requestA, time.Now().Add(-time.Hour).UTC())
+	backdateHeartbeat(t, ctx, store, tenantB, requestB, time.Now().Add(-time.Hour).UTC())
+
+	store.runAdoption(ctx)
+
+	require.Len(t, dispatcher.calls, 2)
+	byTenant := make(map[string]fakeDispatchCall, 2)
+	for _, c := range dispatcher.calls {
+		byTenant[c.tenantID] = c
+	}
+	require.Equal(t, requestA, byTenant[tenantA].requestID)
+	require.Equal(t, requestB, byTenant[tenantB].requestID)
+	require.True(t, proto.Equal(specA, byTenant[tenantA].spec))
+	require.True(t, proto.Equal(specB, byTenant[tenantB].spec))
+
+	require.Equal(t, float64(1), testutil.ToFloat64(store.adoptionAttempts.WithLabelValues(tenantA)))
+	require.Equal(t, float64(1), testutil.ToFloat64(store.adoptionAttempts.WithLabelValues(tenantB)))
+	require.Equal(t, float64(1), testutil.ToFloat64(store.adoptionSuccesses.WithLabelValues(tenantA)))
+	require.Equal(t, float64(1), testutil.ToFloat64(store.adoptionSuccesses.WithLabelValues(tenantB)))
+}
+
+// TestStoreGet_AnchorReportsSuccessDespiteLaterFailureWrite is the headline,
+// fully sequential regression test for the primary invariant: once a
+// success has landed, get() reports it regardless of any later write.
+func TestStoreGet_AnchorReportsSuccessDespiteLaterFailureWrite(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	require.NoError(t, store.create(ctx, tenantID, requestID, &querierv1.SelectMergeStacktracesRequest{}))
+
+	resp := &querierv1.SelectMergeStacktracesResponse{Tree: []byte("done")}
+	require.NoError(t, store.complete(ctx, tenantID, requestID, resp))
+	require.NoError(t, store.fail(ctx, tenantID, requestID, errors.New("late straggler failure")))
+
+	result, err := store.get(ctx, tenantID, requestID)
+	require.NoError(t, err)
+	require.Equal(t, StatusSuccess, result.Metadata.Status)
+	require.True(t, proto.Equal(resp, result.Response))
+}
+
+// TestStoreComplete_SuccessOverwritesPriorFailure isolates the guard-polarity
+// fix from get()'s anchor: it asserts on the raw metadata.json record
+// directly, not through get().
+func TestStoreComplete_SuccessOverwritesPriorFailure(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	require.NoError(t, store.create(ctx, tenantID, requestID, &querierv1.SelectMergeStacktracesRequest{}))
+
+	require.NoError(t, store.fail(ctx, tenantID, requestID, errors.New("first failure")))
+	require.NoError(t, store.complete(ctx, tenantID, requestID, &querierv1.SelectMergeStacktracesResponse{Tree: []byte("late-success")}))
+
+	var meta Metadata
+	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &meta))
+	require.Equal(t, StatusSuccess, meta.Status)
+	require.Empty(t, meta.ErrorMessage)
+}
+
+// TestStoreAdopt_SkipsClaimAndDispatchWhenResultAlreadyExists proves the
+// early (pre-readSpec) anchor check in adopt(): a candidate that already
+// succeeded is skipped entirely, without ever consulting the dispatcher.
+func TestStoreAdopt_SkipsClaimAndDispatchWhenResultAlreadyExists(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+	dispatcher := &fakeDispatcher{}
+	store.SetDispatcher(dispatcher)
+
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	spec := &querierv1.SelectMergeStacktracesRequest{ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"}
+	require.NoError(t, store.create(ctx, tenantID, requestID, spec))
+	require.NoError(t, store.complete(ctx, tenantID, requestID, &querierv1.SelectMergeStacktracesResponse{Tree: []byte("done")}))
+
+	stale := Metadata{
+		RequestID:     requestID,
+		TenantID:      tenantID,
+		Status:        StatusInProgress,
+		LastHeartbeat: time.Now().Add(-time.Hour).UTC(),
+	}
+	store.adopt(ctx, stale)
+
+	require.Empty(t, dispatcher.calls)
+}
+
+// TestStoreHeartbeat_CanRevertSoftFailureToInProgress documents an accepted
+// residual: a metadata write carrying a stale, already-in-flight read of
+// Status: InProgress (captured before a racing fail() lands) can still land
+// afterward and revert the failure. Nothing guards against this -- the
+// guard only inspects the read that already happened, not what the object
+// holds by the time the write lands. This is never a permanent wrong
+// answer (the residual state space always converges once every dispatched
+// execution has exited), so it must not be "fixed" by a future change.
+func TestStoreHeartbeat_CanRevertSoftFailureToInProgress(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	require.NoError(t, store.create(ctx, tenantID, requestID, &querierv1.SelectMergeStacktracesRequest{}))
+
+	base := store.basePath(tenantID, requestID)
+	var staleRead Metadata
+	require.NoError(t, store.readJSON(ctx, base+"metadata.json", &staleRead))
+
+	require.NoError(t, store.fail(ctx, tenantID, requestID, errors.New("straggler failure")))
+
+	staleRead.LastHeartbeat = time.Now().UTC()
+	staleRead.Owner = store.ownerID
+	require.NoError(t, store.saveJSON(ctx, base+"metadata.json", &staleRead))
+
+	var meta Metadata
+	require.NoError(t, store.readJSON(ctx, base+"metadata.json", &meta))
+	require.Equal(t, StatusInProgress, meta.Status)
+}
+
+func TestStoreCompleteFail_SuccessAlwaysWinsOverFailure(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("complete then fail", func(t *testing.T) {
+		store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+		const tenantID = "tenant-a"
+		requestID := uuid.New().String()
+		require.NoError(t, store.create(ctx, tenantID, requestID, &querierv1.SelectMergeStacktracesRequest{}))
+
+		want := &querierv1.SelectMergeStacktracesResponse{Tree: []byte("done")}
+		require.NoError(t, store.complete(ctx, tenantID, requestID, want))
+		require.NoError(t, store.fail(ctx, tenantID, requestID, errors.New("late straggler failure")))
+
+		var meta Metadata
+		require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &meta))
+		require.Equal(t, StatusSuccess, meta.Status)
+		require.Empty(t, meta.ErrorMessage)
+
+		result, err := store.get(ctx, tenantID, requestID)
+		require.NoError(t, err)
+		require.Equal(t, StatusSuccess, result.Metadata.Status)
+		require.True(t, proto.Equal(want, result.Response))
+	})
+
+	t.Run("fail then complete", func(t *testing.T) {
+		store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+		const tenantID = "tenant-a"
+		requestID := uuid.New().String()
+		require.NoError(t, store.create(ctx, tenantID, requestID, &querierv1.SelectMergeStacktracesRequest{}))
+
+		require.NoError(t, store.fail(ctx, tenantID, requestID, errors.New("first failure")))
+		want := &querierv1.SelectMergeStacktracesResponse{Tree: []byte("late-success")}
+		require.NoError(t, store.complete(ctx, tenantID, requestID, want))
+
+		// A real success always wins over a prior failure: at least one
+		// execution produced the correct answer, so it must be reported --
+		// regardless of what any differently-outcome'd execution wrote first.
+		var meta Metadata
+		require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &meta))
+		require.Equal(t, StatusSuccess, meta.Status)
+		require.Empty(t, meta.ErrorMessage)
+
+		result, err := store.get(ctx, tenantID, requestID)
+		require.NoError(t, err)
+		require.Equal(t, StatusSuccess, result.Metadata.Status)
+		require.True(t, proto.Equal(want, result.Response))
+	})
+}
+
+func TestStoreHeartbeat_DoesNotResurrectTerminalRecord(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	require.NoError(t, store.create(ctx, tenantID, requestID, &querierv1.SelectMergeStacktracesRequest{}))
+
+	want := &querierv1.SelectMergeStacktracesResponse{Tree: []byte("done")}
+	require.NoError(t, store.complete(ctx, tenantID, requestID, want))
+
+	// Simulates the original owner's still-alive awaitResult goroutine ticking
+	// a heartbeat after a racing execution has already completed the record.
+	require.NoError(t, store.heartbeat(ctx, tenantID, requestID))
+
+	var meta Metadata
+	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &meta))
+	require.Equal(t, StatusSuccess, meta.Status)
+
+	result, err := store.get(ctx, tenantID, requestID)
+	require.NoError(t, err)
+	require.Equal(t, StatusSuccess, result.Metadata.Status)
+	require.True(t, proto.Equal(want, result.Response))
+}
+
+// TestStoreGet_AnchorSurvivesHeartbeatGatedRevert reproduces a persisted
+// success being reverted to in_progress by a stale, concurrently-in-flight
+// heartbeat write, then proves get() still reports the success anyway.
+func TestStoreGet_AnchorSurvivesHeartbeatGatedRevert(t *testing.T) {
+	ctx := context.Background()
+	inner := objstore.NewInMemBucket()
+
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	seed := NewStore(log.NewNopLogger(), inner, nil)
+	require.NoError(t, seed.create(ctx, tenantID, requestID, &querierv1.SelectMergeStacktracesRequest{}))
+
+	target := seed.basePath(tenantID, requestID) + "metadata.json"
+	gated := newGatedUploadBucket(inner, target)
+	heartbeatStore := NewStore(log.NewNopLogger(), gated, nil)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = heartbeatStore.heartbeat(ctx, tenantID, requestID)
+	}()
+	<-gated.reached
+
+	resp := &querierv1.SelectMergeStacktracesResponse{Tree: []byte("done")}
+	completeStore := NewStore(log.NewNopLogger(), inner, nil)
+	require.NoError(t, completeStore.complete(ctx, tenantID, requestID, resp))
+
+	close(gated.proceed)
+	wg.Wait()
+
+	// Informational only: proves the interleaving actually landed -- the raw
+	// record was reverted by the stale heartbeat write.
+	var raw Metadata
+	require.NoError(t, seed.readJSON(ctx, seed.basePath(tenantID, requestID)+"metadata.json", &raw))
+	require.Equal(t, StatusInProgress, raw.Status)
+
+	result, err := seed.get(ctx, tenantID, requestID)
+	require.NoError(t, err)
+	require.Equal(t, StatusSuccess, result.Metadata.Status)
+	require.True(t, proto.Equal(resp, result.Response))
+}
+
+// TestStoreAdopt_ClaimGatedByConcurrentCompletion reproduces a concurrent
+// completion landing while adopt()'s claim write is in flight. Only the
+// primary (client-visible, via get()) invariant is asserted -- gating at the
+// claim Upload itself lands in the accepted, timing-dependent sliver where a
+// stale claim and a wasted redispatch are tolerated.
+func TestStoreAdopt_ClaimGatedByConcurrentCompletion(t *testing.T) {
+	ctx := context.Background()
+	inner := objstore.NewInMemBucket()
+
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	seed := NewStore(log.NewNopLogger(), inner, nil)
+	spec := &querierv1.SelectMergeStacktracesRequest{ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"}
+	require.NoError(t, seed.create(ctx, tenantID, requestID, spec))
+	backdateHeartbeat(t, ctx, seed, tenantID, requestID, time.Now().Add(-time.Hour).UTC())
+
+	var snapshot Metadata
+	require.NoError(t, seed.readJSON(ctx, seed.basePath(tenantID, requestID)+"metadata.json", &snapshot))
+
+	target := seed.basePath(tenantID, requestID) + "metadata.json"
+	gated := newGatedUploadBucket(inner, target)
+	adoptStore := NewStore(log.NewNopLogger(), gated, nil)
+	adoptStore.SetDispatcher(&fakeDispatcher{})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		adoptStore.adopt(ctx, snapshot)
+	}()
+	<-gated.reached
+
+	resp := &querierv1.SelectMergeStacktracesResponse{Tree: []byte("already-done")}
+	completeStore := NewStore(log.NewNopLogger(), inner, nil)
+	require.NoError(t, completeStore.complete(ctx, tenantID, requestID, resp))
+
+	close(gated.proceed)
+	wg.Wait()
+
+	result, err := seed.get(ctx, tenantID, requestID)
+	require.NoError(t, err)
+	require.Equal(t, StatusSuccess, result.Metadata.Status)
+	require.True(t, proto.Equal(resp, result.Response))
+}
+
+func TestStoreAdopt_ReReadAbortsOnConcurrentCompletion(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+	dispatcher := &fakeDispatcher{}
+	store.SetDispatcher(dispatcher)
+
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	spec := &querierv1.SelectMergeStacktracesRequest{ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"}
+	require.NoError(t, store.create(ctx, tenantID, requestID, spec))
+	backdateHeartbeat(t, ctx, store, tenantID, requestID, time.Now().Add(-time.Hour).UTC())
+
+	// Snapshot metadata the way runAdoption's scan would, then simulate the
+	// true owner completing the query while adopt()'s readSpec round trip is
+	// "in flight" -- i.e. after the scan's read but before the claim write.
+	var stale Metadata
+	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &stale))
+	require.NoError(t, store.complete(ctx, tenantID, requestID, &querierv1.SelectMergeStacktracesResponse{Tree: []byte("already-done")}))
+
+	store.adopt(ctx, stale)
+
+	require.Empty(t, dispatcher.calls)
+
+	var final Metadata
+	require.NoError(t, store.readJSON(ctx, store.basePath(tenantID, requestID)+"metadata.json", &final))
+	require.Equal(t, StatusSuccess, final.Status)
+
+	// result.pb already exists by the time adopt() runs, so its entry-point
+	// anchor check short-circuits before readSpec/adoptionAttempts is ever
+	// reached -- a strictly earlier abort than the re-read this test was
+	// originally named for, with the same net outcome (no dispatch).
+	require.Equal(t, float64(0), testutil.ToFloat64(store.adoptionAttempts.WithLabelValues(tenantID)))
+	require.Equal(t, float64(0), testutil.ToFloat64(store.adoptionSuccesses.WithLabelValues(tenantID)))
+}
+
+func TestStoreAdopt_ConcurrentRaceProducesSingleTerminalStatus(t *testing.T) {
+	ctx := context.Background()
+	bucket := objstore.NewInMemBucket()
+	storeA := NewStore(log.NewNopLogger(), bucket, nil)
+	storeB := NewStore(log.NewNopLogger(), bucket, nil)
+	storeA.ownerID = "owner-a"
+	storeB.ownerID = "owner-b"
+
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	spec := &querierv1.SelectMergeStacktracesRequest{ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"}
+	require.NoError(t, storeA.create(ctx, tenantID, requestID, spec))
+	backdateHeartbeat(t, ctx, storeA, tenantID, requestID, time.Now().Add(-time.Hour).UTC())
+
+	// Simulates two independent re-executions of the same adopted query
+	// finishing around the same time, one on each store. Which action (the
+	// success path or the failure path) actually reaches the store first is
+	// randomized per run rather than fixed, so both orderings are exercised
+	// across repeated runs: whichever terminal write lands first must win,
+	// regardless of which action it is.
+	successWritesFirst := rand.Intn(2) == 0
+
+	var dispatchCount atomic.Int32
+	var completeCalled atomic.Bool
+	var writesDone sync.WaitGroup
+	raceDispatcher := &fakeDispatcher{
+		onDispatch: func(_, _ string, _ *querierv1.SelectMergeStacktracesRequest) {
+			isFirstDispatch := dispatchCount.Inc() == 1
+			doComplete := isFirstDispatch == successWritesFirst
+			delay := time.Millisecond
+			if !isFirstDispatch {
+				delay = 50 * time.Millisecond
+			}
+			writesDone.Add(1)
+			go func() {
+				defer writesDone.Done()
+				time.Sleep(delay)
+				if doComplete {
+					_ = storeA.complete(ctx, tenantID, requestID, &querierv1.SelectMergeStacktracesResponse{Tree: []byte("done")})
+					completeCalled.Store(true)
+				} else {
+					_ = storeB.fail(ctx, tenantID, requestID, errors.New("simulated concurrent failure"))
+				}
+			}()
+		},
+	}
+	storeA.SetDispatcher(raceDispatcher)
+	storeB.SetDispatcher(raceDispatcher)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); storeA.runAdoption(ctx) }()
+	go func() { defer wg.Done(); storeB.runAdoption(ctx) }()
+	wg.Wait()
+
+	// Both writers -- not just whichever is faster -- must have actually
+	// attempted their write before asserting first-terminal-wins semantics;
+	// otherwise a reintroduced clobber by the slower writer would go unnoticed.
+	writesDone.Wait()
+
+	// Order-independent invariant: if either racer succeeded, the query is
+	// genuinely successful and must be reported as such regardless of which
+	// terminal write physically landed last; only if neither racer ever
+	// called complete() may the final answer be failure.
+	wantStatus := StatusFailure
+	if completeCalled.Load() {
+		wantStatus = StatusSuccess
+	}
+	result, err := storeA.get(ctx, tenantID, requestID)
+	require.NoError(t, err)
+	require.Equal(t, wantStatus, result.Metadata.Status,
+		"a real success must be reported regardless of write ordering")
+}

--- a/pkg/frontend/async/store_test.go
+++ b/pkg/frontend/async/store_test.go
@@ -115,6 +115,7 @@ func TestMetadataUnmarshal_BackwardCompatible(t *testing.T) {
 	require.NoError(t, json.Unmarshal(raw, &meta))
 	require.Equal(t, StatusInProgress, meta.Status)
 	require.Equal(t, "", meta.Owner)
+	require.Equal(t, 0, meta.AdoptionCount)
 }
 
 func TestStoreCreate_PersistsSpecBeforeMetadata(t *testing.T) {
@@ -518,6 +519,80 @@ func TestStoreAdopt_MultiTenantScanIsIsolated(t *testing.T) {
 	require.Equal(t, float64(1), testutil.ToFloat64(store.adoptionAttempts.WithLabelValues(tenantB)))
 	require.Equal(t, float64(1), testutil.ToFloat64(store.adoptionSuccesses.WithLabelValues(tenantA)))
 	require.Equal(t, float64(1), testutil.ToFloat64(store.adoptionSuccesses.WithLabelValues(tenantB)))
+}
+
+// TestStoreAdopt_AdoptionCountIncrementsAcrossClaims proves AdoptionCount
+// rides the same metadata write as each successful claim, rather than being
+// tracked separately.
+func TestStoreAdopt_AdoptionCountIncrementsAcrossClaims(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+	dispatcher := &fakeDispatcher{}
+	store.SetDispatcher(dispatcher)
+
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	spec := &querierv1.SelectMergeStacktracesRequest{ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"}
+	require.NoError(t, store.create(ctx, tenantID, requestID, spec))
+
+	backdateHeartbeat(t, ctx, store, tenantID, requestID, time.Now().Add(-time.Hour).UTC())
+	store.runAdoption(ctx)
+
+	var meta Metadata
+	require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &meta))
+	require.Equal(t, 1, meta.AdoptionCount)
+
+	// The fakeDispatcher never renews the lease, so the record is stale again
+	// and eligible for a second adoption.
+	backdateHeartbeat(t, ctx, store, tenantID, requestID, time.Now().Add(-time.Hour).UTC())
+	store.runAdoption(ctx)
+
+	require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &meta))
+	require.Equal(t, 2, meta.AdoptionCount)
+	require.Equal(t, StatusInProgress, meta.Status)
+	require.Len(t, dispatcher.calls, 2)
+}
+
+// TestStoreAdopt_ExceedsMaxAdoptionsMarksFailureNoDispatch proves that once
+// AdoptionCount reaches defaultMaxAdoptions, a further stale lease is refused
+// adoption and the query is persisted as a terminal failure instead of being
+// claimed and dispatched again.
+func TestStoreAdopt_ExceedsMaxAdoptionsMarksFailureNoDispatch(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
+	dispatcher := &fakeDispatcher{}
+	store.SetDispatcher(dispatcher)
+
+	const tenantID = "tenant-a"
+	requestID := uuid.New().String()
+	spec := &querierv1.SelectMergeStacktracesRequest{ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"}
+	require.NoError(t, store.create(ctx, tenantID, requestID, spec))
+
+	for i := 0; i < defaultMaxAdoptions; i++ {
+		backdateHeartbeat(t, ctx, store, tenantID, requestID, time.Now().Add(-time.Hour).UTC())
+		store.runAdoption(ctx)
+	}
+	require.Len(t, dispatcher.calls, defaultMaxAdoptions)
+
+	var meta Metadata
+	require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &meta))
+	require.Equal(t, defaultMaxAdoptions, meta.AdoptionCount)
+	require.Equal(t, StatusInProgress, meta.Status)
+
+	// One more stale lease pushes AdoptionCount to the cap: no further claim
+	// or dispatch, a terminal failure is persisted instead.
+	backdateHeartbeat(t, ctx, store, tenantID, requestID, time.Now().Add(-time.Hour).UTC())
+	store.runAdoption(ctx)
+
+	require.Len(t, dispatcher.calls, defaultMaxAdoptions, "no additional dispatch once the cap is hit")
+
+	var final Metadata
+	require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &final))
+	require.Equal(t, StatusFailure, final.Status)
+	require.Equal(t, errTooManyAdoptions.Error(), final.ErrorMessage)
+
+	require.Equal(t, float64(defaultMaxAdoptions+1), testutil.ToFloat64(store.adoptionAttempts.WithLabelValues(tenantID)))
+	require.Equal(t, float64(defaultMaxAdoptions), testutil.ToFloat64(store.adoptionSuccesses.WithLabelValues(tenantID)))
 }
 
 // TestStoreGet_AnchorReportsSuccessDespiteLaterFailureWrite is the headline,

--- a/pkg/frontend/async/store_test.go
+++ b/pkg/frontend/async/store_test.go
@@ -40,14 +40,26 @@ type fakeDispatchCall struct {
 	spec      *querierv1.SelectMergeStacktracesRequest
 }
 
-// fakeDispatcher is a test double for Dispatcher. It always records the call;
+// fakeDispatcher is a test double for Dispatcher. CanDispatch defaults to
+// true (spare capacity) unless canDispatch is explicitly set to false,
+// simulating a saturated tenant. Dispatch always records the call;
 // onDispatch, if set, runs synchronously afterward. Leaving onDispatch nil
-// simulates a dispatcher that declines to do anything, e.g. Coordinator's
-// concurrency limit rejecting the adopted query.
+// simulates a dispatcher whose execution declines to do anything further
+// once dispatched (distinct from CanDispatch returning false, which never
+// reaches Dispatch at all).
 type fakeDispatcher struct {
-	mu         sync.Mutex
-	calls      []fakeDispatchCall
-	onDispatch func(tenantID, requestID string, spec *querierv1.SelectMergeStacktracesRequest)
+	mu               sync.Mutex
+	calls            []fakeDispatchCall
+	canDispatchCalls int
+	atCapacity       bool // when true, CanDispatch reports no spare capacity; default (false) has capacity.
+	onDispatch       func(tenantID, requestID string, spec *querierv1.SelectMergeStacktracesRequest)
+}
+
+func (f *fakeDispatcher) CanDispatch(tenantID string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.canDispatchCalls++
+	return !f.atCapacity
 }
 
 func (f *fakeDispatcher) Dispatch(tenantID, requestID string, spec *querierv1.SelectMergeStacktracesRequest) {
@@ -483,25 +495,40 @@ func TestStoreAdopt_NilDispatcherIsNoop(t *testing.T) {
 	require.Equal(t, float64(1), testutil.ToFloat64(store.adoptionAttempts.WithLabelValues(tenantID)))
 }
 
-func TestStoreAdopt_ClaimSucceedsEvenIfDispatcherDeclines(t *testing.T) {
+// TestStoreAdopt_AtCapacityLeavesRecordUntouched proves the fix for the
+// claim-before-capacity-check bug: when CanDispatch reports no spare
+// capacity (e.g. the tenant is at its concurrency limit), adopt() must not
+// touch the record at all -- no Owner/LastHeartbeat change, no AdoptionCount
+// spend, and no claim success recorded -- so the lease stays expired and any
+// frontend with spare capacity can adopt it on the very next scan instead of
+// waiting out a full lease period for nothing.
+func TestStoreAdopt_AtCapacityLeavesRecordUntouched(t *testing.T) {
 	ctx := context.Background()
 	store := NewStore(log.NewNopLogger(), objstore.NewInMemBucket(), nil)
-	dispatcher := &fakeDispatcher{} // no onDispatch hook: declines to run anything further.
+	dispatcher := &fakeDispatcher{atCapacity: true}
 	store.SetDispatcher(dispatcher)
 
 	const tenantID = "tenant-a"
 	requestID := uuid.New().String()
 	spec := &querierv1.SelectMergeStacktracesRequest{ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"}
 	require.NoError(t, store.create(ctx, tenantID, requestID, spec))
-	backdateHeartbeat(t, ctx, store, tenantID, requestID, time.Now().Add(-time.Hour).UTC())
+	var before Metadata
+	require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &before))
+	stale := time.Now().Add(-time.Hour).UTC()
+	backdateHeartbeat(t, ctx, store, tenantID, requestID, stale)
 
 	store.runAdoption(ctx)
 
+	require.Empty(t, dispatcher.calls)
+	require.Greater(t, dispatcher.canDispatchCalls, 0, "CanDispatch must still be consulted")
+
 	var meta Metadata
 	require.NoError(t, store.readJSON(ctx, store.buildPath(tenantID, requestID, metadataFilename), &meta))
-	require.Equal(t, store.ownerID, meta.Owner)
-	require.WithinDuration(t, time.Now(), meta.LastHeartbeat, 5*time.Second)
-	require.Equal(t, float64(1), testutil.ToFloat64(store.adoptionSuccesses.WithLabelValues(tenantID)))
+	require.Equal(t, before.Owner, meta.Owner)
+	require.WithinDuration(t, stale, meta.LastHeartbeat, time.Second)
+	require.Equal(t, 0, meta.AdoptionCount)
+	require.Equal(t, StatusInProgress, meta.Status)
+	require.Equal(t, float64(0), testutil.ToFloat64(store.adoptionSuccesses.WithLabelValues(tenantID)))
 }
 
 func TestStoreAdopt_MultiTenantScanIsIsolated(t *testing.T) {

--- a/pkg/pyroscope/modules_experimental.go
+++ b/pkg/pyroscope/modules_experimental.go
@@ -108,8 +108,10 @@ func (f *Pyroscope) initQueryFrontendV2() (services.Service, error) {
 			log.With(f.logger, "component", "async-query-coordinator"),
 			f.asyncQueryStore,
 			f.Overrides,
+			querierHandler,
 			f.reg,
 		)
+		f.asyncQueryStore.SetDispatcher(coordinator)
 		querierHandler = asyncquery.NewHandler(querierHandler, coordinator)
 	}
 
@@ -169,8 +171,10 @@ func (f *Pyroscope) initQueryFrontendV12() (services.Service, error) {
 			log.With(f.logger, "component", "async-query-coordinator"),
 			f.asyncQueryStore,
 			f.Overrides,
+			querierHandler,
 			f.reg,
 		)
+		f.asyncQueryStore.SetDispatcher(coordinator)
 		querierHandler = asyncquery.NewHandler(querierHandler, coordinator)
 	}
 
@@ -208,6 +212,7 @@ func (f *Pyroscope) initAsyncQueryStore() (services.Service, error) {
 	f.asyncQueryStore = asyncquery.NewStore(
 		log.With(f.logger, "component", "async-query-store"),
 		f.storageBucket,
+		f.reg,
 	)
 	return f.asyncQueryStore, nil
 }

--- a/pkg/pyroscope/modules_experimental.go
+++ b/pkg/pyroscope/modules_experimental.go
@@ -166,17 +166,6 @@ func (f *Pyroscope) initQueryFrontendV12() (services.Service, error) {
 	wrappedHandler := spanlogger.NewLogSpanParametersWrapper(handler, queryFrontendLogger)
 
 	querierHandler := querierv1connect.QuerierServiceHandler(wrappedHandler)
-	if f.Cfg.Frontend.AsyncQueriesEnabled && f.asyncQueryStore != nil {
-		coordinator := asyncquery.NewCoordinator(
-			log.With(f.logger, "component", "async-query-coordinator"),
-			f.asyncQueryStore,
-			f.Overrides,
-			querierHandler,
-			f.reg,
-		)
-		f.asyncQueryStore.SetDispatcher(coordinator)
-		querierHandler = asyncquery.NewHandler(querierHandler, coordinator)
-	}
 
 	vcsService := vcs.New(
 		log.With(f.logger, "component", "vcs-service"),


### PR DESCRIPTION
# What

Async query execution currently lives entirely on the query frontend that accepted the request: the request spec exists only in that process's memory, and progress is tracked via an in-memory heartbeat. If that frontend pod dies
mid-query (OOM, rollout, node eviction), the query becomes permanently unrecoverable — the persisted metadata record stays `IN_PROGRESS` forever, and any client polling for the result does so indefinitely with no way to detect or recover from the loss.

This change makes async queries resumable across frontend restarts:

- **Spec persistence at submit time.** The full request spec is written to
  object storage (`spec.pb`) as part of `Submit`, before dispatch, so any
  frontend — not just the one that accepted the request — has everything
  needed to re-run the query later.
- **Heartbeat as an ownership lease.** The existing heartbeat mechanism is
  reinterpreted as a lease: as long as heartbeats keep landing within
  `leaseTimeout`, the current owner is presumed alive and the record is left
  alone.
- **Adoption scan.** The async store's background loop gained a periodic scan
  that looks for in-progress records whose lease has expired. Any frontend
  that observes one claims ownership and redispatches the query from the
  persisted `spec.pb`, transparently to the polling client. Note that the adoption mechanism triggers only on silent owner death (stale lease + in progress query), never on query failure.

## Why `result.pb` is the source of truth for success

`metadata.json` is a mutable record that several frontends can rewrite concurrently once adoption exists — a slow-but-alive owner and a new adopter, for example — and object storage gives writers no way to notice that someone else wrote first: the last write simply wins. A stale write can therefore overwrite a terminal status, which makes the mutable record unreliable as the sole source of truth.

`result.pb` is different: only successful executions ever write it, so its existence proves success no matter what the metadata says. Racing duplicate executions may replace it with another valid result: existence, not content, is the invariant. Readers check for it first and repair the metadata when the two disagree, and the adoption scan skips any record that already has a result.

## Deliberate behavior change

**A real success now overwrites a previously persisted stale failure status.**

Before this change, a terminal status was never revisited. With adoption, it's possible for a stale, incorrect `FAILURE` to have been written (e.g. by a duplicate/racing execution that failed) before a genuinely successful result lands. Since `result.pb`'s existence is authoritative, a confirmed success is now allowed to correct a previously recorded failure. 

Closes https://github.com/grafana/pyroscope-squad/issues/838
