### PR TITLE
fix(adaptiveplacement): key distribution stats by tenant and dataset

### DIFF
--- a/pkg/segmentwriter/client/distributor/placement/adaptiveplacement/distribution_stats.go
+++ b/pkg/segmentwriter/client/distributor/placement/adaptiveplacement/distribution_stats.go
@@ -114,7 +114,7 @@ func (d *DistributionStats) build(now int64) *adaptive_placementpb.DistributionS
 	defer d.mu.Unlock()
 
 	tenants := make(map[string]int)
-	datasets := make(map[string]int)
+	datasets := make(map[datasetKey]int)
 	shards := make(map[shard]int)
 
 	// Although, not strictly required, we iterate over the keys
@@ -144,10 +144,11 @@ func (d *DistributionStats) build(now int64) *adaptive_placementpb.DistributionS
 			})
 		}
 
-		di, ok := datasets[k.dataset]
+		dk := datasetKey{tenant: k.tenant, dataset: k.dataset}
+		di, ok := datasets[dk]
 		if !ok {
 			di = len(stats.Datasets)
-			datasets[k.dataset] = di
+			datasets[dk] = di
 			stats.Datasets = append(stats.Datasets, &adaptive_placementpb.DatasetStats{
 				Tenant: uint32(ti),
 				Name:   k.dataset,

--- a/pkg/segmentwriter/client/distributor/placement/adaptiveplacement/distribution_stats_test.go
+++ b/pkg/segmentwriter/client/distributor/placement/adaptiveplacement/distribution_stats_test.go
@@ -177,3 +177,46 @@ func Test_StatsTracker(t *testing.T) {
 	assert.Empty(t, s.Shards)
 	assert.Empty(t, stats.counters)
 }
+
+func Test_StatsTracker_SameDatasetNameAcrossTenants(t *testing.T) {
+	const window = time.Second * 10
+	stats := NewDistributionStats(window)
+	var now time.Duration
+
+	for ; now < window; now += time.Second {
+		stats.recordStats(now.Nanoseconds(), iter.NewSliceIterator([]Sample{
+			{TenantID: "tenant-a", DatasetName: "dataset-a", ShardID: 1, Size: 10},
+			{TenantID: "tenant-b", DatasetName: "dataset-a", ShardID: 2, Size: 30},
+		}))
+	}
+
+	// Each tenant must get its own dataset entry: otherwise the usage of
+	// one tenant is attributed to another, and no placement rule is built
+	// for the former.
+	expected := &adaptive_placementpb.DistributionStats{
+		Tenants: []*adaptive_placementpb.TenantStats{
+			{TenantId: "tenant-a"},
+			{TenantId: "tenant-b"},
+		},
+		Datasets: []*adaptive_placementpb.DatasetStats{
+			{
+				Tenant: 0,
+				Name:   "dataset-a",
+				Shards: []uint32{0},
+				Usage:  []uint64{5},
+			},
+			{
+				Tenant: 1,
+				Name:   "dataset-a",
+				Shards: []uint32{1},
+				Usage:  []uint64{15},
+			},
+		},
+		Shards: []*adaptive_placementpb.ShardStats{
+			{Id: 1},
+			{Id: 2},
+		},
+		CreatedAt: now.Nanoseconds(),
+	}
+	assert.Equal(t, expected.String(), stats.build(now.Nanoseconds()).String())
+}


### PR DESCRIPTION
The stats builder in the adaptive placement manager keyed datasets by name only. When two tenants ingest a dataset with the same name, all of its usage is attributed to whichever tenant sorts first: the other tenant never appears in the stats, no placement rule is ever built for it, and its ingest stays pinned to the default single shard regardless of load, while the first tenant's shard limit is inflated by usage that isn't its own.

Key the stats by tenant+dataset instead.