### PR TITLE
fix: restrict UI routes to query frontend

### DIFF
--- a/pkg/api/admin_server_test.go
+++ b/pkg/api/admin_server_test.go
@@ -116,3 +116,16 @@ func TestSetAdminRouter_NilSafe(t *testing.T) {
 	})
 	assert.Equal(t, http.StatusTeapot, probe(t, mainMux, "/nil-safe-route"))
 }
+
+func TestRegisterNoUI(t *testing.T) {
+	a, mainMux, _ := newTestAPIWithMode(t, AdminServerDisabled)
+	a.RegisterNoUI()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	mainMux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "query-frontend")
+	assert.Contains(t, rec.Body.String(), "/admin")
+}

--- a/pkg/api/admin_server_test.go
+++ b/pkg/api/admin_server_test.go
@@ -118,14 +118,33 @@ func TestSetAdminRouter_NilSafe(t *testing.T) {
 }
 
 func TestRegisterNoUI(t *testing.T) {
-	a, mainMux, _ := newTestAPIWithMode(t, AdminServerDisabled)
-	a.RegisterNoUI()
+	for _, tt := range []struct {
+		name            string
+		mode            AdminServerMode
+		wantAdminStatus int
+	}{
+		{name: "disabled", mode: AdminServerDisabled, wantAdminStatus: http.StatusNotFound},
+		{name: "additional", mode: AdminServerAdditional, wantAdminStatus: http.StatusFound},
+		{name: "exclusive", mode: AdminServerExclusive, wantAdminStatus: http.StatusFound},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			a, mainMux, adminRouter := newTestAPIWithMode(t, tt.mode)
+			a.RegisterNoUI()
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	rec := httptest.NewRecorder()
-	mainMux.ServeHTTP(rec, req)
+			mainReq := httptest.NewRequest(http.MethodGet, "/", nil)
+			mainRec := httptest.NewRecorder()
+			mainMux.ServeHTTP(mainRec, mainReq)
+			assert.Equal(t, http.StatusNotFound, mainRec.Code)
+			assert.Contains(t, mainRec.Body.String(), "query-frontend")
+			assert.Contains(t, mainRec.Body.String(), "/admin")
 
-	assert.Equal(t, http.StatusNotFound, rec.Code)
-	assert.Contains(t, rec.Body.String(), "query-frontend")
-	assert.Contains(t, rec.Body.String(), "/admin")
+			adminReq := httptest.NewRequest(http.MethodGet, "/", nil)
+			adminRec := httptest.NewRecorder()
+			adminRouter.ServeHTTP(adminRec, adminReq)
+			assert.Equal(t, tt.wantAdminStatus, adminRec.Code)
+			if tt.wantAdminStatus == http.StatusFound {
+				assert.Equal(t, "/admin", adminRec.Header().Get("Location"))
+			}
+		})
+	}
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -216,13 +216,24 @@ func (a *API) RegisterAPI(statusService statusv1.StatusServiceServer) error {
 }
 
 func (a *API) RegisterNoUI() {
-	a.RegisterRoute("/", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	noUIHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(
 			w,
 			"The user interface is not available on this component. Connect to the query-frontend component to run queries. Administrative endpoints are available at /admin.",
 			http.StatusNotFound,
 		)
-	}), a.registerOptionsPublicAccess()...)
+	})
+	a.RegisterRoute("/", noUIHandler, a.registerOptionsPublicAccess()...)
+
+	if a.adminRouter != nil && a.adminMode != AdminServerDisabled {
+		registerRoute(
+			a.logger,
+			a.adminRouter,
+			"/",
+			http.RedirectHandler("/admin", http.StatusFound),
+			a.registerOptionsPublicAccess()...,
+		)
+	}
 }
 
 func (a *API) RegisterCatchAll() error {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -215,8 +215,14 @@ func (a *API) RegisterAPI(statusService statusv1.StatusServiceServer) error {
 	return nil
 }
 
-func (a *API) RegisterRedirectToAdmin() {
-	a.registerAdminRoute("/", http.RedirectHandler("/admin", http.StatusFound), a.registerOptionsPublicAccess()...)
+func (a *API) RegisterNoUI() {
+	a.RegisterRoute("/", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(
+			w,
+			"The user interface is not available on this component. Connect to the query-frontend component to run queries. Administrative endpoints are available at /admin.",
+			http.StatusNotFound,
+		)
+	}), a.registerOptionsPublicAccess()...)
 }
 
 func (a *API) RegisterCatchAll() error {

--- a/pkg/pyroscope/pyroscope.go
+++ b/pkg/pyroscope/pyroscope.go
@@ -791,17 +791,12 @@ func (f *Pyroscope) Run() error {
 		}
 	}
 
-	// only query-frontend, query-backend, querier and target all should register the UI
-	if slices.Contains(f.Cfg.Target, All) ||
-		slices.Contains(f.Cfg.Target, QueryFrontend) ||
-		slices.Contains(f.Cfg.Target, QueryBackend) ||
-		slices.Contains(f.Cfg.Target, Querier) {
-
+	if f.shouldRegisterUI() {
 		if err = f.API.RegisterCatchAll(); err != nil {
 			return err
 		}
 	} else {
-		f.API.RegisterRedirectToAdmin()
+		f.API.RegisterNoUI()
 	}
 
 	serviceFailed := func(service services.Service) {
@@ -864,6 +859,14 @@ func (f *Pyroscope) Run() error {
 	}
 
 	return err
+}
+
+func (f *Pyroscope) shouldRegisterUI() bool {
+	if slices.Contains(f.Cfg.Target, All) || slices.Contains(f.Cfg.Target, QueryFrontend) {
+		return true
+	}
+
+	return f.Cfg.ArchitectureStorage != V2 && slices.Contains(f.Cfg.Target, Querier)
 }
 
 func (f *Pyroscope) readyHandler(sm *services.Manager) http.HandlerFunc {

--- a/pkg/pyroscope/pyroscope_test.go
+++ b/pkg/pyroscope/pyroscope_test.go
@@ -116,6 +116,31 @@ func TestSetupModuleManager_V2_ExcludesV1Components(t *testing.T) {
 	})
 }
 
+func TestShouldRegisterUI(t *testing.T) {
+	tests := []struct {
+		name         string
+		architecture StorageLayer
+		targets      []string
+		want         bool
+	}{
+		{name: "v2 all", architecture: V2, targets: []string{All}, want: true},
+		{name: "v2 query frontend", architecture: V2, targets: []string{QueryFrontend}, want: true},
+		{name: "v2 query backend", architecture: V2, targets: []string{QueryBackend}, want: false},
+		{name: "v2 legacy querier", architecture: V2, targets: []string{Querier}, want: false},
+		{name: "v2 non-query component", architecture: V2, targets: []string{Distributor}, want: false},
+		{name: "v1 querier", architecture: V1, targets: []string{Querier}, want: true},
+		{name: "dual-storage querier", architecture: V1V2Dual, targets: []string{Querier}, want: true},
+		{name: "query frontend among multiple targets", architecture: V2, targets: []string{Distributor, QueryFrontend}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &Pyroscope{Cfg: Config{ArchitectureStorage: tt.architecture, Target: tt.targets}}
+			assert.Equal(t, tt.want, f.shouldRegisterUI())
+		})
+	}
+}
+
 func TestRegisterServerFlagsWithChangedDefaultValues_V2(t *testing.T) {
 	t.Run("registers default v2 architecture flag with default value", func(t *testing.T) {
 		cfg := newTestConfig(t, []string{})


### PR DESCRIPTION
Fixes #2748

In v2, `query-backend` and other non-frontend components could serve the frontend shell even though their query APIs return 404. Their admin pages also advertised a UI that could not work on that component.

This change limits v2 UI routes to `all` and `query-frontend`. Non-UI components now return a clear message at `/` that points users to the query frontend and keeps `/admin` discoverable. The legacy v1 and dual-storage `querier` behavior stays unchanged.

Tests cover the v1 and v2 target combinations and the response shown by non-UI components.

Validation:

- `go test ./pkg/api ./pkg/pyroscope`
- `golangci-lint run ./...`
- `go vet ./...`
- Helm chart lint through the repository's `make lint` target

Prepared with OpenAI Codex. The listed checks were run locally before opening this draft.
