### PR TITLE
docs(contributing): clarify build targets and ui/dist requirement

### DIFF
--- a/docs/internal/contributing/README.md
+++ b/docs/internal/contributing/README.md
@@ -42,11 +42,26 @@ Use `make lint` to ensure formatting is correct.
 
 ## Building Grafana Pyroscope
 
-To build:
+To do a full production build (frontend + backend):
 
 ```
-make go/bin
+make build
 ```
+
+This runs `make frontend/build` to build the web UI (in Docker, so Docker must be running) and then
+builds the Go binaries with the frontend assets embedded.
+
+If you're only working on the backend and don't need the embedded UI, use the Docker-free dev build,
+which skips the frontend entirely:
+
+```
+make build-dev
+```
+
+The lower-level `make go/bin` target builds only the Go binaries. By default it embeds the frontend
+assets (build tag `embedassets`), so it requires `ui/dist/` to already exist — build it once with
+`make frontend/build` (or use `make build`/`make build-dev` above). Otherwise the build fails with
+`pattern dist: no matching files found`.
 
 To run the unit test suite:
 


### PR DESCRIPTION
## What

Rework the "Building Grafana Pyroscope" section of the contributing guide to lead with `make build` (full production build) and `make build-dev` (backend-only, Docker-free), and to explain the `ui/dist`/`embedassets` requirement of the lower-level `make go/bin` target.

## Why

The Building section previously pointed newcomers straight at `make go/bin`. By default that target embeds the frontend assets (build tag `embedassets`, via `//go:embed dist` in `ui/assets_embedded.go`), which requires `ui/dist/` to exist. On a fresh checkout the frontend has never been built, so the build fails with a cryptic error:

```
ui/assets_embedded.go:16:12: pattern dist: no matching files found
```

The docs now guide contributors to the targets that handle this correctly (`make build` runs `frontend/build` first; `make build-dev` skips the frontend entirely) and document why `make go/bin` needs `ui/dist`, including the exact error string so it's searchable.

Docs-only change; no build behavior is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)