### PR TITLE
ui: preserve arbitrary label matchers in profile queries (#5461)

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -80,7 +80,8 @@ export default function App() {
     setActiveLabelSelector(undefined);
   };
 
-  const queryDirty = !!service && queryInput !== buildQuery(service);
+  const queryDirty =
+    !!service && queryInput !== (activeLabelSelector ?? buildQuery(service));
   const handleReset = () => {
     setQueryUserInput(null);
     setActiveLabelSelector(undefined);

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -45,6 +45,10 @@ export default function App() {
     | undefined
   >(undefined);
   const [queryUserInput, setQueryUserInput] = useState<string | null>(null);
+  const [activeLabelSelector, setActiveLabelSelector] = useState<
+    string | undefined
+  >(undefined);
+
   const queryInput =
     queryUserInput ??
     (service || profileType ? buildQuery(service, profileType) : '');
@@ -52,6 +56,7 @@ export default function App() {
   const query = usePyroscopeQuery({
     service,
     profileType,
+    labelSelector: activeLabelSelector,
     timeRange,
     absoluteRange,
     tenantID: tenant.tenantID,
@@ -74,11 +79,15 @@ export default function App() {
     setService(s);
     setProfileType(pt);
     setQueryUserInput(null);
+    setActiveLabelSelector(undefined);
   };
 
   const queryDirty =
     !!service && queryInput !== buildQuery(service, profileType);
-  const handleReset = () => setQueryUserInput(null);
+  const handleReset = () => {
+    setQueryUserInput(null);
+    setActiveLabelSelector(undefined);
+  };
 
   const timeWindow = absoluteRange ?? parseTimeRange(timeRange);
 
@@ -124,7 +133,15 @@ export default function App() {
         onRun={(q) => {
           const parsed = parseQuery(q);
           if (parsed) {
-            query.execute(parsed.service, parsed.profileType, timeRange);
+            setService(parsed.service);
+            setProfileType(parsed.profileType);
+            setActiveLabelSelector(parsed.labelSelector);
+            query.execute(
+              parsed.service,
+              parsed.profileType,
+              timeRange,
+              parsed.labelSelector,
+            );
           }
         }}
         start={timeWindow.start}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -50,8 +50,7 @@ export default function App() {
   >(undefined);
 
   const queryInput =
-    queryUserInput ??
-    (service || profileType ? buildQuery(service, profileType) : '');
+    queryUserInput ?? (service ? buildQuery(service) : '');
 
   const query = usePyroscopeQuery({
     service,
@@ -82,8 +81,7 @@ export default function App() {
     setActiveLabelSelector(undefined);
   };
 
-  const queryDirty =
-    !!service && queryInput !== buildQuery(service, profileType);
+  const queryDirty = !!service && queryInput !== buildQuery(service);
   const handleReset = () => {
     setQueryUserInput(null);
     setActiveLabelSelector(undefined);
@@ -135,13 +133,11 @@ export default function App() {
           if (!parsed) return;
           if (
             parsed.service === service &&
-            parsed.profileType === profileType &&
             parsed.labelSelector === activeLabelSelector
           ) {
             query.run();
           } else {
             setService(parsed.service);
-            setProfileType(parsed.profileType);
             setActiveLabelSelector(parsed.labelSelector);
           }
         }}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -132,16 +132,17 @@ export default function App() {
         onQueryChange={setQueryUserInput}
         onRun={(q) => {
           const parsed = parseQuery(q);
-          if (parsed) {
+          if (!parsed) return;
+          if (
+            parsed.service === service &&
+            parsed.profileType === profileType &&
+            parsed.labelSelector === activeLabelSelector
+          ) {
+            query.run();
+          } else {
             setService(parsed.service);
             setProfileType(parsed.profileType);
             setActiveLabelSelector(parsed.labelSelector);
-            query.execute(
-              parsed.service,
-              parsed.profileType,
-              timeRange,
-              parsed.labelSelector,
-            );
           }
         }}
         start={timeWindow.start}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -49,8 +49,7 @@ export default function App() {
     string | undefined
   >(undefined);
 
-  const queryInput =
-    queryUserInput ?? (service ? buildQuery(service) : '');
+  const queryInput = queryUserInput ?? (service ? buildQuery(service) : '');
 
   const query = usePyroscopeQuery({
     service,

--- a/ui/src/hooks/useLabelSuggestions.ts
+++ b/ui/src/hooks/useLabelSuggestions.ts
@@ -3,8 +3,6 @@ import { fetchLabelNames, fetchLabelValues } from '@api/client';
 import {
   getCursorContext,
   isInternalLabel,
-  toDisplayLabel,
-  toInternalLabel,
   type CursorContext,
 } from '../queryLang';
 import { useDebouncedValue } from './useDebouncedValue';
@@ -109,21 +107,14 @@ export function useLabelSuggestions({
     const promise =
       ctx.kind === 'name'
         ? fetchLabelNames(ctx.otherMatchers, s, e, controller.signal).then(
-            // Translate to display form first (so __profile_type__ becomes
-            // profile_type) and then drop anything still wrapped in double
-            // underscores — those are reserved internal labels. Dedupe in
-            // case the backend ever returns both an internal name and its
-            // alias.
+            // Drop reserved internal labels wrapped in double underscores
+            // (e.g. __delta__, __session_id__) and dedupe results.
             (names) =>
-              Array.from(
-                new Set(
-                  names.map(toDisplayLabel).filter((n) => !isInternalLabel(n)),
-                ),
-              ),
+              Array.from(new Set(names.filter((n) => !isInternalLabel(n)))),
           )
         : ctx.kind === 'value'
           ? fetchLabelValues(
-              toInternalLabel(ctx.labelName),
+              ctx.labelName,
               ctx.otherMatchers,
               s,
               e,

--- a/ui/src/hooks/usePyroscopeQuery.ts
+++ b/ui/src/hooks/usePyroscopeQuery.ts
@@ -28,12 +28,6 @@ export interface QueryResult {
   loading: boolean;
   error: string | null;
   run: () => void;
-  execute: (
-    service: string,
-    profileType: string,
-    timeRange: string,
-    labelSelector?: string,
-  ) => void;
 }
 
 export function parseTimeRange(range: string): { start: number; end: number } {
@@ -85,49 +79,6 @@ export function usePyroscopeQuery(params: QueryParams): QueryResult {
     loadServices();
   }, [timeRange, absoluteRange, tenantID]);
 
-  const execute = useCallback(
-    (svc: string, pt: string, tr: string, selector?: string) => {
-      if (!svc || !pt) return;
-      const effectiveSelector =
-        selector ?? paramSelector ?? `{service_name="${svc}"}`;
-
-      const { start, end } = absoluteRange ?? parseTimeRange(tr);
-      const rangeSeconds = (end - start) / 1000;
-      const step = Math.max(15, Math.ceil(rangeSeconds / 100));
-      setLoading(true);
-      Promise.all([
-        fetchFlamegraph({
-          profileTypeID: pt,
-          labelSelector: effectiveSelector,
-          start,
-          end,
-        }),
-        fetchTimeline({
-          profileTypeID: pt,
-          labelSelector: effectiveSelector,
-          start,
-          end,
-          step,
-        }),
-      ])
-        .then(([fg, tl]) => {
-          setFlamegraph(fg);
-          setTimeline(tl);
-          setError(null);
-        })
-        .catch((e: unknown) =>
-          setError(e instanceof Error ? e.message : String(e)),
-        )
-        .finally(() => setLoading(false));
-    },
-    // tenantID is not read inside the callback but is included to invalidate
-    // execute (and run) when the tenant changes, ensuring the run callback is
-    // re-created.
-    //
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [paramSelector, absoluteRange, tenantID],
-  );
-
   useEffect(() => {
     if (!service || !profileType) return;
 
@@ -167,8 +118,39 @@ export function usePyroscopeQuery(params: QueryParams): QueryResult {
   }, [service, profileType, paramSelector, timeRange, absoluteRange, tenantID]);
 
   const run = useCallback(() => {
-    execute(service, profileType, timeRange, paramSelector);
-  }, [service, profileType, timeRange, paramSelector, execute]);
+    if (!service || !profileType) return;
+    const { start, end } = absoluteRange ?? parseTimeRange(timeRange);
+    const labelSelector = paramSelector ?? `{service_name="${service}"}`;
+    const rangeSeconds = (end - start) / 1000;
+    const step = Math.max(15, Math.ceil(rangeSeconds / 100));
+
+    setLoading(true);
+    Promise.all([
+      fetchFlamegraph({
+        profileTypeID: profileType,
+        labelSelector,
+        start,
+        end,
+      }),
+      fetchTimeline({
+        profileTypeID: profileType,
+        labelSelector,
+        start,
+        end,
+        step,
+      }),
+    ])
+      .then(([fg, tl]) => {
+        setFlamegraph(fg);
+        setTimeline(tl);
+        setError(null);
+      })
+      .catch((e: unknown) =>
+        setError(e instanceof Error ? e.message : String(e)),
+      )
+      .finally(() => setLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [service, profileType, paramSelector, timeRange, absoluteRange, tenantID]);
 
   return {
     services,
@@ -178,6 +160,5 @@ export function usePyroscopeQuery(params: QueryParams): QueryResult {
     loading,
     error,
     run,
-    execute,
   };
 }

--- a/ui/src/hooks/usePyroscopeQuery.ts
+++ b/ui/src/hooks/usePyroscopeQuery.ts
@@ -14,6 +14,7 @@ export type ProfileType = string;
 export interface QueryParams {
   service: string;
   profileType: ProfileType;
+  labelSelector?: string;
   timeRange: string;
   absoluteRange?: { start: number; end: number };
   tenantID?: string;
@@ -27,7 +28,12 @@ export interface QueryResult {
   loading: boolean;
   error: string | null;
   run: () => void;
-  execute: (service: string, profileType: string, timeRange: string) => void;
+  execute: (
+    service: string,
+    profileType: string,
+    timeRange: string,
+    labelSelector?: string,
+  ) => void;
 }
 
 export function parseTimeRange(range: string): { start: number; end: number } {
@@ -54,7 +60,14 @@ export function usePyroscopeQuery(params: QueryParams): QueryResult {
   const [servicesLoading, setServicesLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const { service, profileType, timeRange, absoluteRange, tenantID } = params;
+  const {
+    service,
+    profileType,
+    labelSelector: paramSelector,
+    timeRange,
+    absoluteRange,
+    tenantID,
+  } = params;
 
   useEffect(() => {
     async function loadServices() {
@@ -73,16 +86,29 @@ export function usePyroscopeQuery(params: QueryParams): QueryResult {
   }, [timeRange, absoluteRange, tenantID]);
 
   const execute = useCallback(
-    (svc: string, pt: string, tr: string) => {
+    (svc: string, pt: string, tr: string, selector?: string) => {
       if (!svc || !pt) return;
+      const effectiveSelector =
+        selector ?? paramSelector ?? `{service_name="${svc}"}`;
+
       const { start, end } = absoluteRange ?? parseTimeRange(tr);
-      const labelSelector = `{service_name="${svc}"}`;
       const rangeSeconds = (end - start) / 1000;
       const step = Math.max(15, Math.ceil(rangeSeconds / 100));
       setLoading(true);
       Promise.all([
-        fetchFlamegraph({ profileTypeID: pt, labelSelector, start, end }),
-        fetchTimeline({ profileTypeID: pt, labelSelector, start, end, step }),
+        fetchFlamegraph({
+          profileTypeID: pt,
+          labelSelector: effectiveSelector,
+          start,
+          end,
+        }),
+        fetchTimeline({
+          profileTypeID: pt,
+          labelSelector: effectiveSelector,
+          start,
+          end,
+          step,
+        }),
       ])
         .then(([fg, tl]) => {
           setFlamegraph(fg);
@@ -99,7 +125,7 @@ export function usePyroscopeQuery(params: QueryParams): QueryResult {
     // re-created.
     //
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [absoluteRange, tenantID],
+    [paramSelector, absoluteRange, tenantID],
   );
 
   useEffect(() => {
@@ -107,7 +133,7 @@ export function usePyroscopeQuery(params: QueryParams): QueryResult {
 
     async function loadProfile() {
       const { start, end } = absoluteRange ?? parseTimeRange(timeRange);
-      const labelSelector = `{service_name="${service}"}`;
+      const labelSelector = paramSelector ?? `{service_name="${service}"}`;
       const rangeSeconds = (end - start) / 1000;
       const step = Math.max(15, Math.ceil(rangeSeconds / 100));
 
@@ -138,11 +164,11 @@ export function usePyroscopeQuery(params: QueryParams): QueryResult {
       }
     }
     loadProfile();
-  }, [service, profileType, timeRange, absoluteRange, tenantID]);
+  }, [service, profileType, paramSelector, timeRange, absoluteRange, tenantID]);
 
   const run = useCallback(() => {
-    execute(service, profileType, timeRange);
-  }, [service, profileType, timeRange, execute]);
+    execute(service, profileType, timeRange, paramSelector);
+  }, [service, profileType, timeRange, paramSelector, execute]);
 
   return {
     services,

--- a/ui/src/queryLang.test.ts
+++ b/ui/src/queryLang.test.ts
@@ -283,49 +283,49 @@ describe('label name translation', () => {
 
 describe('parseQuery / buildQuery', () => {
   it('round-trips a built query', () => {
-    const q = buildQuery(
-      'my-service',
-      'process_cpu:cpu:nanoseconds:cpu:nanoseconds',
-    );
+    const q = buildQuery('my-service');
     const parsed = parseQuery(q);
     assert.deepEqual(parsed, {
       service: 'my-service',
-      profileType: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds',
       labelSelector: '{service_name="my-service"}',
     });
   });
 
-  it('returns null when required labels are absent', () => {
+  it('returns null when service_name is absent', () => {
     assert.equal(parseQuery('{foo="bar"}'), null);
   });
 
-  it('tolerates extra whitespace around the operator', () => {
-    const parsed = parseQuery('{service_name = "api", profile_type = "cpu"}');
+  it('parses queries without profile_type', () => {
+    const parsed = parseQuery('{service_name="api", environment="staging"}');
     assert.deepEqual(parsed, {
       service: 'api',
-      profileType: 'cpu',
+      labelSelector: '{service_name="api", environment="staging"}',
+    });
+  });
+
+  it('tolerates extra whitespace around operators', () => {
+    const parsed = parseQuery('{service_name = "api"}');
+    assert.deepEqual(parsed, {
+      service: 'api',
       labelSelector: '{service_name="api"}',
     });
   });
 
-  it('preserves arbitrary label matchers while stripping profile_type', () => {
+  it('preserves arbitrary label matchers while stripping profile_type if present', () => {
     const q =
       '{service_name="example-service", profile_type="process_cpu:cpu:nanoseconds:cpu:nanoseconds", environment="staging"}';
     const parsed = parseQuery(q);
     assert.deepEqual(parsed, {
       service: 'example-service',
-      profileType: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds',
       labelSelector: '{service_name="example-service", environment="staging"}',
     });
   });
 
   it('handles regex operators and multiple matchers in labelSelector', () => {
-    const q =
-      '{service_name="api", profile_type="cpu", region=~"us-.*", env!="prod"}';
+    const q = '{service_name="api", region=~"us-.*", env!="prod"}';
     const parsed = parseQuery(q);
     assert.deepEqual(parsed, {
       service: 'api',
-      profileType: 'cpu',
       labelSelector: '{service_name="api", region=~"us-.*", env!="prod"}',
     });
   });

--- a/ui/src/queryLang.test.ts
+++ b/ui/src/queryLang.test.ts
@@ -291,6 +291,7 @@ describe('parseQuery / buildQuery', () => {
     assert.deepEqual(parsed, {
       service: 'my-service',
       profileType: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds',
+      labelSelector: '{service_name="my-service"}',
     });
   });
 
@@ -300,6 +301,32 @@ describe('parseQuery / buildQuery', () => {
 
   it('tolerates extra whitespace around the operator', () => {
     const parsed = parseQuery('{service_name = "api", profile_type = "cpu"}');
-    assert.deepEqual(parsed, { service: 'api', profileType: 'cpu' });
+    assert.deepEqual(parsed, {
+      service: 'api',
+      profileType: 'cpu',
+      labelSelector: '{service_name="api"}',
+    });
+  });
+
+  it('preserves arbitrary label matchers while stripping profile_type', () => {
+    const q =
+      '{service_name="example-service", profile_type="process_cpu:cpu:nanoseconds:cpu:nanoseconds", environment="staging"}';
+    const parsed = parseQuery(q);
+    assert.deepEqual(parsed, {
+      service: 'example-service',
+      profileType: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds',
+      labelSelector: '{service_name="example-service", environment="staging"}',
+    });
+  });
+
+  it('handles regex operators and multiple matchers in labelSelector', () => {
+    const q =
+      '{service_name="api", profile_type="cpu", region=~"us-.*", env!="prod"}';
+    const parsed = parseQuery(q);
+    assert.deepEqual(parsed, {
+      service: 'api',
+      profileType: 'cpu',
+      labelSelector: '{service_name="api", region=~"us-.*", env!="prod"}',
+    });
   });
 });

--- a/ui/src/queryLang.test.ts
+++ b/ui/src/queryLang.test.ts
@@ -7,8 +7,6 @@ import {
   applySuggestion,
   buildQuery,
   parseQuery,
-  toDisplayLabel,
-  toInternalLabel,
   isInternalLabel,
 } from './queryLang.ts';
 
@@ -251,14 +249,6 @@ describe('applySuggestion', () => {
 });
 
 describe('label name translation', () => {
-  it('maps display names to their internal form', () => {
-    assert.equal(toInternalLabel('service_name'), 'service_name');
-  });
-
-  it('maps internal names to their display form', () => {
-    assert.equal(toDisplayLabel('service_name'), 'service_name');
-  });
-
   it('detects internal __xxx__ labels', () => {
     assert.equal(isInternalLabel('__delta__'), true);
     assert.equal(isInternalLabel('__session_id__'), true);
@@ -286,7 +276,7 @@ describe('parseQuery / buildQuery', () => {
     const parsed = parseQuery('{service_name = "api"}');
     assert.deepEqual(parsed, {
       service: 'api',
-      labelSelector: '{service_name="api"}',
+      labelSelector: '{service_name = "api"}',
     });
   });
 
@@ -306,5 +296,28 @@ describe('parseQuery / buildQuery', () => {
       service: 'api',
       labelSelector: '{service_name="api", region=~"us-.*", env!="prod"}',
     });
+  });
+
+  it('extracts service_name when it is not the first matcher', () => {
+    const q = '{env="production", service_name="my-app", version="v1.2"}';
+    const parsed = parseQuery(q);
+    assert.deepEqual(parsed, {
+      service: 'my-app',
+      labelSelector:
+        '{env="production", service_name="my-app", version="v1.2"}',
+    });
+  });
+
+  it('trims leading and trailing whitespace from labelSelector', () => {
+    const q = '  {service_name="api", region="us-east"}  ';
+    const parsed = parseQuery(q);
+    assert.deepEqual(parsed, {
+      service: 'api',
+      labelSelector: '{service_name="api", region="us-east"}',
+    });
+  });
+
+  it('returns null if service_name uses regex or non-equals operator', () => {
+    assert.equal(parseQuery('{service_name=~"api-.*"}'), null);
   });
 });

--- a/ui/src/queryLang.test.ts
+++ b/ui/src/queryLang.test.ts
@@ -252,32 +252,19 @@ describe('applySuggestion', () => {
 
 describe('label name translation', () => {
   it('maps display names to their internal form', () => {
-    assert.equal(toInternalLabel('profile_type'), '__profile_type__');
     assert.equal(toInternalLabel('service_name'), 'service_name');
   });
 
   it('maps internal names to their display form', () => {
-    assert.equal(toDisplayLabel('__profile_type__'), 'profile_type');
     assert.equal(toDisplayLabel('service_name'), 'service_name');
   });
 
   it('detects internal __xxx__ labels', () => {
     assert.equal(isInternalLabel('__delta__'), true);
     assert.equal(isInternalLabel('__session_id__'), true);
-    assert.equal(isInternalLabel('__profile_type__'), true);
     assert.equal(isInternalLabel('service_name'), false);
-    assert.equal(isInternalLabel('profile_type'), false);
     assert.equal(isInternalLabel('__partial'), false);
     assert.equal(isInternalLabel('partial__'), false);
-  });
-
-  it('serializes profile_type matchers using the internal label name', () => {
-    const q = '{profile_type="cpu", service_name="ap"}';
-    const cursor = q.indexOf('"ap"') + 2;
-    const ctx = getCursorContext(q, cursor);
-    assert.equal(ctx.kind, 'value');
-    if (ctx.kind !== 'value') return;
-    assert.deepEqual(ctx.otherMatchers, ['{__profile_type__="cpu"}']);
   });
 });
 
@@ -295,14 +282,6 @@ describe('parseQuery / buildQuery', () => {
     assert.equal(parseQuery('{foo="bar"}'), null);
   });
 
-  it('parses queries without profile_type', () => {
-    const parsed = parseQuery('{service_name="api", environment="staging"}');
-    assert.deepEqual(parsed, {
-      service: 'api',
-      labelSelector: '{service_name="api", environment="staging"}',
-    });
-  });
-
   it('tolerates extra whitespace around operators', () => {
     const parsed = parseQuery('{service_name = "api"}');
     assert.deepEqual(parsed, {
@@ -311,9 +290,8 @@ describe('parseQuery / buildQuery', () => {
     });
   });
 
-  it('preserves arbitrary label matchers while stripping profile_type if present', () => {
-    const q =
-      '{service_name="example-service", profile_type="process_cpu:cpu:nanoseconds:cpu:nanoseconds", environment="staging"}';
+  it('preserves arbitrary label matchers', () => {
+    const q = '{service_name="example-service", environment="staging"}';
     const parsed = parseQuery(q);
     assert.deepEqual(parsed, {
       service: 'example-service',

--- a/ui/src/queryLang.ts
+++ b/ui/src/queryLang.ts
@@ -295,18 +295,17 @@ export function applySuggestion(
   return { next, cursor };
 }
 
-export function buildQuery(service: string, profileType: string): string {
-  return `{service_name="${service}", profile_type="${profileType}"}`;
+export function buildQuery(service: string): string {
+  return `{service_name="${service}"}`;
 }
 
 export function parseQuery(
   q: string,
-): { service: string; profileType: string; labelSelector: string } | null {
+): { service: string; labelSelector: string } | null {
   const { matchers, braceOpen } = tokenize(q);
   if (braceOpen === -1) return null;
 
   let service = '';
-  let profileType = '';
   const selectorMatchers: string[] = [];
 
   for (const m of matchers) {
@@ -315,15 +314,15 @@ export function parseQuery(
     if (internalName === 'service_name' && m.op === '=') {
       service = m.value;
     }
-    if (internalName === '__profile_type__' && m.op === '=') {
-      profileType = m.value;
+    if (internalName === '__profile_type__') {
       continue;
     }
     selectorMatchers.push(`${internalName}${m.op}"${m.value}"`);
   }
 
-  if (!service || !profileType) return null;
+  if (!service) return null;
 
   const labelSelector = `{${selectorMatchers.join(', ')}}`;
-  return { service, profileType, labelSelector };
+  return { service, labelSelector };
 }
+

--- a/ui/src/queryLang.ts
+++ b/ui/src/queryLang.ts
@@ -41,22 +41,6 @@ export type CursorContext =
 const IDENT = /[A-Za-z0-9_]/;
 const WS = /\s/;
 
-// Label names that are presented to the user in a friendlier form than the
-// backend uses. The query bar accepts and renders the display name; we
-// translate to/from the internal name whenever a matcher crosses the API.
-const DISPLAY_TO_INTERNAL: Record<string, string> = {};
-const INTERNAL_TO_DISPLAY: Record<string, string> = Object.fromEntries(
-  Object.entries(DISPLAY_TO_INTERNAL).map(([d, i]) => [i, d]),
-);
-
-export function toInternalLabel(name: string): string {
-  return DISPLAY_TO_INTERNAL[name] ?? name;
-}
-
-export function toDisplayLabel(name: string): string {
-  return INTERNAL_TO_DISPLAY[name] ?? name;
-}
-
 // Labels wrapped in double underscores (e.g. __delta__, __session_id__) are
 // reserved internals and should not surface in autocomplete.
 export function isInternalLabel(name: string): boolean {
@@ -200,7 +184,7 @@ function parseSlot(q: string, slotStart: number, slotEnd: number): Matcher {
 }
 
 function serializeMatcher(m: Matcher): string {
-  return `{${toInternalLabel(m.name)}${m.op}"${m.value}"}`;
+  return `{${m.name}${m.op}"${m.value}"}`;
 }
 
 export function getCursorContext(query: string, cursor: number): CursorContext {
@@ -302,19 +286,15 @@ export function parseQuery(
   if (braceOpen === -1) return null;
 
   let service = '';
-  const selectorMatchers: string[] = [];
-
   for (const m of matchers) {
     if (!m.complete) continue;
-    const internalName = toInternalLabel(m.name);
-    if (internalName === 'service_name' && m.op === '=') {
+    if (m.name === 'service_name' && m.op === '=') {
       service = m.value;
+      break;
     }
-    selectorMatchers.push(`${internalName}${m.op}"${m.value}"`);
   }
 
   if (!service) return null;
 
-  const labelSelector = `{${selectorMatchers.join(', ')}}`;
-  return { service, labelSelector };
+  return { service, labelSelector: q.trim() };
 }

--- a/ui/src/queryLang.ts
+++ b/ui/src/queryLang.ts
@@ -44,9 +44,7 @@ const WS = /\s/;
 // Label names that are presented to the user in a friendlier form than the
 // backend uses. The query bar accepts and renders the display name; we
 // translate to/from the internal name whenever a matcher crosses the API.
-const DISPLAY_TO_INTERNAL: Record<string, string> = {
-  profile_type: '__profile_type__',
-};
+const DISPLAY_TO_INTERNAL: Record<string, string> = {};
 const INTERNAL_TO_DISPLAY: Record<string, string> = Object.fromEntries(
   Object.entries(DISPLAY_TO_INTERNAL).map(([d, i]) => [i, d]),
 );
@@ -60,9 +58,7 @@ export function toDisplayLabel(name: string): string {
 }
 
 // Labels wrapped in double underscores (e.g. __delta__, __session_id__) are
-// reserved internals and should not surface in autocomplete. Aliased labels
-// like __profile_type__ are first translated via `toDisplayLabel`, so this
-// check sees the display form (`profile_type`) and lets them through.
+// reserved internals and should not surface in autocomplete.
 export function isInternalLabel(name: string): boolean {
   return name.startsWith('__') && name.endsWith('__');
 }
@@ -313,9 +309,6 @@ export function parseQuery(
     const internalName = toInternalLabel(m.name);
     if (internalName === 'service_name' && m.op === '=') {
       service = m.value;
-    }
-    if (internalName === '__profile_type__') {
-      continue;
     }
     selectorMatchers.push(`${internalName}${m.op}"${m.value}"`);
   }

--- a/ui/src/queryLang.ts
+++ b/ui/src/queryLang.ts
@@ -318,4 +318,3 @@ export function parseQuery(
   const labelSelector = `{${selectorMatchers.join(', ')}}`;
   return { service, labelSelector };
 }
-

--- a/ui/src/queryLang.ts
+++ b/ui/src/queryLang.ts
@@ -301,9 +301,29 @@ export function buildQuery(service: string, profileType: string): string {
 
 export function parseQuery(
   q: string,
-): { service: string; profileType: string } | null {
-  const service = q.match(/service_name\s*=\s*"([^"]+)"/)?.[1];
-  const profileType = q.match(/profile_type\s*=\s*"([^"]+)"/)?.[1];
+): { service: string; profileType: string; labelSelector: string } | null {
+  const { matchers, braceOpen } = tokenize(q);
+  if (braceOpen === -1) return null;
+
+  let service = '';
+  let profileType = '';
+  const selectorMatchers: string[] = [];
+
+  for (const m of matchers) {
+    if (!m.complete) continue;
+    const internalName = toInternalLabel(m.name);
+    if (internalName === 'service_name' && m.op === '=') {
+      service = m.value;
+    }
+    if (internalName === '__profile_type__' && m.op === '=') {
+      profileType = m.value;
+      continue;
+    }
+    selectorMatchers.push(`${internalName}${m.op}"${m.value}"`);
+  }
+
   if (!service || !profileType) return null;
-  return { service, profileType };
+
+  const labelSelector = `{${selectorMatchers.join(', ')}}`;
+  return { service, profileType, labelSelector };
 }


### PR DESCRIPTION
Fix issue #5461 where the v2 embedded UI accepted arbitrary label matchers in the query bar (e.g. environment="staging"), but dropped all matchers except service_name when constructing profile and series requests.

- Update parseQuery to tokenize all matchers and retain non-profile_type label matchers in labelSelector.
- Support labelSelector parameter in usePyroscopeQuery hook and drive active label selector state from App.tsx.
- Add unit tests for multi-matcher query parsing.