### PR TITLE
fix(compaction): Use `raft_log.CompactionJobStatusUpdate` instead of `metastorev1.CompactionJobStatusUpdate`

### DIFF
--- a/api/gen/proto/go/metastore/v1/raft_log/raft_log.pb.go
+++ b/api/gen/proto/go/metastore/v1/raft_log/raft_log.pb.go
@@ -1027,11 +1027,11 @@ const file_metastore_v1_raft_log_raft_log_proto_rawDesc = "" +
 	"\x18AddBlockMetadataResponse\"\x94\x01\n" +
 	"\x1eGetCompactionPlanUpdateRequest\x12J\n" +
 	"\x0estatus_updates\x18\x01 \x03(\v2#.raft_log.CompactionJobStatusUpdateR\rstatusUpdates\x12&\n" +
-	"\x0fassign_jobs_max\x18\x02 \x01(\rR\rassignJobsMax\"\x80\x01\n" +
+	"\x0fassign_jobs_max\x18\x02 \x01(\rR\rassignJobsMax\"\x86\x01\n" +
 	"\x19CompactionJobStatusUpdate\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05token\x18\x02 \x01(\x04R\x05token\x129\n" +
-	"\x06status\x18\x03 \x01(\x0e2!.metastore.v1.CompactionJobStatusR\x06status\"v\n" +
+	"\x06status\x18\x03 \x01(\x0e2!.metastore.v1.CompactionJobStatusR\x06statusJ\x04\b\x04\x10\x05\"v\n" +
 	"\x1fGetCompactionPlanUpdateResponse\x12\x12\n" +
 	"\x04term\x18\x01 \x01(\x04R\x04term\x12?\n" +
 	"\vplan_update\x18\x02 \x01(\v2\x1e.raft_log.CompactionPlanUpdateR\n" +

--- a/api/metastore/v1/raft_log/raft_log.proto
+++ b/api/metastore/v1/raft_log/raft_log.proto
@@ -33,6 +33,11 @@ message CompactionJobStatusUpdate {
   string name = 1;
   uint64 token = 2;
   metastore.v1.CompactionJobStatus status = 3;
+  // Reserved field represents `compacted_blocks`. The message must remain
+  // wire-compatible with metastore.v1.CompactionJobStatusUpdate: raft log
+  // entries written by older versions may erroneously contain field data for
+  // metastore.v1.CompactionJobStatusUpdate#compacted_blocks.
+  reserved 4;
 }
 
 // GetCompactionPlanUpdateResponse includes the planned change.

--- a/pkg/metastore/compaction_service.go
+++ b/pkg/metastore/compaction_service.go
@@ -68,7 +68,7 @@ func (svc *CompactionService) PollCompactionJobs(
 	// First, we ask the current leader to prepare the change. This is a read
 	// operation conducted through the raft log: at this stage, we only
 	// prepare changes; the command handler does not alter the state.
-	request := &raft_log.GetCompactionPlanUpdateRequest{
+	proposeReq := &raft_log.GetCompactionPlanUpdateRequest{
 		StatusUpdates: make([]*raft_log.CompactionJobStatusUpdate, 0, len(req.StatusUpdates)),
 		AssignJobsMax: req.JobCapacity,
 	}
@@ -82,7 +82,7 @@ func (svc *CompactionService) PollCompactionJobs(
 		if update.CompactedBlocks != nil {
 			compacted[update.Name] = update
 		}
-		request.StatusUpdates = append(request.StatusUpdates, &raft_log.CompactionJobStatusUpdate{
+		proposeReq.StatusUpdates = append(proposeReq.StatusUpdates, &raft_log.CompactionJobStatusUpdate{
 			Name:   update.Name,
 			Token:  update.Token,
 			Status: update.Status,
@@ -90,7 +90,7 @@ func (svc *CompactionService) PollCompactionJobs(
 	}
 
 	cmd := fsm.RaftLogEntryType(raft_log.RaftCommand_RAFT_COMMAND_GET_COMPACTION_PLAN_UPDATE)
-	proposeResp, err := svc.raft.Propose(ctx, cmd, req)
+	proposeResp, err := svc.raft.Propose(ctx, cmd, proposeReq)
 	if err != nil {
 		if !raftnode.IsRaftLeadershipError(err) {
 			level.Error(svc.logger).Log("msg", "failed to prepare compaction plan", "err", err)

--- a/pkg/metastore/compaction_service_test.go
+++ b/pkg/metastore/compaction_service_test.go
@@ -92,3 +92,56 @@ func TestCompactionService_PollCompactionJobs_proposals(t *testing.T) {
 	require.Len(t, resp.Assignments, 1)
 	assert.Equal(t, uint64(41), resp.Assignments[0].Token)
 }
+
+// Prior to https://github.com/grafana/pyroscope/pull/5465, the prepare step
+// proposed the worker request as-is, so the raft log may contain
+// metastore.v1.PollCompactionJobsRequest entries under the
+// GET_COMPACTION_PLAN_UPDATE command. The FSM decodes the entry payload as
+// raft_log.GetCompactionPlanUpdateRequest: replaying such a log must not fail,
+// and the entry must be interpreted exactly as it was when written.
+func TestGetCompactionPlanUpdateRequest_oldLogEntry(t *testing.T) {
+	oldEntry := &metastorev1.PollCompactionJobsRequest{
+		StatusUpdates: []*metastorev1.CompactionJobStatusUpdate{{
+			Name:   "job-done",
+			Token:  40,
+			Status: metastorev1.CompactionJobStatus_COMPACTION_STATUS_SUCCESS,
+			// The field the raft_log message reserves: entries written by
+			// older versions carry the compaction results.
+			CompactedBlocks: &metastorev1.CompactedBlocks{
+				SourceBlocks: &metastorev1.BlockList{Tenant: "tenant-a", Blocks: []string{"b1"}},
+				NewBlocks:    []*metastorev1.BlockMeta{{Id: "b2"}},
+			},
+		}, {
+			Name:   "job-running",
+			Token:  41,
+			Status: metastorev1.CompactionJobStatus_COMPACTION_STATUS_IN_PROGRESS,
+		}},
+		JobCapacity: 3,
+	}
+
+	raw, err := proto.Marshal(oldEntry)
+	require.NoError(t, err)
+
+	// The FSM command handler decodes the raw entry payload into the request
+	// type registered for the command.
+	var decoded raft_log.GetCompactionPlanUpdateRequest
+	require.NoError(t, proto.Unmarshal(raw, &decoded))
+
+	assert.Equal(t, oldEntry.JobCapacity, decoded.AssignJobsMax)
+	require.Len(t, decoded.StatusUpdates, 2)
+	assert.Equal(t, "job-done", decoded.StatusUpdates[0].Name)
+	assert.Equal(t, uint64(40), decoded.StatusUpdates[0].Token)
+	assert.Equal(t, metastorev1.CompactionJobStatus_COMPACTION_STATUS_SUCCESS, decoded.StatusUpdates[0].Status)
+	assert.Equal(t, "job-running", decoded.StatusUpdates[1].Name)
+	assert.Equal(t, uint64(41), decoded.StatusUpdates[1].Token)
+	assert.Equal(t, metastorev1.CompactionJobStatus_COMPACTION_STATUS_IN_PROGRESS, decoded.StatusUpdates[1].Status)
+
+	// The reserved field is retained as an unknown field, so re-encoding the
+	// entry does not discard the data written by the older version.
+	assert.NotEmpty(t, decoded.StatusUpdates[0].ProtoReflect().GetUnknown())
+	reencoded, err := proto.Marshal(&decoded)
+	require.NoError(t, err)
+	var roundTripped metastorev1.PollCompactionJobsRequest
+	require.NoError(t, proto.Unmarshal(reencoded, &roundTripped))
+	assert.True(t, proto.Equal(oldEntry, &roundTripped), "want: %v\ngot:  %v", oldEntry, &roundTripped)
+}

--- a/pkg/metastore/compaction_service_test.go
+++ b/pkg/metastore/compaction_service_test.go
@@ -1,0 +1,94 @@
+package metastore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	"github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1/raft_log"
+	"github.com/grafana/pyroscope/v2/pkg/metastore/fsm"
+)
+
+// proposalRecorder is a Raft implementation that records the proposed
+// commands and returns canned responses.
+type proposalRecorder struct {
+	proposals []proto.Message
+	responses []proto.Message
+}
+
+func (r *proposalRecorder) Propose(_ context.Context, _ fsm.RaftLogEntryType, m proto.Message) (proto.Message, error) {
+	r.proposals = append(r.proposals, m)
+	resp := r.responses[0]
+	r.responses = r.responses[1:]
+	return resp, nil
+}
+
+// The test pins the content of the raft proposals: the prepare step must
+// propose the raft_log request stripped of the compacted blocks (these are
+// only replicated with the final plan update).
+func TestCompactionService_PollCompactionJobs_proposals(t *testing.T) {
+	completed := &raft_log.CompactionJobState{
+		Name:   "job-done",
+		Token:  40,
+		Status: metastorev1.CompactionJobStatus_COMPACTION_STATUS_SUCCESS,
+	}
+	assigned := &raft_log.CompactionJobState{
+		Name:   "job-new",
+		Token:  41,
+		Status: metastorev1.CompactionJobStatus_COMPACTION_STATUS_IN_PROGRESS,
+	}
+	planUpdate := &raft_log.CompactionPlanUpdate{
+		CompletedJobs: []*raft_log.CompletedCompactionJob{{State: completed}},
+		AssignedJobs: []*raft_log.AssignedCompactionJob{{
+			State: assigned,
+			Plan:  &raft_log.CompactionJobPlan{Name: "job-new", Tenant: "tenant-a"},
+		}},
+	}
+	raft := &proposalRecorder{responses: []proto.Message{
+		&raft_log.GetCompactionPlanUpdateResponse{Term: 1, PlanUpdate: planUpdate},
+		&raft_log.UpdateCompactionPlanResponse{PlanUpdate: planUpdate},
+	}}
+
+	svc := NewCompactionService(log.NewNopLogger(), raft)
+	compactedBlocks := &metastorev1.CompactedBlocks{
+		SourceBlocks: &metastorev1.BlockList{Tenant: "tenant-a", Blocks: []string{"b1"}},
+		NewBlocks:    []*metastorev1.BlockMeta{{Id: "b2"}},
+	}
+	resp, err := svc.PollCompactionJobs(context.Background(), &metastorev1.PollCompactionJobsRequest{
+		StatusUpdates: []*metastorev1.CompactionJobStatusUpdate{{
+			Name:            "job-done",
+			Token:           40,
+			Status:          metastorev1.CompactionJobStatus_COMPACTION_STATUS_SUCCESS,
+			CompactedBlocks: compactedBlocks,
+		}},
+		JobCapacity: 1,
+	})
+	require.NoError(t, err)
+	require.Len(t, raft.proposals, 2)
+
+	prepare, ok := raft.proposals[0].(*raft_log.GetCompactionPlanUpdateRequest)
+	require.True(t, ok, "the prepare step must propose the raft_log request, got %T", raft.proposals[0])
+	assert.Equal(t, uint32(1), prepare.AssignJobsMax)
+	require.Len(t, prepare.StatusUpdates, 1)
+	assert.Equal(t, "job-done", prepare.StatusUpdates[0].Name)
+	assert.Equal(t, uint64(40), prepare.StatusUpdates[0].Token)
+
+	proposal, ok := raft.proposals[1].(*raft_log.UpdateCompactionPlanRequest)
+	require.True(t, ok, "the update step must propose the raft_log request, got %T", raft.proposals[1])
+	assert.Equal(t, uint64(1), proposal.Term)
+	// The compacted blocks reported by the worker are attached
+	// to the completed job of the final proposal.
+	require.Len(t, proposal.PlanUpdate.CompletedJobs, 1)
+	assert.Equal(t, compactedBlocks, proposal.PlanUpdate.CompletedJobs[0].CompactedBlocks)
+
+	// The worker response includes the new assignment and its plan.
+	require.Len(t, resp.CompactionJobs, 1)
+	assert.Equal(t, "job-new", resp.CompactionJobs[0].Name)
+	require.Len(t, resp.Assignments, 1)
+	assert.Equal(t, uint64(41), resp.Assignments[0].Token)
+}


### PR DESCRIPTION
This code previously used `req` to prepare compaction updates to the metastore Raft log. We're supposed to be using `proposeReq` to prepare updates.

The bug sequence:

1. Worker finishes a job and calls `PollCompactionJobs` with a status update carrying `CompactedBlocks`.
2. The service builds the trimmed request (name/token/status only), but then (incorrectly) proposes req, the full worker request.
3. `Propose()` serializes the full request, including `CompactedBlocks`, and that byte blob is fsync'd into the leader's log and replicated to all peers.
4. The FSM unmarshals the entry as `GetCompactionPlanUpdateRequest`. Since field 4 doesn't exist on that type, the CompactedBlocks` bytes land in protobuf unknown fields and are ignored.
5. Then the service does the second proposal (`UpdateCompactionPlanRequest`), which intentionally includes `CompactedBlocks` for completed jobs, so the same block metadata got written to the raft log a second time.