### PR TITLE
fix(deps): bump brace-expansion in /ui [security]

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -46,8 +46,8 @@
     "node": ">=24"
   },
   "resolutions": {
-    "brace-expansion@npm:^1.1.7": "npm:1.1.16",
-    "brace-expansion@npm:^5.0.2": "npm:5.0.7",
+    "brace-expansion@npm:^1.1.7": "npm:1.1.18",
+    "brace-expansion@npm:^5.0.8": "npm:5.0.9",
     "js-yaml@npm:^4.1.1": "npm:4.3.0",
     "tar@npm:^7.5.4": "npm:7.5.21"
   }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -918,22 +918,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:1.1.16":
-  version: 1.1.16
-  resolution: "brace-expansion@npm:1.1.16"
+"brace-expansion@npm:1.1.18":
+  version: 1.1.18
+  resolution: "brace-expansion@npm:1.1.18"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
+  checksum: 10c0/3432c18a9e2ebf94162d4effb62198bd0adea06a9f332b2c0188df5d5e30b1e51ea3c848b6608e47d0b857ebe1ea5b3888ed3326dd3c4f6f9645c94153cf9c14
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.8":
-  version: 5.0.8
-  resolution: "brace-expansion@npm:5.0.8"
+"brace-expansion@npm:5.0.9":
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/73304caafd00fdc5b0168e693ac15bf25b6357dec76d1195fcd628fe2cf99c46f9c889a7ecfa3cfe236dbd2d5ce3e27a6ccc4370b46d475d0d19081e11f86019
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Fixes the last 2 HIGH vulnerability findings on `main` (CVE-2026-14257 / CVE-2026-69152, brace-expansion DoS):

- `brace-expansion@1.1.16` → **1.1.18** (bumped the existing `ui/package.json` resolution)
- `brace-expansion@5.0.8` → **5.0.9** — this one escaped the previous pin: the resolution key was `brace-expansion@npm:^5.0.2`, but `minimatch@10.2.6` (from #5418's lock file maintenance) requests `^5.0.8`, a descriptor that key doesn't match, so an unpinned 5.0.8 entry appeared in the lockfile. The resolution key is updated to `^5.0.2` → `^5.0.8` (the old key matched no descriptor anymore).

After this, `ui/yarn.lock` contains only the fixed versions.

Backport labels for `release/v2.2` and `release/v2.1` are set: both branches carry the identical vulnerable versions, and this clears the remaining HIGHs there ahead of the v2.2.1 / v2.1.2 patch releases.

## Testing

- `yarn install` regenerated the lockfile; `grep brace-expansion ui/yarn.lock` shows only 1.1.18 / 5.0.9
- `yarn build` ✅
- `yarn test` ✅ (61/61)

🤖 Generated with [Claude Code](https://claude.com/claude-code)