### PR TITLE
ci: do not publish latest image or update Homebrew from release/v2.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,8 @@ jobs:
         run: echo "GIT_LAST_COMMIT_DATE=$(git log -1 --date=iso-strict --format=%cd)" >> $GITHUB_ENV
       - name: Set IMAGE_TAG from git tag
         run: echo "IMAGE_TAG=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
-      - name: Set IMAGE_PUBLISH_LATEST=true, so we overwrite the latest docker image tag and update Homebrew
-        run: echo "IMAGE_PUBLISH_LATEST=true" >> $GITHUB_ENV
+      - name: Set IMAGE_PUBLISH_LATEST=false, so older patch releases do not overwrite the latest docker image tag or update Homebrew
+        run: echo "IMAGE_PUBLISH_LATEST=false" >> $GITHUB_ENV
       # Forces goreleaser to use the correct previous tag for the changelog
       - name: Set GORELEASER_PREVIOUS_TAG
         run: echo "GORELEASER_PREVIOUS_TAG=$(git tag -l --sort=-version:refname | grep -E '^v.*' | head -n 2 | tail -1)" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

Prep for the upcoming `v2.1.2` security patch release: `release/v2.1`'s release workflow still sets `IMAGE_PUBLISH_LATEST=true`, so tagging a v2.1.x patch today would overwrite the `:latest` Docker image tag and open a Homebrew formula PR — even though v2.2 is now the latest release line.

Flips it to `false`, mirroring what `release/v2.0` already does (per the warning in `docs/internal/RELEASE.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)