### PR TITLE
docs: add v2.2.1 release notes

### DIFF
--- a/docs/sources/release-notes/v2-2.md
+++ b/docs/sources/release-notes/v2-2.md
@@ -5,6 +5,19 @@ description: Release notes for Grafana Pyroscope 2.2
 weight: 660
 ---
 
+## Version 2.2.1 release notes
+
+### Security fixes
+
+* Update `github.com/getkin/kin-openapi` to v0.144.0, addressing GHSA-r277-6w6q-xmqw ([#5416](https://github.com/grafana/pyroscope/pull/5416))
+* Update `google.golang.org/grpc` to v1.82.1, addressing GHSA-hrxh-6v49-42gf ([#5392](https://github.com/grafana/pyroscope/pull/5392), [#5393](https://github.com/grafana/pyroscope/pull/5393))
+* Update `golang.org/x/text` to v0.39.0, addressing CVE-2026-56852 ([#5383](https://github.com/grafana/pyroscope/pull/5383), [#5385](https://github.com/grafana/pyroscope/pull/5385))
+* Update `golang.org/x/net` to v0.56.0, addressing CVE-2026-46600 ([#5382](https://github.com/grafana/pyroscope/pull/5382), [#5384](https://github.com/grafana/pyroscope/pull/5384))
+* Update `github.com/klauspost/compress` to v1.18.7 ([#5429](https://github.com/grafana/pyroscope/pull/5429))
+* **ui**: Bump `tar`, `js-yaml`, and `brace-expansion` ([#5413](https://github.com/grafana/pyroscope/pull/5413))
+* **ui**: Bump `brace-expansion` to 1.1.18 and 5.0.9, addressing CVE-2026-14257 and CVE-2026-69152 ([#5466](https://github.com/grafana/pyroscope/pull/5466))
+* **ui**: Refresh the Yarn lockfile, removing the vulnerable `ip-address` package and updating `postcss` ([#5419](https://github.com/grafana/pyroscope/pull/5419))
+
 ## Version 2.2.0 release notes
 
 The Pyroscope team is excited to present Grafana Pyroscope 2.2.0.


### PR DESCRIPTION
Release notes for the upcoming v2.2.1 security patch release, listing the security fixes accumulated on `release/v2.2` since v2.2.0 (plus #5466, pending backport).

🤖 Generated with [Claude Code](https://claude.com/claude-code)