### PR TITLE
docs: add v2.1.2 release notes

### DIFF
--- a/docs/sources/release-notes/v2-1.md
+++ b/docs/sources/release-notes/v2-1.md
@@ -5,6 +5,19 @@ description: Release notes for Grafana Pyroscope 2.1
 weight: 670
 ---
 
+## Version 2.1.2 release notes
+
+### Security fixes
+
+* Update `github.com/getkin/kin-openapi` to v0.144.0, addressing GHSA-r277-6w6q-xmqw ([#5417](https://github.com/grafana/pyroscope/pull/5417))
+* Update `google.golang.org/grpc` to v1.82.1, addressing GHSA-hrxh-6v49-42gf ([#5394](https://github.com/grafana/pyroscope/pull/5394), [#5395](https://github.com/grafana/pyroscope/pull/5395))
+* Update `golang.org/x/text` to v0.39.0, addressing CVE-2026-56852 ([#5387](https://github.com/grafana/pyroscope/pull/5387), [#5389](https://github.com/grafana/pyroscope/pull/5389))
+* Update `golang.org/x/net` to v0.56.0, addressing CVE-2026-46600 ([#5386](https://github.com/grafana/pyroscope/pull/5386), [#5388](https://github.com/grafana/pyroscope/pull/5388))
+* Update `github.com/klauspost/compress` to v1.18.7 ([#5430](https://github.com/grafana/pyroscope/pull/5430))
+* **ui**: Bump `tar`, `js-yaml`, and `brace-expansion` ([#5413](https://github.com/grafana/pyroscope/pull/5413))
+* **ui**: Bump `brace-expansion` to 1.1.18 and 5.0.9, addressing CVE-2026-14257 and CVE-2026-69152 ([#5466](https://github.com/grafana/pyroscope/pull/5466))
+* **ui**: Refresh the Yarn lockfile, removing the vulnerable `ip-address` package and updating `postcss` ([#5420](https://github.com/grafana/pyroscope/pull/5420))
+
 ## Version 2.1.1 release notes
 
 ### Security fixes


### PR DESCRIPTION
Release notes for the upcoming v2.1.2 security patch release, listing the security fixes accumulated on `release/v2.1` since v2.1.1 (plus #5466, pending backport).

🤖 Generated with [Claude Code](https://claude.com/claude-code)