### PR TITLE
chore: bump Helm chart to v2.2.1

### DIFF
--- a/operations/pyroscope/helm/pyroscope/Chart.yaml
+++ b/operations/pyroscope/helm/pyroscope/Chart.yaml
@@ -3,8 +3,8 @@ name: pyroscope
 description: A horizontally scalable, highly available, multi-tenant continuous profiling database.
 home: https://grafana.com/oss/pyroscope/
 type: application
-version: 2.2.0
-appVersion: 2.2.0
+version: 2.2.1
+appVersion: 2.2.1
 dependencies:
   - name: grafana-agent
     alias: agent

--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -1,6 +1,6 @@
 # pyroscope
 
-![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
+![Version: 2.2.1](https://img.shields.io/badge/Version-2.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
 
 A horizontally scalable, highly available, multi-tenant continuous profiling database.
 

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -27,10 +27,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -48,10 +48,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -69,10 +69,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -90,10 +90,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -111,10 +111,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -132,10 +132,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -176,10 +176,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -523,10 +523,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1396,10 +1396,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1413,10 +1413,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1571,10 +1571,10 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -1596,10 +1596,10 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1743,10 +1743,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1770,10 +1770,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1799,10 +1799,10 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1829,10 +1829,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1858,10 +1858,10 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1888,10 +1888,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1917,10 +1917,10 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1947,10 +1947,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1976,10 +1976,10 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2006,10 +2006,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2035,10 +2035,10 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2065,10 +2065,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2094,10 +2094,10 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2124,10 +2124,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2153,10 +2153,10 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2183,10 +2183,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2198,9 +2198,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2223,7 +2223,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2293,10 +2293,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2308,9 +2308,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2333,7 +2333,7 @@ spec:
         - name: "querier"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -2403,10 +2403,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2418,9 +2418,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2443,7 +2443,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2513,10 +2513,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2528,9 +2528,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2553,7 +2553,7 @@ spec:
         - name: "query-scheduler"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-scheduler"
@@ -2623,10 +2623,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2651,10 +2651,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2682,10 +2682,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2710,10 +2710,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2921,10 +2921,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -2939,9 +2939,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2964,7 +2964,7 @@ spec:
         - name: "compactor"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -3039,10 +3039,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -3057,9 +3057,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3082,7 +3082,7 @@ spec:
         - name: "ingester"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -3153,10 +3153,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -3171,9 +3171,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3196,7 +3196,7 @@ spec:
         - name: "store-gateway"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -27,10 +27,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -48,10 +48,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -69,10 +69,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -90,10 +90,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -111,10 +111,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -132,10 +132,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -153,10 +153,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -174,10 +174,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -218,10 +218,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -565,10 +565,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1438,10 +1438,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1455,10 +1455,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1613,10 +1613,10 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -1638,10 +1638,10 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1785,10 +1785,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1812,10 +1812,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1841,10 +1841,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1871,10 +1871,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1900,10 +1900,10 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1930,10 +1930,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1959,10 +1959,10 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1989,10 +1989,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -2018,10 +2018,10 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -2048,10 +2048,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2077,10 +2077,10 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2107,10 +2107,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2136,10 +2136,10 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2166,10 +2166,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2195,10 +2195,10 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2225,10 +2225,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2254,10 +2254,10 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2284,10 +2284,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2313,10 +2313,10 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2343,10 +2343,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -2359,9 +2359,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2384,7 +2384,7 @@ spec:
         - name: "ad-hoc-profiles"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ad-hoc-profiles"
@@ -2454,10 +2454,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2470,9 +2470,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2495,7 +2495,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2565,10 +2565,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2581,9 +2581,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2606,7 +2606,7 @@ spec:
         - name: "querier"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -2676,10 +2676,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2692,9 +2692,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2717,7 +2717,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2787,10 +2787,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2803,9 +2803,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2828,7 +2828,7 @@ spec:
         - name: "query-scheduler"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-scheduler"
@@ -2898,10 +2898,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2914,9 +2914,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2939,7 +2939,7 @@ spec:
         - name: "tenant-settings"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tenant-settings"
@@ -3192,10 +3192,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -3210,9 +3210,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3235,7 +3235,7 @@ spec:
         - name: "compactor"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -3310,10 +3310,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -3328,9 +3328,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3353,7 +3353,7 @@ spec:
         - name: "ingester"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -3424,10 +3424,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -3442,9 +3442,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3467,7 +3467,7 @@ spec:
         - name: "store-gateway"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -27,10 +27,10 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -48,10 +48,10 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -69,10 +69,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -90,10 +90,10 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -111,10 +111,10 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -132,10 +132,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -153,10 +153,10 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -174,10 +174,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -218,10 +218,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -565,10 +565,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1438,10 +1438,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1455,10 +1455,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1613,10 +1613,10 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -1638,10 +1638,10 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1785,10 +1785,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1812,10 +1812,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1841,10 +1841,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1871,10 +1871,10 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -1900,10 +1900,10 @@ metadata:
   name: pyroscope-dev-admin-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -1930,10 +1930,10 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -1959,10 +1959,10 @@ metadata:
   name: pyroscope-dev-compaction-worker-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -1989,10 +1989,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2018,10 +2018,10 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2048,10 +2048,10 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -2081,10 +2081,10 @@ metadata:
   name: pyroscope-dev-metastore-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -2116,10 +2116,10 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2145,10 +2145,10 @@ metadata:
   name: pyroscope-dev-query-backend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2175,10 +2175,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2204,10 +2204,10 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2234,10 +2234,10 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -2263,10 +2263,10 @@ metadata:
   name: pyroscope-dev-segment-writer-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -2293,10 +2293,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2322,10 +2322,10 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2352,10 +2352,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -2368,9 +2368,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2393,7 +2393,7 @@ spec:
         - name: "ad-hoc-profiles"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ad-hoc-profiles"
@@ -2462,10 +2462,10 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -2478,9 +2478,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2503,7 +2503,7 @@ spec:
         - name: "admin"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=admin"
@@ -2572,10 +2572,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2588,9 +2588,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2613,7 +2613,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2682,10 +2682,10 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2698,9 +2698,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2723,7 +2723,7 @@ spec:
         - name: "query-backend"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-backend"
@@ -2792,10 +2792,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2808,9 +2808,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2833,7 +2833,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2902,10 +2902,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2918,9 +2918,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2943,7 +2943,7 @@ spec:
         - name: "tenant-settings"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tenant-settings"
@@ -3195,10 +3195,10 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -3213,9 +3213,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3238,7 +3238,7 @@ spec:
         - name: "compaction-worker"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compaction-worker"
@@ -3308,10 +3308,10 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -3326,9 +3326,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3351,7 +3351,7 @@ spec:
         - name: "metastore"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=metastore"
@@ -3437,10 +3437,10 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -3455,9 +3455,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3480,7 +3480,7 @@ spec:
         - name: "segment-writer"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=segment-writer"

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -27,10 +27,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -48,10 +48,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -69,10 +69,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -90,10 +90,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -111,10 +111,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -132,10 +132,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -153,10 +153,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -174,10 +174,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -218,10 +218,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -565,10 +565,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1438,10 +1438,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1455,10 +1455,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1740,10 +1740,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1767,10 +1767,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1792,10 +1792,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1818,10 +1818,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1843,10 +1843,10 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1869,10 +1869,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1894,10 +1894,10 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1920,10 +1920,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1945,10 +1945,10 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1971,10 +1971,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1996,10 +1996,10 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2022,10 +2022,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2047,10 +2047,10 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2073,10 +2073,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2098,10 +2098,10 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2124,10 +2124,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2149,10 +2149,10 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2175,10 +2175,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2200,10 +2200,10 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2226,10 +2226,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -2242,9 +2242,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2267,7 +2267,7 @@ spec:
         - name: "ad-hoc-profiles"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ad-hoc-profiles"
@@ -2330,10 +2330,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2346,9 +2346,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2371,7 +2371,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2434,10 +2434,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2450,9 +2450,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2475,7 +2475,7 @@ spec:
         - name: "querier"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -2539,10 +2539,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2555,9 +2555,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2580,7 +2580,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2643,10 +2643,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2659,9 +2659,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2684,7 +2684,7 @@ spec:
         - name: "query-scheduler"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-scheduler"
@@ -2747,10 +2747,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2763,9 +2763,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2788,7 +2788,7 @@ spec:
         - name: "tenant-settings"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tenant-settings"
@@ -3034,10 +3034,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -3052,9 +3052,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3077,7 +3077,7 @@ spec:
         - name: "compactor"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -3145,10 +3145,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -3163,9 +3163,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3188,7 +3188,7 @@ spec:
         - name: "ingester"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -3252,10 +3252,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -3270,9 +3270,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78e5f1ddee5b4eec11ff83ec57e0ebaf27459a30022d096148780261a7be67cf
+        checksum/config: a5664efbcf3752f7fee918250d8e648d5ca441731afc666c9055cbc4853609d5
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3295,7 +3295,7 @@ spec:
         - name: "store-gateway"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -43,10 +43,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/templates/configmap-alloy.yaml
@@ -56,10 +56,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -929,10 +929,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -946,10 +946,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1097,10 +1097,10 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -1122,10 +1122,10 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1201,10 +1201,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1228,10 +1228,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1261,10 +1261,10 @@ metadata:
   name: pyroscope-dev-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1386,10 +1386,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1404,9 +1404,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3aef793cd0d75d5d3e04e7a3cd572a8ef043518118df43b74beee3f27e623929
+        checksum/config: bc7e4906e690c2f5c4b3e69ae4e66974ffee551adabf51a43c173b6f6aa0d858
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -1429,7 +1429,7 @@ spec:
         - name: "pyroscope"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=all"

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -43,10 +43,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/templates/configmap-alloy.yaml
@@ -56,10 +56,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -929,10 +929,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -946,10 +946,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1156,10 +1156,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1183,10 +1183,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1208,10 +1208,10 @@ metadata:
   name: pyroscope-dev-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1324,10 +1324,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-2.2.0
+    helm.sh/chart: pyroscope-2.2.1
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "2.2.0"
+    app.kubernetes.io/version: "2.2.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1342,9 +1342,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3aef793cd0d75d5d3e04e7a3cd572a8ef043518118df43b74beee3f27e623929
+        checksum/config: bc7e4906e690c2f5c4b3e69ae4e66974ffee551adabf51a43c173b6f6aa0d858
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v2.2.0"
+        profiles.grafana.com/service_git_ref: "v2.2.1"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -1367,7 +1367,7 @@ spec:
         - name: "pyroscope"
           securityContext:
             {}
-          image: "grafana/pyroscope:2.2.0"
+          image: "grafana/pyroscope:2.2.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=all"


### PR DESCRIPTION
Bumps the Helm chart `version` and `appVersion` to 2.2.1, following the [v2.2.1 security release](https://github.com/grafana/pyroscope/releases/tag/v2.2.1). Merging publishes the chart automatically.

`make helm/docs` and the `helm/check` renders were run; all rendered manifests validate with kubeconform (the only changes are `2.2.0` → `2.2.1` image tags and version labels, matching #5346).

🤖 Generated with [Claude Code](https://claude.com/claude-code)