### PR TITLE
fix(v2): serve profile-type Series queries from metadata when the selector is empty (backport #5483)

### DIFF
--- a/pkg/frontend/readpath/queryfrontend/compat.go
+++ b/pkg/frontend/readpath/queryfrontend/compat.go
@@ -69,7 +69,7 @@ func parseMatchers(matchers []string) ([]*labels.Matcher, error) {
 	for _, m := range matchers {
 		s, err := phlaremodel.ParseMetricSelector(m)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse label selector %q: %w", s, err)
+			return nil, fmt.Errorf("failed to parse label selector %q: %w", m, err)
 		}
 		parsed = append(parsed, s...)
 	}

--- a/pkg/frontend/readpath/queryfrontend/query_series_labels.go
+++ b/pkg/frontend/readpath/queryfrontend/query_series_labels.go
@@ -72,15 +72,17 @@ func (q *QueryFrontend) Series(
 		return connect.NewResponse(&querierv1.SeriesResponse{}), nil
 	}
 
-	if q.isProfileTypeQuery(c.Msg.LabelNames, c.Msg.Matchers) {
+	matchers, err := parseMatchers(c.Msg.Matchers)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+
+	if q.isProfileTypeQuery(c.Msg.LabelNames, matchers) {
 		level.Debug(q.logger).Log("msg", "listing profile types from metadata as series labels")
 		return q.queryProfileTypeMetadataLabels(ctx, tenantIDs, c.Msg.Start, c.Msg.End, c.Msg.LabelNames)
 	}
 
-	labelSelector, err := buildLabelSelectorFromMatchers(c.Msg.Matchers)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, err)
-	}
+	labelSelector := matchersToLabelSelector(matchers)
 
 	labelNames, err := q.filterLabelNames(ctx, c, c.Msg.LabelNames, c.Msg.Matchers)
 	if err != nil {

--- a/pkg/frontend/readpath/queryfrontend/query_series_labels_compat.go
+++ b/pkg/frontend/readpath/queryfrontend/query_series_labels_compat.go
@@ -9,6 +9,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/go-kit/log/level"
+	"github.com/prometheus/prometheus/model/labels"
 
 	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
@@ -35,12 +36,18 @@ var profileTypeLabels5 = []string{
 	phlaremodel.LabelNameServiceName,
 }
 
-func (q *QueryFrontend) isProfileTypeQuery(labels, matchers []string) bool {
+// isProfileTypeQuery reports whether the request can be served from block
+// metadata instead of scanning the TSDB index of every block in the range.
+//
+// Matchers must already be parsed: an unfiltered query reaches us either as an
+// empty list or as a single empty selector ("{}") depending on the client, and
+// both are semantically unconstrained.
+func (q *QueryFrontend) isProfileTypeQuery(names []string, matchers []*labels.Matcher) bool {
 	if len(matchers) > 0 {
 		return false
 	}
 	var s []string
-	switch len(labels) {
+	switch len(names) {
 	case 2:
 		s = profileTypeLabels2
 	case 5:
@@ -48,8 +55,8 @@ func (q *QueryFrontend) isProfileTypeQuery(labels, matchers []string) bool {
 	default:
 		return false
 	}
-	sort.Strings(labels)
-	return slices.Compare(s, labels) == 0
+	sort.Strings(names)
+	return slices.Compare(s, names) == 0
 }
 
 func (q *QueryFrontend) queryProfileTypeMetadataLabels(

--- a/pkg/frontend/readpath/queryfrontend/query_series_labels_compat_test.go
+++ b/pkg/frontend/readpath/queryfrontend/query_series_labels_compat_test.go
@@ -1,0 +1,161 @@
+package queryfrontend
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	phlaremodel "github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/tenant"
+	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockfrontend"
+	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockmetastorev1"
+	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockqueryfrontend"
+)
+
+func Test_isProfileTypeQuery(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		names    []string
+		matchers []string
+		expected bool
+	}{
+		{
+			name:     "no matchers",
+			names:    profileTypeLabels2,
+			matchers: nil,
+			expected: true,
+		},
+		{
+			// Profiles Drilldown spells an unfiltered query this way.
+			name:     "empty selector",
+			names:    profileTypeLabels2,
+			matchers: []string{"{}"},
+			expected: true,
+		},
+		{
+			name:     "empty selector with whitespace",
+			names:    profileTypeLabels2,
+			matchers: []string{"{} "},
+			expected: true,
+		},
+		{
+			name:     "several empty selectors",
+			names:    profileTypeLabels2,
+			matchers: []string{"{}", "{}"},
+			expected: true,
+		},
+		{
+			name:     "empty selector with five label names",
+			names:    profileTypeLabels5,
+			matchers: []string{"{}"},
+			expected: true,
+		},
+		{
+			name:     "label names in arbitrary order",
+			names:    []string{phlaremodel.LabelNameServiceName, phlaremodel.LabelNameProfileType},
+			matchers: []string{"{}"},
+			expected: true,
+		},
+		{
+			name:     "constraining matcher",
+			names:    profileTypeLabels2,
+			matchers: []string{`{service_name="a"}`},
+			expected: false,
+		},
+		{
+			name:     "empty selector alongside a constraining matcher",
+			names:    profileTypeLabels2,
+			matchers: []string{"{}", `{service_name="a"}`},
+			expected: false,
+		},
+		{
+			name:     "unrelated label names",
+			names:    []string{"foo", "bar"},
+			matchers: []string{"{}"},
+			expected: false,
+		},
+		{
+			name:     "unsupported label name count",
+			names:    []string{phlaremodel.LabelNameServiceName},
+			matchers: []string{"{}"},
+			expected: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			matchers, err := parseMatchers(tc.matchers)
+			require.NoError(t, err)
+
+			names := make([]string, len(tc.names))
+			copy(names, tc.names)
+
+			q := new(QueryFrontend)
+			assert.Equal(t, tc.expected, q.isProfileTypeQuery(names, matchers))
+		})
+	}
+}
+
+// Test_QueryFrontend_Series_ProfileTypeQueryServedFromMetadata guards the read
+// amplification fixed here: an unfiltered profile-type query spelled "{}" used
+// to miss the metadata path and scan the TSDB index of every block in range.
+func Test_QueryFrontend_Series_ProfileTypeQueryServedFromMetadata(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		matchers []string
+	}{
+		{name: "no matchers", matchers: nil},
+		{name: "empty selector", matchers: []string{"{}"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// No expectations are set on the query backend, so reaching it at
+			// all fails the test.
+			mockQueryBackend := mockqueryfrontend.NewMockQueryBackend(t)
+
+			mockMetadataClient := new(mockmetastorev1.MockMetadataQueryServiceClient)
+			mockMetadataClient.On("QueryMetadataLabels", mock.Anything, mock.Anything).
+				Return(&metastorev1.QueryMetadataLabelsResponse{
+					Labels: []*typesv1.Labels{{Labels: []*typesv1.LabelPair{
+						{Name: phlaremodel.LabelNameServiceName, Value: "service-a"},
+						{Name: phlaremodel.LabelNameProfileType, Value: smpProfileType},
+					}}},
+				}, nil).
+				Once()
+
+			mockLimits := mockfrontend.NewMockLimits(t)
+			mockLimits.On("MaxQueryLookback", "test-tenant").Return(time.Duration(0))
+			mockLimits.On("MaxQueryLength", "test-tenant").Return(time.Duration(0))
+
+			qf := NewQueryFrontend(
+				log.NewNopLogger(),
+				mockLimits,
+				mockMetadataClient,
+				nil,
+				mockQueryBackend,
+				nil,
+				nil,
+				nil,
+			)
+
+			start, end := smpValidTimeRange()
+			ctx := tenant.InjectTenantID(context.Background(), "test-tenant")
+			resp, err := qf.Series(ctx, connect.NewRequest(&querierv1.SeriesRequest{
+				Matchers:   tc.matchers,
+				LabelNames: []string{phlaremodel.LabelNameServiceName, phlaremodel.LabelNameProfileType},
+				Start:      start,
+				End:        end,
+			}))
+
+			require.NoError(t, err)
+			require.Len(t, resp.Msg.LabelsSet, 1)
+			mockMetadataClient.AssertExpectations(t)
+		})
+	}
+}


### PR DESCRIPTION
Clean cherry-pick of 62677fe13 (#5483) onto `weekly/f183`. No conflicts, diff is identical to main.

`isProfileTypeQuery` guarded the metastore fast path with `len(matchers) > 0`, but clients spell an unfiltered query either as an empty list or as a single empty selector `["{}"]`. Both parse to zero matchers, so the guard rejected on notation alone and the query fell through to a full TSDB index scan of every block in the range.

Verified on the merged commit in a dev environment. Same tenant, same 48h window, same client:

| | before | after |
|---|---|---|
| fetched object bytes | 15 GB | 0 B |
| latency | 6.3-30.3s (one deadline exceeded) | 240-333ms |

Traces for that query went from ~2,800 `executeQuery.QUERYSERIESLABELS` spans and ~3,000 object-storage range reads to 4 metastore metadata lookups, with no block reads at all.