### PR TITLE
chore(examples): bump puma and sinatra in ruby examples

### DIFF
--- a/examples/language-sdk-instrumentation/ruby/rideshare/Gemfile
+++ b/examples/language-sdk-instrumentation/ruby/rideshare/Gemfile
@@ -12,4 +12,4 @@ gem 'opentelemetry-sdk'
 gem 'opentelemetry-exporter-otlp'
 
 gem "rackup", "~> 2.2"
-gem "puma", "~> 6.6"
+gem "puma", "~> 7.2"

--- a/examples/language-sdk-instrumentation/ruby/rideshare/Gemfile.lock
+++ b/examples/language-sdk-instrumentation/ruby/rideshare/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
     logger (1.7.0)
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
-    nio4r (2.7.4)
+    nio4r (2.7.5)
     opentelemetry-api (1.5.0)
     opentelemetry-common (0.21.0)
       opentelemetry-api (~> 1.0)
@@ -59,7 +59,7 @@ GEM
       opentelemetry-semantic_conventions
     opentelemetry-semantic_conventions (1.10.1)
       opentelemetry-api (~> 1.0)
-    puma (6.6.0)
+    puma (7.2.1)
       nio4r (~> 2.0)
     pyroscope (1.0.1)
       ffi
@@ -119,7 +119,7 @@ PLATFORMS
 DEPENDENCIES
   opentelemetry-exporter-otlp
   opentelemetry-sdk
-  puma (~> 6.6)
+  puma (~> 7.2)
   pyroscope (= 1.0.1)
   pyroscope-otel
   rackup (~> 2.2)

--- a/examples/language-sdk-instrumentation/ruby/rideshare_rails/Gemfile
+++ b/examples/language-sdk-instrumentation/ruby/rideshare_rails/Gemfile
@@ -18,7 +18,7 @@ gem "sprockets-rails"
 gem "sqlite3", "~> 1.4"
 
 # Use the Puma web server [https://github.com/puma/puma]
-gem "puma", "~> 6.0"
+gem "puma", "~> 7.2"
 
 gem 'pyroscope', '= 1.0.1'
 

--- a/examples/language-sdk-instrumentation/ruby/rideshare_rails/Gemfile.lock
+++ b/examples/language-sdk-instrumentation/ruby/rideshare_rails/Gemfile.lock
@@ -203,7 +203,7 @@ GEM
     psych (5.3.1)
       date
       stringio
-    puma (6.6.1)
+    puma (7.2.1)
       nio4r (~> 2.0)
     pyroscope (1.0.1-aarch64-linux)
       ffi
@@ -305,7 +305,7 @@ DEPENDENCIES
   opentelemetry-exporter-jaeger (~> 0.22.0)
   opentelemetry-instrumentation-rails
   opentelemetry-sdk (~> 1.2.0)
-  puma (~> 6.0)
+  puma (~> 7.2)
   pyroscope (= 1.0.1)
   pyroscope-otel (~> 0.2.0)
   rails (~> 7.2.3, >= 7.2.3.1)

--- a/examples/tracing/ruby/Gemfile
+++ b/examples/tracing/ruby/Gemfile
@@ -5,11 +5,11 @@ source "https://rubygems.org"
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem 'pyroscope', '= 0.6.4'
-gem "sinatra", "~> 4.1"
+gem "sinatra", "~> 4.2"
 gem "thin", "~> 2.0"
 gem 'pyroscope-otel'
 gem 'opentelemetry-sdk'
 gem 'opentelemetry-exporter-otlp'
 
 gem "rackup", "~> 2.2"
-gem "puma", "~> 6.6"
+gem "puma", "~> 7.2"

--- a/examples/tracing/ruby/Gemfile.lock
+++ b/examples/tracing/ruby/Gemfile.lock
@@ -37,9 +37,8 @@ GEM
     googleapis-common-protos-types (1.16.0)
       google-protobuf (>= 3.18, < 5.a)
     logger (1.7.0)
-    mustermann (3.0.3)
-      ruby2_keywords (~> 0.0.1)
-    nio4r (2.7.4)
+    mustermann (3.1.1)
+    nio4r (2.7.5)
     opentelemetry-api (1.5.0)
     opentelemetry-common (0.21.0)
       opentelemetry-api (~> 1.0)
@@ -59,7 +58,7 @@ GEM
       opentelemetry-semantic_conventions
     opentelemetry-semantic_conventions (1.10.1)
       opentelemetry-api (~> 1.0)
-    puma (6.6.0)
+    puma (7.2.1)
       nio4r (~> 2.0)
     pyroscope (0.6.4)
       ffi
@@ -75,7 +74,7 @@ GEM
       opentelemetry-api (~> 1.1)
       pyroscope (>= 0.5.1, < 1.0)
     rack (3.2.6)
-    rack-protection (4.1.1)
+    rack-protection (4.2.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
       rack (>= 3.0.0, < 4)
@@ -85,12 +84,11 @@ GEM
     rackup (2.2.1)
       rack (>= 3)
     rake (13.2.1)
-    ruby2_keywords (0.0.5)
-    sinatra (4.1.1)
+    sinatra (4.2.1)
       logger (>= 1.6.0)
       mustermann (~> 3.0)
       rack (>= 3.0.0, < 4)
-      rack-protection (= 4.1.1)
+      rack-protection (= 4.2.1)
       rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
     thin (2.0.1)
@@ -98,7 +96,7 @@ GEM
       eventmachine (~> 1.0, >= 1.0.4)
       logger
       rack (>= 1, < 4)
-    tilt (2.6.0)
+    tilt (2.8.0)
 
 PLATFORMS
   aarch64-linux
@@ -119,11 +117,11 @@ PLATFORMS
 DEPENDENCIES
   opentelemetry-exporter-otlp
   opentelemetry-sdk
-  puma (~> 6.6)
+  puma (~> 7.2)
   pyroscope (= 0.6.4)
   pyroscope-otel
   rackup (~> 2.2)
-  sinatra (~> 4.1)
+  sinatra (~> 4.2)
   thin (~> 2.0)
 
 BUNDLED WITH


### PR DESCRIPTION
puma `6.6.x -> 7.2.1` across the three examples that run it, and sinatra `4.1.1 -> 4.2.1` in the tracing example. Clears 6 alerts.

Verified with `make examples/test`.