### PR TITLE
chore(examples): bump OpenTelemetry in dotnet examples

### DIFF
--- a/examples/language-sdk-instrumentation/dotnet/rideshare/example/Example.csproj
+++ b/examples/language-sdk-instrumentation/dotnet/rideshare/example/Example.csproj
@@ -7,11 +7,11 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.8.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageReference Include="Pyroscope.OpenTelemetry" Version="0.4.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/examples/tracing/dotnet/example/Example.csproj
+++ b/examples/tracing/dotnet/example/Example.csproj
@@ -7,9 +7,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.2" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageReference Include="Pyroscope.OpenTelemetry" Version="0.4.0" />
   </ItemGroup>


### PR DESCRIPTION
OTel `1.15.3` clears 3 alerts.

Notes:
- It requires `System.Diagnostics.DiagnosticSource >= 10.0.0`, so the rideshare example's `8.0.1` pin moves too — otherwise restore fails with NU1605.
- `Instrumentation.AspNetCore` has no 1.15.3 release and stays on 1.15.2; it is not the package under advisory.

Verified with `make examples/test`.