### PR TITLE
fix(examples): repair the examples update cron

### DIFF
--- a/.github/workflows/update-examples-cron.yml
+++ b/.github/workflows/update-examples-cron.yml
@@ -22,12 +22,17 @@ jobs:
         with:
           github_app: pyroscope-development-app
 
+      # A failing ecosystem must not hold back the rest of the sweep: still open
+      # the PR for whatever did update, with the report saying what failed, and
+      # only then fail the job so the breakage stays visible.
       - run: |
-          make tools/update_examples
+          rc=0
+          make tools/update_examples || rc=$?
           if ! git diff --exit-code;
           then
             make tools/update_examples_pr
           fi
+          exit $rc
         env:
           GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/Makefile.examples
+++ b/Makefile.examples
@@ -1,5 +1,9 @@
 GITHUB_REPOSITORY ?= grafana/pyroscope
 
+# Written by tools/update_examples.go, used as the body of the PR it opens.
+# Lives under .tmp so that `git add .` in tools/update_examples_pr skips it.
+UPDATE_EXAMPLES_REPORT ?= .tmp/update_examples_report.md
+
 # Sync all example files from templates.
 .PHONY: examples/sync-templates
 examples/sync-templates:
@@ -13,7 +17,7 @@ examples/check-templates:
 .PHONY: tools/update_examples
 tools/update_examples:
 	docker buildx build --platform linux/amd64 -t update_pyroscope_examples -f tools/update_examples.Dockerfile  tools
-	docker run --rm  --platform=linux/amd64 -e GITHUB_TOKEN=$(GITHUB_TOKEN) -v$(shell pwd):/pyroscope -w /pyroscope update_pyroscope_examples bash -l -c "go run tools/update_examples.go"
+	docker run --rm  --platform=linux/amd64 -e GITHUB_TOKEN=$(GITHUB_TOKEN) -v$(shell pwd):/pyroscope -w /pyroscope update_pyroscope_examples bash -l -c "go run tools/update_examples.go -report $(UPDATE_EXAMPLES_REPORT)"
 
 .PHONY: tools/update_examples_pr
 tools/update_examples_pr:
@@ -23,8 +27,8 @@ tools/update_examples_pr:
 	git add .
 	git commit -m "chore(examples): update examples"
 	git push -f https://x-access-token:$(GITHUB_TOKEN)@github.com/$(GITHUB_REPOSITORY).git gh_bot_examples_update 2> /dev/null
-	gh pr create --head gh_bot_examples_update --title "chore(examples): update examples" --body "make tools/update_examples" --repo $(GITHUB_REPOSITORY) || \
-	   gh pr edit gh_bot_examples_update --title "chore(examples): update examples" --body "make tools/update_examples" --repo $(GITHUB_REPOSITORY)
+	gh pr create --head gh_bot_examples_update --title "chore(examples): update examples" --body-file $(UPDATE_EXAMPLES_REPORT) --repo $(GITHUB_REPOSITORY) || \
+	   gh pr edit gh_bot_examples_update --title "chore(examples): update examples" --body-file $(UPDATE_EXAMPLES_REPORT) --repo $(GITHUB_REPOSITORY)
 
 
 .PHONY: rideshare/docker/push

--- a/examples/language-sdk-instrumentation/ruby/rideshare/Gemfile.lock
+++ b/examples/language-sdk-instrumentation/ruby/rideshare/Gemfile.lock
@@ -5,27 +5,14 @@ GEM
     bigdecimal (3.1.8)
     daemons (1.4.1)
     eventmachine (1.2.7)
-    ffi (1.17.4)
     ffi (1.17.4-aarch64-linux-gnu)
-    ffi (1.17.4-aarch64-linux-musl)
-    ffi (1.17.4-arm-linux-gnu)
-    ffi (1.17.4-arm-linux-musl)
     ffi (1.17.4-arm64-darwin)
-    ffi (1.17.4-x86-linux-gnu)
-    ffi (1.17.4-x86-linux-musl)
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
-    ffi (1.17.4-x86_64-linux-musl)
-    google-protobuf (4.29.1)
-      bigdecimal
-      rake (>= 13)
     google-protobuf (4.29.1-aarch64-linux)
       bigdecimal
       rake (>= 13)
     google-protobuf (4.29.1-arm64-darwin)
-      bigdecimal
-      rake (>= 13)
-    google-protobuf (4.29.1-x86-linux)
       bigdecimal
       rake (>= 13)
     google-protobuf (4.29.1-x86_64-darwin)
@@ -61,8 +48,6 @@ GEM
       opentelemetry-api (~> 1.0)
     puma (7.2.1)
       nio4r (~> 2.0)
-    pyroscope (1.0.1)
-      ffi
     pyroscope (1.0.1-aarch64-linux)
       ffi
     pyroscope (1.0.1-arm64-darwin)
@@ -102,19 +87,9 @@ GEM
 
 PLATFORMS
   aarch64-linux
-  aarch64-linux-gnu
-  aarch64-linux-musl
-  arm-linux-gnu
-  arm-linux-musl
   arm64-darwin
-  ruby
-  x86-linux
-  x86-linux-gnu
-  x86-linux-musl
   x86_64-darwin
   x86_64-linux
-  x86_64-linux-gnu
-  x86_64-linux-musl
 
 DEPENDENCIES
   opentelemetry-exporter-otlp

--- a/tools/update_examples.Dockerfile
+++ b/tools/update_examples.Dockerfile
@@ -34,3 +34,8 @@ RUN /bin/bash -l -c "rvm install ruby-${RUBY_VERSION} && rvm --default use ruby-
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
 ENV PATH=$PATH:/root/.cargo/bin
+
+# The repo is bind-mounted at /pyroscope (see Makefile.examples) and owned by
+# the runner user, while this image runs as root, so git refuses to operate on
+# it until the path is trusted.
+RUN git config --global --add safe.directory /pyroscope

--- a/tools/update_examples.go
+++ b/tools/update_examples.go
@@ -73,10 +73,12 @@ func main() {
 		if !l.enabled {
 			continue
 		}
+		before := changedFiles()
 		err := runUpdate(l.update)
 		if err != nil {
 			log.Printf("updating %s failed: %v", l.name, err)
 			failed = append(failed, l.name)
+			revertNewlyChanged(before)
 		}
 		results = append(results, updateResult{name: l.name, err: err})
 	}
@@ -555,23 +557,60 @@ func names(results []updateResult) []string {
 	return out
 }
 
+// changedFiles lists the tracked files currently differing from HEAD. Untracked
+// files are ignored: the updaters only rewrite files that already exist.
+func changedFiles() []string {
+	out, err := exec.Command("git", "diff", "--name-only").Output()
+	if err != nil {
+		log.Printf("collecting changed files: %v", err)
+		return nil
+	}
+	var files []string
+	for f := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		if f != "" {
+			files = append(files, f)
+		}
+	}
+	return files
+}
+
+// revertNewlyChanged restores the files a failed updater had already rewritten
+// before it gave up, so that a half-applied update (a Gemfile bumped past its
+// lockfile, say) never reaches the PR. Files that were already dirty belong to
+// an earlier updater that succeeded, so they are left alone.
+func revertNewlyChanged(before []string) {
+	was := make(map[string]bool, len(before))
+	for _, f := range before {
+		was[f] = true
+	}
+
+	var partial []string
+	for _, f := range changedFiles() {
+		if !was[f] {
+			partial = append(partial, f)
+		}
+	}
+	if len(partial) == 0 {
+		return
+	}
+	slices.Sort(partial)
+
+	args := append([]string{"checkout", "--"}, partial...)
+	if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+		log.Printf("reverting partial changes: %v: %s", err, out)
+		return
+	}
+	log.Printf("reverted partial changes: %s", strings.Join(partial, ", "))
+}
+
 // changedExamples maps the working tree diff onto the examples it touched,
 // collapsing each changed file to the example directory that owns it. Anything
 // outside an example (docs, the root go.mod) is returned separately. Best
 // effort: the report is still worth writing without it.
 func changedExamples() (examples, other []string) {
-	out, err := exec.Command("git", "diff", "--name-only").Output()
-	if err != nil {
-		log.Printf("collecting changed files: %v", err)
-		return nil, nil
-	}
-
 	seenExample := map[string]bool{}
 	seenOther := map[string]bool{}
-	for f := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
-		if f == "" {
-			continue
-		}
+	for _, f := range changedFiles() {
 		if dir := owningExample(f); dir != "" {
 			if !seenExample[dir] {
 				seenExample[dir] = true

--- a/tools/update_examples.go
+++ b/tools/update_examples.go
@@ -171,8 +171,6 @@ func updateTempo() {
 	reDockerTempo := regexp.MustCompile(`grafana/tempo:\d+\.\d+\.\d+`)
 	replDockerTempo := fmt.Sprintf("grafana/tempo:%s", last.version())
 	for _, f := range []string{
-		// The examples are checked against this template by
-		// `make examples/check-templates`, so it has to move with them.
 		"examples/_templates/tempo/docker-compose.yml",
 		"examples/tracing/dotnet/docker-compose.yml",
 		"examples/tracing/golang-push/docker-compose.yml",
@@ -501,8 +499,6 @@ type updateResult struct {
 	err  error
 }
 
-// writeReport renders the run outcome as the body of the PR the cron opens, so
-// that a partially successful sweep says which ecosystems it skipped and why.
 func writeReport(path string, results []updateResult) {
 	var b strings.Builder
 	b.WriteString("`make tools/update_examples`\n")
@@ -560,8 +556,6 @@ func names(results []updateResult) []string {
 	return out
 }
 
-// changedFiles lists the tracked files currently differing from HEAD. Untracked
-// files are ignored: the updaters only rewrite files that already exist.
 func changedFiles() []string {
 	out, err := exec.Command("git", "diff", "--name-only").Output()
 	if err != nil {
@@ -577,10 +571,6 @@ func changedFiles() []string {
 	return files
 }
 
-// revertNewlyChanged restores the files a failed updater had already rewritten
-// before it gave up, so that a half-applied update (a Gemfile bumped past its
-// lockfile, say) never reaches the PR. Files that were already dirty belong to
-// an earlier updater that succeeded, so they are left alone.
 func revertNewlyChanged(before []string) {
 	was := make(map[string]bool, len(before))
 	for _, f := range before {
@@ -606,10 +596,6 @@ func revertNewlyChanged(before []string) {
 	log.Printf("reverted partial changes: %s", strings.Join(partial, ", "))
 }
 
-// changedExamples maps the working tree diff onto the examples it touched,
-// collapsing each changed file to the example directory that owns it. Anything
-// outside an example (docs, the root go.mod) is returned separately. Best
-// effort: the report is still worth writing without it.
 func changedExamples() (examples, other []string) {
 	seenExample := map[string]bool{}
 	seenOther := map[string]bool{}
@@ -631,8 +617,6 @@ func changedExamples() (examples, other []string) {
 	return examples, other
 }
 
-// owningExample walks up from a changed file to the nearest directory holding a
-// compose file, which is what the example test harness treats as one example.
 func owningExample(file string) string {
 	dir := filepath.Dir(file)
 	for dir != "." && dir != string(filepath.Separator) && strings.HasPrefix(dir, "examples") {

--- a/tools/update_examples.go
+++ b/tools/update_examples.go
@@ -540,11 +540,10 @@ func writeReport(path string, results []updateResult) {
 	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		log.Printf("creating report dir: %v", err)
-		return
+		log.Fatalf("creating report dir: %v", err)
 	}
 	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
-		log.Printf("writing report: %v", err)
+		log.Fatalf("writing report: %v", err)
 	}
 }
 
@@ -559,8 +558,7 @@ func names(results []updateResult) []string {
 func changedFiles() []string {
 	out, err := exec.Command("git", "diff", "--name-only").Output()
 	if err != nil {
-		log.Printf("collecting changed files: %v", err)
-		return nil
+		log.Fatalf("collecting changed files: %v", err)
 	}
 	var files []string
 	for f := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
@@ -590,8 +588,7 @@ func revertNewlyChanged(before []string) {
 
 	args := append([]string{"checkout", "--"}, partial...)
 	if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
-		log.Printf("reverting partial changes: %v: %s", err, out)
-		return
+		log.Fatalf("reverting partial changes: %v: %s", err, out)
 	}
 	log.Printf("reverted partial changes: %s", strings.Join(partial, ", "))
 }

--- a/tools/update_examples.go
+++ b/tools/update_examples.go
@@ -171,6 +171,9 @@ func updateTempo() {
 	reDockerTempo := regexp.MustCompile(`grafana/tempo:\d+\.\d+\.\d+`)
 	replDockerTempo := fmt.Sprintf("grafana/tempo:%s", last.version())
 	for _, f := range []string{
+		// The examples are checked against this template by
+		// `make examples/check-templates`, so it has to move with them.
+		"examples/_templates/tempo/docker-compose.yml",
 		"examples/tracing/dotnet/docker-compose.yml",
 		"examples/tracing/golang-push/docker-compose.yml",
 		"examples/tracing/java/docker-compose.yml",

--- a/tools/update_examples.go
+++ b/tools/update_examples.go
@@ -26,6 +26,7 @@ var dotnet = flag.Bool("dotnet", false, "")
 var node = flag.Bool("node", false, "")
 var rust = flag.Bool("rust", false, "")
 var tempo = flag.Bool("tempo", false, "")
+var report = flag.String("report", ".tmp/update_examples_report.md", "path to write the run report to, used as the PR body")
 
 // this program requires ruby, bundle, yarn, go to be installed
 func main() {
@@ -43,34 +44,47 @@ func main() {
 		*tempo = true
 	}
 
-	if *golang {
-		updateGolang()
-		updateGodeltaprof()
-		updateJfrParser()
-		s.sh("make go/mod")
+	languages := []struct {
+		name    string
+		enabled bool
+		update  func()
+	}{
+		{"go", *golang, func() {
+			updateGolang()
+			updateGodeltaprof()
+			updateJfrParser()
+			s.sh("make go/mod")
+		}},
+		{"java", *java, func() {
+			updateJava()
+			updateOtelProfilingJava()
+		}},
+		{"ruby", *ruby, updateRuby},
+		{"python", *python, updatePython},
+		{"dotnet", *dotnet, updateDotnet},
+		{"node", *node, updateNodeJS},
+		{"rust", *rust, updateRust},
+		{"tempo", *tempo, updateTempo},
 	}
 
-	if *java {
-		updateJava()
-		updateOtelProfilingJava()
+	var results []updateResult
+	var failed []string
+	for _, l := range languages {
+		if !l.enabled {
+			continue
+		}
+		err := runUpdate(l.update)
+		if err != nil {
+			log.Printf("updating %s failed: %v", l.name, err)
+			failed = append(failed, l.name)
+		}
+		results = append(results, updateResult{name: l.name, err: err})
 	}
-	if *ruby {
-		updateRuby()
-	}
-	if *python {
-		updatePython()
-	}
-	if *dotnet {
-		updateDotnet()
-	}
-	if *node {
-		updateNodeJS()
-	}
-	if *rust {
-		updateRust()
-	}
-	if *tempo {
-		updateTempo()
+
+	writeReport(*report, results)
+
+	if len(failed) > 0 {
+		log.Fatalf("failed to update: %s", strings.Join(failed, ", "))
 	}
 }
 
@@ -162,7 +176,6 @@ func updateTempo() {
 		"examples/tracing/python/docker-compose.yaml",
 		"examples/tracing/ruby/docker-compose.yml",
 		"examples/tracing/tempo/docker-compose.yml",
-		"tools/tracing/docker-compose.yml",
 	} {
 		replaceInplace(reDockerTempo, f, replDockerTempo)
 	}
@@ -430,7 +443,7 @@ func getTags(repo string) []Tag {
 		resp, err := http.DefaultClient.Do(req)
 		requireNoError(err, "do request")
 		if resp.StatusCode != 200 {
-			log.Fatalf("status code %d", resp.StatusCode)
+			panic(fmt.Errorf("GET %s: status code %d", url, resp.StatusCode))
 		}
 		defer resp.Body.Close()
 		err = json.NewDecoder(resp.Body).Decode(&pageTags)
@@ -478,8 +491,138 @@ func (s *sh) cmd(cmdArgs ...string) (string, string) {
 	return stdout.String(), stderr.String()
 }
 
+type updateResult struct {
+	name string
+	err  error
+}
+
+// writeReport renders the run outcome as the body of the PR the cron opens, so
+// that a partially successful sweep says which ecosystems it skipped and why.
+func writeReport(path string, results []updateResult) {
+	var b strings.Builder
+	b.WriteString("`make tools/update_examples`\n")
+
+	var updated, failed []updateResult
+	for _, r := range results {
+		if r.err == nil {
+			updated = append(updated, r)
+		} else {
+			failed = append(failed, r)
+		}
+	}
+
+	examples, other := changedExamples()
+	if len(examples) > 0 {
+		b.WriteString("\n### Examples updated\n\n")
+		for _, e := range examples {
+			fmt.Fprintf(&b, "- %s\n", e)
+		}
+	}
+	if len(other) > 0 {
+		b.WriteString("\n### Other files updated\n\n")
+		for _, f := range other {
+			fmt.Fprintf(&b, "- %s\n", f)
+		}
+	}
+	if len(examples) == 0 && len(other) == 0 {
+		b.WriteString("\nNo files changed.\n")
+	}
+
+	if len(failed) > 0 {
+		b.WriteString("\n### Updaters that failed\n\n")
+		for _, r := range failed {
+			fmt.Fprintf(&b, "- **%s**: `%v`\n", r.name, r.err)
+		}
+	}
+	if len(updated) > 0 {
+		fmt.Fprintf(&b, "\nUpdaters that ran clean: %s.\n", strings.Join(names(updated), ", "))
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		log.Printf("creating report dir: %v", err)
+		return
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		log.Printf("writing report: %v", err)
+	}
+}
+
+func names(results []updateResult) []string {
+	out := make([]string, 0, len(results))
+	for _, r := range results {
+		out = append(out, r.name)
+	}
+	return out
+}
+
+// changedExamples maps the working tree diff onto the examples it touched,
+// collapsing each changed file to the example directory that owns it. Anything
+// outside an example (docs, the root go.mod) is returned separately. Best
+// effort: the report is still worth writing without it.
+func changedExamples() (examples, other []string) {
+	out, err := exec.Command("git", "diff", "--name-only").Output()
+	if err != nil {
+		log.Printf("collecting changed files: %v", err)
+		return nil, nil
+	}
+
+	seenExample := map[string]bool{}
+	seenOther := map[string]bool{}
+	for f := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		if f == "" {
+			continue
+		}
+		if dir := owningExample(f); dir != "" {
+			if !seenExample[dir] {
+				seenExample[dir] = true
+				examples = append(examples, dir)
+			}
+			continue
+		}
+		if !seenOther[f] {
+			seenOther[f] = true
+			other = append(other, f)
+		}
+	}
+	slices.Sort(examples)
+	slices.Sort(other)
+	return examples, other
+}
+
+// owningExample walks up from a changed file to the nearest directory holding a
+// compose file, which is what the example test harness treats as one example.
+func owningExample(file string) string {
+	dir := filepath.Dir(file)
+	for dir != "." && dir != string(filepath.Separator) && strings.HasPrefix(dir, "examples") {
+		for _, name := range []string{"docker-compose.yml", "docker-compose.yaml"} {
+			if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+				return dir
+			}
+		}
+		dir = filepath.Dir(dir)
+	}
+	return ""
+}
+
+// runUpdate isolates one language's updates so that a failure in one ecosystem
+// does not skip the ones queued behind it. The updaters signal failure by
+// panicking via requireNoError.
+func runUpdate(update func()) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = e
+				return
+			}
+			err = fmt.Errorf("%v", r)
+		}
+	}()
+	update()
+	return nil
+}
+
 func requireNoError(err error, msg string) {
 	if err != nil {
-		log.Fatalf("msg %s err %v", msg, err)
+		panic(fmt.Errorf("%s: %w", msg, err))
 	}
 }


### PR DESCRIPTION
The cron has failed every 8h since 2026-06-04, so the examples had no SDK refresh for over two months. Three causes:

- `bundle update pyroscope` cannot resolve in the rideshare example: its lockfile lists 14 platforms including `ruby` and the `-gnu`/`-musl` variants, and the gem publishes builds for only four. Restricting `PLATFORMS` fixes it; bundler does not re-add them.
- One failing ecosystem aborted the whole run (`requireNoError` called `log.Fatalf`). Ruby is third of eight, so python, dotnet, node, rust and tempo never ran.
- The tempo updater pointed at `tools/tracing/docker-compose.yml`, which no longer exists

Each language now runs independently, and the run writes a report of which examples changed and which updaters failed, used as the PR body. The workflow opens the PR for whatever did update, then still fails the job so breakage stays visible.

Example report from a local run with ruby deliberately still broken:

```
### Examples updated

- examples/language-sdk-instrumentation/nodejs/express
- examples/language-sdk-instrumentation/python/rideshare/fastapi
- examples/tracing/tempo

### Updaters that failed

- **ruby**: `cd examples/.../ruby/rideshare && bundle update pyroscope: exit status 1`

Updaters that ran clean: python, node, tempo.
```