### PR TITLE
ci(examples): push rideshare images on a schedule

### DIFF
--- a/.github/workflows/push-example-images.yml
+++ b/.github/workflows/push-example-images.yml
@@ -1,0 +1,79 @@
+name: Push Example Images
+
+# Builds and publishes the rideshare example images, tagged yyyy-MM-dd-<short sha>.
+# Re-running at the same commit on the same day moves the tag to the new build.
+on:
+  schedule:
+    - cron: '0 6 1,15 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Cancelling mid-run would leave only some images at the new tag.
+concurrency:
+  group: push-example-images
+  cancel-in-progress: false
+
+jobs:
+  push:
+    name: Build and push
+    if: github.repository == 'grafana/pyroscope'
+    permissions:
+      contents: read # checkout
+      id-token: write # federated credentials for the registry login
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: 'false'
+
+      - name: Install Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version: 1.25.12
+
+      - name: Verify examples
+        env:
+          # One example per image. The golang stack also builds the loadgen.
+          PYROSCOPE_TEST_EXAMPLES: |
+            examples/language-sdk-instrumentation/golang-push/rideshare
+            examples/language-sdk-instrumentation/python/rideshare/flask
+            examples/language-sdk-instrumentation/ruby/rideshare_rails
+            examples/language-sdk-instrumentation/dotnet/rideshare
+            examples/language-sdk-instrumentation/java/rideshare
+            examples/language-sdk-instrumentation/rust/rideshare
+            examples/language-sdk-instrumentation/nodejs/express
+        run: make examples/test
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Log into GAR
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+        with:
+          registry: us-docker.pkg.dev
+
+      - name: Compute image tag
+        id: tag
+        env:
+          SHA: ${{ github.sha }}
+        run: echo "tag=$(date -u +%Y-%m-%d)-${SHA:0:9}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push rideshare images
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: make rideshare/docker/push IMAGE_TAG="$TAG"
+
+      - name: Summary
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          {
+            echo "Pushed rideshare images tagged \`$TAG\` from ${GITHUB_SHA}."
+            echo
+            echo "\`\`\`"
+            echo "us-docker.pkg.dev/grafanalabs-dev/docker-pyroscope-dev/pyroscope-rideshare-<lang>:$TAG"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Makefile.examples
+++ b/Makefile.examples
@@ -27,39 +27,42 @@ tools/update_examples_pr:
 	   gh pr edit gh_bot_examples_update --title "chore(examples): update examples" --body "make tools/update_examples" --repo $(GITHUB_REPOSITORY)
 
 
+# Deliberately not IMAGE_PREFIX/IMAGE_PLATFORM, whose global defaults point at a
+# different registry and the host architecture.
+RIDESHARE_IMAGE_PREFIX ?= us-docker.pkg.dev/grafanalabs-dev/docker-pyroscope-dev/
+RIDESHARE_IMAGE_PLATFORM ?= linux/amd64
+
 .PHONY: rideshare/docker/push
-rideshare/docker/push: IMAGE_PLATFORM := linux/amd64
-rideshare/docker/push: IMAGE_PREFIX := us-docker.pkg.dev/grafanalabs-dev/docker-pyroscope-dev/
 rideshare/docker/push: rideshare/docker/push-golang rideshare/docker/push-loadgen rideshare/docker/push-python rideshare/docker/push-ruby rideshare/docker/push-dotnet rideshare/docker/push-java rideshare/docker/push-rust rideshare/docker/push-nodejs
 
 .PHONY: rideshare/docker/push-golang
 rideshare/docker/push-golang:
-	docker buildx build --push --platform $(IMAGE_PLATFORM) -t $(IMAGE_PREFIX)pyroscope-rideshare-golang -t $(IMAGE_PREFIX)pyroscope-rideshare-golang:$(IMAGE_TAG) examples/language-sdk-instrumentation/golang-push/rideshare
+	docker buildx build --push --platform $(RIDESHARE_IMAGE_PLATFORM) -t $(RIDESHARE_IMAGE_PREFIX)pyroscope-rideshare-golang -t $(RIDESHARE_IMAGE_PREFIX)pyroscope-rideshare-golang:$(IMAGE_TAG) examples/language-sdk-instrumentation/golang-push/rideshare
 
 .PHONY: rideshare/docker/push-loadgen
 rideshare/docker/push-loadgen:
-	docker buildx build --push --platform $(IMAGE_PLATFORM) -t $(IMAGE_PREFIX)pyroscope-rideshare-loadgen -t $(IMAGE_PREFIX)pyroscope-rideshare-loadgen:$(IMAGE_TAG) -f examples/language-sdk-instrumentation/golang-push/rideshare/Dockerfile.load-generator examples/language-sdk-instrumentation/golang-push/rideshare
+	docker buildx build --push --platform $(RIDESHARE_IMAGE_PLATFORM) -t $(RIDESHARE_IMAGE_PREFIX)pyroscope-rideshare-loadgen -t $(RIDESHARE_IMAGE_PREFIX)pyroscope-rideshare-loadgen:$(IMAGE_TAG) -f examples/language-sdk-instrumentation/golang-push/rideshare/Dockerfile.load-generator examples/language-sdk-instrumentation/golang-push/rideshare
 
 .PHONY: rideshare/docker/push-python
 rideshare/docker/push-python:
-	docker buildx build --push --platform $(IMAGE_PLATFORM) -t $(IMAGE_PREFIX)pyroscope-rideshare-python -t $(IMAGE_PREFIX)pyroscope-rideshare-python:$(IMAGE_TAG) examples/language-sdk-instrumentation/python/rideshare/flask
+	docker buildx build --push --platform $(RIDESHARE_IMAGE_PLATFORM) -t $(RIDESHARE_IMAGE_PREFIX)pyroscope-rideshare-python -t $(RIDESHARE_IMAGE_PREFIX)pyroscope-rideshare-python:$(IMAGE_TAG) examples/language-sdk-instrumentation/python/rideshare/flask
 
 .PHONY: rideshare/docker/push-ruby
 rideshare/docker/push-ruby:
-	docker buildx build --push --platform $(IMAGE_PLATFORM) -t $(IMAGE_PREFIX)pyroscope-rideshare-ruby -t $(IMAGE_PREFIX)pyroscope-rideshare-ruby:$(IMAGE_TAG) examples/language-sdk-instrumentation/ruby/rideshare_rails
+	docker buildx build --push --platform $(RIDESHARE_IMAGE_PLATFORM) -t $(RIDESHARE_IMAGE_PREFIX)pyroscope-rideshare-ruby -t $(RIDESHARE_IMAGE_PREFIX)pyroscope-rideshare-ruby:$(IMAGE_TAG) examples/language-sdk-instrumentation/ruby/rideshare_rails
 
 .PHONY: rideshare/docker/push-dotnet
 rideshare/docker/push-dotnet:
-	docker buildx build --push --platform $(IMAGE_PLATFORM) -t $(IMAGE_PREFIX)pyroscope-rideshare-dotnet -t $(IMAGE_PREFIX)pyroscope-rideshare-dotnet:$(IMAGE_TAG) examples/language-sdk-instrumentation/dotnet/rideshare/
+	docker buildx build --push --platform $(RIDESHARE_IMAGE_PLATFORM) -t $(RIDESHARE_IMAGE_PREFIX)pyroscope-rideshare-dotnet -t $(RIDESHARE_IMAGE_PREFIX)pyroscope-rideshare-dotnet:$(IMAGE_TAG) examples/language-sdk-instrumentation/dotnet/rideshare/
 
 .PHONY: rideshare/docker/push-java
 rideshare/docker/push-java:
-	docker buildx build --push --platform $(IMAGE_PLATFORM) -t $(IMAGE_PREFIX)pyroscope-rideshare-java -t $(IMAGE_PREFIX)pyroscope-rideshare-java:$(IMAGE_TAG) examples/language-sdk-instrumentation/java/rideshare
+	docker buildx build --push --platform $(RIDESHARE_IMAGE_PLATFORM) -t $(RIDESHARE_IMAGE_PREFIX)pyroscope-rideshare-java -t $(RIDESHARE_IMAGE_PREFIX)pyroscope-rideshare-java:$(IMAGE_TAG) examples/language-sdk-instrumentation/java/rideshare
 
 .PHONY: rideshare/docker/push-rust
 rideshare/docker/push-rust:
-	docker buildx build --push --platform $(IMAGE_PLATFORM) -t $(IMAGE_PREFIX)pyroscope-rideshare-rust -t $(IMAGE_PREFIX)pyroscope-rideshare-rust:$(IMAGE_TAG) examples/language-sdk-instrumentation/rust/rideshare
+	docker buildx build --push --platform $(RIDESHARE_IMAGE_PLATFORM) -t $(RIDESHARE_IMAGE_PREFIX)pyroscope-rideshare-rust -t $(RIDESHARE_IMAGE_PREFIX)pyroscope-rideshare-rust:$(IMAGE_TAG) examples/language-sdk-instrumentation/rust/rideshare
 
 .PHONY: rideshare/docker/push-nodejs
 rideshare/docker/push-nodejs:
-	docker buildx build --push --platform $(IMAGE_PLATFORM) -t $(IMAGE_PREFIX)pyroscope-rideshare-nodejs -t $(IMAGE_PREFIX)pyroscope-rideshare-nodejs:$(IMAGE_TAG) examples/language-sdk-instrumentation/nodejs/express
+	docker buildx build --push --platform $(RIDESHARE_IMAGE_PLATFORM) -t $(RIDESHARE_IMAGE_PREFIX)pyroscope-rideshare-nodejs -t $(RIDESHARE_IMAGE_PREFIX)pyroscope-rideshare-nodejs:$(IMAGE_TAG) examples/language-sdk-instrumentation/nodejs/express


### PR DESCRIPTION
The rideshare images are built and published by hand today, so they drift behind the examples. This publishes them on the 1st and 15th, plus manual dispatch.

Each image is verified with the existing example harness before anything is pushed, using the example that owns its build context. The golang rideshare stack builds the load generator from the same Dockerfile as the loadgen image, so seven examples cover all eight.

Tagged `yyyy-MM-dd-<short sha>`, so the newest sorts last lexicographically. Re-running at the same commit on the same day moves the tag to the new build, which is what you want when finishing a partially failed run.

Also moves the registry and platform onto rideshare-specific make variables. They were set only on the aggregate target, so a single-language target fell back to the global defaults:

```
$ make -n rideshare/docker/push-golang   # before
docker buildx build --push --platform linux/arm64 \
  -t us-docker.pkg.dev/grafanalabs-global/dockerhub-pyroscope-prod-mirror/pyroscope-rideshare-golang ...
```