### PR TITLE
fix(examples): create the update commit through the API

### DIFF
--- a/.github/workflows/update-examples-cron.yml
+++ b/.github/workflows/update-examples-cron.yml
@@ -1,17 +1,31 @@
 name: Update Examples Cron
 
+# Commits through the GitHub API so they are signed on behalf of the app.
+
 on:
   schedule:
     - cron: '0 */8 * * *'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  id-token: write
+permissions: {}
+
+# Two sweeps at once would both reset the branch and race on the PR.
+concurrency:
+  group: update-examples-cron
+  cancel-in-progress: false
+
+env:
+  BRANCH: gh_bot_examples_update
+  REPORT: .tmp/update_examples_report.md
+  TITLE: 'chore(examples): update examples'
 
 jobs:
   update-examples-cron:
+    name: Update examples
     if: github.repository == 'grafana/pyroscope'
+    permissions:
+      contents: read # checkout
+      id-token: write # federated credentials for the app token
     runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -22,17 +36,51 @@ jobs:
         with:
           github_app: pyroscope-development-app
 
-      # A failing ecosystem must not hold back the rest of the sweep: still open
-      # the PR for whatever did update, with the report saying what failed, and
-      # only then fail the job so the breakage stays visible.
-      - run: |
-          rc=0
-          make tools/update_examples || rc=$?
-          if ! git diff --exit-code;
-          then
-            make tools/update_examples_pr
-          fi
-          exit $rc
+      # A failing ecosystem must not hold back the rest of the sweep, so the
+      # exit code is carried to the last step instead of ending the job here.
+      - name: Update examples
+        id: update
         env:
           GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          rc=0
+          make tools/update_examples || rc=$?
+          {
+            echo "rc=$rc"
+            echo "changed=$(git status --porcelain | grep -q . && echo true || echo false)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Reset branch to the checked out commit
+        if: steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+        run: |
+          head_oid="$(git rev-parse HEAD)"
+          gh api "repos/${GITHUB_REPOSITORY}/git/refs" --method POST \
+            -f "ref=refs/heads/${BRANCH}" -f "sha=${head_oid}" \
+          || gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BRANCH}" --method PATCH \
+            -f "sha=${head_oid}" -F force=true
+
+      - name: Commit the update
+        if: steps.update.outputs.changed == 'true'
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
+        with:
+          commit_message: ${{ env.TITLE }}
+          repo: ${{ github.repository }}
+          branch: ${{ env.BRANCH }}
+        env:
+          GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+
+      - name: Open or update the PR
+        if: steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+        run: |
+          gh pr create --head "$BRANCH" --base main --title "$TITLE" --body-file "$REPORT" \
+          || gh pr edit "$BRANCH" --title "$TITLE" --body-file "$REPORT"
+
+      - name: Report updater failures
+        if: steps.update.outputs.rc != '0'
+        run: |
+          echo "one or more updaters failed; see the report on the PR"
+          exit 1

--- a/.github/workflows/update-examples-cron.yml
+++ b/.github/workflows/update-examples-cron.yml
@@ -68,6 +68,11 @@ jobs:
           commit_message: ${{ env.TITLE }}
           repo: ${{ github.repository }}
           branch: ${{ env.BRANCH }}
+          # Everything the updater writes, and nothing else: the action commits
+          # untracked files too, so an unrelated stray file would ride along.
+          file_pattern: >-
+            examples docs/sources/configure-client go.mod go.sum
+            api/go.mod api/go.sum lidia/go.mod lidia/go.sum
         env:
           GITHUB_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
 

--- a/.github/workflows/update-examples-cron.yml
+++ b/.github/workflows/update-examples-cron.yml
@@ -1,7 +1,5 @@
 name: Update Examples Cron
 
-# Commits through the GitHub API so they are signed on behalf of the app.
-
 on:
   schedule:
     - cron: '0 */8 * * *'
@@ -68,8 +66,7 @@ jobs:
           commit_message: ${{ env.TITLE }}
           repo: ${{ github.repository }}
           branch: ${{ env.BRANCH }}
-          # Everything the updater writes, and nothing else: the action commits
-          # untracked files too, so an unrelated stray file would ride along.
+          # Everything the updater writes, and nothing else.
           file_pattern: >-
             examples docs/sources/configure-client go.mod go.sum
             api/go.mod api/go.sum lidia/go.mod lidia/go.sum

--- a/Makefile.examples
+++ b/Makefile.examples
@@ -1,7 +1,5 @@
-GITHUB_REPOSITORY ?= grafana/pyroscope
-
-# Written by tools/update_examples.go, used as the body of the PR it opens.
-# Lives under .tmp so that `git add .` in tools/update_examples_pr skips it.
+# Written by tools/update_examples.go and used as the PR body by the cron.
+# Lives under .tmp so that it is not picked up as part of the update itself.
 UPDATE_EXAMPLES_REPORT ?= .tmp/update_examples_report.md
 
 # Sync all example files from templates.
@@ -18,17 +16,6 @@ examples/check-templates:
 tools/update_examples:
 	docker buildx build --platform linux/amd64 -t update_pyroscope_examples -f tools/update_examples.Dockerfile  tools
 	docker run --rm  --platform=linux/amd64 -e GITHUB_TOKEN=$(GITHUB_TOKEN) -v$(shell pwd):/pyroscope -w /pyroscope update_pyroscope_examples bash -l -c "go run tools/update_examples.go -report $(UPDATE_EXAMPLES_REPORT)"
-
-.PHONY: tools/update_examples_pr
-tools/update_examples_pr:
-	git config --local user.name 'Pyroscope Bot'
-	git config --local user.email 'dmitry+bot@pyroscope.io'
-	git checkout -b gh_bot_examples_update
-	git add .
-	git commit -m "chore(examples): update examples"
-	git push -f https://x-access-token:$(GITHUB_TOKEN)@github.com/$(GITHUB_REPOSITORY).git gh_bot_examples_update 2> /dev/null
-	gh pr create --head gh_bot_examples_update --title "chore(examples): update examples" --body-file $(UPDATE_EXAMPLES_REPORT) --repo $(GITHUB_REPOSITORY) || \
-	   gh pr edit gh_bot_examples_update --title "chore(examples): update examples" --body-file $(UPDATE_EXAMPLES_REPORT) --repo $(GITHUB_REPOSITORY)
 
 
 # Deliberately not IMAGE_PREFIX/IMAGE_PLATFORM, whose global defaults point at a

--- a/tools/update_examples.go
+++ b/tools/update_examples.go
@@ -555,18 +555,32 @@ func names(results []updateResult) []string {
 	return out
 }
 
-func changedFiles() []string {
-	out, err := exec.Command("git", "diff", "--name-only").Output()
+func gitLines(args ...string) []string {
+	out, err := exec.Command("git", args...).Output()
 	if err != nil {
-		log.Fatalf("collecting changed files: %v", err)
+		log.Fatalf("git %s: %v", strings.Join(args, " "), err)
 	}
-	var files []string
-	for f := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
-		if f != "" {
-			files = append(files, f)
+	var lines []string
+	for l := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		if l != "" {
+			lines = append(lines, l)
 		}
 	}
-	return files
+	return lines
+}
+
+func modifiedFiles() []string {
+	return gitLines("diff", "--name-only")
+}
+
+func untrackedFiles() []string {
+	return gitLines("ls-files", "--others", "--exclude-standard")
+}
+
+// Untracked files count as changed because the commit the cron creates picks
+// them up as well.
+func changedFiles() []string {
+	return append(modifiedFiles(), untrackedFiles()...)
 }
 
 func revertNewlyChanged(before []string) {
@@ -575,22 +589,35 @@ func revertNewlyChanged(before []string) {
 		was[f] = true
 	}
 
-	var partial []string
-	for _, f := range changedFiles() {
+	var restore, remove []string
+	for _, f := range modifiedFiles() {
 		if !was[f] {
-			partial = append(partial, f)
+			restore = append(restore, f)
 		}
 	}
-	if len(partial) == 0 {
+	for _, f := range untrackedFiles() {
+		if !was[f] {
+			remove = append(remove, f)
+		}
+	}
+	if len(restore) == 0 && len(remove) == 0 {
 		return
 	}
-	slices.Sort(partial)
+	slices.Sort(restore)
+	slices.Sort(remove)
 
-	args := append([]string{"checkout", "--"}, partial...)
-	if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
-		log.Fatalf("reverting partial changes: %v: %s", err, out)
+	if len(restore) > 0 {
+		args := append([]string{"checkout", "--"}, restore...)
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			log.Fatalf("reverting partial changes: %v: %s", err, out)
+		}
 	}
-	log.Printf("reverted partial changes: %s", strings.Join(partial, ", "))
+	for _, f := range remove {
+		if err := os.Remove(f); err != nil {
+			log.Fatalf("removing partial change %s: %v", f, err)
+		}
+	}
+	log.Printf("reverted partial changes: %s", strings.Join(append(restore, remove...), ", "))
 }
 
 func changedExamples() (examples, other []string) {


### PR DESCRIPTION
The cron reached the push for the first time since June and was rejected: the bot commit is unsigned.

Commits with `planetscale/ghcommit-action` instead, like `update-homebrew-formulas`. Branch creation and PR opening move out of the Makefile into the workflow, so the push error is no longer hidden behind `2> /dev/null`.

Also adds a concurrency group; two sweeps at once would both reset the branch and race on the PR.