### PR TITLE
monitoring: point v2 dashboard event annotations at the Alloy events stream

### DIFF
--- a/operations/monitoring/dashboards-classic-histogram/v2-metastore.json
+++ b/operations/monitoring/dashboards-classic-histogram/v2-metastore.json
@@ -34,13 +34,13 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",container=\"eventrouter\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
+        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
         "hide": false,
         "iconColor": "orange",
         "instant": false,
         "name": "K8s Warnings",
-        "tagKeys": "type,object_kind,object_name",
-        "textFormat": "{{message}}",
+        "tagKeys": "type,kind,name",
+        "textFormat": "{{msg}}",
         "titleFormat": ""
       },
       {
@@ -49,13 +49,13 @@
           "uid": "${loki_datasource}"
         },
         "enable": true,
-        "expr": "{namespace=\"$namespace\",container=\"eventrouter\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
+        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
         "hide": false,
         "iconColor": "red",
         "instant": false,
         "name": "K8s Errors",
-        "tagKeys": "type,object_kind,object_name",
-        "textFormat": "{{message}}"
+        "tagKeys": "type,kind,name",
+        "textFormat": "{{msg}}"
       },
       {
         "datasource": {
@@ -63,13 +63,13 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",container=\"eventrouter\"} | logfmt",
+        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt",
         "hide": false,
         "iconColor": "blue",
         "instant": false,
         "name": "K8s All Events",
-        "tagKeys": "type,object_kind,object_name",
-        "textFormat": "{{message}}"
+        "tagKeys": "type,kind,name",
+        "textFormat": "{{msg}}"
       }
     ]
   },

--- a/operations/monitoring/dashboards-classic-histogram/v2-metastore.json
+++ b/operations/monitoring/dashboards-classic-histogram/v2-metastore.json
@@ -34,7 +34,7 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
+        "expr": "{cluster=\"$cluster\", job=~\"loki\\.source\\.kubernetes_events|integrations/kubernetes/eventhandler\", namespace=\"$namespace\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
         "hide": false,
         "iconColor": "orange",
         "instant": false,
@@ -49,7 +49,7 @@
           "uid": "${loki_datasource}"
         },
         "enable": true,
-        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
+        "expr": "{cluster=\"$cluster\", job=~\"loki\\.source\\.kubernetes_events|integrations/kubernetes/eventhandler\", namespace=\"$namespace\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
         "hide": false,
         "iconColor": "red",
         "instant": false,
@@ -63,7 +63,7 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt",
+        "expr": "{cluster=\"$cluster\", job=~\"loki\\.source\\.kubernetes_events|integrations/kubernetes/eventhandler\", namespace=\"$namespace\"} | logfmt",
         "hide": false,
         "iconColor": "blue",
         "instant": false,

--- a/operations/monitoring/dashboards-classic-histogram/v2-read-path.json
+++ b/operations/monitoring/dashboards-classic-histogram/v2-read-path.json
@@ -34,7 +34,7 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
+        "expr": "{cluster=\"$cluster\", job=~\"loki\\.source\\.kubernetes_events|integrations/kubernetes/eventhandler\", namespace=\"$namespace\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
         "hide": false,
         "iconColor": "orange",
         "instant": false,
@@ -49,7 +49,7 @@
           "uid": "${loki_datasource}"
         },
         "enable": true,
-        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
+        "expr": "{cluster=\"$cluster\", job=~\"loki\\.source\\.kubernetes_events|integrations/kubernetes/eventhandler\", namespace=\"$namespace\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
         "hide": false,
         "iconColor": "red",
         "instant": false,
@@ -63,7 +63,7 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt",
+        "expr": "{cluster=\"$cluster\", job=~\"loki\\.source\\.kubernetes_events|integrations/kubernetes/eventhandler\", namespace=\"$namespace\"} | logfmt",
         "hide": false,
         "iconColor": "blue",
         "instant": false,

--- a/operations/monitoring/dashboards-classic-histogram/v2-read-path.json
+++ b/operations/monitoring/dashboards-classic-histogram/v2-read-path.json
@@ -34,13 +34,13 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",container=\"eventrouter\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
+        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
         "hide": false,
         "iconColor": "orange",
         "instant": false,
         "name": "K8s Warnings",
-        "tagKeys": "type,object_kind,object_name",
-        "textFormat": "{{message}}",
+        "tagKeys": "type,kind,name",
+        "textFormat": "{{msg}}",
         "titleFormat": ""
       },
       {
@@ -49,13 +49,13 @@
           "uid": "${loki_datasource}"
         },
         "enable": true,
-        "expr": "{namespace=\"$namespace\",container=\"eventrouter\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
+        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
         "hide": false,
         "iconColor": "red",
         "instant": false,
         "name": "K8s Errors",
-        "tagKeys": "type,object_kind,object_name",
-        "textFormat": "{{message}}"
+        "tagKeys": "type,kind,name",
+        "textFormat": "{{msg}}"
       },
       {
         "datasource": {
@@ -63,13 +63,13 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",container=\"eventrouter\"} | logfmt",
+        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt",
         "hide": false,
         "iconColor": "blue",
         "instant": false,
         "name": "K8s All events",
-        "tagKeys": "type,object_kind,object_name",
-        "textFormat": "{{message}}"
+        "tagKeys": "type,kind,name",
+        "textFormat": "{{msg}}"
       }
     ]
   },

--- a/operations/monitoring/dashboards-classic-histogram/v2-write-path.json
+++ b/operations/monitoring/dashboards-classic-histogram/v2-write-path.json
@@ -34,13 +34,13 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",container=\"eventrouter\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
+        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
         "hide": false,
         "iconColor": "orange",
         "instant": false,
         "name": "K8s Warnings",
-        "tagKeys": "type,object_kind,object_name",
-        "textFormat": "{{message}}",
+        "tagKeys": "type,kind,name",
+        "textFormat": "{{msg}}",
         "titleFormat": ""
       },
       {
@@ -49,13 +49,13 @@
           "uid": "${loki_datasource}"
         },
         "enable": true,
-        "expr": "{namespace=\"$namespace\",container=\"eventrouter\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
+        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
         "hide": false,
         "iconColor": "red",
         "instant": false,
         "name": "K8s Errors",
-        "tagKeys": "type,object_kind,object_name",
-        "textFormat": "{{message}}"
+        "tagKeys": "type,kind,name",
+        "textFormat": "{{msg}}"
       },
       {
         "datasource": {
@@ -63,13 +63,13 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",container=\"eventrouter\"} | logfmt",
+        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt",
         "hide": false,
         "iconColor": "blue",
         "instant": false,
         "name": "K8s All Events",
-        "tagKeys": "type,object_kind,object_name",
-        "textFormat": "{{message}}"
+        "tagKeys": "type,kind,name",
+        "textFormat": "{{msg}}"
       }
     ]
   },

--- a/operations/monitoring/dashboards-classic-histogram/v2-write-path.json
+++ b/operations/monitoring/dashboards-classic-histogram/v2-write-path.json
@@ -34,7 +34,7 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
+        "expr": "{cluster=\"$cluster\", job=~\"loki\\.source\\.kubernetes_events|integrations/kubernetes/eventhandler\", namespace=\"$namespace\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
         "hide": false,
         "iconColor": "orange",
         "instant": false,
@@ -49,7 +49,7 @@
           "uid": "${loki_datasource}"
         },
         "enable": true,
-        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
+        "expr": "{cluster=\"$cluster\", job=~\"loki\\.source\\.kubernetes_events|integrations/kubernetes/eventhandler\", namespace=\"$namespace\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
         "hide": false,
         "iconColor": "red",
         "instant": false,
@@ -63,7 +63,7 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt",
+        "expr": "{cluster=\"$cluster\", job=~\"loki\\.source\\.kubernetes_events|integrations/kubernetes/eventhandler\", namespace=\"$namespace\"} | logfmt",
         "hide": false,
         "iconColor": "blue",
         "instant": false,

--- a/operations/monitoring/dashboards/v2-metastore.json
+++ b/operations/monitoring/dashboards/v2-metastore.json
@@ -34,13 +34,13 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",container=\"eventrouter\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
+        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
         "hide": false,
         "iconColor": "orange",
         "instant": false,
         "name": "K8s Warnings",
-        "tagKeys": "type,object_kind,object_name",
-        "textFormat": "{{message}}",
+        "tagKeys": "type,kind,name",
+        "textFormat": "{{msg}}",
         "titleFormat": ""
       },
       {
@@ -49,13 +49,13 @@
           "uid": "${loki_datasource}"
         },
         "enable": true,
-        "expr": "{namespace=\"$namespace\",container=\"eventrouter\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
+        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
         "hide": false,
         "iconColor": "red",
         "instant": false,
         "name": "K8s Errors",
-        "tagKeys": "type,object_kind,object_name",
-        "textFormat": "{{message}}"
+        "tagKeys": "type,kind,name",
+        "textFormat": "{{msg}}"
       },
       {
         "datasource": {
@@ -63,13 +63,13 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",container=\"eventrouter\"} | logfmt",
+        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt",
         "hide": false,
         "iconColor": "blue",
         "instant": false,
         "name": "K8s All Events",
-        "tagKeys": "type,object_kind,object_name",
-        "textFormat": "{{message}}"
+        "tagKeys": "type,kind,name",
+        "textFormat": "{{msg}}"
       }
     ]
   },

--- a/operations/monitoring/dashboards/v2-metastore.json
+++ b/operations/monitoring/dashboards/v2-metastore.json
@@ -34,7 +34,7 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
+        "expr": "{cluster=\"$cluster\", job=~\"loki\\.source\\.kubernetes_events|integrations/kubernetes/eventhandler\", namespace=\"$namespace\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
         "hide": false,
         "iconColor": "orange",
         "instant": false,
@@ -49,7 +49,7 @@
           "uid": "${loki_datasource}"
         },
         "enable": true,
-        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
+        "expr": "{cluster=\"$cluster\", job=~\"loki\\.source\\.kubernetes_events|integrations/kubernetes/eventhandler\", namespace=\"$namespace\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
         "hide": false,
         "iconColor": "red",
         "instant": false,
@@ -63,7 +63,7 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt",
+        "expr": "{cluster=\"$cluster\", job=~\"loki\\.source\\.kubernetes_events|integrations/kubernetes/eventhandler\", namespace=\"$namespace\"} | logfmt",
         "hide": false,
         "iconColor": "blue",
         "instant": false,

--- a/operations/monitoring/dashboards/v2-read-path.json
+++ b/operations/monitoring/dashboards/v2-read-path.json
@@ -34,7 +34,7 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
+        "expr": "{cluster=\"$cluster\", job=~\"loki\\.source\\.kubernetes_events|integrations/kubernetes/eventhandler\", namespace=\"$namespace\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
         "hide": false,
         "iconColor": "orange",
         "instant": false,
@@ -49,7 +49,7 @@
           "uid": "${loki_datasource}"
         },
         "enable": true,
-        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
+        "expr": "{cluster=\"$cluster\", job=~\"loki\\.source\\.kubernetes_events|integrations/kubernetes/eventhandler\", namespace=\"$namespace\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
         "hide": false,
         "iconColor": "red",
         "instant": false,
@@ -63,7 +63,7 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt",
+        "expr": "{cluster=\"$cluster\", job=~\"loki\\.source\\.kubernetes_events|integrations/kubernetes/eventhandler\", namespace=\"$namespace\"} | logfmt",
         "hide": false,
         "iconColor": "blue",
         "instant": false,

--- a/operations/monitoring/dashboards/v2-read-path.json
+++ b/operations/monitoring/dashboards/v2-read-path.json
@@ -34,13 +34,13 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",container=\"eventrouter\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
+        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
         "hide": false,
         "iconColor": "orange",
         "instant": false,
         "name": "K8s Warnings",
-        "tagKeys": "type,object_kind,object_name",
-        "textFormat": "{{message}}",
+        "tagKeys": "type,kind,name",
+        "textFormat": "{{msg}}",
         "titleFormat": ""
       },
       {
@@ -49,13 +49,13 @@
           "uid": "${loki_datasource}"
         },
         "enable": true,
-        "expr": "{namespace=\"$namespace\",container=\"eventrouter\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
+        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
         "hide": false,
         "iconColor": "red",
         "instant": false,
         "name": "K8s Errors",
-        "tagKeys": "type,object_kind,object_name",
-        "textFormat": "{{message}}"
+        "tagKeys": "type,kind,name",
+        "textFormat": "{{msg}}"
       },
       {
         "datasource": {
@@ -63,13 +63,13 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",container=\"eventrouter\"} | logfmt",
+        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt",
         "hide": false,
         "iconColor": "blue",
         "instant": false,
         "name": "K8s All events",
-        "tagKeys": "type,object_kind,object_name",
-        "textFormat": "{{message}}"
+        "tagKeys": "type,kind,name",
+        "textFormat": "{{msg}}"
       }
     ]
   },

--- a/operations/monitoring/dashboards/v2-write-path.json
+++ b/operations/monitoring/dashboards/v2-write-path.json
@@ -34,13 +34,13 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",container=\"eventrouter\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
+        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
         "hide": false,
         "iconColor": "orange",
         "instant": false,
         "name": "K8s Warnings",
-        "tagKeys": "type,object_kind,object_name",
-        "textFormat": "{{message}}",
+        "tagKeys": "type,kind,name",
+        "textFormat": "{{msg}}",
         "titleFormat": ""
       },
       {
@@ -49,13 +49,13 @@
           "uid": "${loki_datasource}"
         },
         "enable": true,
-        "expr": "{namespace=\"$namespace\",container=\"eventrouter\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
+        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
         "hide": false,
         "iconColor": "red",
         "instant": false,
         "name": "K8s Errors",
-        "tagKeys": "type,object_kind,object_name",
-        "textFormat": "{{message}}"
+        "tagKeys": "type,kind,name",
+        "textFormat": "{{msg}}"
       },
       {
         "datasource": {
@@ -63,13 +63,13 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",container=\"eventrouter\"} | logfmt",
+        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt",
         "hide": false,
         "iconColor": "blue",
         "instant": false,
         "name": "K8s All Events",
-        "tagKeys": "type,object_kind,object_name",
-        "textFormat": "{{message}}"
+        "tagKeys": "type,kind,name",
+        "textFormat": "{{msg}}"
       }
     ]
   },

--- a/operations/monitoring/dashboards/v2-write-path.json
+++ b/operations/monitoring/dashboards/v2-write-path.json
@@ -34,7 +34,7 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
+        "expr": "{cluster=\"$cluster\", job=~\"loki\\.source\\.kubernetes_events|integrations/kubernetes/eventhandler\", namespace=\"$namespace\"} != \"Preemption is not helpful\" != \"Failed deploy model\" | logfmt | type=\"Warning\"",
         "hide": false,
         "iconColor": "orange",
         "instant": false,
@@ -49,7 +49,7 @@
           "uid": "${loki_datasource}"
         },
         "enable": true,
-        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
+        "expr": "{cluster=\"$cluster\", job=~\"loki\\.source\\.kubernetes_events|integrations/kubernetes/eventhandler\", namespace=\"$namespace\"} | logfmt | type!=\"Normal\" | type!=\"Warning\"",
         "hide": false,
         "iconColor": "red",
         "instant": false,
@@ -63,7 +63,7 @@
           "uid": "${loki_datasource}"
         },
         "enable": false,
-        "expr": "{namespace=\"$namespace\",job=\"loki.source.kubernetes_events\"} | logfmt",
+        "expr": "{cluster=\"$cluster\", job=~\"loki\\.source\\.kubernetes_events|integrations/kubernetes/eventhandler\", namespace=\"$namespace\"} | logfmt",
         "hide": false,
         "iconColor": "blue",
         "instant": false,

--- a/operations/monitoring/helm/pyroscope-monitoring/README.md
+++ b/operations/monitoring/helm/pyroscope-monitoring/README.md
@@ -39,6 +39,7 @@ The committed JSON files under `operations/monitoring/dashboards/` (native) and 
 | dashboards.cloudBackendGateway | bool | `false` |  |
 | dashboards.cloudBackendGatewaySelector | string | `"container=~\"cortex-gw(-internal)?\""` |  |
 | dashboards.cluster | string | `"pyroscope-dev"` |  |
+| dashboards.eventsSelector | string | `"job=~\"loki\\.source\\.kubernetes_events|integrations/kubernetes/eventhandler\""` |  |
 | dashboards.ingestNamespaceSelector | string | `"namespace=~\"$namespace\""` |  |
 | dashboards.ingestSelector | string | `"container=~\"pyroscope|distributor|query-frontend\""` |  |
 | dashboards.kubeStateMetricsSelector | string | `"job=~\"(.*/)?kube-state-metrics\""` |  |

--- a/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboard_v2-metastore.yaml
+++ b/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboard_v2-metastore.yaml
@@ -30,7 +30,7 @@ annotations:
         uid: ${loki_datasource}
       enable: false
       expr: >-
-        {namespace="$namespace",job="loki.source.kubernetes_events"} != "Preemption is not
+        {cluster="$cluster", {{ .Values.dashboards.eventsSelector }}, namespace="$namespace"} != "Preemption is not
         helpful" != "Failed deploy model" | logfmt | type="Warning"
       hide: false
       iconColor: orange
@@ -44,7 +44,7 @@ annotations:
         uid: ${loki_datasource}
       enable: true
       expr: >-
-        {namespace="$namespace",job="loki.source.kubernetes_events"} | logfmt |
+        {cluster="$cluster", {{ .Values.dashboards.eventsSelector }}, namespace="$namespace"} | logfmt |
         type!="Normal" | type!="Warning"
       hide: false
       iconColor: red
@@ -56,7 +56,7 @@ annotations:
         type: loki
         uid: ${loki_datasource}
       enable: false
-      expr: '{namespace="$namespace",job="loki.source.kubernetes_events"} | logfmt'
+      expr: '{cluster="$cluster", {{ .Values.dashboards.eventsSelector }}, namespace="$namespace"} | logfmt'
       hide: false
       iconColor: blue
       instant: false

--- a/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboard_v2-metastore.yaml
+++ b/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboard_v2-metastore.yaml
@@ -30,39 +30,39 @@ annotations:
         uid: ${loki_datasource}
       enable: false
       expr: >-
-        {namespace="$namespace",container="eventrouter"} != "Preemption is not
+        {namespace="$namespace",job="loki.source.kubernetes_events"} != "Preemption is not
         helpful" != "Failed deploy model" | logfmt | type="Warning"
       hide: false
       iconColor: orange
       instant: false
       name: K8s Warnings
-      tagKeys: type,object_kind,object_name
-      textFormat: '{{"{{message}}"}}'
+      tagKeys: type,kind,name
+      textFormat: '{{"{{msg}}"}}'
       titleFormat: ''
     - datasource:
         type: loki
         uid: ${loki_datasource}
       enable: true
       expr: >-
-        {namespace="$namespace",container="eventrouter"} | logfmt |
+        {namespace="$namespace",job="loki.source.kubernetes_events"} | logfmt |
         type!="Normal" | type!="Warning"
       hide: false
       iconColor: red
       instant: false
       name: K8s Errors
-      tagKeys: type,object_kind,object_name
-      textFormat: '{{"{{message}}"}}'
+      tagKeys: type,kind,name
+      textFormat: '{{"{{msg}}"}}'
     - datasource:
         type: loki
         uid: ${loki_datasource}
       enable: false
-      expr: '{namespace="$namespace",container="eventrouter"} | logfmt'
+      expr: '{namespace="$namespace",job="loki.source.kubernetes_events"} | logfmt'
       hide: false
       iconColor: blue
       instant: false
       name: K8s All Events
-      tagKeys: type,object_kind,object_name
-      textFormat: '{{"{{message}}"}}'
+      tagKeys: type,kind,name
+      textFormat: '{{"{{msg}}"}}'
 editable: true
 fiscalYearStartMonth: 0
 graphTooltip: 1

--- a/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboard_v2-read-path.yaml
+++ b/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboard_v2-read-path.yaml
@@ -30,7 +30,7 @@ annotations:
         uid: ${loki_datasource}
       enable: false
       expr: >-
-        {namespace="$namespace",job="loki.source.kubernetes_events"} != "Preemption is not
+        {cluster="$cluster", {{ .Values.dashboards.eventsSelector }}, namespace="$namespace"} != "Preemption is not
         helpful" != "Failed deploy model" | logfmt | type="Warning"
       hide: false
       iconColor: orange
@@ -44,7 +44,7 @@ annotations:
         uid: ${loki_datasource}
       enable: true
       expr: >-
-        {namespace="$namespace",job="loki.source.kubernetes_events"} | logfmt |
+        {cluster="$cluster", {{ .Values.dashboards.eventsSelector }}, namespace="$namespace"} | logfmt |
         type!="Normal" | type!="Warning"
       hide: false
       iconColor: red
@@ -56,7 +56,7 @@ annotations:
         type: loki
         uid: ${loki_datasource}
       enable: false
-      expr: '{namespace="$namespace",job="loki.source.kubernetes_events"} | logfmt'
+      expr: '{cluster="$cluster", {{ .Values.dashboards.eventsSelector }}, namespace="$namespace"} | logfmt'
       hide: false
       iconColor: blue
       instant: false

--- a/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboard_v2-read-path.yaml
+++ b/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboard_v2-read-path.yaml
@@ -30,39 +30,39 @@ annotations:
         uid: ${loki_datasource}
       enable: false
       expr: >-
-        {namespace="$namespace",container="eventrouter"} != "Preemption is not
+        {namespace="$namespace",job="loki.source.kubernetes_events"} != "Preemption is not
         helpful" != "Failed deploy model" | logfmt | type="Warning"
       hide: false
       iconColor: orange
       instant: false
       name: K8s Warnings
-      tagKeys: type,object_kind,object_name
-      textFormat: '{{"{{message}}"}}'
+      tagKeys: type,kind,name
+      textFormat: '{{"{{msg}}"}}'
       titleFormat: ''
     - datasource:
         type: loki
         uid: ${loki_datasource}
       enable: true
       expr: >-
-        {namespace="$namespace",container="eventrouter"} | logfmt |
+        {namespace="$namespace",job="loki.source.kubernetes_events"} | logfmt |
         type!="Normal" | type!="Warning"
       hide: false
       iconColor: red
       instant: false
       name: K8s Errors
-      tagKeys: type,object_kind,object_name
-      textFormat: '{{"{{message}}"}}'
+      tagKeys: type,kind,name
+      textFormat: '{{"{{msg}}"}}'
     - datasource:
         type: loki
         uid: ${loki_datasource}
       enable: false
-      expr: '{namespace="$namespace",container="eventrouter"} | logfmt'
+      expr: '{namespace="$namespace",job="loki.source.kubernetes_events"} | logfmt'
       hide: false
       iconColor: blue
       instant: false
       name: K8s All events
-      tagKeys: type,object_kind,object_name
-      textFormat: '{{"{{message}}"}}'
+      tagKeys: type,kind,name
+      textFormat: '{{"{{msg}}"}}'
 editable: true
 fiscalYearStartMonth: 0
 graphTooltip: 1

--- a/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboard_v2-write-path.yaml
+++ b/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboard_v2-write-path.yaml
@@ -30,7 +30,7 @@ annotations:
         uid: ${loki_datasource}
       enable: false
       expr: >-
-        {namespace="$namespace",job="loki.source.kubernetes_events"} != "Preemption is not
+        {cluster="$cluster", {{ .Values.dashboards.eventsSelector }}, namespace="$namespace"} != "Preemption is not
         helpful" != "Failed deploy model" | logfmt | type="Warning"
       hide: false
       iconColor: orange
@@ -44,7 +44,7 @@ annotations:
         uid: ${loki_datasource}
       enable: true
       expr: >-
-        {namespace="$namespace",job="loki.source.kubernetes_events"} | logfmt |
+        {cluster="$cluster", {{ .Values.dashboards.eventsSelector }}, namespace="$namespace"} | logfmt |
         type!="Normal" | type!="Warning"
       hide: false
       iconColor: red
@@ -56,7 +56,7 @@ annotations:
         type: loki
         uid: ${loki_datasource}
       enable: false
-      expr: '{namespace="$namespace",job="loki.source.kubernetes_events"} | logfmt'
+      expr: '{cluster="$cluster", {{ .Values.dashboards.eventsSelector }}, namespace="$namespace"} | logfmt'
       hide: false
       iconColor: blue
       instant: false

--- a/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboard_v2-write-path.yaml
+++ b/operations/monitoring/helm/pyroscope-monitoring/templates/_dashboard_v2-write-path.yaml
@@ -30,39 +30,39 @@ annotations:
         uid: ${loki_datasource}
       enable: false
       expr: >-
-        {namespace="$namespace",container="eventrouter"} != "Preemption is not
+        {namespace="$namespace",job="loki.source.kubernetes_events"} != "Preemption is not
         helpful" != "Failed deploy model" | logfmt | type="Warning"
       hide: false
       iconColor: orange
       instant: false
       name: K8s Warnings
-      tagKeys: type,object_kind,object_name
-      textFormat: '{{"{{message}}"}}'
+      tagKeys: type,kind,name
+      textFormat: '{{"{{msg}}"}}'
       titleFormat: ''
     - datasource:
         type: loki
         uid: ${loki_datasource}
       enable: true
       expr: >-
-        {namespace="$namespace",container="eventrouter"} | logfmt |
+        {namespace="$namespace",job="loki.source.kubernetes_events"} | logfmt |
         type!="Normal" | type!="Warning"
       hide: false
       iconColor: red
       instant: false
       name: K8s Errors
-      tagKeys: type,object_kind,object_name
-      textFormat: '{{"{{message}}"}}'
+      tagKeys: type,kind,name
+      textFormat: '{{"{{msg}}"}}'
     - datasource:
         type: loki
         uid: ${loki_datasource}
       enable: false
-      expr: '{namespace="$namespace",container="eventrouter"} | logfmt'
+      expr: '{namespace="$namespace",job="loki.source.kubernetes_events"} | logfmt'
       hide: false
       iconColor: blue
       instant: false
       name: K8s All Events
-      tagKeys: type,object_kind,object_name
-      textFormat: '{{"{{message}}"}}'
+      tagKeys: type,kind,name
+      textFormat: '{{"{{msg}}"}}'
 editable: true
 fiscalYearStartMonth: 0
 graphTooltip: 1

--- a/operations/monitoring/helm/pyroscope-monitoring/values.yaml
+++ b/operations/monitoring/helm/pyroscope-monitoring/values.yaml
@@ -129,9 +129,6 @@ dashboards:
   cloudBackendGatewaySelector: container=~"cortex-gw(-internal)?"
 
   kubeStateMetricsSelector: job=~"(.*/)?kube-state-metrics"
-  # Kubernetes events stream selector. Matches both Alloy's
-  # loki.source.kubernetes_events default job_name and the job label the
-  # k8s-monitoring chart sets for cluster events.
   eventsSelector: job=~"loki\.source\.kubernetes_events|integrations/kubernetes/eventhandler"
   cadvisorSelector: job=~"(.*/)?cadvisor"
 

--- a/operations/monitoring/helm/pyroscope-monitoring/values.yaml
+++ b/operations/monitoring/helm/pyroscope-monitoring/values.yaml
@@ -129,6 +129,10 @@ dashboards:
   cloudBackendGatewaySelector: container=~"cortex-gw(-internal)?"
 
   kubeStateMetricsSelector: job=~"(.*/)?kube-state-metrics"
+  # Kubernetes events stream selector. Matches both Alloy's
+  # loki.source.kubernetes_events default job_name and the job label the
+  # k8s-monitoring chart sets for cluster events.
+  eventsSelector: job=~"loki\.source\.kubernetes_events|integrations/kubernetes/eventhandler"
   cadvisorSelector: job=~"(.*/)?cadvisor"
 
   # Default namespace


### PR DESCRIPTION
## What / Why

The Kubernetes-events annotations in the `v2-metastore`, `v2-read-path` and `v2-write-path`
dashboards select `{namespace="$namespace", container="eventrouter"}` — a standalone
[eventrouter](https://github.com/heptiolabs/eventrouter) deployment that emitted events to stdout.
That's being replaced by Alloy's native `loki.source.kubernetes_events`, so the annotations need
repointing or they go blank.

Three changes per annotation, three annotations per dashboard:

1. **Selector** — the native stream has no `container` label, and keeps `namespace` as a stream
   label carrying the involved object's namespace, so `$namespace` still selects the right events.
   The job label varies by collector, so it's a new `dashboards.eventsSelector` value alongside the
   chart's existing selector knobs, defaulting to a regex that covers both Alloy's default
   `job_name` (`loki.source.kubernetes_events`) and the label the
   [k8s-monitoring](https://github.com/grafana/k8s-monitoring-helm) chart sets for cluster events
   (`integrations/kubernetes/eventhandler`, from `feature-cluster-events`' `jobLabel`).
2. **Annotation fields** — Alloy's logfmt output uses different key names, so `tagKeys` and
   `textFormat` need updating too, or the annotations render with no tags and empty text:
   `object_kind` → `kind`, `object_name` → `name`, `{{message}}` → `{{msg}}`.
3. **Cluster scope** — added `cluster="$cluster"`, matching the sibling `K8s Changes` annotation in
   the same dashboards. Since `namespace` is the involved object's namespace, a fleet-wide events
   tenant would otherwise return other clusters' same-named namespaces.

`type` is unchanged and still parsed via `| logfmt`, so the `type="Warning"` / `type!="Normal"`
filters and the message line-filters are untouched. `v2-compaction` and the other dashboards have
no events annotations, so they're unaffected.

## Notes

The chart templates are the source of truth; `operations/monitoring/dashboards/` and
`operations/monitoring/dashboards-classic-histogram/` are regenerated from them via
`make helm/check`, and the README via `make helm/docs` — those are the JSON and README changes
here. `helm lint` passes and the rendered output has no remaining `eventrouter` references.
