### PR TITLE
ci(examples): deploy the images after publishing them

### DIFF
--- a/.github/workflows/push-example-images.yml
+++ b/.github/workflows/push-example-images.yml
@@ -66,9 +66,21 @@ jobs:
           TAG: ${{ steps.tag.outputs.tag }}
         run: make rideshare/docker/push IMAGE_TAG="$TAG"
 
+      # Only reached when every image pushed, so the deployment never sees a
+      # partially published set.
+      - name: Deploy the images
+        id: submit-argowfs-deployment
+        uses: grafana/shared-workflows/actions/trigger-argo-workflow@c2f1df59dba624b3fd509e5181aa8da5217120c0
+        with:
+          namespace: "phlare-cd"
+          workflow_template: "deploy-pyroscope-rideshare"
+          parameters: |
+            tag=${{ steps.tag.outputs.tag }}
+
       - name: Summary
         env:
           TAG: ${{ steps.tag.outputs.tag }}
+          URI: ${{ steps.submit-argowfs-deployment.outputs.uri }}
         run: |
           {
             echo "Pushed rideshare images tagged \`$TAG\` from ${GITHUB_SHA}."
@@ -76,4 +88,6 @@ jobs:
             echo "\`\`\`"
             echo "us-docker.pkg.dev/grafanalabs-dev/docker-pyroscope-dev/pyroscope-rideshare-<lang>:$TAG"
             echo "\`\`\`"
+            echo
+            echo "Deployment: $URI"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Submits `deploy-pyroscope-rideshare` with the tag just published, the same way `ci.yml` hands a tag to `deploy-pyroscope-dev`. The deployment used to look the tag up in the registry, which needed credentials it did not have.

The step only runs when every image pushed, so a partially published set cannot reach a deployment.