### PR TITLE
fix(jfr): treat a profile size limit of 0 as unlimited

### DIFF
--- a/pkg/og/convert/jfr/profile.go
+++ b/pkg/og/convert/jfr/profile.go
@@ -2,7 +2,6 @@ package jfr
 
 import (
 	"bytes"
-	"github.com/klauspost/compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -12,6 +11,7 @@ import (
 	"github.com/grafana/dskit/tenant"
 	jfrPprof "github.com/grafana/jfr-parser/pprof"
 	jfrPprofPyroscope "github.com/grafana/jfr-parser/pprof/pyroscope"
+	"github.com/klauspost/compress/gzip"
 
 	distributormodel "github.com/grafana/pyroscope/v2/pkg/distributor/model"
 	"github.com/grafana/pyroscope/v2/pkg/pprof"
@@ -130,24 +130,28 @@ func loadJFRFromForm(r []byte, contentType string, maxBytes int) ([]byte, *jfrPp
 	return jfrField, labels, nil
 }
 
+// decompress gunzips bs if it is gzip-compressed, rejecting payloads whose
+// decompressed size exceeds maxBytes. maxBytes of 0 means no limit.
 func decompress(bs []byte, maxBytes int) ([]byte, error) {
-	var err error
 	if len(bs) < 2 {
 		return nil, fmt.Errorf("failed to read magic")
 	} else if bs[0] == 0x1f && bs[1] == 0x8b {
-		var gzipr *gzip.Reader
-		gzipr, err = gzip.NewReader(bytes.NewReader(bs))
-		defer gzipr.Close()
+		gzipr, err := gzip.NewReader(bytes.NewReader(bs))
 		if err != nil {
 			return nil, fmt.Errorf("failed to read gzip header: %w", err)
 		}
-		// Use maxBytes+1 to detect if limit is exceeded
-		limitReader := io.LimitReader(gzipr, int64(maxBytes+1))
+		defer gzipr.Close()
+
+		var r io.Reader = gzipr
+		if maxBytes > 0 {
+			// Use maxBytes+1 to detect if limit is exceeded
+			r = io.LimitReader(gzipr, int64(maxBytes)+1)
+		}
 		buf := bytes.NewBuffer(nil)
-		if _, err = io.Copy(buf, limitReader); err != nil {
+		if _, err = io.Copy(buf, r); err != nil {
 			return nil, fmt.Errorf("failed to decompress jfr: %w", err)
 		}
-		if buf.Len() > maxBytes {
+		if maxBytes > 0 && buf.Len() > maxBytes {
 			return nil, fmt.Errorf("decompressed size exceeds maximum allowed size of %d bytes", maxBytes)
 		}
 		return buf.Bytes(), nil

--- a/pkg/og/convert/jfr/profile_test.go
+++ b/pkg/og/convert/jfr/profile_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/grafana/dskit/user"
+	jfrPprof "github.com/grafana/jfr-parser/pprof"
+	"github.com/klauspost/compress/gzip"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -60,17 +62,10 @@ func TestParseToPprof_MultipartGzipJFR_SizesDiffer(t *testing.T) {
 	rawJFR, err := bench.ReadGzipFile("testdata/cortex-dev-01__kafka-0__cpu__0.jfr.gz")
 	require.NoError(t, err)
 
-	var b bytes.Buffer
-	w := multipart.NewWriter(&b)
-	jfrField, err := w.CreateFormFile("jfr", "jfr")
-	require.NoError(t, err)
-	_, err = jfrField.Write(gzippedJFR)
-	require.NoError(t, err)
-	require.NoError(t, w.Close())
-	multipartBody := b.Bytes()
+	multipartBody, contentType := multipartJFR(t, gzippedJFR, nil)
 
 	p := &RawProfile{
-		FormDataContentType: w.FormDataContentType(),
+		FormDataContentType: contentType,
 		RawData:             multipartBody,
 	}
 	result, err := p.ParseToPprof(testContext(), testMetadata(), fixedMaxProfileSize(32<<20))
@@ -78,4 +73,96 @@ func TestParseToPprof_MultipartGzipJFR_SizesDiffer(t *testing.T) {
 
 	assert.Equal(t, len(multipartBody), result.ReceivedCompressedProfileSize)
 	assert.Equal(t, len(rawJFR), result.ReceivedDecompressedProfileSize)
+}
+
+// TestParseToPprof_MultipartGzipJFR_ProfileSizeLimit covers the decompression size limit
+// applied to the gzipped multipart fields. A limit of 0 means "no limit", matching the
+// documented semantics of validation.max-profile-size-bytes and the pprof ingest path.
+func TestParseToPprof_MultipartGzipJFR_ProfileSizeLimit(t *testing.T) {
+	gzippedJFR, err := os.ReadFile("testdata/cortex-dev-01__kafka-0__cpu__0.jfr.gz")
+	require.NoError(t, err)
+
+	rawJFR, err := bench.ReadGzipFile("testdata/cortex-dev-01__kafka-0__cpu__0.jfr.gz")
+	require.NoError(t, err)
+
+	gzippedLabels := gzipBytes(t, marshalLabels(t))
+
+	for _, tc := range []struct {
+		name    string
+		limit   fixedMaxProfileSize
+		wantErr string
+	}{
+		{
+			name:  "no limit",
+			limit: 0,
+		},
+		{
+			name:  "limit above decompressed size",
+			limit: fixedMaxProfileSize(len(rawJFR)),
+		},
+		{
+			name:    "limit below decompressed size",
+			limit:   fixedMaxProfileSize(len(rawJFR) - 1),
+			wantErr: "decompressed size exceeds maximum allowed size",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			multipartBody, contentType := multipartJFR(t, gzippedJFR, gzippedLabels)
+
+			p := &RawProfile{
+				FormDataContentType: contentType,
+				RawData:             multipartBody,
+			}
+			result, err := p.ParseToPprof(testContext(), testMetadata(), tc.limit)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, len(rawJFR), result.ReceivedDecompressedProfileSize)
+		})
+	}
+}
+
+func marshalLabels(t *testing.T) []byte {
+	t.Helper()
+
+	snapshot := &jfrPprof.LabelsSnapshot{
+		Strings:  map[int64]string{1: "region", 2: "eu-west-1"},
+		Contexts: map[int64]*jfrPprof.Context{1: {Labels: map[int64]int64{1: 2}}},
+	}
+	b, err := snapshot.MarshalVT()
+	require.NoError(t, err)
+	return b
+}
+
+func gzipBytes(t *testing.T, b []byte) []byte {
+	t.Helper()
+
+	var out bytes.Buffer
+	w := gzip.NewWriter(&out)
+	_, err := w.Write(b)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	return out.Bytes()
+}
+
+func multipartJFR(t *testing.T, jfr, labels []byte) ([]byte, string) {
+	t.Helper()
+
+	var b bytes.Buffer
+	w := multipart.NewWriter(&b)
+	jfrField, err := w.CreateFormFile("jfr", "jfr")
+	require.NoError(t, err)
+	_, err = jfrField.Write(jfr)
+	require.NoError(t, err)
+	if labels != nil {
+		labelsField, err := w.CreateFormFile("labels", "labels")
+		require.NoError(t, err)
+		_, err = labelsField.Write(labels)
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Close())
+
+	return b.Bytes(), w.FormDataContentType()
 }


### PR DESCRIPTION
`validation.max-profile-size-bytes` is documented as "0 to disable", and that's how the pprof and OTLP ingest paths read it. The gzip decompression in the JFR `/ingest` path doesn't: it caps the reader at `maxBytes+1` unconditionally, so with the limit set to 0 every compressed JFR upload fails with

```
loadJFRFromForm failed to decompress jfr: decompressed size exceeds maximum allowed size of 0 bytes
```
### Fix

Skip the limit when it's 0, matching `pprof.RawFromBytesWithLimit`. The test covers all three cases (unset, above, below).

Notes: the `defer gzipr.Close()` sat before the error check, so a bad gzip header would nil-deref — moved it down while I was there.