### PR TITLE
fix(segmentwriter): allow shard shuffle table to grow past 4096 entries

### DIFF
--- a/pkg/segmentwriter/client/distributor/distributor.go
+++ b/pkg/segmentwriter/client/distributor/distributor.go
@@ -313,6 +313,7 @@ func (i *iterator) At() ring.InstanceDesc {
 type perm struct{ v []uint32 }
 
 func (p *perm) resize(n int) {
+	s := loadSteps(n)
 	d := max(0, n-len(p.v))
 	p.v = slices.Grow(p.v, d)[:n]
 	// We do want to start with 0 (in contrast to the standard
@@ -321,26 +322,40 @@ func (p *perm) resize(n int) {
 	// Although, it's possible to make the change incrementally,
 	// for simplicity, we just rebuild the permutation.
 	for i := 0; i < n; i++ {
-		j := steps[i]
+		j := s[i]
 		p.v[i], p.v[j] = p.v[j], uint32(i)
 	}
 }
 
-var steps [4 << 10]uint32
+var (
+	stepsMu sync.Mutex
+	steps   []uint32
+)
+
+// The seed impacts mapping of shards to nodes.
+const stepsSeed = -3035313949336265834
 
 func init() {
-	// The seed impacts mapping of shards to nodes.
-	// TODO(kolesnikovae):
-	//  Stochastic approach does not work well
-	//  in all the cases; it should be replaced
-	//  with a deterministic one.
-	const randSeed = -3035313949336265834
-	setSeed(randSeed)
+	loadSteps(4 << 10)
 }
 
-func setSeed(n int64) {
-	r := rand.New(rand.NewSource(n))
-	for i := range steps {
-		steps[i] = uint32(r.Intn(i + 1))
+// loadSteps returns a shuffle table with at least n entries, growing it
+// from the same fixed seed if it's too small.
+//
+// TODO(kolesnikovae):
+//
+//	Stochastic approach does not work well
+//	in all the cases; it should be replaced
+//	with a deterministic one.
+func loadSteps(n int) []uint32 {
+	stepsMu.Lock()
+	defer stepsMu.Unlock()
+	if n > len(steps) {
+		r := rand.New(rand.NewSource(stepsSeed))
+		steps = make([]uint32, n)
+		for i := range steps {
+			steps[i] = uint32(r.Intn(i + 1))
+		}
 	}
+	return steps
 }

--- a/pkg/segmentwriter/client/distributor/distributor_test.go
+++ b/pkg/segmentwriter/client/distributor/distributor_test.go
@@ -443,6 +443,42 @@ func Test_permutation(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+// Regression test: steps used to be a fixed-size [4096]uint32 array, so any
+// resize past 4096 total ring tokens would panic
+func Test_permutation_grows_past_former_fixed_size(t *testing.T) {
+	var p perm
+	require.NotPanics(t, func() { p.resize(5000) })
+	assert.Len(t, p.v, 5000)
+}
+
+func Test_Distributor_Distribute_LargeRing(t *testing.T) {
+	const numInstances = 5
+	const numTokens = 1024 // total tokens: 5120, exceeds the former 4096 limit.
+
+	instances := make([]ring.InstanceDesc, numInstances)
+	for i := range instances {
+		instances[i] = ring.InstanceDesc{
+			Id:     fmt.Sprintf("segment-writer-%d", i),
+			Tokens: make([]uint32, numTokens),
+		}
+	}
+
+	r := testhelper.NewMockRing(instances, 1)
+	m := new(mockplacement.MockPlacement)
+	k := placement.Key{Tenant: 1, Dataset: 1, Fingerprint: 1}
+	m.On("Policy", k).Return(placement.Policy{
+		TenantShards:  numInstances,
+		DatasetShards: numInstances,
+		PickShard:     zeroShard,
+	})
+	d := NewDistributor(m, r)
+
+	require.NotPanics(t, func() {
+		_, err := d.Distribute(k)
+		require.NoError(t, err)
+	})
+}
+
 func collectN(i iter.Iterator[ring.InstanceDesc], n int) []string {
 	s := make([]string, 0, n)
 	for n > 0 && i.Next() {


### PR DESCRIPTION
While playing with tokens on segment-writer, I hit a panic during shard shuffling when the number of shards in the ring exceeds the fixed steps[4096] table:
```
distributor-1  | panic: runtime error: index out of range [4096] with length 4096
distributor-1  | goroutine 601 [running]:
distributor-1  | github.com/grafana/pyroscope/v2/pkg/util.PanicError({0x34820c0, 0xc000e14180})
distributor-1  | 	/home/lweglarz/pyroscope/pkg/util/recovery.go:46 +0x4d
distributor-1  | github.com/grafana/pyroscope/v2/pkg/distributor/writepath.(*Router).sendToSegmentWriterOnly.(*Router).send.func1.1()
distributor-1  | 	/home/lweglarz/pyroscope/pkg/distributor/writepath/router.go:230 +0x67
distributor-1  | panic({0x34820c0?, 0xc000e14180?})
...
distributor-1  | github.com/grafana/pyroscope/v2/pkg/segmentwriter/client/distributor.(*perm).resize(...)
distributor-1  | 	.../distributor.go:324 +0x15d
```

I hit it with `-segment-writer.num-tokens=1024` (5 instances × 1024 tokens = 5120 total shards). 
The panic triggers whenever instances × num-tokens > 4096.

The fix lets steps grow to fit the ring's actual shard count instead of being capped at a fixed size.