### PR TITLE
chore(ui): bump nanoid to 3.3.18 in the lockfile

### DIFF
--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1770,11 +1770,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.17":
-  version: 3.3.17
-  resolution: "nanoid@npm:3.3.17"
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/06f7949c7cce5c92c6aea66022f29a1eae7f56e05acbfddf1e049e819b4bf234c44a765cc44da7163482b111677948514012e27acdfa56f95309295768bdae32
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Found by a `trivy fs --include-dev-deps` scan of the repo's `yarn.lock` files.

**CVE-2026-67213** (HIGH) — denial of service via an infinite loop in nanoid's random ID generation. Fixed in 3.3.18.

nanoid is a transitive dependency of `postcss@8.5.26`, which comes from the Vite/Tailwind build chain. It is a build-time dependency and is not shipped to the browser, so real-world impact is minimal.

The existing range is `^3.3.17`, which already permits 3.3.18, so this is a lockfile-only change via `yarn up -R nanoid` — no `package.json` edit. `yarn lint` and `yarn build` both pass, and a re-scan reports `ui/yarn.lock` clean.