### PR TITLE
Add security reporting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -386,3 +386,4 @@ make docker-image/pyroscope/build  # Build Docker image
 For detailed setup and contributing instructions, see:
 - `docs/internal/contributing/README.md` - Development setup and workflow
 - `docs/sources/reference-pyroscope-architecture/` - System architecture deep dive
+- Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.


### PR DESCRIPTION
## What changed

- Added guidance to the repository's agent instructions directing security issues to Grafana's security reporting page instead of the repository.

## Why

This makes the expected reporting channel explicit for coding agents working in the repository.

## Validation

- `git diff --check`
- Confirmed the commit changes only one agent instruction file with one added line.
