### PR TITLE
[release/v2.2] fix(ci): bump create-github-app-token to v0.3.1 to mask app tokens

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     steps:
       - id: get-github-app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: pyroscope-development-app
 

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: 'false'
           ref: main
       - id: get-github-app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: pyroscope-development-app
       - name: Get GitHub App User ID

--- a/.github/workflows/update-examples-cron.yml
+++ b/.github/workflows/update-examples-cron.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           persist-credentials: 'false'
       - id: get-github-app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: pyroscope-development-app
 

--- a/.github/workflows/update-homebrew-formulas.yml
+++ b/.github/workflows/update-homebrew-formulas.yml
@@ -31,7 +31,7 @@ jobs:
       BRANCH: update-formulas-${{ inputs.tag }}
     steps:
       - id: get-github-app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: grafana-pyroscope-bot
       - name: Checkout grafana/homebrew-pyroscope


### PR DESCRIPTION
Backport of commit ceb071c7129f09b96a1b57cae986a4075e7844be from #5529.
