### PR TITLE
chore(ci): enable Renovate updates for shared workflows

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,13 @@
     "github>grafana/grafana-renovate-config//presets/base",
     "security:only-security-updates"
   ],
-  "baseBranchPatterns": ["$default", "release/v2.2", "release/v2.1"]
+  "baseBranchPatterns": ["$default", "release/v2.2", "release/v2.1"],
+  "packageRules": [
+    {
+      "description": "Enable Grafana shared workflow updates",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["grafana/shared-workflows"],
+      "enabled": true
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- enable regular Renovate updates for GitHub Actions from `grafana/shared-workflows`
- keep the existing security-only policy for all other dependencies

This will cover tagged shared-workflow actions. The existing `trigger-argo-workflow` pins remain unmanaged because they point to an untagged commit without a version annotation.

## Test plan
- [x] Validate `renovate.json` with `jq`
- [ ] Confirm the Renovate config validation workflow passes