### PR TITLE
chore(examples): pass GITHUB_TOKEN through to the container

### DIFF
--- a/Makefile.examples
+++ b/Makefile.examples
@@ -15,7 +15,7 @@ examples/check-templates:
 .PHONY: tools/update_examples
 tools/update_examples:
 	docker buildx build --platform linux/amd64 -t update_pyroscope_examples -f tools/update_examples.Dockerfile  tools
-	docker run --rm  --platform=linux/amd64 -e GITHUB_TOKEN=$(GITHUB_TOKEN) -v$(shell pwd):/pyroscope -w /pyroscope update_pyroscope_examples bash -l -c "go run tools/update_examples.go -report $(UPDATE_EXAMPLES_REPORT)"
+	docker run --rm  --platform=linux/amd64 -e GITHUB_TOKEN -v$(shell pwd):/pyroscope -w /pyroscope update_pyroscope_examples bash -l -c "go run tools/update_examples.go -report $(UPDATE_EXAMPLES_REPORT)"
 
 
 # Deliberately not IMAGE_PREFIX/IMAGE_PLATFORM, whose global defaults point at a


### PR DESCRIPTION
`make` echoes recipe lines after variable expansion, so interpolating `$(GITHUB_TOKEN)` into the `docker run` invocation puts its value into the build output. Passing `-e GITHUB_TOKEN` without a value makes docker read it from the environment instead, so it never appears on the command line.

Tidy-up only, no behaviour change.

## Test plan

Verified the container receives the same value in all three invocation modes:

- `GITHUB_TOKEN=… make tools/update_examples` (how the cron does it) — passed through
- `make tools/update_examples GITHUB_TOKEN=…` (make argument) — passed through, since make exports command-line variables to recipes
- `GITHUB_TOKEN` unset — empty inside the container, no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
