### PR TITLE
optimize(index): align symbol cache entries

### DIFF
--- a/pkg/phlaredb/tsdb/index/index.go
+++ b/pkg/phlaredb/tsdb/index/index.go
@@ -97,8 +97,8 @@ func newCRC32() hash.Hash32 {
 }
 
 type symbolCacheEntry struct {
-	index          uint32
 	lastValue      string
+	index          uint32
 	lastValueIndex uint32
 }
 

--- a/pkg/segmentwriter/memdb/index/index.go
+++ b/pkg/segmentwriter/memdb/index/index.go
@@ -95,8 +95,8 @@ func newCRC32() hash.Hash32 {
 }
 
 type symbolCacheEntry struct {
-	index          uint32
 	lastValue      string
+	index          uint32
 	lastValueIndex uint32
 }
 


### PR DESCRIPTION
## Summary

Reorder `symbolCacheEntry` fields in both index writers to remove alignment padding.

Aligo before:
```
// Size: 32 (Optimal: 24)
index          uint32  ■ ■ ■ ■ □ □ □ □
lastValue      string  ■ ■ ■ ■ ■ ■ ■ ■
                       ■ ■ ■ ■ ■ ■ ■ ■
lastValueIndex uint32  ■ ■ ■ ■ □ □ □ □
```

Aligo after:
```
// Size: 24
lastValue      string  ■ ■ ■ ■ ■ ■ ■ ■
                       ■ ■ ■ ■ ■ ■ ■ ■
index          uint32  ■ ■ ■ ■
lastValueIndex uint32          ■ ■ ■ ■
```

This applies independently to `pkg/phlaredb/tsdb/index` and `pkg/segmentwriter/memdb/index`.

## Test

- `go test ./pkg/phlaredb/tsdb/index ./pkg/segmentwriter/memdb/index`
- `aligo check ./pkg/phlaredb/tsdb/index ./pkg/segmentwriter/memdb/index`