### PR TITLE
optimize(symdb): align sample appender

### DIFF
--- a/pkg/phlaredb/symdb/sample_appender.go
+++ b/pkg/phlaredb/symdb/sample_appender.go
@@ -22,11 +22,11 @@ import (
 //     matches the chunk range. In addition, values are ordered by stack trace
 //     ID without being sorted explicitly.
 type SampleAppender struct {
+	hashmap map[uint32]uint64
 	// Max number of elements in the map.
 	// Once the limit is exceeded, values
 	// are migrated to the chunked set.
 	maxMapSize uint32
-	hashmap    map[uint32]uint64
 	chunkSize  uint32 // Must be a power of 2.
 	chunks     [][]uint64
 	size       int


### PR DESCRIPTION
## Summary

Reorder `SampleAppender` fields to remove alignment padding without changing behavior.

Aligo before:
```
// Size: 72 (Optimal: 64)
maxMapSize uint32                                       ■ ■ ■ ■ □ □ □ □
hashmap    map[uint32]uint64                            ■ ■ ■ ■ ■ ■ ■ ■
chunkSize  uint32                                       ■ ■ ■ ■ □ □ □ □
chunks     [][]uint64                                   ■ ■ ■ ■ ■ ■ ■ ■
                                                        ■ ■ ■ ■ ■ ■ ■ ■
                                                        ■ ■ ■ ■ ■ ■ ■ ■
size       int                                          ■ ■ ■ ■ ■ ■ ■ ■
Append     func(stacktrace uint32, value uint64)        ■ ■ ■ ■ ■ ■ ■ ■
AppendMany func(stacktraces []uint32, values []uint64)  ■ ■ ■ ■ ■ ■ ■ ■
```

Aligo after:
```
// Size: 64
hashmap    map[uint32]uint64                            ■ ■ ■ ■ ■ ■ ■ ■
maxMapSize uint32                                       ■ ■ ■ ■
chunkSize  uint32                                               ■ ■ ■ ■
chunks     [][]uint64                                   ■ ■ ■ ■ ■ ■ ■ ■
                                                        ■ ■ ■ ■ ■ ■ ■ ■
                                                        ■ ■ ■ ■ ■ ■ ■ ■
size       int                                          ■ ■ ■ ■ ■ ■ ■ ■
Append     func(stacktrace uint32, value uint64)        ■ ■ ■ ■ ■ ■ ■ ■
AppendMany func(stacktraces []uint32, values []uint64)  ■ ■ ■ ■ ■ ■ ■ ■
```

## Test

- `go test ./pkg/phlaredb/symdb`
- `aligo check ./pkg/phlaredb/symdb` (`SampleAppender` is no longer reported; pre-existing `Config` finding remains.)