### PR TITLE
feat(metastore): optionally exit when a log store write times out

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -617,6 +617,8 @@ Usage of ./pyroscope:
     	
   -metastore.raft.dir string
     	Directory to store WAL and raft state. It must be a persistent directory, not a tmpfs or similar. (default "./data/v2/metastore/raft")
+  -metastore.raft.exit-on-log-store-timeout
+    	Terminate the process when a raft log store write exceeds log-store-timeout, instead of returning an error to raft. A timed-out write cannot be cancelled and may still land, leaving the raft view of the log inconsistent with what is on disk; restarting rebuilds that view from disk. Costs a process restart per timeout.
   -metastore.raft.log-index-check-interval duration
     	 (default 14ms)
   -metastore.raft.log-store-timeout duration

--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -618,7 +618,7 @@ Usage of ./pyroscope:
   -metastore.raft.dir string
     	Directory to store WAL and raft state. It must be a persistent directory, not a tmpfs or similar. (default "./data/v2/metastore/raft")
   -metastore.raft.exit-on-log-store-timeout
-    	Terminate the process when a raft log store write exceeds log-store-timeout, instead of returning an error to raft. A timed-out write cannot be cancelled and may still land, leaving the raft view of the log inconsistent with what is on disk; restarting rebuilds that view from disk. Costs a process restart per timeout.
+    	Terminate the process when a raft log store write exceeds log-store-timeout.
   -metastore.raft.log-index-check-interval duration
     	 (default 14ms)
   -metastore.raft.log-store-timeout duration

--- a/pkg/metastore/raftnode/logstore.go
+++ b/pkg/metastore/raftnode/logstore.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/hashicorp/raft"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -16,22 +18,43 @@ import (
 // the raft leader. Without this, a blocked StoreLogs call freezes the
 // leader's main goroutine while heartbeats continue on separate goroutines,
 // preventing followers from ever triggering an election.
+//
+// Returning an error leaves a subtle problem behind, which exitOnTimeout
+// exists to sidestep: the write is abandoned, not cancelled. The goroutine
+// performing it keeps running and may still land its entries, so raft's
+// belief that the append failed stops matching what is on disk. Raft's retry
+// for the same index then hits raft-wal's monotonicity check and the follower
+// livelocks. With exitOnTimeout the node terminates instead, and raft-wal
+// truncates any partially written tail when the segment is reopened, so the
+// node restarts with a valid prefix and raft rebuilds its view from disk.
 type timeoutLogStore struct {
 	store        raft.LogStore
 	timeout      time.Duration
 	writeLatency prometheus.Histogram
 	timeouts     prometheus.Counter
+	logger       log.Logger
+
+	// exitOnTimeout terminates the process rather than returning an error.
+	exitOnTimeout bool
+	// exit is os.Exit outside of tests.
+	exit func(int)
 }
 
-func newTimeoutLogStore(store raft.LogStore, timeout time.Duration, writeLatency prometheus.Histogram, timeouts prometheus.Counter) raft.LogStore {
-	if timeout <= 0 {
+func newTimeoutLogStore(store raft.LogStore, cfg Config, m *metrics, logger log.Logger, exit func(int)) raft.LogStore {
+	if cfg.LogStoreTimeout <= 0 {
 		return store
 	}
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
 	return &timeoutLogStore{
-		store:        store,
-		timeout:      timeout,
-		writeLatency: writeLatency,
-		timeouts:     timeouts,
+		store:         store,
+		timeout:       cfg.LogStoreTimeout,
+		writeLatency:  m.logStoreWrite,
+		timeouts:      m.logStoreTimeout,
+		logger:        logger,
+		exitOnTimeout: cfg.ExitOnLogStoreTimeout,
+		exit:          exit,
 	}
 }
 
@@ -89,6 +112,14 @@ func (s *timeoutLogStore) withTimeout(fn func() error) error {
 		}
 		s.writeLatency.Observe(time.Since(start).Seconds())
 		s.timeouts.Inc()
+		if s.exitOnTimeout {
+			level.Error(s.logger).Log(
+				"msg", "log store write timed out, exiting: the write cannot be cancelled, "+
+					"so raft's view of the log may no longer match what is on disk",
+				"timeout", s.timeout,
+			)
+			s.exit(1)
+		}
 		return fmt.Errorf("log store write timed out after %s", s.timeout)
 	}
 }

--- a/pkg/metastore/raftnode/logstore.go
+++ b/pkg/metastore/raftnode/logstore.go
@@ -18,15 +18,6 @@ import (
 // the raft leader. Without this, a blocked StoreLogs call freezes the
 // leader's main goroutine while heartbeats continue on separate goroutines,
 // preventing followers from ever triggering an election.
-//
-// Returning an error leaves a subtle problem behind, which exitOnTimeout
-// exists to sidestep: the write is abandoned, not cancelled. The goroutine
-// performing it keeps running and may still land its entries, so raft's
-// belief that the append failed stops matching what is on disk. Raft's retry
-// for the same index then hits raft-wal's monotonicity check and the follower
-// livelocks. With exitOnTimeout the node terminates instead, and raft-wal
-// truncates any partially written tail when the segment is reopened, so the
-// node restarts with a valid prefix and raft rebuilds its view from disk.
 type timeoutLogStore struct {
 	store        raft.LogStore
 	timeout      time.Duration
@@ -35,6 +26,13 @@ type timeoutLogStore struct {
 	logger       log.Logger
 
 	// exitOnTimeout terminates the process rather than returning an error.
+	// Returning an error means the write is abandoned, not cancelled. The goroutine
+	// performing it keeps running and may still land its entries, so raft's
+	// belief that the append failed stops matching what is on disk.
+	//
+	// With exitOnTimeout the node terminates instead, and raft-wal
+	// truncates any partially written tail when the segment is reopened, so the
+	// node restarts with a valid prefix and raft rebuilds its view from disk.
 	exitOnTimeout bool
 	// exit is os.Exit outside of tests.
 	exit func(int)

--- a/pkg/metastore/raftnode/logstore_test.go
+++ b/pkg/metastore/raftnode/logstore_test.go
@@ -1,0 +1,71 @@
+package raftnode
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// blockingLogStore models a disk that has stopped answering: StoreLogs never
+// returns until the test releases it, which is what drives withTimeout past
+// its deadline.
+type blockingLogStore struct {
+	raft.LogStore
+	release chan struct{}
+}
+
+func (b *blockingLogStore) StoreLogs([]*raft.Log) error {
+	<-b.release
+	return nil
+}
+
+func TestTimeoutLogStore_ExitOnTimeout(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		exitOn     bool
+		wantExited bool
+	}{
+		{name: "disabled returns an error to raft", exitOn: false, wantExited: false},
+		{name: "enabled terminates the process", exitOn: true, wantExited: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			blocking := &blockingLogStore{release: make(chan struct{})}
+			// Released only at the end: the write is abandoned, not
+			// cancelled, so the goroutine is still parked in StoreLogs when
+			// withTimeout gives up on it.
+			t.Cleanup(func() { close(blocking.release) })
+
+			var exited atomic.Bool
+			cfg := Config{
+				LogStoreTimeout:       50 * time.Millisecond,
+				ExitOnLogStoreTimeout: tc.exitOn,
+			}
+			s := newTimeoutLogStore(blocking, cfg, newMetrics(prometheus.NewRegistry()), nil,
+				func(int) { exited.Store(true) })
+
+			err := s.StoreLogs([]*raft.Log{{Index: 1, Term: 1}})
+
+			// The error is returned either way; with the flag on, the real
+			// os.Exit would not have come back at all.
+			require.ErrorContains(t, err, "timed out")
+			require.Equal(t, tc.wantExited, exited.Load())
+		})
+	}
+}
+
+func TestTimeoutLogStore_NoExitOnSuccessfulWrite(t *testing.T) {
+	var exited atomic.Bool
+	cfg := Config{
+		LogStoreTimeout:       time.Minute,
+		ExitOnLogStoreTimeout: true,
+	}
+	s := newTimeoutLogStore(raft.NewInmemStore(), cfg, newMetrics(prometheus.NewRegistry()), nil,
+		func(int) { exited.Store(true) })
+
+	require.NoError(t, s.StoreLogs([]*raft.Log{{Index: 1, Term: 1}}))
+	require.False(t, exited.Load())
+}

--- a/pkg/metastore/raftnode/node.go
+++ b/pkg/metastore/raftnode/node.go
@@ -119,7 +119,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.Uint64Var(&cfg.TransportConnPoolSize, prefix+"transport-conn-pool-size", defaultTransportConnPoolSize, "")
 	f.DurationVar(&cfg.TransportTimeout, prefix+"transport-timeout", defaultTransportTimeout, "")
 	f.DurationVar(&cfg.LogStoreTimeout, prefix+"log-store-timeout", defaultLogStoreTimeout, "")
-	f.BoolVar(&cfg.ExitOnLogStoreTimeout, prefix+"exit-on-log-store-timeout", false, "Terminate the process when a raft log store write exceeds log-store-timeout, instead of returning an error to raft. A timed-out write cannot be cancelled and may still land, leaving the raft view of the log inconsistent with what is on disk; restarting rebuilds that view from disk. Costs a process restart per timeout.")
+	f.BoolVar(&cfg.ExitOnLogStoreTimeout, prefix+"exit-on-log-store-timeout", false, "Terminate the process when a raft log store write exceeds log-store-timeout.")
 }
 
 func (cfg *Config) Validate() error {

--- a/pkg/metastore/raftnode/node.go
+++ b/pkg/metastore/raftnode/node.go
@@ -56,6 +56,7 @@ type Config struct {
 	TransportConnPoolSize uint64        `yaml:"transport_conn_pool_size" category:"advanced" doc:"hidden"`
 	TransportTimeout      time.Duration `yaml:"transport_timeout" category:"advanced" doc:"hidden"`
 	LogStoreTimeout       time.Duration `yaml:"log_store_timeout" category:"advanced" doc:"hidden"`
+	ExitOnLogStoreTimeout bool          `yaml:"exit_on_log_store_timeout" category:"advanced" doc:"hidden"`
 
 	// If set, wraps the log store after construction. Used only for testing.
 	LogStoreMiddleware func(raft.LogStore) raft.LogStore `yaml:"-"`
@@ -118,6 +119,7 @@ func (cfg *Config) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
 	f.Uint64Var(&cfg.TransportConnPoolSize, prefix+"transport-conn-pool-size", defaultTransportConnPoolSize, "")
 	f.DurationVar(&cfg.TransportTimeout, prefix+"transport-timeout", defaultTransportTimeout, "")
 	f.DurationVar(&cfg.LogStoreTimeout, prefix+"log-store-timeout", defaultLogStoreTimeout, "")
+	f.BoolVar(&cfg.ExitOnLogStoreTimeout, prefix+"exit-on-log-store-timeout", false, "Terminate the process when a raft log store write exceeds log-store-timeout, instead of returning an error to raft. A timed-out write cannot be cancelled and may still land, leaving the raft view of the log inconsistent with what is on disk; restarting rebuilds that view from disk. Costs a process restart per timeout.")
 }
 
 func (cfg *Config) Validate() error {
@@ -266,7 +268,7 @@ func (n *Node) openStore() (err error) {
 		n.logStore = n.config.LogStoreMiddleware(n.logStore)
 	}
 
-	n.logStore = newTimeoutLogStore(n.logStore, n.config.LogStoreTimeout, n.metrics.logStoreWrite, n.metrics.logStoreTimeout)
+	n.logStore = newTimeoutLogStore(n.logStore, n.config, n.metrics, n.logger, os.Exit)
 	n.stableStore = n.wal
 	n.snapshotStore = n.snapshots
 	return nil


### PR DESCRIPTION
Follow-up to #5518, which stopped a follower disk stall from deadlocking raft's pipeline replication. The other half of that failure is still open: `timeoutLogStore` stops waiting for a slow write but cannot cancel it, so the goroutine keeps running and may still land its entries. Raft believes the append failed, the disk disagrees, and raft's retry for the same index hits raft-wal's monotonicity check.

#5307 reconciles that on every later write. This adds the opposite option: don't reconcile, terminate. raft-wal truncates any partially written tail when it reopens the segment, so the node restarts with a valid prefix and raft rebuilds its view from disk. A replica returning with uncommitted entries the leader lacks is an ordinary raft state, resolved by the usual conflict truncation.

Off by default (`-metastore.raft.exit-on-log-store-timeout`); nothing changes unless it is set.

Notes:

- The trade is availability for provability. Each timeout costs a restart plus a snapshot restore instead of being ridden out in place; a persistently bad disk becomes `CrashLoopBackOff`
- No write serialisation is needed here, unlike #5307: after the first timeout the process is leaving, so there is no second write to race the abandoned one.
- This and #5307 are alternatives, not companions. Enabling this flag makes #5307 unnecessary; leaving it off makes #5307 the fix.
- If hashicorp/raft#683 lands, `timeoutLogStore` and everything built on it can go away.

cc @simonswine