### PR TITLE
chore: Add more logging to async queries

### DIFF
--- a/pkg/frontend/async/coordinator.go
+++ b/pkg/frontend/async/coordinator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/common/model"
 	"google.golang.org/protobuf/proto"
 
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
@@ -99,8 +100,18 @@ func (c *Coordinator) Submit(ctx context.Context, tenantID string, req *querierv
 		return "", fmt.Errorf("failed to create async query: %w", err)
 	}
 
+	// Logged before dispatch so a request's lines always start with its
+	// submission: a fast query can otherwise record its completion first.
+	level.Info(c.logger).Log("msg", "async query submitted",
+		"tenant", tenantID,
+		"request_id", requestID,
+		"profile_type", spec.GetProfileTypeID(),
+		"label_selector", spec.GetLabelSelector(),
+		"start", model.Time(spec.GetStart()).Time().String(),
+		"end", model.Time(spec.GetEnd()).Time().String(),
+		"query_window", model.Time(spec.GetEnd()).Sub(model.Time(spec.GetStart())).String(),
+	)
 	c.dispatch(tenantID, requestID, spec)
-	level.Info(c.logger).Log("msg", "async query submitted", "tenant", tenantID, "request_id", requestID)
 	return requestID, nil
 }
 
@@ -133,6 +144,7 @@ func (c *Coordinator) Dispatch(tenantID, requestID string, spec *querierv1.Selec
 func (c *Coordinator) dispatch(tenantID, requestID string, spec *querierv1.SelectMergeStacktracesRequest) {
 	queryCtx := tenant.InjectTenantID(context.Background(), tenantID)
 	resultCh := make(chan queryResult, 1)
+	started := time.Now()
 
 	// query goroutine: runs the spec end-to-end.
 	go func() {
@@ -145,10 +157,14 @@ func (c *Coordinator) dispatch(tenantID, requestID string, spec *querierv1.Selec
 	}()
 
 	// supervisor goroutine: renews the lease and records the outcome.
-	go c.awaitResult(tenantID, requestID, resultCh)
+	go c.awaitResult(tenantID, requestID, resultCh, started)
 }
 
-func (c *Coordinator) awaitResult(tenantID, requestID string, resultCh <-chan queryResult) {
+// awaitResult records the outcome of one execution attempt. started marks the
+// beginning of that attempt, not of the request: an adopted query is dispatched
+// afresh, so its duration excludes the dead owner's time. The client-observed
+// latency is the poll path's age field.
+func (c *Coordinator) awaitResult(tenantID, requestID string, resultCh <-chan queryResult, started time.Time) {
 	defer c.decrement(tenantID)
 
 	ctx := tenant.InjectTenantID(context.Background(), tenantID)
@@ -159,17 +175,18 @@ func (c *Coordinator) awaitResult(tenantID, requestID string, resultCh <-chan qu
 	for {
 		select {
 		case res := <-resultCh:
+			duration := time.Since(started).Round(time.Millisecond)
 			if res.Err != nil {
-				level.Error(c.logger).Log("msg", "async query failed", "tenant", tenantID, "request_id", requestID, "err", res.Err)
+				level.Error(c.logger).Log("msg", "async query failed", "tenant", tenantID, "request_id", requestID, "duration", duration, "err", res.Err)
 				if storeErr := c.store.fail(ctx, tenantID, requestID, res.Err); storeErr != nil {
 					level.Error(c.logger).Log("msg", "failed to store async query failure", "tenant", tenantID, "request_id", requestID, "err", storeErr)
 				}
 				return
 			}
 			if err := c.store.complete(ctx, tenantID, requestID, res.Response); err != nil {
-				level.Error(c.logger).Log("msg", "failed to store async query result", "tenant", tenantID, "request_id", requestID, "err", err)
+				level.Error(c.logger).Log("msg", "failed to store async query result", "tenant", tenantID, "request_id", requestID, "duration", duration, "err", err)
 			} else {
-				level.Info(c.logger).Log("msg", "async query completed", "tenant", tenantID, "request_id", requestID)
+				level.Info(c.logger).Log("msg", "async query completed", "tenant", tenantID, "request_id", requestID, "duration", duration)
 			}
 			return
 		case <-ticker.C:

--- a/pkg/frontend/async/handler.go
+++ b/pkg/frontend/async/handler.go
@@ -131,7 +131,7 @@ func (h *Handler) poll(
 	case StatusInProgress:
 		level.Debug(logger).Log("msg", "async query polled, still in progress")
 	case StatusFailure:
-		level.Info(logger).Log("msg", "async query result returned to client", "err", result.Metadata.ErrorMessage)
+		level.Error(logger).Log("msg", "async query result returned to client", "err", result.Metadata.ErrorMessage)
 	default:
 		level.Info(logger).Log("msg", "async query result returned to client")
 	}

--- a/pkg/frontend/async/handler.go
+++ b/pkg/frontend/async/handler.go
@@ -3,8 +3,11 @@ package async
 import (
 	"context"
 	"errors"
+	"time"
 
 	"connectrpc.com/connect"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/tenant"
 
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
@@ -16,12 +19,14 @@ import (
 // handler unchanged.
 type Handler struct {
 	querierv1connect.QuerierServiceHandler
+	logger      log.Logger
 	coordinator *Coordinator
 }
 
-func NewHandler(next querierv1connect.QuerierServiceHandler, coordinator *Coordinator) *Handler {
+func NewHandler(logger log.Logger, next querierv1connect.QuerierServiceHandler, coordinator *Coordinator) *Handler {
 	return &Handler{
 		QuerierServiceHandler: next,
+		logger:                logger,
 		coordinator:           coordinator,
 	}
 }
@@ -67,6 +72,9 @@ func (h *Handler) submit(
 ) (*connect.Response[querierv1.SelectMergeStacktracesResponse], error) {
 	requestID, err := h.coordinator.Submit(ctx, tenantID, req)
 	if err != nil {
+		// No request ID exists yet, so this line is only findable by tenant:
+		// the submission never became part of any request's lifecycle.
+		level.Warn(h.logger).Log("msg", "async query submission rejected", "tenant", tenantID, "err", err)
 		return nil, connect.NewError(connect.CodeResourceExhausted, err)
 	}
 	return connect.NewResponse(&querierv1.SelectMergeStacktracesResponse{
@@ -82,11 +90,17 @@ func (h *Handler) poll(
 	tenantID string,
 	requestID string,
 ) (*connect.Response[querierv1.SelectMergeStacktracesResponse], error) {
+	logger := log.With(h.logger, "tenant", tenantID, "request_id", requestID)
+
 	result, err := h.coordinator.PollQuery(ctx, tenantID, requestID)
 	if err != nil {
+		level.Warn(logger).Log("msg", "async query poll failed", "err", err)
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 	if result == nil {
+		// Also covers a poll for another tenant's request: get() reports a
+		// cross-tenant lookup as not found rather than leaking its existence.
+		level.Warn(logger).Log("msg", "async query polled but not found")
 		return nil, connect.NewError(connect.CodeNotFound, errors.New("async query not found"))
 	}
 
@@ -109,5 +123,17 @@ func (h *Handler) poll(
 		resp.Async.ErrorMessage = result.Metadata.ErrorMessage
 	}
 
+	logger = log.With(logger,
+		"status", string(result.Metadata.Status),
+		"age", time.Since(result.Metadata.CreatedAt).Round(time.Millisecond),
+	)
+	switch result.Metadata.Status {
+	case StatusInProgress:
+		level.Debug(logger).Log("msg", "async query polled, still in progress")
+	case StatusFailure:
+		level.Info(logger).Log("msg", "async query result returned to client", "err", result.Metadata.ErrorMessage)
+	default:
+		level.Info(logger).Log("msg", "async query result returned to client")
+	}
 	return connect.NewResponse(resp), nil
 }

--- a/pkg/frontend/async/handler_test.go
+++ b/pkg/frontend/async/handler_test.go
@@ -27,7 +27,7 @@ func TestHandlerPollCopiesPprofResponse(t *testing.T) {
 		Pprof: &querierv1.PprofProfile{Profile: want},
 	}))
 
-	handler := &Handler{coordinator: &Coordinator{store: store}}
+	handler := &Handler{logger: log.NewNopLogger(), coordinator: &Coordinator{store: store}}
 	resp, err := handler.poll(ctx, tenantID, requestID)
 
 	require.NoError(t, err)
@@ -45,7 +45,7 @@ func TestHandlerPollTenantIsolation(t *testing.T) {
 	)
 	require.NoError(t, store.create(ctx, tenantA, requestID, &querierv1.SelectMergeStacktracesRequest{}))
 
-	handler := &Handler{coordinator: &Coordinator{store: store}}
+	handler := &Handler{logger: log.NewNopLogger(), coordinator: &Coordinator{store: store}}
 	_, err := handler.poll(ctx, tenantB, requestID)
 
 	require.Error(t, err)

--- a/pkg/pyroscope/modules_experimental.go
+++ b/pkg/pyroscope/modules_experimental.go
@@ -112,7 +112,11 @@ func (f *Pyroscope) initQueryFrontendV2() (services.Service, error) {
 			f.reg,
 		)
 		f.asyncQueryStore.SetDispatcher(coordinator)
-		querierHandler = asyncquery.NewHandler(querierHandler, coordinator)
+		querierHandler = asyncquery.NewHandler(
+			log.With(f.logger, "component", "async-query-handler"),
+			querierHandler,
+			coordinator,
+		)
 	}
 
 	vcsService := vcs.New(


### PR DESCRIPTION
We don't have great logging visibility into the lifecycle of a async query. This adds some logging points to make it easier to trace a query across polls.