### PR TITLE
docs(config): document the retention_period limit

### DIFF
--- a/cmd/pyroscope/pyroscope.yaml
+++ b/cmd/pyroscope/pyroscope.yaml
@@ -481,6 +481,9 @@ limits:
   # limit is enforced in the distributor. 0 to disable, defaults to 10m.
   # reject_newer_than: 10m
 
+  # Retention period for the data. 0 means data never deleted.
+  # retention_period: 31d
+
   # Maximum number of recording rules a tenant can create. 0 to disable.
   # max_recording_rules: 25
 

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -3397,6 +3397,10 @@ distributor_usage_groups:
 # CLI flag: -validation.reject-newer-than
 [reject_newer_than: <duration> | default = 10m]
 
+# Retention period for the data. 0 means data never deleted.
+# CLI flag: -retention-period
+[retention_period: <duration> | default = 31d]
+
 # Maximum number of recording rules a tenant can create. 0 to disable.
 # CLI flag: -recording-rules.max-rules-per-tenant
 [max_recording_rules: <int> | default = 25]

--- a/docs/sources/reference-pyroscope-v2-architecture/metadata-index/index.md
+++ b/docs/sources/reference-pyroscope-v2-architecture/metadata-index/index.md
@@ -145,7 +145,7 @@ Retention policies delete entire partitions based on:
 - **Block creation time**: Primary retention criteria
 - **Data timestamps**: Blocks are only deleted if data is also past retention
 
-Retention policies are tenant-specific and configurable per tenant.
+Retention policies are tenant-specific and configurable per tenant with the [`retention_period`](../../configure-server/reference-configuration-parameters/#limits) limit.
 
 ## Cleanup process
 

--- a/pkg/metastore/index/cleaner/retention/retention.go
+++ b/pkg/metastore/index/cleaner/retention/retention.go
@@ -24,7 +24,7 @@ type Policy interface {
 }
 
 type Config struct {
-	RetentionPeriod model.Duration `yaml:"retention_period" doc:"hidden"`
+	RetentionPeriod model.Duration `yaml:"retention_period"`
 }
 
 type Overrides interface {


### PR DESCRIPTION
Fixes #5523

`retention_period` is tagged `doc:"hidden"`, so `tools/doc-generator` skips it and it has never appeared in the configuration reference. The reporter found it in the source and asked whether that was deliberate.

It reads as an oversight rather than a knob you meant to keep private:

* it is inlined into `Limits` and read through `Overrides.Retention()`, like every other tenant limit
* it already shows up in the basic `-help` output, not only in `-help-all`
* its sibling `compactor_blocks_retention_period` is documented with no such tag
* per-tenant overrides are already covered by `TestRetentionOverridesYAML`

So this drops the tag and regenerates the reference page and the example config. It also names the parameter in the metadata index architecture page, whose time-based retention section explained the behavior without ever saying which setting controls it.

No behavior change. The help printer classifies flags by the `category` tag rather than the `doc` tag, so `help.txt.tmpl` and `help-all.txt.tmpl` are byte identical and `TestHelp` passes unchanged.

**Changes**

* `pkg/metastore/index/cleaner/retention/retention.go`: remove `doc:"hidden"`
* `docs/sources/configure-server/reference-configuration-parameters/index.md`: regenerated
* `cmd/pyroscope/pyroscope.yaml`: regenerated
* `docs/sources/reference-pyroscope-v2-architecture/metadata-index/index.md`: link the parameter from the retention section

**Verification**

* both `doc-generator` invocations from the `generate` target re-run; the diff is the 4 and 3 added lines above and nothing else
* `go test ./cmd/pyroscope/` passes, both help golden files unchanged
* `go test ./pkg/validation/... ./pkg/metastore/index/cleaner/...` passes

I left the flag's description string as it is to keep the diff mechanical. Happy to reword it here if you would rather it read differently now that it is published.