### PR TITLE
fix(examples): run the nodejs rideshare on a slim base

### DIFF
--- a/examples/language-sdk-instrumentation/nodejs/express/Dockerfile
+++ b/examples/language-sdk-instrumentation/nodejs/express/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:25
+# Must stay glibc: the SDK ships prebuilt binaries.
+FROM node:25-trixie-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
`node:25` is built on `buildpack-deps`, so the deployed image ships MariaDB and OpenEXR dev headers to serve four express routes. 2548 of its 2578 scanner findings are OS packages it never uses.

Staying on the 25 line, just off the fat variant. Measured with grype (db 2026-08-19) on the deployed image vs. this build:

| | before | after |
|---|---|---|
| total findings | 2578 | 239 |
| critical / high | 88 / 518 | 10 / 47 |
| distinct critical | 29 | 8 |

Across the five `pyroscope-rideshare-dev-*` namespaces that takes distinct criticals from 37 to 23, and critical+high from 254 to 142. It is the only single-image change worth doing alone — the other Debian images share their criticals with each other, so they need to move together in a follow-up.

Nothing else has to change: `.npmrc` and `.yarnrc` already set `ignore-scripts`, so no native code is built here, and the SDK's prebuilt binaries need glibc rather than a toolchain — hence slim and not alpine.

Verified locally on linux/amd64: builds, container starts on node v25.9.0 (ABI 141, which the bundled `abi141` prebuild resolves), `/bike`, `/car` and `/scooter` all return 200 through `wrapWithLabels`, and the native `TimeProfiler` binding loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
