### PR TITLE
fix(examples): build the golang rideshare images on distroless

### DIFF
--- a/examples/language-sdk-instrumentation/golang-push/rideshare/Dockerfile
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare/Dockerfile
@@ -1,6 +1,13 @@
-FROM golang:1.25.13
+FROM golang:1.25.13 AS build
 
 WORKDIR /go/src/app
 COPY . .
-RUN go build main.go
+# loadgen.go shares this directory, so the build has to name the file.
+RUN CGO_ENABLED=0 go build -o main main.go
+
+FROM gcr.io/distroless/static-debian12:nonroot
+
+# Path must match: the deployment invokes the binary relative to this workdir.
+WORKDIR /go/src/app
+COPY --from=build /go/src/app/main .
 CMD ["./main"]

--- a/examples/language-sdk-instrumentation/golang-push/rideshare/Dockerfile.load-generator
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare/Dockerfile.load-generator
@@ -1,6 +1,13 @@
-FROM golang:1.25.13
+FROM golang:1.25.13 AS build
 
 WORKDIR /go/src/app
 COPY . .
-RUN go build loadgen.go
+# main.go shares this directory, so the build has to name the file.
+RUN CGO_ENABLED=0 go build -o loadgen loadgen.go
+
+FROM gcr.io/distroless/static-debian12:nonroot
+
+# Path must match: the deployment invokes ./loadgen relative to this workdir.
+WORKDIR /go/src/app
+COPY --from=build /go/src/app/loadgen .
 CMD ["./loadgen"]


### PR DESCRIPTION
Both images shipped the entire `golang` base — 207 Debian packages plus the Go toolchain — in order to run a single static binary. `curl`, `perl`, `libc6` and `openssh-client` accounted for most of the criticals, and none of them are used at runtime: the compiler is needed to build the app, not to run it.

So compile in a build stage and copy only the resulting binary into `gcr.io/distroless/static`, which has no shell, no package manager and no OS packages to scan.

Measured with grype (db 2026-08-19), per image:

| | before | after |
|---|---|---|
| total findings | 1087 | 1 |
| critical / high | 45 / 227 | 0 / 1 |
| image size | 864MB | 27.5MB |

Across the five `pyroscope-rideshare-dev-*` namespaces that takes distinct criticals from 23 to 14. The one remaining finding is `CVE-2026-46600` in the Go stdlib compiled into the binary — a toolchain bump, not a base image change.

Two things to know:

- `WORKDIR` and the binary names are deliberately unchanged, so `withCommand('./loadgen')` in `deployment_tools` keeps resolving and no jsonnet change is needed.
- `CGO_ENABLED=0` is required — `distroless/static` has no libc. The app is pure Go, so nothing is lost. It also now runs as nonroot (uid 65532) rather than root.

Verified on linux/amd64: both images build, `/bike` returns 200, and loadgen drives the server using the deployment's exact command form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
