### PR TITLE
fix(examples): clear the java rideshare CVEs

### DIFF
--- a/examples/language-sdk-instrumentation/java/rideshare/build.gradle.kts
+++ b/examples/language-sdk-instrumentation/java/rideshare/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java")
-    id("org.springframework.boot") version "3.3.6"
+    id("org.springframework.boot") version "3.3.13"
     id("io.spring.dependency-management") version "1.1.6"
 }
 
@@ -11,7 +11,8 @@ repositories {
     mavenCentral()
 }
 
-ext["tomcat.version"] = "10.1.35"
+ext["tomcat.version"] = "10.1.55"
+ext["jackson-bom.version"] = "2.21.4"
 
 dependencies {
     implementation("io.pyroscope:agent:2.9.1")


### PR DESCRIPTION
Tomcat was pinned to `10.1.35`, which carries three criticals fixed in `10.1.55`. The pin has to stay rather than be removed: every Spring Boot release manages `10.1.42`, including the latest 3.5.3. Jackson needs the same treatment — its advisories only clear in `2.21.4` and the BOM ships `2.17.3`.

Measured with grype on the built image:

| | before | after |
|---|---|---|
| critical | 3 | 0 |
| high | 21 | 5 |

The five remaining are `spring-core`, `spring-webmvc`, `spring-expression` and `spring-boot`, none of which have a published fix.

Spring Boot goes 3.3.6 → 3.3.13, which clears one high and stays compatible with the Gradle 8.2.1 wrapper (3.4+ needs 8.4+, and manages the same Tomcat anyway).

Verified on linux/amd64: builds, app starts, `/bike`, `/car` and `/scooter` all return 200 with no exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
