### PR TITLE
fix(usagestats): let the segment writer create the cluster seed on v2 storage

### DIFF
--- a/pkg/pyroscope/modules.go
+++ b/pkg/pyroscope/modules.go
@@ -603,11 +603,8 @@ func (f *Pyroscope) initUsageReport() (services.Service, error) {
 	if !f.Cfg.Analytics.Enabled {
 		return nil, nil
 	}
-	f.Cfg.Analytics.Leader = false
-	// ingester is the only component that can be a leader
-	if f.isModuleActive(Ingester) {
-		f.Cfg.Analytics.Leader = true
-	}
+	// Only the write path component creates the cluster seed: ingester on v1, segment writer on v2.
+	f.Cfg.Analytics.Leader = f.isModuleActive(Ingester) || f.isModuleActive(SegmentWriter)
 
 	usagestats.Target(f.Cfg.Target.String())
 

--- a/pkg/pyroscope/modules_test.go
+++ b/pkg/pyroscope/modules_test.go
@@ -1,0 +1,46 @@
+package pyroscope
+
+import (
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Every architecture must leave exactly one kind of seed writer; every other target follows.
+func TestInitUsageReport_SeedLeader(t *testing.T) {
+	for _, tc := range []struct {
+		architecture string
+		target       string
+		wantLeader   bool
+	}{
+		{architecture: "v2", target: All, wantLeader: true},
+		{architecture: "v2", target: SegmentWriter, wantLeader: true},
+		// Distributor reaches SegmentWriterRing via SegmentWriterClient, but never SegmentWriter.
+		{architecture: "v2", target: Distributor, wantLeader: false},
+
+		{architecture: "v1-v2-dual", target: Ingester, wantLeader: true},
+		{architecture: "v1-v2-dual", target: SegmentWriter, wantLeader: true},
+
+		// v1 drops the segment writer from All, leaving the ingester.
+		{architecture: "v1", target: All, wantLeader: true},
+		{architecture: "v1", target: Distributor, wantLeader: false},
+	} {
+		t.Run(tc.architecture+"/"+tc.target, func(t *testing.T) {
+			f := &Pyroscope{
+				Cfg:    newTestConfig(t, []string{"-architecture.storage=" + tc.architecture, "-target=" + tc.target}),
+				logger: &logger{Logger: log.NewNopLogger()},
+			}
+			// Without a configured object store, initUsageReport writes a filesystem bucket here.
+			f.Cfg.PhlareDB.DataPath = t.TempDir()
+			require.NoError(t, f.setupModuleManager())
+
+			svc, err := f.initUsageReport()
+			require.NoError(t, err)
+			require.NotNil(t, svc, "usage report service should be constructed")
+
+			assert.Equal(t, tc.wantLeader, f.Cfg.Analytics.Leader)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Fixes https://github.com/grafana/pyroscope-squad/issues/902

`initUsageReport` marks a process as the cluster seed writer only when the **ingester** is active, and the ingester is registered only under `v1` or `v1-v2-dual` storage. A `v2`-only deployment therefore has no seed writer: nothing uploads `pyroscope_cluster_seed.json`, and every component depending on `usage-stats` polls for it forever with infinite retries.

Once a minute per pod, on distributor, query-frontend and segment-writer:

```
caller=reporter.go:201 level=debug msg="failed to read cluster seed file"
err="... RESPONSE 404 ... ERROR CODE: BlobNotFound"
```

So a permanent stream of failed GETs against the data bucket (57% of all GETs on one affected cluster), and usage reporting never starts. Only clusters born on v2 are hit; those that once ran v1 had an ingester write the seed, and nothing deletes it.

## Fix

Make the write path component the seed writer: ingester on v1, segment writer on v2.

Nothing else needed wiring. `SegmentWriter` already depends on `UsageReport`, the reporter's KV config is set to memberlist unconditionally, and `usagestats.JSONCodec` is always registered. Nothing depends on `SegmentWriter`, so leadership cannot leak into read path components via the dependency graph.

Clusters with an existing seed file are unaffected: `fetchSeed` succeeds and `initLeader` returns the remote seed, so cluster identity and report schedule stay put. Multiple segment writers all become candidates, as multiple ingesters did on v1; convergence via memberlist CAS and `ClusterSeed.Merge` is already covered by `Test_LeaderElection`.

## Tests

`TestInitUsageReport_SeedLeader` asserts which targets become the seed writer across all three architectures. Without the fix, `v2/all`, `v2/segment-writer` and `v1-v2-dual/segment-writer` fail.
