### PR TITLE
fix(metastore): double prefix on index cache and DLQ metrics

### DIFF
--- a/pkg/metastore/index/dlq/metrics.go
+++ b/pkg/metastore/index/dlq/metrics.go
@@ -12,10 +12,8 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 	m := &metrics{
 		recoveryAttempts: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Namespace: "pyroscope",
-				Subsystem: "metastore",
-				Name:      "dlq_recovery_attempts_total",
-				Help:      "Total number of DLQ block recovery attempts by status.",
+				Name: "dlq_recovery_attempts_total",
+				Help: "Total number of DLQ block recovery attempts by status.",
 			},
 			[]string{"status"},
 		),

--- a/pkg/metastore/index/metrics.go
+++ b/pkg/metastore/index/metrics.go
@@ -10,9 +10,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 	m := &metrics{
 		cacheRequests: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Namespace: "pyroscope",
-				Subsystem: "metastore",
-				Name:      "index_cache_requests_total",
+				Name: "index_cache_requests_total",
 				Help: "Total number of metastore index cache lookups, partitioned by cache and result. " +
 					"The block cache has two tiers; result distinguishes which tier served the " +
 					"lookup (read_hit / write_hit) or whether both tiers missed.",


### PR DESCRIPTION
Both counters set `Namespace`/`Subsystem` explicitly, but the metastore module already wraps its registerer with `pyroscope_metastore_`, so they were emitted as `pyroscope_metastore_pyroscope_metastore_index_cache_requests_total` and `..._dlq_recovery_attempts_total`. Dropping the explicit prefix matches the sibling packages, which only set `Name`.

Nothing references the old names yet.