### PR TITLE
feat(querybackend): cache metadata query results

### DIFF
--- a/api/connect-openapi/gen/query/v1/query.openapi.yaml
+++ b/api/connect-openapi/gen/query/v1/query.openapi.yaml
@@ -823,6 +823,10 @@ components:
         collectDiagnostics:
           type: boolean
           title: collect_diagnostics
+        bypassResultCache:
+          type: boolean
+          title: bypass_result_cache
+          description: Prevent child query-backends from attempting result-cache coordination.
       title: InvokeOptions
       additionalProperties: false
     query.v1.InvokeRequest:

--- a/api/gen/proto/go/query/v1/query.pb.go
+++ b/api/gen/proto/go/query/v1/query.pb.go
@@ -380,8 +380,10 @@ type InvokeOptions struct {
 	// be listed in the request explicitly.
 	SanitizeOnMerge    bool `protobuf:"varint,1,opt,name=sanitize_on_merge,json=sanitizeOnMerge,proto3" json:"sanitize_on_merge,omitempty"`
 	CollectDiagnostics bool `protobuf:"varint,2,opt,name=collect_diagnostics,json=collectDiagnostics,proto3" json:"collect_diagnostics,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// Prevent child query-backends from attempting result-cache coordination.
+	BypassResultCache bool `protobuf:"varint,3,opt,name=bypass_result_cache,json=bypassResultCache,proto3" json:"bypass_result_cache,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *InvokeOptions) Reset() {
@@ -424,6 +426,13 @@ func (x *InvokeOptions) GetSanitizeOnMerge() bool {
 func (x *InvokeOptions) GetCollectDiagnostics() bool {
 	if x != nil {
 		return x.CollectDiagnostics
+	}
+	return false
+}
+
+func (x *InvokeOptions) GetBypassResultCache() bool {
+	if x != nil {
+		return x.BypassResultCache
 	}
 	return false
 }
@@ -791,6 +800,58 @@ func (x *InvokeResponse) GetDiagnostics() *Diagnostics {
 	return nil
 }
 
+type ResultCacheEntry struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Query         *QueryRequest          `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty"`
+	Reports       []*Report              `protobuf:"bytes,2,rep,name=reports,proto3" json:"reports,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResultCacheEntry) Reset() {
+	*x = ResultCacheEntry{}
+	mi := &file_query_v1_query_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResultCacheEntry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResultCacheEntry) ProtoMessage() {}
+
+func (x *ResultCacheEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_query_v1_query_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResultCacheEntry.ProtoReflect.Descriptor instead.
+func (*ResultCacheEntry) Descriptor() ([]byte, []int) {
+	return file_query_v1_query_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *ResultCacheEntry) GetQuery() *QueryRequest {
+	if x != nil {
+		return x.Query
+	}
+	return nil
+}
+
+func (x *ResultCacheEntry) GetReports() []*Report {
+	if x != nil {
+		return x.Reports
+	}
+	return nil
+}
+
 // Diagnostic messages, events, statistics, analytics, etc.
 type Diagnostics struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -802,7 +863,7 @@ type Diagnostics struct {
 
 func (x *Diagnostics) Reset() {
 	*x = Diagnostics{}
-	mi := &file_query_v1_query_proto_msgTypes[8]
+	mi := &file_query_v1_query_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -814,7 +875,7 @@ func (x *Diagnostics) String() string {
 func (*Diagnostics) ProtoMessage() {}
 
 func (x *Diagnostics) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[8]
+	mi := &file_query_v1_query_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -827,7 +888,7 @@ func (x *Diagnostics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Diagnostics.ProtoReflect.Descriptor instead.
 func (*Diagnostics) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{8}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *Diagnostics) GetQueryPlan() *QueryPlan {
@@ -860,7 +921,7 @@ type ExecutionNode struct {
 
 func (x *ExecutionNode) Reset() {
 	*x = ExecutionNode{}
-	mi := &file_query_v1_query_proto_msgTypes[9]
+	mi := &file_query_v1_query_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -872,7 +933,7 @@ func (x *ExecutionNode) String() string {
 func (*ExecutionNode) ProtoMessage() {}
 
 func (x *ExecutionNode) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[9]
+	mi := &file_query_v1_query_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -885,7 +946,7 @@ func (x *ExecutionNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionNode.ProtoReflect.Descriptor instead.
 func (*ExecutionNode) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{9}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ExecutionNode) GetType() QueryNode_Type {
@@ -954,7 +1015,7 @@ type ExecutionStats struct {
 
 func (x *ExecutionStats) Reset() {
 	*x = ExecutionStats{}
-	mi := &file_query_v1_query_proto_msgTypes[10]
+	mi := &file_query_v1_query_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -966,7 +1027,7 @@ func (x *ExecutionStats) String() string {
 func (*ExecutionStats) ProtoMessage() {}
 
 func (x *ExecutionStats) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[10]
+	mi := &file_query_v1_query_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -979,7 +1040,7 @@ func (x *ExecutionStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionStats.ProtoReflect.Descriptor instead.
 func (*ExecutionStats) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{10}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ExecutionStats) GetBlocksRead() int64 {
@@ -1026,7 +1087,7 @@ type BlockExecution struct {
 
 func (x *BlockExecution) Reset() {
 	*x = BlockExecution{}
-	mi := &file_query_v1_query_proto_msgTypes[11]
+	mi := &file_query_v1_query_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1038,7 +1099,7 @@ func (x *BlockExecution) String() string {
 func (*BlockExecution) ProtoMessage() {}
 
 func (x *BlockExecution) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[11]
+	mi := &file_query_v1_query_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1051,7 +1112,7 @@ func (x *BlockExecution) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BlockExecution.ProtoReflect.Descriptor instead.
 func (*BlockExecution) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{11}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *BlockExecution) GetBlockId() string {
@@ -1122,7 +1183,7 @@ type Report struct {
 
 func (x *Report) Reset() {
 	*x = Report{}
-	mi := &file_query_v1_query_proto_msgTypes[12]
+	mi := &file_query_v1_query_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1134,7 +1195,7 @@ func (x *Report) String() string {
 func (*Report) ProtoMessage() {}
 
 func (x *Report) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[12]
+	mi := &file_query_v1_query_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1147,7 +1208,7 @@ func (x *Report) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Report.ProtoReflect.Descriptor instead.
 func (*Report) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{12}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *Report) GetReportType() ReportType {
@@ -1221,7 +1282,7 @@ type LabelNamesQuery struct {
 
 func (x *LabelNamesQuery) Reset() {
 	*x = LabelNamesQuery{}
-	mi := &file_query_v1_query_proto_msgTypes[13]
+	mi := &file_query_v1_query_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1233,7 +1294,7 @@ func (x *LabelNamesQuery) String() string {
 func (*LabelNamesQuery) ProtoMessage() {}
 
 func (x *LabelNamesQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[13]
+	mi := &file_query_v1_query_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1246,7 +1307,7 @@ func (x *LabelNamesQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LabelNamesQuery.ProtoReflect.Descriptor instead.
 func (*LabelNamesQuery) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{13}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{14}
 }
 
 type LabelNamesReport struct {
@@ -1259,7 +1320,7 @@ type LabelNamesReport struct {
 
 func (x *LabelNamesReport) Reset() {
 	*x = LabelNamesReport{}
-	mi := &file_query_v1_query_proto_msgTypes[14]
+	mi := &file_query_v1_query_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1271,7 +1332,7 @@ func (x *LabelNamesReport) String() string {
 func (*LabelNamesReport) ProtoMessage() {}
 
 func (x *LabelNamesReport) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[14]
+	mi := &file_query_v1_query_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1284,7 +1345,7 @@ func (x *LabelNamesReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LabelNamesReport.ProtoReflect.Descriptor instead.
 func (*LabelNamesReport) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{14}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *LabelNamesReport) GetQuery() *LabelNamesQuery {
@@ -1310,7 +1371,7 @@ type LabelValuesQuery struct {
 
 func (x *LabelValuesQuery) Reset() {
 	*x = LabelValuesQuery{}
-	mi := &file_query_v1_query_proto_msgTypes[15]
+	mi := &file_query_v1_query_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1322,7 +1383,7 @@ func (x *LabelValuesQuery) String() string {
 func (*LabelValuesQuery) ProtoMessage() {}
 
 func (x *LabelValuesQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[15]
+	mi := &file_query_v1_query_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1335,7 +1396,7 @@ func (x *LabelValuesQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LabelValuesQuery.ProtoReflect.Descriptor instead.
 func (*LabelValuesQuery) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{15}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *LabelValuesQuery) GetLabelName() string {
@@ -1355,7 +1416,7 @@ type LabelValuesReport struct {
 
 func (x *LabelValuesReport) Reset() {
 	*x = LabelValuesReport{}
-	mi := &file_query_v1_query_proto_msgTypes[16]
+	mi := &file_query_v1_query_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1367,7 +1428,7 @@ func (x *LabelValuesReport) String() string {
 func (*LabelValuesReport) ProtoMessage() {}
 
 func (x *LabelValuesReport) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[16]
+	mi := &file_query_v1_query_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1380,7 +1441,7 @@ func (x *LabelValuesReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LabelValuesReport.ProtoReflect.Descriptor instead.
 func (*LabelValuesReport) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{16}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *LabelValuesReport) GetQuery() *LabelValuesQuery {
@@ -1406,7 +1467,7 @@ type SeriesLabelsQuery struct {
 
 func (x *SeriesLabelsQuery) Reset() {
 	*x = SeriesLabelsQuery{}
-	mi := &file_query_v1_query_proto_msgTypes[17]
+	mi := &file_query_v1_query_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1418,7 +1479,7 @@ func (x *SeriesLabelsQuery) String() string {
 func (*SeriesLabelsQuery) ProtoMessage() {}
 
 func (x *SeriesLabelsQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[17]
+	mi := &file_query_v1_query_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1431,7 +1492,7 @@ func (x *SeriesLabelsQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SeriesLabelsQuery.ProtoReflect.Descriptor instead.
 func (*SeriesLabelsQuery) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{17}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *SeriesLabelsQuery) GetLabelNames() []string {
@@ -1451,7 +1512,7 @@ type SeriesLabelsReport struct {
 
 func (x *SeriesLabelsReport) Reset() {
 	*x = SeriesLabelsReport{}
-	mi := &file_query_v1_query_proto_msgTypes[18]
+	mi := &file_query_v1_query_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1463,7 +1524,7 @@ func (x *SeriesLabelsReport) String() string {
 func (*SeriesLabelsReport) ProtoMessage() {}
 
 func (x *SeriesLabelsReport) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[18]
+	mi := &file_query_v1_query_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1476,7 +1537,7 @@ func (x *SeriesLabelsReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SeriesLabelsReport.ProtoReflect.Descriptor instead.
 func (*SeriesLabelsReport) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{18}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *SeriesLabelsReport) GetQuery() *SeriesLabelsQuery {
@@ -1505,7 +1566,7 @@ type TimeSeriesQuery struct {
 
 func (x *TimeSeriesQuery) Reset() {
 	*x = TimeSeriesQuery{}
-	mi := &file_query_v1_query_proto_msgTypes[19]
+	mi := &file_query_v1_query_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1517,7 +1578,7 @@ func (x *TimeSeriesQuery) String() string {
 func (*TimeSeriesQuery) ProtoMessage() {}
 
 func (x *TimeSeriesQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[19]
+	mi := &file_query_v1_query_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1530,7 +1591,7 @@ func (x *TimeSeriesQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TimeSeriesQuery.ProtoReflect.Descriptor instead.
 func (*TimeSeriesQuery) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{19}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *TimeSeriesQuery) GetStep() float64 {
@@ -1571,7 +1632,7 @@ type TimeSeriesReport struct {
 
 func (x *TimeSeriesReport) Reset() {
 	*x = TimeSeriesReport{}
-	mi := &file_query_v1_query_proto_msgTypes[20]
+	mi := &file_query_v1_query_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1583,7 +1644,7 @@ func (x *TimeSeriesReport) String() string {
 func (*TimeSeriesReport) ProtoMessage() {}
 
 func (x *TimeSeriesReport) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[20]
+	mi := &file_query_v1_query_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1596,7 +1657,7 @@ func (x *TimeSeriesReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TimeSeriesReport.ProtoReflect.Descriptor instead.
 func (*TimeSeriesReport) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{20}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *TimeSeriesReport) GetQuery() *TimeSeriesQuery {
@@ -1636,7 +1697,7 @@ type TreeQuery struct {
 
 func (x *TreeQuery) Reset() {
 	*x = TreeQuery{}
-	mi := &file_query_v1_query_proto_msgTypes[21]
+	mi := &file_query_v1_query_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1648,7 +1709,7 @@ func (x *TreeQuery) String() string {
 func (*TreeQuery) ProtoMessage() {}
 
 func (x *TreeQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[21]
+	mi := &file_query_v1_query_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1661,7 +1722,7 @@ func (x *TreeQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TreeQuery.ProtoReflect.Descriptor instead.
 func (*TreeQuery) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{21}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *TreeQuery) GetMaxNodes() int64 {
@@ -1736,7 +1797,7 @@ type TreeSymbols struct {
 
 func (x *TreeSymbols) Reset() {
 	*x = TreeSymbols{}
-	mi := &file_query_v1_query_proto_msgTypes[22]
+	mi := &file_query_v1_query_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1748,7 +1809,7 @@ func (x *TreeSymbols) String() string {
 func (*TreeSymbols) ProtoMessage() {}
 
 func (x *TreeSymbols) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[22]
+	mi := &file_query_v1_query_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1761,7 +1822,7 @@ func (x *TreeSymbols) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TreeSymbols.ProtoReflect.Descriptor instead.
 func (*TreeSymbols) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{22}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *TreeSymbols) GetMappings() []*v12.Mapping {
@@ -1849,7 +1910,7 @@ type SymbolRefTable struct {
 
 func (x *SymbolRefTable) Reset() {
 	*x = SymbolRefTable{}
-	mi := &file_query_v1_query_proto_msgTypes[23]
+	mi := &file_query_v1_query_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1861,7 +1922,7 @@ func (x *SymbolRefTable) String() string {
 func (*SymbolRefTable) ProtoMessage() {}
 
 func (x *SymbolRefTable) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[23]
+	mi := &file_query_v1_query_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1874,7 +1935,7 @@ func (x *SymbolRefTable) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SymbolRefTable.ProtoReflect.Descriptor instead.
 func (*SymbolRefTable) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{23}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *SymbolRefTable) GetNames() []string {
@@ -1924,7 +1985,7 @@ type TreeReport struct {
 
 func (x *TreeReport) Reset() {
 	*x = TreeReport{}
-	mi := &file_query_v1_query_proto_msgTypes[24]
+	mi := &file_query_v1_query_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1936,7 +1997,7 @@ func (x *TreeReport) String() string {
 func (*TreeReport) ProtoMessage() {}
 
 func (x *TreeReport) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[24]
+	mi := &file_query_v1_query_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1949,7 +2010,7 @@ func (x *TreeReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TreeReport.ProtoReflect.Descriptor instead.
 func (*TreeReport) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{24}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *TreeReport) GetQuery() *TreeQuery {
@@ -1993,7 +2054,7 @@ type PprofQuery struct {
 
 func (x *PprofQuery) Reset() {
 	*x = PprofQuery{}
-	mi := &file_query_v1_query_proto_msgTypes[25]
+	mi := &file_query_v1_query_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2005,7 +2066,7 @@ func (x *PprofQuery) String() string {
 func (*PprofQuery) ProtoMessage() {}
 
 func (x *PprofQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[25]
+	mi := &file_query_v1_query_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2018,7 +2079,7 @@ func (x *PprofQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PprofQuery.ProtoReflect.Descriptor instead.
 func (*PprofQuery) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{25}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *PprofQuery) GetMaxNodes() int64 {
@@ -2066,7 +2127,7 @@ type PprofReport struct {
 
 func (x *PprofReport) Reset() {
 	*x = PprofReport{}
-	mi := &file_query_v1_query_proto_msgTypes[26]
+	mi := &file_query_v1_query_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2078,7 +2139,7 @@ func (x *PprofReport) String() string {
 func (*PprofReport) ProtoMessage() {}
 
 func (x *PprofReport) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[26]
+	mi := &file_query_v1_query_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2091,7 +2152,7 @@ func (x *PprofReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PprofReport.ProtoReflect.Descriptor instead.
 func (*PprofReport) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{26}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *PprofReport) GetQuery() *PprofQuery {
@@ -2121,7 +2182,7 @@ type HeatmapQuery struct {
 
 func (x *HeatmapQuery) Reset() {
 	*x = HeatmapQuery{}
-	mi := &file_query_v1_query_proto_msgTypes[27]
+	mi := &file_query_v1_query_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2133,7 +2194,7 @@ func (x *HeatmapQuery) String() string {
 func (*HeatmapQuery) ProtoMessage() {}
 
 func (x *HeatmapQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[27]
+	mi := &file_query_v1_query_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2146,7 +2207,7 @@ func (x *HeatmapQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeatmapQuery.ProtoReflect.Descriptor instead.
 func (*HeatmapQuery) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{27}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *HeatmapQuery) GetStep() float64 {
@@ -2194,7 +2255,7 @@ type AttributeTable struct {
 
 func (x *AttributeTable) Reset() {
 	*x = AttributeTable{}
-	mi := &file_query_v1_query_proto_msgTypes[28]
+	mi := &file_query_v1_query_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2206,7 +2267,7 @@ func (x *AttributeTable) String() string {
 func (*AttributeTable) ProtoMessage() {}
 
 func (x *AttributeTable) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[28]
+	mi := &file_query_v1_query_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2219,7 +2280,7 @@ func (x *AttributeTable) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttributeTable.ProtoReflect.Descriptor instead.
 func (*AttributeTable) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{28}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *AttributeTable) GetKeys() []string {
@@ -2250,7 +2311,7 @@ type HeatmapPoint struct {
 
 func (x *HeatmapPoint) Reset() {
 	*x = HeatmapPoint{}
-	mi := &file_query_v1_query_proto_msgTypes[29]
+	mi := &file_query_v1_query_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2262,7 +2323,7 @@ func (x *HeatmapPoint) String() string {
 func (*HeatmapPoint) ProtoMessage() {}
 
 func (x *HeatmapPoint) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[29]
+	mi := &file_query_v1_query_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2275,7 +2336,7 @@ func (x *HeatmapPoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeatmapPoint.ProtoReflect.Descriptor instead.
 func (*HeatmapPoint) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{29}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *HeatmapPoint) GetTimestamp() int64 {
@@ -2330,7 +2391,7 @@ type HeatmapSeries struct {
 
 func (x *HeatmapSeries) Reset() {
 	*x = HeatmapSeries{}
-	mi := &file_query_v1_query_proto_msgTypes[30]
+	mi := &file_query_v1_query_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2342,7 +2403,7 @@ func (x *HeatmapSeries) String() string {
 func (*HeatmapSeries) ProtoMessage() {}
 
 func (x *HeatmapSeries) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[30]
+	mi := &file_query_v1_query_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2355,7 +2416,7 @@ func (x *HeatmapSeries) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeatmapSeries.ProtoReflect.Descriptor instead.
 func (*HeatmapSeries) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{30}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *HeatmapSeries) GetAttributeRefs() []int64 {
@@ -2383,7 +2444,7 @@ type HeatmapReport struct {
 
 func (x *HeatmapReport) Reset() {
 	*x = HeatmapReport{}
-	mi := &file_query_v1_query_proto_msgTypes[31]
+	mi := &file_query_v1_query_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2395,7 +2456,7 @@ func (x *HeatmapReport) String() string {
 func (*HeatmapReport) ProtoMessage() {}
 
 func (x *HeatmapReport) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[31]
+	mi := &file_query_v1_query_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2408,7 +2469,7 @@ func (x *HeatmapReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeatmapReport.ProtoReflect.Descriptor instead.
 func (*HeatmapReport) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{31}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *HeatmapReport) GetQuery() *HeatmapQuery {
@@ -2446,7 +2507,7 @@ type Exemplar struct {
 
 func (x *Exemplar) Reset() {
 	*x = Exemplar{}
-	mi := &file_query_v1_query_proto_msgTypes[32]
+	mi := &file_query_v1_query_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2458,7 +2519,7 @@ func (x *Exemplar) String() string {
 func (*Exemplar) ProtoMessage() {}
 
 func (x *Exemplar) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[32]
+	mi := &file_query_v1_query_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2471,7 +2532,7 @@ func (x *Exemplar) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Exemplar.ProtoReflect.Descriptor instead.
 func (*Exemplar) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{32}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *Exemplar) GetTimestamp() int64 {
@@ -2524,7 +2585,7 @@ type Point struct {
 
 func (x *Point) Reset() {
 	*x = Point{}
-	mi := &file_query_v1_query_proto_msgTypes[33]
+	mi := &file_query_v1_query_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2536,7 +2597,7 @@ func (x *Point) String() string {
 func (*Point) ProtoMessage() {}
 
 func (x *Point) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[33]
+	mi := &file_query_v1_query_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2549,7 +2610,7 @@ func (x *Point) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Point.ProtoReflect.Descriptor instead.
 func (*Point) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{33}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *Point) GetValue() float64 {
@@ -2593,7 +2654,7 @@ type Series struct {
 
 func (x *Series) Reset() {
 	*x = Series{}
-	mi := &file_query_v1_query_proto_msgTypes[34]
+	mi := &file_query_v1_query_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2605,7 +2666,7 @@ func (x *Series) String() string {
 func (*Series) ProtoMessage() {}
 
 func (x *Series) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[34]
+	mi := &file_query_v1_query_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2618,7 +2679,7 @@ func (x *Series) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Series.ProtoReflect.Descriptor instead.
 func (*Series) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{34}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *Series) GetAttributeRefs() []int64 {
@@ -2646,7 +2707,7 @@ type TimeSeriesCompactReport struct {
 
 func (x *TimeSeriesCompactReport) Reset() {
 	*x = TimeSeriesCompactReport{}
-	mi := &file_query_v1_query_proto_msgTypes[35]
+	mi := &file_query_v1_query_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2658,7 +2719,7 @@ func (x *TimeSeriesCompactReport) String() string {
 func (*TimeSeriesCompactReport) ProtoMessage() {}
 
 func (x *TimeSeriesCompactReport) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[35]
+	mi := &file_query_v1_query_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2671,7 +2732,7 @@ func (x *TimeSeriesCompactReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TimeSeriesCompactReport.ProtoReflect.Descriptor instead.
 func (*TimeSeriesCompactReport) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{35}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *TimeSeriesCompactReport) GetQuery() *TimeSeriesQuery {
@@ -2707,10 +2768,11 @@ const file_query_v1_query_proto_rawDesc = "" +
 	"\x0elabel_selector\x18\x03 \x01(\tR\rlabelSelector\x12%\n" +
 	"\x05query\x18\x04 \x03(\v2\x0f.query.v1.QueryR\x05query\";\n" +
 	"\rQueryResponse\x12*\n" +
-	"\areports\x18\x01 \x03(\v2\x10.query.v1.ReportR\areports\"l\n" +
+	"\areports\x18\x01 \x03(\v2\x10.query.v1.ReportR\areports\"\x9c\x01\n" +
 	"\rInvokeOptions\x12*\n" +
 	"\x11sanitize_on_merge\x18\x01 \x01(\bR\x0fsanitizeOnMerge\x12/\n" +
-	"\x13collect_diagnostics\x18\x02 \x01(\bR\x12collectDiagnostics\"\x96\x02\n" +
+	"\x13collect_diagnostics\x18\x02 \x01(\bR\x12collectDiagnostics\x12.\n" +
+	"\x13bypass_result_cache\x18\x03 \x01(\bR\x11bypassResultCache\"\x96\x02\n" +
 	"\rInvokeRequest\x12\x16\n" +
 	"\x06tenant\x18\x01 \x03(\tR\x06tenant\x12\x1d\n" +
 	"\n" +
@@ -2746,7 +2808,10 @@ const file_query_v1_query_proto_rawDesc = "" +
 	"\x13time_series_compact\x18\t \x01(\v2\x19.query.v1.TimeSeriesQueryR\x11timeSeriesCompact\"u\n" +
 	"\x0eInvokeResponse\x12*\n" +
 	"\areports\x18\x01 \x03(\v2\x10.query.v1.ReportR\areports\x127\n" +
-	"\vdiagnostics\x18\x02 \x01(\v2\x15.query.v1.DiagnosticsR\vdiagnostics\"\x81\x01\n" +
+	"\vdiagnostics\x18\x02 \x01(\v2\x15.query.v1.DiagnosticsR\vdiagnostics\"l\n" +
+	"\x10ResultCacheEntry\x12,\n" +
+	"\x05query\x18\x01 \x01(\v2\x16.query.v1.QueryRequestR\x05query\x12*\n" +
+	"\areports\x18\x02 \x03(\v2\x10.query.v1.ReportR\areports\"\x81\x01\n" +
 	"\vDiagnostics\x122\n" +
 	"\n" +
 	"query_plan\x18\x01 \x01(\v2\x13.query.v1.QueryPlanR\tqueryPlan\x12>\n" +
@@ -2952,7 +3017,7 @@ func file_query_v1_query_proto_rawDescGZIP() []byte {
 }
 
 var file_query_v1_query_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_query_v1_query_proto_msgTypes = make([]protoimpl.MessageInfo, 36)
+var file_query_v1_query_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
 var file_query_v1_query_proto_goTypes = []any{
 	(QueryType)(0),                  // 0: query.v1.QueryType
 	(ReportType)(0),                 // 1: query.v1.ReportType
@@ -2966,117 +3031,120 @@ var file_query_v1_query_proto_goTypes = []any{
 	(*QueryNode)(nil),               // 9: query.v1.QueryNode
 	(*Query)(nil),                   // 10: query.v1.Query
 	(*InvokeResponse)(nil),          // 11: query.v1.InvokeResponse
-	(*Diagnostics)(nil),             // 12: query.v1.Diagnostics
-	(*ExecutionNode)(nil),           // 13: query.v1.ExecutionNode
-	(*ExecutionStats)(nil),          // 14: query.v1.ExecutionStats
-	(*BlockExecution)(nil),          // 15: query.v1.BlockExecution
-	(*Report)(nil),                  // 16: query.v1.Report
-	(*LabelNamesQuery)(nil),         // 17: query.v1.LabelNamesQuery
-	(*LabelNamesReport)(nil),        // 18: query.v1.LabelNamesReport
-	(*LabelValuesQuery)(nil),        // 19: query.v1.LabelValuesQuery
-	(*LabelValuesReport)(nil),       // 20: query.v1.LabelValuesReport
-	(*SeriesLabelsQuery)(nil),       // 21: query.v1.SeriesLabelsQuery
-	(*SeriesLabelsReport)(nil),      // 22: query.v1.SeriesLabelsReport
-	(*TimeSeriesQuery)(nil),         // 23: query.v1.TimeSeriesQuery
-	(*TimeSeriesReport)(nil),        // 24: query.v1.TimeSeriesReport
-	(*TreeQuery)(nil),               // 25: query.v1.TreeQuery
-	(*TreeSymbols)(nil),             // 26: query.v1.TreeSymbols
-	(*SymbolRefTable)(nil),          // 27: query.v1.SymbolRefTable
-	(*TreeReport)(nil),              // 28: query.v1.TreeReport
-	(*PprofQuery)(nil),              // 29: query.v1.PprofQuery
-	(*PprofReport)(nil),             // 30: query.v1.PprofReport
-	(*HeatmapQuery)(nil),            // 31: query.v1.HeatmapQuery
-	(*AttributeTable)(nil),          // 32: query.v1.AttributeTable
-	(*HeatmapPoint)(nil),            // 33: query.v1.HeatmapPoint
-	(*HeatmapSeries)(nil),           // 34: query.v1.HeatmapSeries
-	(*HeatmapReport)(nil),           // 35: query.v1.HeatmapReport
-	(*Exemplar)(nil),                // 36: query.v1.Exemplar
-	(*Point)(nil),                   // 37: query.v1.Point
-	(*Series)(nil),                  // 38: query.v1.Series
-	(*TimeSeriesCompactReport)(nil), // 39: query.v1.TimeSeriesCompactReport
-	(*v1.BlockMeta)(nil),            // 40: metastore.v1.BlockMeta
-	(*v11.Labels)(nil),              // 41: types.v1.Labels
-	(v11.ExemplarType)(0),           // 42: types.v1.ExemplarType
-	(*v11.Series)(nil),              // 43: types.v1.Series
-	(*v11.StackTraceSelector)(nil),  // 44: types.v1.StackTraceSelector
-	(*v12.Mapping)(nil),             // 45: google.v1.Mapping
-	(*v12.Location)(nil),            // 46: google.v1.Location
-	(*v12.Function)(nil),            // 47: google.v1.Function
-	(v13.HeatmapQueryType)(0),       // 48: querier.v1.HeatmapQueryType
+	(*ResultCacheEntry)(nil),        // 12: query.v1.ResultCacheEntry
+	(*Diagnostics)(nil),             // 13: query.v1.Diagnostics
+	(*ExecutionNode)(nil),           // 14: query.v1.ExecutionNode
+	(*ExecutionStats)(nil),          // 15: query.v1.ExecutionStats
+	(*BlockExecution)(nil),          // 16: query.v1.BlockExecution
+	(*Report)(nil),                  // 17: query.v1.Report
+	(*LabelNamesQuery)(nil),         // 18: query.v1.LabelNamesQuery
+	(*LabelNamesReport)(nil),        // 19: query.v1.LabelNamesReport
+	(*LabelValuesQuery)(nil),        // 20: query.v1.LabelValuesQuery
+	(*LabelValuesReport)(nil),       // 21: query.v1.LabelValuesReport
+	(*SeriesLabelsQuery)(nil),       // 22: query.v1.SeriesLabelsQuery
+	(*SeriesLabelsReport)(nil),      // 23: query.v1.SeriesLabelsReport
+	(*TimeSeriesQuery)(nil),         // 24: query.v1.TimeSeriesQuery
+	(*TimeSeriesReport)(nil),        // 25: query.v1.TimeSeriesReport
+	(*TreeQuery)(nil),               // 26: query.v1.TreeQuery
+	(*TreeSymbols)(nil),             // 27: query.v1.TreeSymbols
+	(*SymbolRefTable)(nil),          // 28: query.v1.SymbolRefTable
+	(*TreeReport)(nil),              // 29: query.v1.TreeReport
+	(*PprofQuery)(nil),              // 30: query.v1.PprofQuery
+	(*PprofReport)(nil),             // 31: query.v1.PprofReport
+	(*HeatmapQuery)(nil),            // 32: query.v1.HeatmapQuery
+	(*AttributeTable)(nil),          // 33: query.v1.AttributeTable
+	(*HeatmapPoint)(nil),            // 34: query.v1.HeatmapPoint
+	(*HeatmapSeries)(nil),           // 35: query.v1.HeatmapSeries
+	(*HeatmapReport)(nil),           // 36: query.v1.HeatmapReport
+	(*Exemplar)(nil),                // 37: query.v1.Exemplar
+	(*Point)(nil),                   // 38: query.v1.Point
+	(*Series)(nil),                  // 39: query.v1.Series
+	(*TimeSeriesCompactReport)(nil), // 40: query.v1.TimeSeriesCompactReport
+	(*v1.BlockMeta)(nil),            // 41: metastore.v1.BlockMeta
+	(*v11.Labels)(nil),              // 42: types.v1.Labels
+	(v11.ExemplarType)(0),           // 43: types.v1.ExemplarType
+	(*v11.Series)(nil),              // 44: types.v1.Series
+	(*v11.StackTraceSelector)(nil),  // 45: types.v1.StackTraceSelector
+	(*v12.Mapping)(nil),             // 46: google.v1.Mapping
+	(*v12.Location)(nil),            // 47: google.v1.Location
+	(*v12.Function)(nil),            // 48: google.v1.Function
+	(v13.HeatmapQueryType)(0),       // 49: querier.v1.HeatmapQueryType
 }
 var file_query_v1_query_proto_depIdxs = []int32{
 	10, // 0: query.v1.QueryRequest.query:type_name -> query.v1.Query
-	16, // 1: query.v1.QueryResponse.reports:type_name -> query.v1.Report
+	17, // 1: query.v1.QueryResponse.reports:type_name -> query.v1.Report
 	10, // 2: query.v1.InvokeRequest.query:type_name -> query.v1.Query
 	8,  // 3: query.v1.InvokeRequest.query_plan:type_name -> query.v1.QueryPlan
 	6,  // 4: query.v1.InvokeRequest.options:type_name -> query.v1.InvokeOptions
 	9,  // 5: query.v1.QueryPlan.root:type_name -> query.v1.QueryNode
 	3,  // 6: query.v1.QueryNode.type:type_name -> query.v1.QueryNode.Type
 	9,  // 7: query.v1.QueryNode.children:type_name -> query.v1.QueryNode
-	40, // 8: query.v1.QueryNode.blocks:type_name -> metastore.v1.BlockMeta
+	41, // 8: query.v1.QueryNode.blocks:type_name -> metastore.v1.BlockMeta
 	0,  // 9: query.v1.Query.query_type:type_name -> query.v1.QueryType
-	17, // 10: query.v1.Query.label_names:type_name -> query.v1.LabelNamesQuery
-	19, // 11: query.v1.Query.label_values:type_name -> query.v1.LabelValuesQuery
-	21, // 12: query.v1.Query.series_labels:type_name -> query.v1.SeriesLabelsQuery
-	23, // 13: query.v1.Query.time_series:type_name -> query.v1.TimeSeriesQuery
-	25, // 14: query.v1.Query.tree:type_name -> query.v1.TreeQuery
-	29, // 15: query.v1.Query.pprof:type_name -> query.v1.PprofQuery
-	31, // 16: query.v1.Query.heatmap:type_name -> query.v1.HeatmapQuery
-	23, // 17: query.v1.Query.time_series_compact:type_name -> query.v1.TimeSeriesQuery
-	16, // 18: query.v1.InvokeResponse.reports:type_name -> query.v1.Report
-	12, // 19: query.v1.InvokeResponse.diagnostics:type_name -> query.v1.Diagnostics
-	8,  // 20: query.v1.Diagnostics.query_plan:type_name -> query.v1.QueryPlan
-	13, // 21: query.v1.Diagnostics.execution_node:type_name -> query.v1.ExecutionNode
-	3,  // 22: query.v1.ExecutionNode.type:type_name -> query.v1.QueryNode.Type
-	13, // 23: query.v1.ExecutionNode.children:type_name -> query.v1.ExecutionNode
-	14, // 24: query.v1.ExecutionNode.stats:type_name -> query.v1.ExecutionStats
-	15, // 25: query.v1.ExecutionStats.block_executions:type_name -> query.v1.BlockExecution
-	1,  // 26: query.v1.Report.report_type:type_name -> query.v1.ReportType
-	18, // 27: query.v1.Report.label_names:type_name -> query.v1.LabelNamesReport
-	20, // 28: query.v1.Report.label_values:type_name -> query.v1.LabelValuesReport
-	22, // 29: query.v1.Report.series_labels:type_name -> query.v1.SeriesLabelsReport
-	24, // 30: query.v1.Report.time_series:type_name -> query.v1.TimeSeriesReport
-	28, // 31: query.v1.Report.tree:type_name -> query.v1.TreeReport
-	30, // 32: query.v1.Report.pprof:type_name -> query.v1.PprofReport
-	35, // 33: query.v1.Report.heatmap:type_name -> query.v1.HeatmapReport
-	39, // 34: query.v1.Report.time_series_compact:type_name -> query.v1.TimeSeriesCompactReport
-	17, // 35: query.v1.LabelNamesReport.query:type_name -> query.v1.LabelNamesQuery
-	19, // 36: query.v1.LabelValuesReport.query:type_name -> query.v1.LabelValuesQuery
-	21, // 37: query.v1.SeriesLabelsReport.query:type_name -> query.v1.SeriesLabelsQuery
-	41, // 38: query.v1.SeriesLabelsReport.series_labels:type_name -> types.v1.Labels
-	42, // 39: query.v1.TimeSeriesQuery.exemplar_type:type_name -> types.v1.ExemplarType
-	23, // 40: query.v1.TimeSeriesReport.query:type_name -> query.v1.TimeSeriesQuery
-	43, // 41: query.v1.TimeSeriesReport.time_series:type_name -> types.v1.Series
-	44, // 42: query.v1.TreeQuery.stack_trace_selector:type_name -> types.v1.StackTraceSelector
-	2,  // 43: query.v1.TreeQuery.symbol_mode:type_name -> query.v1.SymbolMode
-	45, // 44: query.v1.TreeSymbols.mappings:type_name -> google.v1.Mapping
-	46, // 45: query.v1.TreeSymbols.locations:type_name -> google.v1.Location
-	47, // 46: query.v1.TreeSymbols.functions:type_name -> google.v1.Function
-	25, // 47: query.v1.TreeReport.query:type_name -> query.v1.TreeQuery
-	26, // 48: query.v1.TreeReport.symbols:type_name -> query.v1.TreeSymbols
-	27, // 49: query.v1.TreeReport.symbol_refs:type_name -> query.v1.SymbolRefTable
-	44, // 50: query.v1.PprofQuery.stack_trace_selector:type_name -> types.v1.StackTraceSelector
-	29, // 51: query.v1.PprofReport.query:type_name -> query.v1.PprofQuery
-	48, // 52: query.v1.HeatmapQuery.query_type:type_name -> querier.v1.HeatmapQueryType
-	42, // 53: query.v1.HeatmapQuery.exemplar_type:type_name -> types.v1.ExemplarType
-	33, // 54: query.v1.HeatmapSeries.points:type_name -> query.v1.HeatmapPoint
-	31, // 55: query.v1.HeatmapReport.query:type_name -> query.v1.HeatmapQuery
-	34, // 56: query.v1.HeatmapReport.heatmap_series:type_name -> query.v1.HeatmapSeries
-	32, // 57: query.v1.HeatmapReport.attribute_table:type_name -> query.v1.AttributeTable
-	36, // 58: query.v1.Point.exemplars:type_name -> query.v1.Exemplar
-	37, // 59: query.v1.Series.points:type_name -> query.v1.Point
-	23, // 60: query.v1.TimeSeriesCompactReport.query:type_name -> query.v1.TimeSeriesQuery
-	38, // 61: query.v1.TimeSeriesCompactReport.time_series:type_name -> query.v1.Series
-	32, // 62: query.v1.TimeSeriesCompactReport.attribute_table:type_name -> query.v1.AttributeTable
-	4,  // 63: query.v1.QueryFrontendService.Query:input_type -> query.v1.QueryRequest
-	7,  // 64: query.v1.QueryBackendService.Invoke:input_type -> query.v1.InvokeRequest
-	5,  // 65: query.v1.QueryFrontendService.Query:output_type -> query.v1.QueryResponse
-	11, // 66: query.v1.QueryBackendService.Invoke:output_type -> query.v1.InvokeResponse
-	65, // [65:67] is the sub-list for method output_type
-	63, // [63:65] is the sub-list for method input_type
-	63, // [63:63] is the sub-list for extension type_name
-	63, // [63:63] is the sub-list for extension extendee
-	0,  // [0:63] is the sub-list for field type_name
+	18, // 10: query.v1.Query.label_names:type_name -> query.v1.LabelNamesQuery
+	20, // 11: query.v1.Query.label_values:type_name -> query.v1.LabelValuesQuery
+	22, // 12: query.v1.Query.series_labels:type_name -> query.v1.SeriesLabelsQuery
+	24, // 13: query.v1.Query.time_series:type_name -> query.v1.TimeSeriesQuery
+	26, // 14: query.v1.Query.tree:type_name -> query.v1.TreeQuery
+	30, // 15: query.v1.Query.pprof:type_name -> query.v1.PprofQuery
+	32, // 16: query.v1.Query.heatmap:type_name -> query.v1.HeatmapQuery
+	24, // 17: query.v1.Query.time_series_compact:type_name -> query.v1.TimeSeriesQuery
+	17, // 18: query.v1.InvokeResponse.reports:type_name -> query.v1.Report
+	13, // 19: query.v1.InvokeResponse.diagnostics:type_name -> query.v1.Diagnostics
+	4,  // 20: query.v1.ResultCacheEntry.query:type_name -> query.v1.QueryRequest
+	17, // 21: query.v1.ResultCacheEntry.reports:type_name -> query.v1.Report
+	8,  // 22: query.v1.Diagnostics.query_plan:type_name -> query.v1.QueryPlan
+	14, // 23: query.v1.Diagnostics.execution_node:type_name -> query.v1.ExecutionNode
+	3,  // 24: query.v1.ExecutionNode.type:type_name -> query.v1.QueryNode.Type
+	14, // 25: query.v1.ExecutionNode.children:type_name -> query.v1.ExecutionNode
+	15, // 26: query.v1.ExecutionNode.stats:type_name -> query.v1.ExecutionStats
+	16, // 27: query.v1.ExecutionStats.block_executions:type_name -> query.v1.BlockExecution
+	1,  // 28: query.v1.Report.report_type:type_name -> query.v1.ReportType
+	19, // 29: query.v1.Report.label_names:type_name -> query.v1.LabelNamesReport
+	21, // 30: query.v1.Report.label_values:type_name -> query.v1.LabelValuesReport
+	23, // 31: query.v1.Report.series_labels:type_name -> query.v1.SeriesLabelsReport
+	25, // 32: query.v1.Report.time_series:type_name -> query.v1.TimeSeriesReport
+	29, // 33: query.v1.Report.tree:type_name -> query.v1.TreeReport
+	31, // 34: query.v1.Report.pprof:type_name -> query.v1.PprofReport
+	36, // 35: query.v1.Report.heatmap:type_name -> query.v1.HeatmapReport
+	40, // 36: query.v1.Report.time_series_compact:type_name -> query.v1.TimeSeriesCompactReport
+	18, // 37: query.v1.LabelNamesReport.query:type_name -> query.v1.LabelNamesQuery
+	20, // 38: query.v1.LabelValuesReport.query:type_name -> query.v1.LabelValuesQuery
+	22, // 39: query.v1.SeriesLabelsReport.query:type_name -> query.v1.SeriesLabelsQuery
+	42, // 40: query.v1.SeriesLabelsReport.series_labels:type_name -> types.v1.Labels
+	43, // 41: query.v1.TimeSeriesQuery.exemplar_type:type_name -> types.v1.ExemplarType
+	24, // 42: query.v1.TimeSeriesReport.query:type_name -> query.v1.TimeSeriesQuery
+	44, // 43: query.v1.TimeSeriesReport.time_series:type_name -> types.v1.Series
+	45, // 44: query.v1.TreeQuery.stack_trace_selector:type_name -> types.v1.StackTraceSelector
+	2,  // 45: query.v1.TreeQuery.symbol_mode:type_name -> query.v1.SymbolMode
+	46, // 46: query.v1.TreeSymbols.mappings:type_name -> google.v1.Mapping
+	47, // 47: query.v1.TreeSymbols.locations:type_name -> google.v1.Location
+	48, // 48: query.v1.TreeSymbols.functions:type_name -> google.v1.Function
+	26, // 49: query.v1.TreeReport.query:type_name -> query.v1.TreeQuery
+	27, // 50: query.v1.TreeReport.symbols:type_name -> query.v1.TreeSymbols
+	28, // 51: query.v1.TreeReport.symbol_refs:type_name -> query.v1.SymbolRefTable
+	45, // 52: query.v1.PprofQuery.stack_trace_selector:type_name -> types.v1.StackTraceSelector
+	30, // 53: query.v1.PprofReport.query:type_name -> query.v1.PprofQuery
+	49, // 54: query.v1.HeatmapQuery.query_type:type_name -> querier.v1.HeatmapQueryType
+	43, // 55: query.v1.HeatmapQuery.exemplar_type:type_name -> types.v1.ExemplarType
+	34, // 56: query.v1.HeatmapSeries.points:type_name -> query.v1.HeatmapPoint
+	32, // 57: query.v1.HeatmapReport.query:type_name -> query.v1.HeatmapQuery
+	35, // 58: query.v1.HeatmapReport.heatmap_series:type_name -> query.v1.HeatmapSeries
+	33, // 59: query.v1.HeatmapReport.attribute_table:type_name -> query.v1.AttributeTable
+	37, // 60: query.v1.Point.exemplars:type_name -> query.v1.Exemplar
+	38, // 61: query.v1.Series.points:type_name -> query.v1.Point
+	24, // 62: query.v1.TimeSeriesCompactReport.query:type_name -> query.v1.TimeSeriesQuery
+	39, // 63: query.v1.TimeSeriesCompactReport.time_series:type_name -> query.v1.Series
+	33, // 64: query.v1.TimeSeriesCompactReport.attribute_table:type_name -> query.v1.AttributeTable
+	4,  // 65: query.v1.QueryFrontendService.Query:input_type -> query.v1.QueryRequest
+	7,  // 66: query.v1.QueryBackendService.Invoke:input_type -> query.v1.InvokeRequest
+	5,  // 67: query.v1.QueryFrontendService.Query:output_type -> query.v1.QueryResponse
+	11, // 68: query.v1.QueryBackendService.Invoke:output_type -> query.v1.InvokeResponse
+	67, // [67:69] is the sub-list for method output_type
+	65, // [65:67] is the sub-list for method input_type
+	65, // [65:65] is the sub-list for extension type_name
+	65, // [65:65] is the sub-list for extension extendee
+	0,  // [0:65] is the sub-list for field type_name
 }
 
 func init() { file_query_v1_query_proto_init() }
@@ -3084,16 +3152,16 @@ func file_query_v1_query_proto_init() {
 	if File_query_v1_query_proto != nil {
 		return
 	}
-	file_query_v1_query_proto_msgTypes[21].OneofWrappers = []any{}
-	file_query_v1_query_proto_msgTypes[24].OneofWrappers = []any{}
+	file_query_v1_query_proto_msgTypes[22].OneofWrappers = []any{}
 	file_query_v1_query_proto_msgTypes[25].OneofWrappers = []any{}
+	file_query_v1_query_proto_msgTypes[26].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_query_v1_query_proto_rawDesc), len(file_query_v1_query_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   36,
+			NumMessages:   37,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/api/gen/proto/go/query/v1/query.pb.go
+++ b/api/gen/proto/go/query/v1/query.pb.go
@@ -800,9 +800,61 @@ func (x *InvokeResponse) GetDiagnostics() *Diagnostics {
 	return nil
 }
 
-type ResultCacheEntry struct {
+type ResultCacheKey struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Query         *QueryRequest          `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty"`
+	BlockIds      []string               `protobuf:"bytes,2,rep,name=block_ids,json=blockIds,proto3" json:"block_ids,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResultCacheKey) Reset() {
+	*x = ResultCacheKey{}
+	mi := &file_query_v1_query_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResultCacheKey) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResultCacheKey) ProtoMessage() {}
+
+func (x *ResultCacheKey) ProtoReflect() protoreflect.Message {
+	mi := &file_query_v1_query_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResultCacheKey.ProtoReflect.Descriptor instead.
+func (*ResultCacheKey) Descriptor() ([]byte, []int) {
+	return file_query_v1_query_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *ResultCacheKey) GetQuery() *QueryRequest {
+	if x != nil {
+		return x.Query
+	}
+	return nil
+}
+
+func (x *ResultCacheKey) GetBlockIds() []string {
+	if x != nil {
+		return x.BlockIds
+	}
+	return nil
+}
+
+type ResultCacheEntry struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Key           *ResultCacheKey        `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	Reports       []*Report              `protobuf:"bytes,2,rep,name=reports,proto3" json:"reports,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -810,7 +862,7 @@ type ResultCacheEntry struct {
 
 func (x *ResultCacheEntry) Reset() {
 	*x = ResultCacheEntry{}
-	mi := &file_query_v1_query_proto_msgTypes[8]
+	mi := &file_query_v1_query_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -822,7 +874,7 @@ func (x *ResultCacheEntry) String() string {
 func (*ResultCacheEntry) ProtoMessage() {}
 
 func (x *ResultCacheEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[8]
+	mi := &file_query_v1_query_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -835,12 +887,12 @@ func (x *ResultCacheEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResultCacheEntry.ProtoReflect.Descriptor instead.
 func (*ResultCacheEntry) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{8}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{9}
 }
 
-func (x *ResultCacheEntry) GetQuery() *QueryRequest {
+func (x *ResultCacheEntry) GetKey() *ResultCacheKey {
 	if x != nil {
-		return x.Query
+		return x.Key
 	}
 	return nil
 }
@@ -863,7 +915,7 @@ type Diagnostics struct {
 
 func (x *Diagnostics) Reset() {
 	*x = Diagnostics{}
-	mi := &file_query_v1_query_proto_msgTypes[9]
+	mi := &file_query_v1_query_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -875,7 +927,7 @@ func (x *Diagnostics) String() string {
 func (*Diagnostics) ProtoMessage() {}
 
 func (x *Diagnostics) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[9]
+	mi := &file_query_v1_query_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -888,7 +940,7 @@ func (x *Diagnostics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Diagnostics.ProtoReflect.Descriptor instead.
 func (*Diagnostics) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{9}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *Diagnostics) GetQueryPlan() *QueryPlan {
@@ -921,7 +973,7 @@ type ExecutionNode struct {
 
 func (x *ExecutionNode) Reset() {
 	*x = ExecutionNode{}
-	mi := &file_query_v1_query_proto_msgTypes[10]
+	mi := &file_query_v1_query_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -933,7 +985,7 @@ func (x *ExecutionNode) String() string {
 func (*ExecutionNode) ProtoMessage() {}
 
 func (x *ExecutionNode) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[10]
+	mi := &file_query_v1_query_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -946,7 +998,7 @@ func (x *ExecutionNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionNode.ProtoReflect.Descriptor instead.
 func (*ExecutionNode) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{10}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ExecutionNode) GetType() QueryNode_Type {
@@ -1015,7 +1067,7 @@ type ExecutionStats struct {
 
 func (x *ExecutionStats) Reset() {
 	*x = ExecutionStats{}
-	mi := &file_query_v1_query_proto_msgTypes[11]
+	mi := &file_query_v1_query_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1027,7 +1079,7 @@ func (x *ExecutionStats) String() string {
 func (*ExecutionStats) ProtoMessage() {}
 
 func (x *ExecutionStats) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[11]
+	mi := &file_query_v1_query_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1040,7 +1092,7 @@ func (x *ExecutionStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutionStats.ProtoReflect.Descriptor instead.
 func (*ExecutionStats) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{11}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ExecutionStats) GetBlocksRead() int64 {
@@ -1087,7 +1139,7 @@ type BlockExecution struct {
 
 func (x *BlockExecution) Reset() {
 	*x = BlockExecution{}
-	mi := &file_query_v1_query_proto_msgTypes[12]
+	mi := &file_query_v1_query_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1099,7 +1151,7 @@ func (x *BlockExecution) String() string {
 func (*BlockExecution) ProtoMessage() {}
 
 func (x *BlockExecution) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[12]
+	mi := &file_query_v1_query_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1112,7 +1164,7 @@ func (x *BlockExecution) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BlockExecution.ProtoReflect.Descriptor instead.
 func (*BlockExecution) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{12}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *BlockExecution) GetBlockId() string {
@@ -1183,7 +1235,7 @@ type Report struct {
 
 func (x *Report) Reset() {
 	*x = Report{}
-	mi := &file_query_v1_query_proto_msgTypes[13]
+	mi := &file_query_v1_query_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1195,7 +1247,7 @@ func (x *Report) String() string {
 func (*Report) ProtoMessage() {}
 
 func (x *Report) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[13]
+	mi := &file_query_v1_query_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1208,7 +1260,7 @@ func (x *Report) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Report.ProtoReflect.Descriptor instead.
 func (*Report) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{13}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *Report) GetReportType() ReportType {
@@ -1282,7 +1334,7 @@ type LabelNamesQuery struct {
 
 func (x *LabelNamesQuery) Reset() {
 	*x = LabelNamesQuery{}
-	mi := &file_query_v1_query_proto_msgTypes[14]
+	mi := &file_query_v1_query_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1294,7 +1346,7 @@ func (x *LabelNamesQuery) String() string {
 func (*LabelNamesQuery) ProtoMessage() {}
 
 func (x *LabelNamesQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[14]
+	mi := &file_query_v1_query_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1307,7 +1359,7 @@ func (x *LabelNamesQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LabelNamesQuery.ProtoReflect.Descriptor instead.
 func (*LabelNamesQuery) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{14}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{15}
 }
 
 type LabelNamesReport struct {
@@ -1320,7 +1372,7 @@ type LabelNamesReport struct {
 
 func (x *LabelNamesReport) Reset() {
 	*x = LabelNamesReport{}
-	mi := &file_query_v1_query_proto_msgTypes[15]
+	mi := &file_query_v1_query_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1332,7 +1384,7 @@ func (x *LabelNamesReport) String() string {
 func (*LabelNamesReport) ProtoMessage() {}
 
 func (x *LabelNamesReport) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[15]
+	mi := &file_query_v1_query_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1345,7 +1397,7 @@ func (x *LabelNamesReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LabelNamesReport.ProtoReflect.Descriptor instead.
 func (*LabelNamesReport) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{15}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *LabelNamesReport) GetQuery() *LabelNamesQuery {
@@ -1371,7 +1423,7 @@ type LabelValuesQuery struct {
 
 func (x *LabelValuesQuery) Reset() {
 	*x = LabelValuesQuery{}
-	mi := &file_query_v1_query_proto_msgTypes[16]
+	mi := &file_query_v1_query_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1383,7 +1435,7 @@ func (x *LabelValuesQuery) String() string {
 func (*LabelValuesQuery) ProtoMessage() {}
 
 func (x *LabelValuesQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[16]
+	mi := &file_query_v1_query_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1396,7 +1448,7 @@ func (x *LabelValuesQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LabelValuesQuery.ProtoReflect.Descriptor instead.
 func (*LabelValuesQuery) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{16}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *LabelValuesQuery) GetLabelName() string {
@@ -1416,7 +1468,7 @@ type LabelValuesReport struct {
 
 func (x *LabelValuesReport) Reset() {
 	*x = LabelValuesReport{}
-	mi := &file_query_v1_query_proto_msgTypes[17]
+	mi := &file_query_v1_query_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1428,7 +1480,7 @@ func (x *LabelValuesReport) String() string {
 func (*LabelValuesReport) ProtoMessage() {}
 
 func (x *LabelValuesReport) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[17]
+	mi := &file_query_v1_query_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1441,7 +1493,7 @@ func (x *LabelValuesReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LabelValuesReport.ProtoReflect.Descriptor instead.
 func (*LabelValuesReport) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{17}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *LabelValuesReport) GetQuery() *LabelValuesQuery {
@@ -1467,7 +1519,7 @@ type SeriesLabelsQuery struct {
 
 func (x *SeriesLabelsQuery) Reset() {
 	*x = SeriesLabelsQuery{}
-	mi := &file_query_v1_query_proto_msgTypes[18]
+	mi := &file_query_v1_query_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1479,7 +1531,7 @@ func (x *SeriesLabelsQuery) String() string {
 func (*SeriesLabelsQuery) ProtoMessage() {}
 
 func (x *SeriesLabelsQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[18]
+	mi := &file_query_v1_query_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1492,7 +1544,7 @@ func (x *SeriesLabelsQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SeriesLabelsQuery.ProtoReflect.Descriptor instead.
 func (*SeriesLabelsQuery) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{18}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *SeriesLabelsQuery) GetLabelNames() []string {
@@ -1512,7 +1564,7 @@ type SeriesLabelsReport struct {
 
 func (x *SeriesLabelsReport) Reset() {
 	*x = SeriesLabelsReport{}
-	mi := &file_query_v1_query_proto_msgTypes[19]
+	mi := &file_query_v1_query_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1524,7 +1576,7 @@ func (x *SeriesLabelsReport) String() string {
 func (*SeriesLabelsReport) ProtoMessage() {}
 
 func (x *SeriesLabelsReport) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[19]
+	mi := &file_query_v1_query_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1537,7 +1589,7 @@ func (x *SeriesLabelsReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SeriesLabelsReport.ProtoReflect.Descriptor instead.
 func (*SeriesLabelsReport) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{19}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *SeriesLabelsReport) GetQuery() *SeriesLabelsQuery {
@@ -1566,7 +1618,7 @@ type TimeSeriesQuery struct {
 
 func (x *TimeSeriesQuery) Reset() {
 	*x = TimeSeriesQuery{}
-	mi := &file_query_v1_query_proto_msgTypes[20]
+	mi := &file_query_v1_query_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1578,7 +1630,7 @@ func (x *TimeSeriesQuery) String() string {
 func (*TimeSeriesQuery) ProtoMessage() {}
 
 func (x *TimeSeriesQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[20]
+	mi := &file_query_v1_query_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1591,7 +1643,7 @@ func (x *TimeSeriesQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TimeSeriesQuery.ProtoReflect.Descriptor instead.
 func (*TimeSeriesQuery) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{20}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *TimeSeriesQuery) GetStep() float64 {
@@ -1632,7 +1684,7 @@ type TimeSeriesReport struct {
 
 func (x *TimeSeriesReport) Reset() {
 	*x = TimeSeriesReport{}
-	mi := &file_query_v1_query_proto_msgTypes[21]
+	mi := &file_query_v1_query_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1644,7 +1696,7 @@ func (x *TimeSeriesReport) String() string {
 func (*TimeSeriesReport) ProtoMessage() {}
 
 func (x *TimeSeriesReport) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[21]
+	mi := &file_query_v1_query_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1657,7 +1709,7 @@ func (x *TimeSeriesReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TimeSeriesReport.ProtoReflect.Descriptor instead.
 func (*TimeSeriesReport) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{21}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *TimeSeriesReport) GetQuery() *TimeSeriesQuery {
@@ -1697,7 +1749,7 @@ type TreeQuery struct {
 
 func (x *TreeQuery) Reset() {
 	*x = TreeQuery{}
-	mi := &file_query_v1_query_proto_msgTypes[22]
+	mi := &file_query_v1_query_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1709,7 +1761,7 @@ func (x *TreeQuery) String() string {
 func (*TreeQuery) ProtoMessage() {}
 
 func (x *TreeQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[22]
+	mi := &file_query_v1_query_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1722,7 +1774,7 @@ func (x *TreeQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TreeQuery.ProtoReflect.Descriptor instead.
 func (*TreeQuery) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{22}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *TreeQuery) GetMaxNodes() int64 {
@@ -1797,7 +1849,7 @@ type TreeSymbols struct {
 
 func (x *TreeSymbols) Reset() {
 	*x = TreeSymbols{}
-	mi := &file_query_v1_query_proto_msgTypes[23]
+	mi := &file_query_v1_query_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1809,7 +1861,7 @@ func (x *TreeSymbols) String() string {
 func (*TreeSymbols) ProtoMessage() {}
 
 func (x *TreeSymbols) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[23]
+	mi := &file_query_v1_query_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1822,7 +1874,7 @@ func (x *TreeSymbols) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TreeSymbols.ProtoReflect.Descriptor instead.
 func (*TreeSymbols) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{23}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *TreeSymbols) GetMappings() []*v12.Mapping {
@@ -1910,7 +1962,7 @@ type SymbolRefTable struct {
 
 func (x *SymbolRefTable) Reset() {
 	*x = SymbolRefTable{}
-	mi := &file_query_v1_query_proto_msgTypes[24]
+	mi := &file_query_v1_query_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1922,7 +1974,7 @@ func (x *SymbolRefTable) String() string {
 func (*SymbolRefTable) ProtoMessage() {}
 
 func (x *SymbolRefTable) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[24]
+	mi := &file_query_v1_query_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1935,7 +1987,7 @@ func (x *SymbolRefTable) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SymbolRefTable.ProtoReflect.Descriptor instead.
 func (*SymbolRefTable) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{24}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *SymbolRefTable) GetNames() []string {
@@ -1985,7 +2037,7 @@ type TreeReport struct {
 
 func (x *TreeReport) Reset() {
 	*x = TreeReport{}
-	mi := &file_query_v1_query_proto_msgTypes[25]
+	mi := &file_query_v1_query_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1997,7 +2049,7 @@ func (x *TreeReport) String() string {
 func (*TreeReport) ProtoMessage() {}
 
 func (x *TreeReport) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[25]
+	mi := &file_query_v1_query_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2010,7 +2062,7 @@ func (x *TreeReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TreeReport.ProtoReflect.Descriptor instead.
 func (*TreeReport) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{25}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *TreeReport) GetQuery() *TreeQuery {
@@ -2054,7 +2106,7 @@ type PprofQuery struct {
 
 func (x *PprofQuery) Reset() {
 	*x = PprofQuery{}
-	mi := &file_query_v1_query_proto_msgTypes[26]
+	mi := &file_query_v1_query_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2066,7 +2118,7 @@ func (x *PprofQuery) String() string {
 func (*PprofQuery) ProtoMessage() {}
 
 func (x *PprofQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[26]
+	mi := &file_query_v1_query_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2079,7 +2131,7 @@ func (x *PprofQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PprofQuery.ProtoReflect.Descriptor instead.
 func (*PprofQuery) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{26}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *PprofQuery) GetMaxNodes() int64 {
@@ -2127,7 +2179,7 @@ type PprofReport struct {
 
 func (x *PprofReport) Reset() {
 	*x = PprofReport{}
-	mi := &file_query_v1_query_proto_msgTypes[27]
+	mi := &file_query_v1_query_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2139,7 +2191,7 @@ func (x *PprofReport) String() string {
 func (*PprofReport) ProtoMessage() {}
 
 func (x *PprofReport) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[27]
+	mi := &file_query_v1_query_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2152,7 +2204,7 @@ func (x *PprofReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PprofReport.ProtoReflect.Descriptor instead.
 func (*PprofReport) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{27}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *PprofReport) GetQuery() *PprofQuery {
@@ -2182,7 +2234,7 @@ type HeatmapQuery struct {
 
 func (x *HeatmapQuery) Reset() {
 	*x = HeatmapQuery{}
-	mi := &file_query_v1_query_proto_msgTypes[28]
+	mi := &file_query_v1_query_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2194,7 +2246,7 @@ func (x *HeatmapQuery) String() string {
 func (*HeatmapQuery) ProtoMessage() {}
 
 func (x *HeatmapQuery) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[28]
+	mi := &file_query_v1_query_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2207,7 +2259,7 @@ func (x *HeatmapQuery) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeatmapQuery.ProtoReflect.Descriptor instead.
 func (*HeatmapQuery) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{28}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *HeatmapQuery) GetStep() float64 {
@@ -2255,7 +2307,7 @@ type AttributeTable struct {
 
 func (x *AttributeTable) Reset() {
 	*x = AttributeTable{}
-	mi := &file_query_v1_query_proto_msgTypes[29]
+	mi := &file_query_v1_query_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2267,7 +2319,7 @@ func (x *AttributeTable) String() string {
 func (*AttributeTable) ProtoMessage() {}
 
 func (x *AttributeTable) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[29]
+	mi := &file_query_v1_query_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2280,7 +2332,7 @@ func (x *AttributeTable) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AttributeTable.ProtoReflect.Descriptor instead.
 func (*AttributeTable) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{29}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *AttributeTable) GetKeys() []string {
@@ -2311,7 +2363,7 @@ type HeatmapPoint struct {
 
 func (x *HeatmapPoint) Reset() {
 	*x = HeatmapPoint{}
-	mi := &file_query_v1_query_proto_msgTypes[30]
+	mi := &file_query_v1_query_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2323,7 +2375,7 @@ func (x *HeatmapPoint) String() string {
 func (*HeatmapPoint) ProtoMessage() {}
 
 func (x *HeatmapPoint) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[30]
+	mi := &file_query_v1_query_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2336,7 +2388,7 @@ func (x *HeatmapPoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeatmapPoint.ProtoReflect.Descriptor instead.
 func (*HeatmapPoint) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{30}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *HeatmapPoint) GetTimestamp() int64 {
@@ -2391,7 +2443,7 @@ type HeatmapSeries struct {
 
 func (x *HeatmapSeries) Reset() {
 	*x = HeatmapSeries{}
-	mi := &file_query_v1_query_proto_msgTypes[31]
+	mi := &file_query_v1_query_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2403,7 +2455,7 @@ func (x *HeatmapSeries) String() string {
 func (*HeatmapSeries) ProtoMessage() {}
 
 func (x *HeatmapSeries) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[31]
+	mi := &file_query_v1_query_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2416,7 +2468,7 @@ func (x *HeatmapSeries) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeatmapSeries.ProtoReflect.Descriptor instead.
 func (*HeatmapSeries) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{31}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *HeatmapSeries) GetAttributeRefs() []int64 {
@@ -2444,7 +2496,7 @@ type HeatmapReport struct {
 
 func (x *HeatmapReport) Reset() {
 	*x = HeatmapReport{}
-	mi := &file_query_v1_query_proto_msgTypes[32]
+	mi := &file_query_v1_query_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2456,7 +2508,7 @@ func (x *HeatmapReport) String() string {
 func (*HeatmapReport) ProtoMessage() {}
 
 func (x *HeatmapReport) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[32]
+	mi := &file_query_v1_query_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2469,7 +2521,7 @@ func (x *HeatmapReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeatmapReport.ProtoReflect.Descriptor instead.
 func (*HeatmapReport) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{32}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *HeatmapReport) GetQuery() *HeatmapQuery {
@@ -2507,7 +2559,7 @@ type Exemplar struct {
 
 func (x *Exemplar) Reset() {
 	*x = Exemplar{}
-	mi := &file_query_v1_query_proto_msgTypes[33]
+	mi := &file_query_v1_query_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2519,7 +2571,7 @@ func (x *Exemplar) String() string {
 func (*Exemplar) ProtoMessage() {}
 
 func (x *Exemplar) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[33]
+	mi := &file_query_v1_query_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2532,7 +2584,7 @@ func (x *Exemplar) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Exemplar.ProtoReflect.Descriptor instead.
 func (*Exemplar) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{33}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *Exemplar) GetTimestamp() int64 {
@@ -2585,7 +2637,7 @@ type Point struct {
 
 func (x *Point) Reset() {
 	*x = Point{}
-	mi := &file_query_v1_query_proto_msgTypes[34]
+	mi := &file_query_v1_query_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2597,7 +2649,7 @@ func (x *Point) String() string {
 func (*Point) ProtoMessage() {}
 
 func (x *Point) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[34]
+	mi := &file_query_v1_query_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2610,7 +2662,7 @@ func (x *Point) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Point.ProtoReflect.Descriptor instead.
 func (*Point) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{34}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *Point) GetValue() float64 {
@@ -2654,7 +2706,7 @@ type Series struct {
 
 func (x *Series) Reset() {
 	*x = Series{}
-	mi := &file_query_v1_query_proto_msgTypes[35]
+	mi := &file_query_v1_query_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2666,7 +2718,7 @@ func (x *Series) String() string {
 func (*Series) ProtoMessage() {}
 
 func (x *Series) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[35]
+	mi := &file_query_v1_query_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2679,7 +2731,7 @@ func (x *Series) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Series.ProtoReflect.Descriptor instead.
 func (*Series) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{35}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *Series) GetAttributeRefs() []int64 {
@@ -2707,7 +2759,7 @@ type TimeSeriesCompactReport struct {
 
 func (x *TimeSeriesCompactReport) Reset() {
 	*x = TimeSeriesCompactReport{}
-	mi := &file_query_v1_query_proto_msgTypes[36]
+	mi := &file_query_v1_query_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2719,7 +2771,7 @@ func (x *TimeSeriesCompactReport) String() string {
 func (*TimeSeriesCompactReport) ProtoMessage() {}
 
 func (x *TimeSeriesCompactReport) ProtoReflect() protoreflect.Message {
-	mi := &file_query_v1_query_proto_msgTypes[36]
+	mi := &file_query_v1_query_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2732,7 +2784,7 @@ func (x *TimeSeriesCompactReport) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TimeSeriesCompactReport.ProtoReflect.Descriptor instead.
 func (*TimeSeriesCompactReport) Descriptor() ([]byte, []int) {
-	return file_query_v1_query_proto_rawDescGZIP(), []int{36}
+	return file_query_v1_query_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *TimeSeriesCompactReport) GetQuery() *TimeSeriesQuery {
@@ -2808,9 +2860,12 @@ const file_query_v1_query_proto_rawDesc = "" +
 	"\x13time_series_compact\x18\t \x01(\v2\x19.query.v1.TimeSeriesQueryR\x11timeSeriesCompact\"u\n" +
 	"\x0eInvokeResponse\x12*\n" +
 	"\areports\x18\x01 \x03(\v2\x10.query.v1.ReportR\areports\x127\n" +
-	"\vdiagnostics\x18\x02 \x01(\v2\x15.query.v1.DiagnosticsR\vdiagnostics\"l\n" +
-	"\x10ResultCacheEntry\x12,\n" +
-	"\x05query\x18\x01 \x01(\v2\x16.query.v1.QueryRequestR\x05query\x12*\n" +
+	"\vdiagnostics\x18\x02 \x01(\v2\x15.query.v1.DiagnosticsR\vdiagnostics\"[\n" +
+	"\x0eResultCacheKey\x12,\n" +
+	"\x05query\x18\x01 \x01(\v2\x16.query.v1.QueryRequestR\x05query\x12\x1b\n" +
+	"\tblock_ids\x18\x02 \x03(\tR\bblockIds\"j\n" +
+	"\x10ResultCacheEntry\x12*\n" +
+	"\x03key\x18\x01 \x01(\v2\x18.query.v1.ResultCacheKeyR\x03key\x12*\n" +
 	"\areports\x18\x02 \x03(\v2\x10.query.v1.ReportR\areports\"\x81\x01\n" +
 	"\vDiagnostics\x122\n" +
 	"\n" +
@@ -3017,7 +3072,7 @@ func file_query_v1_query_proto_rawDescGZIP() []byte {
 }
 
 var file_query_v1_query_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_query_v1_query_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
+var file_query_v1_query_proto_msgTypes = make([]protoimpl.MessageInfo, 38)
 var file_query_v1_query_proto_goTypes = []any{
 	(QueryType)(0),                  // 0: query.v1.QueryType
 	(ReportType)(0),                 // 1: query.v1.ReportType
@@ -3031,120 +3086,122 @@ var file_query_v1_query_proto_goTypes = []any{
 	(*QueryNode)(nil),               // 9: query.v1.QueryNode
 	(*Query)(nil),                   // 10: query.v1.Query
 	(*InvokeResponse)(nil),          // 11: query.v1.InvokeResponse
-	(*ResultCacheEntry)(nil),        // 12: query.v1.ResultCacheEntry
-	(*Diagnostics)(nil),             // 13: query.v1.Diagnostics
-	(*ExecutionNode)(nil),           // 14: query.v1.ExecutionNode
-	(*ExecutionStats)(nil),          // 15: query.v1.ExecutionStats
-	(*BlockExecution)(nil),          // 16: query.v1.BlockExecution
-	(*Report)(nil),                  // 17: query.v1.Report
-	(*LabelNamesQuery)(nil),         // 18: query.v1.LabelNamesQuery
-	(*LabelNamesReport)(nil),        // 19: query.v1.LabelNamesReport
-	(*LabelValuesQuery)(nil),        // 20: query.v1.LabelValuesQuery
-	(*LabelValuesReport)(nil),       // 21: query.v1.LabelValuesReport
-	(*SeriesLabelsQuery)(nil),       // 22: query.v1.SeriesLabelsQuery
-	(*SeriesLabelsReport)(nil),      // 23: query.v1.SeriesLabelsReport
-	(*TimeSeriesQuery)(nil),         // 24: query.v1.TimeSeriesQuery
-	(*TimeSeriesReport)(nil),        // 25: query.v1.TimeSeriesReport
-	(*TreeQuery)(nil),               // 26: query.v1.TreeQuery
-	(*TreeSymbols)(nil),             // 27: query.v1.TreeSymbols
-	(*SymbolRefTable)(nil),          // 28: query.v1.SymbolRefTable
-	(*TreeReport)(nil),              // 29: query.v1.TreeReport
-	(*PprofQuery)(nil),              // 30: query.v1.PprofQuery
-	(*PprofReport)(nil),             // 31: query.v1.PprofReport
-	(*HeatmapQuery)(nil),            // 32: query.v1.HeatmapQuery
-	(*AttributeTable)(nil),          // 33: query.v1.AttributeTable
-	(*HeatmapPoint)(nil),            // 34: query.v1.HeatmapPoint
-	(*HeatmapSeries)(nil),           // 35: query.v1.HeatmapSeries
-	(*HeatmapReport)(nil),           // 36: query.v1.HeatmapReport
-	(*Exemplar)(nil),                // 37: query.v1.Exemplar
-	(*Point)(nil),                   // 38: query.v1.Point
-	(*Series)(nil),                  // 39: query.v1.Series
-	(*TimeSeriesCompactReport)(nil), // 40: query.v1.TimeSeriesCompactReport
-	(*v1.BlockMeta)(nil),            // 41: metastore.v1.BlockMeta
-	(*v11.Labels)(nil),              // 42: types.v1.Labels
-	(v11.ExemplarType)(0),           // 43: types.v1.ExemplarType
-	(*v11.Series)(nil),              // 44: types.v1.Series
-	(*v11.StackTraceSelector)(nil),  // 45: types.v1.StackTraceSelector
-	(*v12.Mapping)(nil),             // 46: google.v1.Mapping
-	(*v12.Location)(nil),            // 47: google.v1.Location
-	(*v12.Function)(nil),            // 48: google.v1.Function
-	(v13.HeatmapQueryType)(0),       // 49: querier.v1.HeatmapQueryType
+	(*ResultCacheKey)(nil),          // 12: query.v1.ResultCacheKey
+	(*ResultCacheEntry)(nil),        // 13: query.v1.ResultCacheEntry
+	(*Diagnostics)(nil),             // 14: query.v1.Diagnostics
+	(*ExecutionNode)(nil),           // 15: query.v1.ExecutionNode
+	(*ExecutionStats)(nil),          // 16: query.v1.ExecutionStats
+	(*BlockExecution)(nil),          // 17: query.v1.BlockExecution
+	(*Report)(nil),                  // 18: query.v1.Report
+	(*LabelNamesQuery)(nil),         // 19: query.v1.LabelNamesQuery
+	(*LabelNamesReport)(nil),        // 20: query.v1.LabelNamesReport
+	(*LabelValuesQuery)(nil),        // 21: query.v1.LabelValuesQuery
+	(*LabelValuesReport)(nil),       // 22: query.v1.LabelValuesReport
+	(*SeriesLabelsQuery)(nil),       // 23: query.v1.SeriesLabelsQuery
+	(*SeriesLabelsReport)(nil),      // 24: query.v1.SeriesLabelsReport
+	(*TimeSeriesQuery)(nil),         // 25: query.v1.TimeSeriesQuery
+	(*TimeSeriesReport)(nil),        // 26: query.v1.TimeSeriesReport
+	(*TreeQuery)(nil),               // 27: query.v1.TreeQuery
+	(*TreeSymbols)(nil),             // 28: query.v1.TreeSymbols
+	(*SymbolRefTable)(nil),          // 29: query.v1.SymbolRefTable
+	(*TreeReport)(nil),              // 30: query.v1.TreeReport
+	(*PprofQuery)(nil),              // 31: query.v1.PprofQuery
+	(*PprofReport)(nil),             // 32: query.v1.PprofReport
+	(*HeatmapQuery)(nil),            // 33: query.v1.HeatmapQuery
+	(*AttributeTable)(nil),          // 34: query.v1.AttributeTable
+	(*HeatmapPoint)(nil),            // 35: query.v1.HeatmapPoint
+	(*HeatmapSeries)(nil),           // 36: query.v1.HeatmapSeries
+	(*HeatmapReport)(nil),           // 37: query.v1.HeatmapReport
+	(*Exemplar)(nil),                // 38: query.v1.Exemplar
+	(*Point)(nil),                   // 39: query.v1.Point
+	(*Series)(nil),                  // 40: query.v1.Series
+	(*TimeSeriesCompactReport)(nil), // 41: query.v1.TimeSeriesCompactReport
+	(*v1.BlockMeta)(nil),            // 42: metastore.v1.BlockMeta
+	(*v11.Labels)(nil),              // 43: types.v1.Labels
+	(v11.ExemplarType)(0),           // 44: types.v1.ExemplarType
+	(*v11.Series)(nil),              // 45: types.v1.Series
+	(*v11.StackTraceSelector)(nil),  // 46: types.v1.StackTraceSelector
+	(*v12.Mapping)(nil),             // 47: google.v1.Mapping
+	(*v12.Location)(nil),            // 48: google.v1.Location
+	(*v12.Function)(nil),            // 49: google.v1.Function
+	(v13.HeatmapQueryType)(0),       // 50: querier.v1.HeatmapQueryType
 }
 var file_query_v1_query_proto_depIdxs = []int32{
 	10, // 0: query.v1.QueryRequest.query:type_name -> query.v1.Query
-	17, // 1: query.v1.QueryResponse.reports:type_name -> query.v1.Report
+	18, // 1: query.v1.QueryResponse.reports:type_name -> query.v1.Report
 	10, // 2: query.v1.InvokeRequest.query:type_name -> query.v1.Query
 	8,  // 3: query.v1.InvokeRequest.query_plan:type_name -> query.v1.QueryPlan
 	6,  // 4: query.v1.InvokeRequest.options:type_name -> query.v1.InvokeOptions
 	9,  // 5: query.v1.QueryPlan.root:type_name -> query.v1.QueryNode
 	3,  // 6: query.v1.QueryNode.type:type_name -> query.v1.QueryNode.Type
 	9,  // 7: query.v1.QueryNode.children:type_name -> query.v1.QueryNode
-	41, // 8: query.v1.QueryNode.blocks:type_name -> metastore.v1.BlockMeta
+	42, // 8: query.v1.QueryNode.blocks:type_name -> metastore.v1.BlockMeta
 	0,  // 9: query.v1.Query.query_type:type_name -> query.v1.QueryType
-	18, // 10: query.v1.Query.label_names:type_name -> query.v1.LabelNamesQuery
-	20, // 11: query.v1.Query.label_values:type_name -> query.v1.LabelValuesQuery
-	22, // 12: query.v1.Query.series_labels:type_name -> query.v1.SeriesLabelsQuery
-	24, // 13: query.v1.Query.time_series:type_name -> query.v1.TimeSeriesQuery
-	26, // 14: query.v1.Query.tree:type_name -> query.v1.TreeQuery
-	30, // 15: query.v1.Query.pprof:type_name -> query.v1.PprofQuery
-	32, // 16: query.v1.Query.heatmap:type_name -> query.v1.HeatmapQuery
-	24, // 17: query.v1.Query.time_series_compact:type_name -> query.v1.TimeSeriesQuery
-	17, // 18: query.v1.InvokeResponse.reports:type_name -> query.v1.Report
-	13, // 19: query.v1.InvokeResponse.diagnostics:type_name -> query.v1.Diagnostics
-	4,  // 20: query.v1.ResultCacheEntry.query:type_name -> query.v1.QueryRequest
-	17, // 21: query.v1.ResultCacheEntry.reports:type_name -> query.v1.Report
-	8,  // 22: query.v1.Diagnostics.query_plan:type_name -> query.v1.QueryPlan
-	14, // 23: query.v1.Diagnostics.execution_node:type_name -> query.v1.ExecutionNode
-	3,  // 24: query.v1.ExecutionNode.type:type_name -> query.v1.QueryNode.Type
-	14, // 25: query.v1.ExecutionNode.children:type_name -> query.v1.ExecutionNode
-	15, // 26: query.v1.ExecutionNode.stats:type_name -> query.v1.ExecutionStats
-	16, // 27: query.v1.ExecutionStats.block_executions:type_name -> query.v1.BlockExecution
-	1,  // 28: query.v1.Report.report_type:type_name -> query.v1.ReportType
-	19, // 29: query.v1.Report.label_names:type_name -> query.v1.LabelNamesReport
-	21, // 30: query.v1.Report.label_values:type_name -> query.v1.LabelValuesReport
-	23, // 31: query.v1.Report.series_labels:type_name -> query.v1.SeriesLabelsReport
-	25, // 32: query.v1.Report.time_series:type_name -> query.v1.TimeSeriesReport
-	29, // 33: query.v1.Report.tree:type_name -> query.v1.TreeReport
-	31, // 34: query.v1.Report.pprof:type_name -> query.v1.PprofReport
-	36, // 35: query.v1.Report.heatmap:type_name -> query.v1.HeatmapReport
-	40, // 36: query.v1.Report.time_series_compact:type_name -> query.v1.TimeSeriesCompactReport
-	18, // 37: query.v1.LabelNamesReport.query:type_name -> query.v1.LabelNamesQuery
-	20, // 38: query.v1.LabelValuesReport.query:type_name -> query.v1.LabelValuesQuery
-	22, // 39: query.v1.SeriesLabelsReport.query:type_name -> query.v1.SeriesLabelsQuery
-	42, // 40: query.v1.SeriesLabelsReport.series_labels:type_name -> types.v1.Labels
-	43, // 41: query.v1.TimeSeriesQuery.exemplar_type:type_name -> types.v1.ExemplarType
-	24, // 42: query.v1.TimeSeriesReport.query:type_name -> query.v1.TimeSeriesQuery
-	44, // 43: query.v1.TimeSeriesReport.time_series:type_name -> types.v1.Series
-	45, // 44: query.v1.TreeQuery.stack_trace_selector:type_name -> types.v1.StackTraceSelector
-	2,  // 45: query.v1.TreeQuery.symbol_mode:type_name -> query.v1.SymbolMode
-	46, // 46: query.v1.TreeSymbols.mappings:type_name -> google.v1.Mapping
-	47, // 47: query.v1.TreeSymbols.locations:type_name -> google.v1.Location
-	48, // 48: query.v1.TreeSymbols.functions:type_name -> google.v1.Function
-	26, // 49: query.v1.TreeReport.query:type_name -> query.v1.TreeQuery
-	27, // 50: query.v1.TreeReport.symbols:type_name -> query.v1.TreeSymbols
-	28, // 51: query.v1.TreeReport.symbol_refs:type_name -> query.v1.SymbolRefTable
-	45, // 52: query.v1.PprofQuery.stack_trace_selector:type_name -> types.v1.StackTraceSelector
-	30, // 53: query.v1.PprofReport.query:type_name -> query.v1.PprofQuery
-	49, // 54: query.v1.HeatmapQuery.query_type:type_name -> querier.v1.HeatmapQueryType
-	43, // 55: query.v1.HeatmapQuery.exemplar_type:type_name -> types.v1.ExemplarType
-	34, // 56: query.v1.HeatmapSeries.points:type_name -> query.v1.HeatmapPoint
-	32, // 57: query.v1.HeatmapReport.query:type_name -> query.v1.HeatmapQuery
-	35, // 58: query.v1.HeatmapReport.heatmap_series:type_name -> query.v1.HeatmapSeries
-	33, // 59: query.v1.HeatmapReport.attribute_table:type_name -> query.v1.AttributeTable
-	37, // 60: query.v1.Point.exemplars:type_name -> query.v1.Exemplar
-	38, // 61: query.v1.Series.points:type_name -> query.v1.Point
-	24, // 62: query.v1.TimeSeriesCompactReport.query:type_name -> query.v1.TimeSeriesQuery
-	39, // 63: query.v1.TimeSeriesCompactReport.time_series:type_name -> query.v1.Series
-	33, // 64: query.v1.TimeSeriesCompactReport.attribute_table:type_name -> query.v1.AttributeTable
-	4,  // 65: query.v1.QueryFrontendService.Query:input_type -> query.v1.QueryRequest
-	7,  // 66: query.v1.QueryBackendService.Invoke:input_type -> query.v1.InvokeRequest
-	5,  // 67: query.v1.QueryFrontendService.Query:output_type -> query.v1.QueryResponse
-	11, // 68: query.v1.QueryBackendService.Invoke:output_type -> query.v1.InvokeResponse
-	67, // [67:69] is the sub-list for method output_type
-	65, // [65:67] is the sub-list for method input_type
-	65, // [65:65] is the sub-list for extension type_name
-	65, // [65:65] is the sub-list for extension extendee
-	0,  // [0:65] is the sub-list for field type_name
+	19, // 10: query.v1.Query.label_names:type_name -> query.v1.LabelNamesQuery
+	21, // 11: query.v1.Query.label_values:type_name -> query.v1.LabelValuesQuery
+	23, // 12: query.v1.Query.series_labels:type_name -> query.v1.SeriesLabelsQuery
+	25, // 13: query.v1.Query.time_series:type_name -> query.v1.TimeSeriesQuery
+	27, // 14: query.v1.Query.tree:type_name -> query.v1.TreeQuery
+	31, // 15: query.v1.Query.pprof:type_name -> query.v1.PprofQuery
+	33, // 16: query.v1.Query.heatmap:type_name -> query.v1.HeatmapQuery
+	25, // 17: query.v1.Query.time_series_compact:type_name -> query.v1.TimeSeriesQuery
+	18, // 18: query.v1.InvokeResponse.reports:type_name -> query.v1.Report
+	14, // 19: query.v1.InvokeResponse.diagnostics:type_name -> query.v1.Diagnostics
+	4,  // 20: query.v1.ResultCacheKey.query:type_name -> query.v1.QueryRequest
+	12, // 21: query.v1.ResultCacheEntry.key:type_name -> query.v1.ResultCacheKey
+	18, // 22: query.v1.ResultCacheEntry.reports:type_name -> query.v1.Report
+	8,  // 23: query.v1.Diagnostics.query_plan:type_name -> query.v1.QueryPlan
+	15, // 24: query.v1.Diagnostics.execution_node:type_name -> query.v1.ExecutionNode
+	3,  // 25: query.v1.ExecutionNode.type:type_name -> query.v1.QueryNode.Type
+	15, // 26: query.v1.ExecutionNode.children:type_name -> query.v1.ExecutionNode
+	16, // 27: query.v1.ExecutionNode.stats:type_name -> query.v1.ExecutionStats
+	17, // 28: query.v1.ExecutionStats.block_executions:type_name -> query.v1.BlockExecution
+	1,  // 29: query.v1.Report.report_type:type_name -> query.v1.ReportType
+	20, // 30: query.v1.Report.label_names:type_name -> query.v1.LabelNamesReport
+	22, // 31: query.v1.Report.label_values:type_name -> query.v1.LabelValuesReport
+	24, // 32: query.v1.Report.series_labels:type_name -> query.v1.SeriesLabelsReport
+	26, // 33: query.v1.Report.time_series:type_name -> query.v1.TimeSeriesReport
+	30, // 34: query.v1.Report.tree:type_name -> query.v1.TreeReport
+	32, // 35: query.v1.Report.pprof:type_name -> query.v1.PprofReport
+	37, // 36: query.v1.Report.heatmap:type_name -> query.v1.HeatmapReport
+	41, // 37: query.v1.Report.time_series_compact:type_name -> query.v1.TimeSeriesCompactReport
+	19, // 38: query.v1.LabelNamesReport.query:type_name -> query.v1.LabelNamesQuery
+	21, // 39: query.v1.LabelValuesReport.query:type_name -> query.v1.LabelValuesQuery
+	23, // 40: query.v1.SeriesLabelsReport.query:type_name -> query.v1.SeriesLabelsQuery
+	43, // 41: query.v1.SeriesLabelsReport.series_labels:type_name -> types.v1.Labels
+	44, // 42: query.v1.TimeSeriesQuery.exemplar_type:type_name -> types.v1.ExemplarType
+	25, // 43: query.v1.TimeSeriesReport.query:type_name -> query.v1.TimeSeriesQuery
+	45, // 44: query.v1.TimeSeriesReport.time_series:type_name -> types.v1.Series
+	46, // 45: query.v1.TreeQuery.stack_trace_selector:type_name -> types.v1.StackTraceSelector
+	2,  // 46: query.v1.TreeQuery.symbol_mode:type_name -> query.v1.SymbolMode
+	47, // 47: query.v1.TreeSymbols.mappings:type_name -> google.v1.Mapping
+	48, // 48: query.v1.TreeSymbols.locations:type_name -> google.v1.Location
+	49, // 49: query.v1.TreeSymbols.functions:type_name -> google.v1.Function
+	27, // 50: query.v1.TreeReport.query:type_name -> query.v1.TreeQuery
+	28, // 51: query.v1.TreeReport.symbols:type_name -> query.v1.TreeSymbols
+	29, // 52: query.v1.TreeReport.symbol_refs:type_name -> query.v1.SymbolRefTable
+	46, // 53: query.v1.PprofQuery.stack_trace_selector:type_name -> types.v1.StackTraceSelector
+	31, // 54: query.v1.PprofReport.query:type_name -> query.v1.PprofQuery
+	50, // 55: query.v1.HeatmapQuery.query_type:type_name -> querier.v1.HeatmapQueryType
+	44, // 56: query.v1.HeatmapQuery.exemplar_type:type_name -> types.v1.ExemplarType
+	35, // 57: query.v1.HeatmapSeries.points:type_name -> query.v1.HeatmapPoint
+	33, // 58: query.v1.HeatmapReport.query:type_name -> query.v1.HeatmapQuery
+	36, // 59: query.v1.HeatmapReport.heatmap_series:type_name -> query.v1.HeatmapSeries
+	34, // 60: query.v1.HeatmapReport.attribute_table:type_name -> query.v1.AttributeTable
+	38, // 61: query.v1.Point.exemplars:type_name -> query.v1.Exemplar
+	39, // 62: query.v1.Series.points:type_name -> query.v1.Point
+	25, // 63: query.v1.TimeSeriesCompactReport.query:type_name -> query.v1.TimeSeriesQuery
+	40, // 64: query.v1.TimeSeriesCompactReport.time_series:type_name -> query.v1.Series
+	34, // 65: query.v1.TimeSeriesCompactReport.attribute_table:type_name -> query.v1.AttributeTable
+	4,  // 66: query.v1.QueryFrontendService.Query:input_type -> query.v1.QueryRequest
+	7,  // 67: query.v1.QueryBackendService.Invoke:input_type -> query.v1.InvokeRequest
+	5,  // 68: query.v1.QueryFrontendService.Query:output_type -> query.v1.QueryResponse
+	11, // 69: query.v1.QueryBackendService.Invoke:output_type -> query.v1.InvokeResponse
+	68, // [68:70] is the sub-list for method output_type
+	66, // [66:68] is the sub-list for method input_type
+	66, // [66:66] is the sub-list for extension type_name
+	66, // [66:66] is the sub-list for extension extendee
+	0,  // [0:66] is the sub-list for field type_name
 }
 
 func init() { file_query_v1_query_proto_init() }
@@ -3152,16 +3209,16 @@ func file_query_v1_query_proto_init() {
 	if File_query_v1_query_proto != nil {
 		return
 	}
-	file_query_v1_query_proto_msgTypes[22].OneofWrappers = []any{}
-	file_query_v1_query_proto_msgTypes[25].OneofWrappers = []any{}
+	file_query_v1_query_proto_msgTypes[23].OneofWrappers = []any{}
 	file_query_v1_query_proto_msgTypes[26].OneofWrappers = []any{}
+	file_query_v1_query_proto_msgTypes[27].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_query_v1_query_proto_rawDesc), len(file_query_v1_query_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   37,
+			NumMessages:   38,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/api/gen/proto/go/query/v1/query_vtproto.pb.go
+++ b/api/gen/proto/go/query/v1/query_vtproto.pb.go
@@ -85,6 +85,7 @@ func (m *InvokeOptions) CloneVT() *InvokeOptions {
 	r := new(InvokeOptions)
 	r.SanitizeOnMerge = m.SanitizeOnMerge
 	r.CollectDiagnostics = m.CollectDiagnostics
+	r.BypassResultCache = m.BypassResultCache
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -227,6 +228,30 @@ func (m *InvokeResponse) CloneVT() *InvokeResponse {
 }
 
 func (m *InvokeResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *ResultCacheEntry) CloneVT() *ResultCacheEntry {
+	if m == nil {
+		return (*ResultCacheEntry)(nil)
+	}
+	r := new(ResultCacheEntry)
+	r.Query = m.Query.CloneVT()
+	if rhs := m.Reports; rhs != nil {
+		tmpContainer := make([]*Report, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v.CloneVT()
+		}
+		r.Reports = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ResultCacheEntry) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
@@ -1104,6 +1129,9 @@ func (this *InvokeOptions) EqualVT(that *InvokeOptions) bool {
 	if this.CollectDiagnostics != that.CollectDiagnostics {
 		return false
 	}
+	if this.BypassResultCache != that.BypassResultCache {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -1321,6 +1349,42 @@ func (this *InvokeResponse) EqualVT(that *InvokeResponse) bool {
 
 func (this *InvokeResponse) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*InvokeResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *ResultCacheEntry) EqualVT(that *ResultCacheEntry) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !this.Query.EqualVT(that.Query) {
+		return false
+	}
+	if len(this.Reports) != len(that.Reports) {
+		return false
+	}
+	for i, vx := range this.Reports {
+		vy := that.Reports[i]
+		if p, q := vx, vy; p != q {
+			if p == nil {
+				p = &Report{}
+			}
+			if q == nil {
+				q = &Report{}
+			}
+			if !p.EqualVT(q) {
+				return false
+			}
+		}
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ResultCacheEntry) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*ResultCacheEntry)
 	if !ok {
 		return false
 	}
@@ -2778,6 +2842,16 @@ func (m *InvokeOptions) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if m.BypassResultCache {
+		i--
+		if m.BypassResultCache {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x18
+	}
 	if m.CollectDiagnostics {
 		i--
 		if m.CollectDiagnostics {
@@ -3178,6 +3252,61 @@ func (m *InvokeResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 			i--
 			dAtA[i] = 0xa
 		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *ResultCacheEntry) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ResultCacheEntry) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ResultCacheEntry) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Reports) > 0 {
+		for iNdEx := len(m.Reports) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Reports[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if m.Query != nil {
+		size, err := m.Query.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
 	}
 	return len(dAtA) - i, nil
 }
@@ -5252,6 +5381,9 @@ func (m *InvokeOptions) SizeVT() (n int) {
 	if m.CollectDiagnostics {
 		n += 2
 	}
+	if m.BypassResultCache {
+		n += 2
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -5401,6 +5533,26 @@ func (m *InvokeResponse) SizeVT() (n int) {
 	if m.Diagnostics != nil {
 		l = m.Diagnostics.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *ResultCacheEntry) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Query != nil {
+		l = m.Query.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.Reports) > 0 {
+		for _, e := range m.Reports {
+			l = e.SizeVT()
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
 	}
 	n += len(m.unknownFields)
 	return n
@@ -6523,6 +6675,26 @@ func (m *InvokeOptions) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.CollectDiagnostics = bool(v != 0)
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BypassResultCache", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.BypassResultCache = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -7491,6 +7663,127 @@ func (m *InvokeResponse) UnmarshalVT(dAtA []byte) error {
 				m.Diagnostics = &Diagnostics{}
 			}
 			if err := m.Diagnostics.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ResultCacheEntry) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ResultCacheEntry: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ResultCacheEntry: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Query", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Query == nil {
+				m.Query = &QueryRequest{}
+			}
+			if err := m.Query.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Reports", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Reports = append(m.Reports, &Report{})
+			if err := m.Reports[len(m.Reports)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/api/gen/proto/go/query/v1/query_vtproto.pb.go
+++ b/api/gen/proto/go/query/v1/query_vtproto.pb.go
@@ -231,12 +231,34 @@ func (m *InvokeResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *ResultCacheKey) CloneVT() *ResultCacheKey {
+	if m == nil {
+		return (*ResultCacheKey)(nil)
+	}
+	r := new(ResultCacheKey)
+	r.Query = m.Query.CloneVT()
+	if rhs := m.BlockIds; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.BlockIds = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *ResultCacheKey) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *ResultCacheEntry) CloneVT() *ResultCacheEntry {
 	if m == nil {
 		return (*ResultCacheEntry)(nil)
 	}
 	r := new(ResultCacheEntry)
-	r.Query = m.Query.CloneVT()
+	r.Key = m.Key.CloneVT()
 	if rhs := m.Reports; rhs != nil {
 		tmpContainer := make([]*Report, len(rhs))
 		for k, v := range rhs {
@@ -1354,13 +1376,41 @@ func (this *InvokeResponse) EqualMessageVT(thatMsg proto.Message) bool {
 	}
 	return this.EqualVT(that)
 }
-func (this *ResultCacheEntry) EqualVT(that *ResultCacheEntry) bool {
+func (this *ResultCacheKey) EqualVT(that *ResultCacheKey) bool {
 	if this == that {
 		return true
 	} else if this == nil || that == nil {
 		return false
 	}
 	if !this.Query.EqualVT(that.Query) {
+		return false
+	}
+	if len(this.BlockIds) != len(that.BlockIds) {
+		return false
+	}
+	for i, vx := range this.BlockIds {
+		vy := that.BlockIds[i]
+		if vx != vy {
+			return false
+		}
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ResultCacheKey) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*ResultCacheKey)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *ResultCacheEntry) EqualVT(that *ResultCacheEntry) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !this.Key.EqualVT(that.Key) {
 		return false
 	}
 	if len(this.Reports) != len(that.Reports) {
@@ -3256,6 +3306,58 @@ func (m *InvokeResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *ResultCacheKey) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ResultCacheKey) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ResultCacheKey) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.BlockIds) > 0 {
+		for iNdEx := len(m.BlockIds) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.BlockIds[iNdEx])
+			copy(dAtA[i:], m.BlockIds[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.BlockIds[iNdEx])))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if m.Query != nil {
+		size, err := m.Query.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *ResultCacheEntry) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -3298,8 +3400,8 @@ func (m *ResultCacheEntry) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 			dAtA[i] = 0x12
 		}
 	}
-	if m.Query != nil {
-		size, err := m.Query.MarshalToSizedBufferVT(dAtA[:i])
+	if m.Key != nil {
+		size, err := m.Key.MarshalToSizedBufferVT(dAtA[:i])
 		if err != nil {
 			return 0, err
 		}
@@ -5538,7 +5640,7 @@ func (m *InvokeResponse) SizeVT() (n int) {
 	return n
 }
 
-func (m *ResultCacheEntry) SizeVT() (n int) {
+func (m *ResultCacheKey) SizeVT() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -5546,6 +5648,26 @@ func (m *ResultCacheEntry) SizeVT() (n int) {
 	_ = l
 	if m.Query != nil {
 		l = m.Query.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.BlockIds) > 0 {
+		for _, s := range m.BlockIds {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *ResultCacheEntry) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Key != nil {
+		l = m.Key.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	if len(m.Reports) > 0 {
@@ -7688,7 +7810,7 @@ func (m *InvokeResponse) UnmarshalVT(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *ResultCacheEntry) UnmarshalVT(dAtA []byte) error {
+func (m *ResultCacheKey) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -7711,10 +7833,10 @@ func (m *ResultCacheEntry) UnmarshalVT(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: ResultCacheEntry: wiretype end group for non-group")
+			return fmt.Errorf("proto: ResultCacheKey: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: ResultCacheEntry: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: ResultCacheKey: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -7750,6 +7872,125 @@ func (m *ResultCacheEntry) UnmarshalVT(dAtA []byte) error {
 				m.Query = &QueryRequest{}
 			}
 			if err := m.Query.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BlockIds", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.BlockIds = append(m.BlockIds, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ResultCacheEntry) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ResultCacheEntry: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ResultCacheEntry: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Key", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Key == nil {
+				m.Key = &ResultCacheKey{}
+			}
+			if err := m.Key.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/api/query/v1/query.proto
+++ b/api/query/v1/query.proto
@@ -43,6 +43,8 @@ message InvokeOptions {
   // be listed in the request explicitly.
   bool sanitize_on_merge = 1;
   bool collect_diagnostics = 2;
+  // Prevent child query-backends from attempting result-cache coordination.
+  bool bypass_result_cache = 3;
 }
 
 message InvokeRequest {
@@ -109,6 +111,11 @@ enum QueryType {
 message InvokeResponse {
   repeated Report reports = 1;
   Diagnostics diagnostics = 2;
+}
+
+message ResultCacheEntry {
+  QueryRequest query = 1;
+  repeated Report reports = 2;
 }
 
 // Diagnostic messages, events, statistics, analytics, etc.

--- a/api/query/v1/query.proto
+++ b/api/query/v1/query.proto
@@ -113,8 +113,13 @@ message InvokeResponse {
   Diagnostics diagnostics = 2;
 }
 
-message ResultCacheEntry {
+message ResultCacheKey {
   QueryRequest query = 1;
+  repeated string block_ids = 2;
+}
+
+message ResultCacheEntry {
+  ResultCacheKey key = 1;
   repeated Report reports = 2;
 }
 

--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -1115,8 +1115,8 @@ Usage of ./pyroscope:
     	Enable query result caching. This sets the default for tenant overrides.
   -result-cache.filesystem.dir string
     	Local filesystem storage directory. (default "./data/v2/shared")
-  -result-cache.fragment-durations comma-separated-list-of-durations
-    	Comma-separated list of aligned result-cache fragment durations. The smallest duration is also the minimum cache age. (default 1d,2h,15m)
+  -result-cache.fragments value
+    	Comma-separated result-cache duration:Redis-TTL pairs. The smallest duration is also the minimum cache age. (default 1d:2d,2h:1d,15m:1d)
   -result-cache.gcs.bucket-name string
     	GCS bucket name
   -result-cache.gcs.expect-continue-timeout duration
@@ -1139,10 +1139,22 @@ Usage of ./pyroscope:
     	Maximum time to wait for a TLS handshake. 0 means no limit. (default 10s)
   -result-cache.generation uint
     	Result-cache invalidation generation. This sets the default for tenant overrides. (default 1)
+  -result-cache.lookup-timeout duration
+    	Maximum time a request may spend looking up result-cache entries. 0 disables the timeout. (default 1s)
   -result-cache.metadata-service-name-min-query-duration duration
     	Bypass result caching for metadata queries with a service_name matcher below this query duration. 0 disables this bypass. (default 1w)
   -result-cache.prefix string
     	Prefix for all objects stored in the backend storage. For simplicity, it may only contain digits and English alphabet characters, hyphens, underscores, dots and forward slashes.
+  -result-cache.redis.address string
+    	Redis server address for the result cache. Result caching requires Redis and result-cache object storage.
+  -result-cache.redis.db int
+    	Redis database for the result cache.
+  -result-cache.redis.password string
+    	Redis password for the result cache.
+  -result-cache.redis.tls-enabled
+    	Use TLS for result-cache Redis connections.
+  -result-cache.redis.username string
+    	Redis username for the result cache.
   -result-cache.s3.access-key-id string
     	S3 access key ID
   -result-cache.s3.bucket-lookup-type string

--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -1061,6 +1061,164 @@ Usage of ./pyroscope:
     	[experimental] Service discovery mode that query-frontends and queriers use to find query-scheduler instances. When query-scheduler ring-based service discovery is enabled, this option needs be set on query-schedulers, query-frontends and queriers. Supported values are: dns, ring. (default "ring")
   -recording-rules.max-rules-per-tenant int
     	Maximum number of recording rules a tenant can create. 0 to disable. (default 25)
+  -result-cache.azure.account-key string
+    	Azure storage account key. If unset, Azure managed identities will be used for authentication instead.
+  -result-cache.azure.account-name string
+    	Azure storage account name
+  -result-cache.azure.az-tenant-id string
+    	Azure Active Directory tenant ID. If set alongside `client-id` and `client-secret`, these values will be used for authentication via a client secret credential.
+  -result-cache.azure.client-id string
+    	Azure Active Directory client ID. If set alongside `az-tenant-id` and `client-secret`, these values will be used for authentication via a client secret credential.
+  -result-cache.azure.client-secret string
+    	Azure Active Directory client secret. If set alongside `az-tenant-id` and `client-id`, these values will be used for authentication via a client secret credential.
+  -result-cache.azure.connection-string string
+    	If `connection-string` is set, the value of `endpoint-suffix` will not be used. Use this method over `account-key` if you need to authenticate via a SAS token. Or if you use the Azurite emulator.
+  -result-cache.azure.container-name string
+    	Azure storage container name
+  -result-cache.azure.endpoint-suffix string
+    	Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN. If set to empty string, default endpoint suffix is used.
+  -result-cache.azure.max-retries int
+    	Number of retries for recoverable errors (default 3)
+  -result-cache.azure.user-assigned-id string
+    	User assigned managed identity. If empty, then System assigned identity is used.
+  -result-cache.backend string
+    	Backend storage to use. Supported backends are: s3, gcs, azure, swift, filesystem, cos.
+  -result-cache.cos.app-id string
+    	COS app id
+  -result-cache.cos.bucket string
+    	COS bucket name
+  -result-cache.cos.endpoint string
+    	COS storage endpoint
+  -result-cache.cos.expect-continue-timeout duration
+    	The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. 0 to send the request body immediately. (default 1s)
+  -result-cache.cos.http.idle-conn-timeout duration
+    	The time an idle connection will remain idle before closing. (default 1m30s)
+  -result-cache.cos.http.insecure-skip-verify
+    	If the client connects to COS via HTTPS and this option is enabled, the client will accept any certificate and hostname.
+  -result-cache.cos.http.response-header-timeout duration
+    	The amount of time the client will wait for a servers response headers. (default 2m0s)
+  -result-cache.cos.max-connections-per-host int
+    	Maximum number of connections per host. 0 means no limit.
+  -result-cache.cos.max-idle-connections int
+    	Maximum number of idle (keep-alive) connections across all hosts. 0 means no limit. (default 100)
+  -result-cache.cos.max-idle-connections-per-host int
+    	Maximum number of idle (keep-alive) connections to keep per-host. If 0, a built-in default value is used. (default 100)
+  -result-cache.cos.region string
+    	COS region name
+  -result-cache.cos.secret-id string
+    	COS secret id
+  -result-cache.cos.secret-key string
+    	COS secret key
+  -result-cache.cos.tls-handshake-timeout duration
+    	Maximum time to wait for a TLS handshake. 0 means no limit. (default 10s)
+  -result-cache.enabled
+    	Enable query result caching. This sets the default for tenant overrides.
+  -result-cache.filesystem.dir string
+    	Local filesystem storage directory. (default "./data/v2/shared")
+  -result-cache.gcs.bucket-name string
+    	GCS bucket name
+  -result-cache.gcs.expect-continue-timeout duration
+    	The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. 0 to send the request body immediately. (default 1s)
+  -result-cache.gcs.http.idle-conn-timeout duration
+    	The time an idle connection will remain idle before closing. (default 1m30s)
+  -result-cache.gcs.http.insecure-skip-verify
+    	If the client connects to GCS via HTTPS and this option is enabled, the client will accept any certificate and hostname.
+  -result-cache.gcs.http.response-header-timeout duration
+    	The amount of time the client will wait for a servers response headers. (default 2m0s)
+  -result-cache.gcs.max-connections-per-host int
+    	Maximum number of connections per host. 0 means no limit.
+  -result-cache.gcs.max-idle-connections int
+    	Maximum number of idle (keep-alive) connections across all hosts. 0 means no limit.
+  -result-cache.gcs.max-idle-connections-per-host int
+    	Maximum number of idle (keep-alive) connections to keep per-host. If 0, a built-in default value is used. (default 100)
+  -result-cache.gcs.service-account string
+    	JSON either from a Google Developers Console client_credentials.json file, or a Google Developers service account key. Needs to be valid JSON, not a filesystem path.
+  -result-cache.gcs.tls-handshake-timeout duration
+    	Maximum time to wait for a TLS handshake. 0 means no limit. (default 10s)
+  -result-cache.generation uint
+    	Result-cache invalidation generation. This sets the default for tenant overrides. (default 1)
+  -result-cache.prefix string
+    	Prefix for all objects stored in the backend storage. For simplicity, it may only contain digits and English alphabet characters, hyphens, underscores, dots and forward slashes.
+  -result-cache.s3.access-key-id string
+    	S3 access key ID
+  -result-cache.s3.bucket-lookup-type string
+    	S3 bucket lookup style, use one of: [path-style virtual-hosted-style auto] (default "auto")
+  -result-cache.s3.bucket-name string
+    	S3 bucket name
+  -result-cache.s3.endpoint string
+    	The S3 bucket endpoint. It could be an AWS S3 endpoint listed at https://docs.aws.amazon.com/general/latest/gr/s3.html or the address of an S3-compatible service in hostname:port format.
+  -result-cache.s3.expect-continue-timeout duration
+    	The time to wait for a server's first response headers after fully writing the request headers if the request has an Expect header. 0 to send the request body immediately. (default 1s)
+  -result-cache.s3.force-path-style
+    	Deprecated, use s3.bucket-lookup-type instead. Set this to `true` to force the bucket lookup to be using path-style.
+  -result-cache.s3.http.idle-conn-timeout duration
+    	The time an idle connection will remain idle before closing. (default 1m30s)
+  -result-cache.s3.http.insecure-skip-verify
+    	If the client connects to S3 via HTTPS and this option is enabled, the client will accept any certificate and hostname.
+  -result-cache.s3.http.response-header-timeout duration
+    	The amount of time the client will wait for a servers response headers. (default 2m0s)
+  -result-cache.s3.insecure
+    	If enabled, use http:// for the S3 endpoint instead of https://. This could be useful in local dev/test environments while using an S3-compatible backend storage, like Minio.
+  -result-cache.s3.max-connections-per-host int
+    	Maximum number of connections per host. 0 means no limit.
+  -result-cache.s3.max-idle-connections int
+    	Maximum number of idle (keep-alive) connections across all hosts. 0 means no limit.
+  -result-cache.s3.max-idle-connections-per-host int
+    	Maximum number of idle (keep-alive) connections to keep per-host. If 0, a built-in default value is used. (default 100)
+  -result-cache.s3.native-aws-auth-enabled
+    	[experimental] If enabled, it will use the default authentication methods of the AWS SDK for go based on known environment variables and known AWS config files.
+  -result-cache.s3.region string
+    	S3 region. If unset, the client will issue a S3 GetBucketLocation API call to autodetect it.
+  -result-cache.s3.secret-access-key string
+    	S3 secret access key
+  -result-cache.s3.signature-version string
+    	The signature version to use for authenticating against S3. Supported values are: v4, v2. (default "v4")
+  -result-cache.s3.sse.kms-encryption-context string
+    	KMS Encryption Context used for object encryption. It expects JSON formatted string.
+  -result-cache.s3.sse.kms-key-id string
+    	KMS Key ID used to encrypt objects in S3
+  -result-cache.s3.sse.type string
+    	Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.
+  -result-cache.s3.tls-handshake-timeout duration
+    	Maximum time to wait for a TLS handshake. 0 means no limit. (default 10s)
+  -result-cache.storage-prefix string
+    	[experimental] Deprecated: Use 'result-cache..prefix' instead. Prefix for all objects stored in the backend storage. For simplicity, it may only contain digits and English alphabet characters, hyphens, underscores, dots and forward slashes.
+  -result-cache.swift.auth-url string
+    	OpenStack Swift authentication URL
+  -result-cache.swift.auth-version int
+    	OpenStack Swift authentication API version. 0 to autodetect.
+  -result-cache.swift.connect-timeout duration
+    	Time after which a connection attempt is aborted. (default 10s)
+  -result-cache.swift.container-name string
+    	Name of the OpenStack Swift container to put chunks in.
+  -result-cache.swift.domain-id string
+    	OpenStack Swift user's domain ID.
+  -result-cache.swift.domain-name string
+    	OpenStack Swift user's domain name.
+  -result-cache.swift.max-retries int
+    	Max retries on requests error. (default 3)
+  -result-cache.swift.password string
+    	OpenStack Swift API key.
+  -result-cache.swift.project-domain-id string
+    	ID of the OpenStack Swift project's domain (v3 auth only), only needed if it differs the from user domain.
+  -result-cache.swift.project-domain-name string
+    	Name of the OpenStack Swift project's domain (v3 auth only), only needed if it differs from the user domain.
+  -result-cache.swift.project-id string
+    	OpenStack Swift project ID (v2,v3 auth only).
+  -result-cache.swift.project-name string
+    	OpenStack Swift project name (v2,v3 auth only).
+  -result-cache.swift.region-name string
+    	OpenStack Swift Region to use (v2,v3 auth only).
+  -result-cache.swift.request-timeout duration
+    	Time after which an idle request is aborted. The timeout watchdog is reset each time some data is received, so the timeout triggers after X time no data is received on a request. (default 5s)
+  -result-cache.swift.user-domain-id string
+    	OpenStack Swift user's domain ID.
+  -result-cache.swift.user-domain-name string
+    	OpenStack Swift user's domain name.
+  -result-cache.swift.user-id string
+    	OpenStack Swift user ID.
+  -result-cache.swift.username string
+    	OpenStack Swift username.
   -retention-period duration
     	Retention period for the data. 0 means data never deleted. (default 31d)
   -ring.heartbeat-timeout duration

--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -1115,8 +1115,8 @@ Usage of ./pyroscope:
     	Enable query result caching. This sets the default for tenant overrides.
   -result-cache.filesystem.dir string
     	Local filesystem storage directory. (default "./data/v2/shared")
-  -result-cache.fragment-durations value
-    	Comma-separated list of aligned result-cache fragment durations. The smallest duration is also the minimum cache age. (default 24h,2h,15m)
+  -result-cache.fragment-durations comma-separated-list-of-durations
+    	Comma-separated list of aligned result-cache fragment durations. The smallest duration is also the minimum cache age. (default 1d,2h,15m)
   -result-cache.gcs.bucket-name string
     	GCS bucket name
   -result-cache.gcs.expect-continue-timeout duration
@@ -1139,6 +1139,8 @@ Usage of ./pyroscope:
     	Maximum time to wait for a TLS handshake. 0 means no limit. (default 10s)
   -result-cache.generation uint
     	Result-cache invalidation generation. This sets the default for tenant overrides. (default 1)
+  -result-cache.metadata-service-name-min-query-duration duration
+    	Bypass result caching for metadata queries with a service_name matcher below this query duration. 0 disables this bypass. (default 1w)
   -result-cache.prefix string
     	Prefix for all objects stored in the backend storage. For simplicity, it may only contain digits and English alphabet characters, hyphens, underscores, dots and forward slashes.
   -result-cache.s3.access-key-id string

--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -1115,6 +1115,8 @@ Usage of ./pyroscope:
     	Enable query result caching. This sets the default for tenant overrides.
   -result-cache.filesystem.dir string
     	Local filesystem storage directory. (default "./data/v2/shared")
+  -result-cache.fragment-durations value
+    	Comma-separated list of aligned result-cache fragment durations. The smallest duration is also the minimum cache age. (default 24h,2h,15m)
   -result-cache.gcs.bucket-name string
     	GCS bucket name
   -result-cache.gcs.expect-continue-timeout duration

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -249,6 +249,8 @@ Usage of ./pyroscope:
     	Enable query result caching. This sets the default for tenant overrides.
   -result-cache.filesystem.dir string
     	Local filesystem storage directory. (default "./data/v2/shared")
+  -result-cache.fragment-durations value
+    	Comma-separated list of aligned result-cache fragment durations. The smallest duration is also the minimum cache age. (default 24h,2h,15m)
   -result-cache.gcs.bucket-name string
     	GCS bucket name
   -result-cache.gcs.service-account string

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -249,14 +249,16 @@ Usage of ./pyroscope:
     	Enable query result caching. This sets the default for tenant overrides.
   -result-cache.filesystem.dir string
     	Local filesystem storage directory. (default "./data/v2/shared")
-  -result-cache.fragment-durations value
-    	Comma-separated list of aligned result-cache fragment durations. The smallest duration is also the minimum cache age. (default 24h,2h,15m)
+  -result-cache.fragment-durations comma-separated-list-of-durations
+    	Comma-separated list of aligned result-cache fragment durations. The smallest duration is also the minimum cache age. (default 1d,2h,15m)
   -result-cache.gcs.bucket-name string
     	GCS bucket name
   -result-cache.gcs.service-account string
     	JSON either from a Google Developers Console client_credentials.json file, or a Google Developers service account key. Needs to be valid JSON, not a filesystem path.
   -result-cache.generation uint
     	Result-cache invalidation generation. This sets the default for tenant overrides. (default 1)
+  -result-cache.metadata-service-name-min-query-duration duration
+    	Bypass result caching for metadata queries with a service_name matcher below this query duration. 0 disables this bypass. (default 1w)
   -result-cache.prefix string
     	Prefix for all objects stored in the backend storage. For simplicity, it may only contain digits and English alphabet characters, hyphens, underscores, dots and forward slashes.
   -result-cache.s3.access-key-id string

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -215,6 +215,94 @@ Usage of ./pyroscope:
     	Backend storage to use for the ring. Supported values are: consul, etcd, inmemory, memberlist, multi. (default "memberlist")
   -recording-rules.max-rules-per-tenant int
     	Maximum number of recording rules a tenant can create. 0 to disable. (default 25)
+  -result-cache.azure.account-key string
+    	Azure storage account key. If unset, Azure managed identities will be used for authentication instead.
+  -result-cache.azure.account-name string
+    	Azure storage account name
+  -result-cache.azure.az-tenant-id string
+    	Azure Active Directory tenant ID. If set alongside `client-id` and `client-secret`, these values will be used for authentication via a client secret credential.
+  -result-cache.azure.client-id string
+    	Azure Active Directory client ID. If set alongside `az-tenant-id` and `client-secret`, these values will be used for authentication via a client secret credential.
+  -result-cache.azure.client-secret string
+    	Azure Active Directory client secret. If set alongside `az-tenant-id` and `client-id`, these values will be used for authentication via a client secret credential.
+  -result-cache.azure.connection-string string
+    	If `connection-string` is set, the value of `endpoint-suffix` will not be used. Use this method over `account-key` if you need to authenticate via a SAS token. Or if you use the Azurite emulator.
+  -result-cache.azure.container-name string
+    	Azure storage container name
+  -result-cache.azure.endpoint-suffix string
+    	Azure storage endpoint suffix without schema. The account name will be prefixed to this value to create the FQDN. If set to empty string, default endpoint suffix is used.
+  -result-cache.backend string
+    	Backend storage to use. Supported backends are: s3, gcs, azure, swift, filesystem, cos.
+  -result-cache.cos.app-id string
+    	COS app id
+  -result-cache.cos.bucket string
+    	COS bucket name
+  -result-cache.cos.endpoint string
+    	COS storage endpoint
+  -result-cache.cos.region string
+    	COS region name
+  -result-cache.cos.secret-id string
+    	COS secret id
+  -result-cache.cos.secret-key string
+    	COS secret key
+  -result-cache.enabled
+    	Enable query result caching. This sets the default for tenant overrides.
+  -result-cache.filesystem.dir string
+    	Local filesystem storage directory. (default "./data/v2/shared")
+  -result-cache.gcs.bucket-name string
+    	GCS bucket name
+  -result-cache.gcs.service-account string
+    	JSON either from a Google Developers Console client_credentials.json file, or a Google Developers service account key. Needs to be valid JSON, not a filesystem path.
+  -result-cache.generation uint
+    	Result-cache invalidation generation. This sets the default for tenant overrides. (default 1)
+  -result-cache.prefix string
+    	Prefix for all objects stored in the backend storage. For simplicity, it may only contain digits and English alphabet characters, hyphens, underscores, dots and forward slashes.
+  -result-cache.s3.access-key-id string
+    	S3 access key ID
+  -result-cache.s3.bucket-name string
+    	S3 bucket name
+  -result-cache.s3.endpoint string
+    	The S3 bucket endpoint. It could be an AWS S3 endpoint listed at https://docs.aws.amazon.com/general/latest/gr/s3.html or the address of an S3-compatible service in hostname:port format.
+  -result-cache.s3.region string
+    	S3 region. If unset, the client will issue a S3 GetBucketLocation API call to autodetect it.
+  -result-cache.s3.secret-access-key string
+    	S3 secret access key
+  -result-cache.s3.sse.kms-encryption-context string
+    	KMS Encryption Context used for object encryption. It expects JSON formatted string.
+  -result-cache.s3.sse.kms-key-id string
+    	KMS Key ID used to encrypt objects in S3
+  -result-cache.s3.sse.type string
+    	Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.
+  -result-cache.swift.auth-url string
+    	OpenStack Swift authentication URL
+  -result-cache.swift.auth-version int
+    	OpenStack Swift authentication API version. 0 to autodetect.
+  -result-cache.swift.container-name string
+    	Name of the OpenStack Swift container to put chunks in.
+  -result-cache.swift.domain-id string
+    	OpenStack Swift user's domain ID.
+  -result-cache.swift.domain-name string
+    	OpenStack Swift user's domain name.
+  -result-cache.swift.password string
+    	OpenStack Swift API key.
+  -result-cache.swift.project-domain-id string
+    	ID of the OpenStack Swift project's domain (v3 auth only), only needed if it differs the from user domain.
+  -result-cache.swift.project-domain-name string
+    	Name of the OpenStack Swift project's domain (v3 auth only), only needed if it differs from the user domain.
+  -result-cache.swift.project-id string
+    	OpenStack Swift project ID (v2,v3 auth only).
+  -result-cache.swift.project-name string
+    	OpenStack Swift project name (v2,v3 auth only).
+  -result-cache.swift.region-name string
+    	OpenStack Swift Region to use (v2,v3 auth only).
+  -result-cache.swift.user-domain-id string
+    	OpenStack Swift user's domain ID.
+  -result-cache.swift.user-domain-name string
+    	OpenStack Swift user's domain name.
+  -result-cache.swift.user-id string
+    	OpenStack Swift user ID.
+  -result-cache.swift.username string
+    	OpenStack Swift username.
   -retention-period duration
     	Retention period for the data. 0 means data never deleted. (default 31d)
   -ring.store string

--- a/cmd/pyroscope/help.txt.tmpl
+++ b/cmd/pyroscope/help.txt.tmpl
@@ -249,18 +249,30 @@ Usage of ./pyroscope:
     	Enable query result caching. This sets the default for tenant overrides.
   -result-cache.filesystem.dir string
     	Local filesystem storage directory. (default "./data/v2/shared")
-  -result-cache.fragment-durations comma-separated-list-of-durations
-    	Comma-separated list of aligned result-cache fragment durations. The smallest duration is also the minimum cache age. (default 1d,2h,15m)
+  -result-cache.fragments value
+    	Comma-separated result-cache duration:Redis-TTL pairs. The smallest duration is also the minimum cache age. (default 1d:2d,2h:1d,15m:1d)
   -result-cache.gcs.bucket-name string
     	GCS bucket name
   -result-cache.gcs.service-account string
     	JSON either from a Google Developers Console client_credentials.json file, or a Google Developers service account key. Needs to be valid JSON, not a filesystem path.
   -result-cache.generation uint
     	Result-cache invalidation generation. This sets the default for tenant overrides. (default 1)
+  -result-cache.lookup-timeout duration
+    	Maximum time a request may spend looking up result-cache entries. 0 disables the timeout. (default 1s)
   -result-cache.metadata-service-name-min-query-duration duration
     	Bypass result caching for metadata queries with a service_name matcher below this query duration. 0 disables this bypass. (default 1w)
   -result-cache.prefix string
     	Prefix for all objects stored in the backend storage. For simplicity, it may only contain digits and English alphabet characters, hyphens, underscores, dots and forward slashes.
+  -result-cache.redis.address string
+    	Redis server address for the result cache. Result caching requires Redis and result-cache object storage.
+  -result-cache.redis.db int
+    	Redis database for the result cache.
+  -result-cache.redis.password string
+    	Redis password for the result cache.
+  -result-cache.redis.tls-enabled
+    	Use TLS for result-cache Redis connections.
+  -result-cache.redis.username string
+    	Redis username for the result cache.
   -result-cache.s3.access-key-id string
     	S3 access key ID
   -result-cache.s3.bucket-name string

--- a/cmd/pyroscope/pyroscope.yaml
+++ b/cmd/pyroscope/pyroscope.yaml
@@ -495,6 +495,10 @@ limits:
   # smallest duration is also the minimum cache age.
   # result_cache_fragment_durations: 24h,2h,15m
 
+  # Bypass result caching for metadata queries with a service_name matcher below
+  # this query duration. 0 disables this bypass.
+  # result_cache_metadata_service_name_min_query_duration: 1w
+
   # Maximum number of recording rules a tenant can create. 0 to disable.
   # max_recording_rules: 25
 

--- a/cmd/pyroscope/pyroscope.yaml
+++ b/cmd/pyroscope/pyroscope.yaml
@@ -493,7 +493,7 @@ limits:
 
   # Comma-separated list of aligned result-cache fragment durations. The
   # smallest duration is also the minimum cache age.
-  # result_cache_fragment_durations: 24h,2h,15m
+  # result_cache_fragment_durations: 1d,2h,15m
 
   # Bypass result caching for metadata queries with a service_name matcher below
   # this query duration. 0 disables this bypass.

--- a/cmd/pyroscope/pyroscope.yaml
+++ b/cmd/pyroscope/pyroscope.yaml
@@ -491,9 +491,9 @@ limits:
   # overrides.
   # result_cache_generation: 1
 
-  # Comma-separated list of aligned result-cache fragment durations. The
-  # smallest duration is also the minimum cache age.
-  # result_cache_fragment_durations: 1d,2h,15m
+  # Comma-separated result-cache duration:Redis-TTL pairs. The smallest duration
+  # is also the minimum cache age.
+  # result_cache_fragments: 1d:2d,2h:1d,15m:1d
 
   # Bypass result caching for metadata queries with a service_name matcher below
   # this query duration. 0 disables this bypass.
@@ -960,6 +960,27 @@ result_cache:
   # only contain digits and English alphabet characters, hyphens, underscores,
   # dots and forward slashes.
   # prefix: ""
+
+  redis:
+    # Redis server address for the result cache. Result caching requires Redis
+    # and result-cache object storage.
+    # address: ""
+
+    # Redis username for the result cache.
+    # username: ""
+
+    # Redis password for the result cache.
+    # password: ""
+
+    # Redis database for the result cache.
+    # db: 0
+
+    # Use TLS for result-cache Redis connections.
+    # tls_enabled: false
+
+  # Maximum time a request may spend looking up result-cache entries. 0 disables
+  # the timeout.
+  # lookup_timeout: 1s
 
 self_profiling:
   # When running in single binary (--target=all) Pyroscope will push (Go SDK)

--- a/cmd/pyroscope/pyroscope.yaml
+++ b/cmd/pyroscope/pyroscope.yaml
@@ -484,6 +484,13 @@ limits:
   # Retention period for the data. 0 means data never deleted.
   # retention_period: 31d
 
+  # Enable query result caching. This sets the default for tenant overrides.
+  # result_cache_enabled: false
+
+  # Result-cache invalidation generation. This sets the default for tenant
+  # overrides.
+  # result_cache_generation: 1
+
   # Maximum number of recording rules a tenant can create. 0 to disable.
   # max_recording_rules: 25
 
@@ -618,6 +625,172 @@ storage:
   # Backend storage to use. Supported backends are: s3, gcs, azure, swift,
   # filesystem, cos.
   # backend: "filesystem"
+
+  s3:
+    # The S3 bucket endpoint. It could be an AWS S3 endpoint listed at
+    # https://docs.aws.amazon.com/general/latest/gr/s3.html or the address of an
+    # S3-compatible service in hostname:port format.
+    # endpoint: ""
+
+    # S3 region. If unset, the client will issue a S3 GetBucketLocation API call
+    # to autodetect it.
+    # region: ""
+
+    # S3 bucket name
+    # bucket_name: ""
+
+    # S3 secret access key
+    # secret_access_key: ""
+
+    # S3 access key ID
+    # access_key_id: ""
+
+    sse:
+      # Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.
+      # type: ""
+
+      # KMS Key ID used to encrypt objects in S3
+      # kms_key_id: ""
+
+      # KMS Encryption Context used for object encryption. It expects JSON
+      # formatted string.
+      # kms_encryption_context: ""
+
+  gcs:
+    # GCS bucket name
+    # bucket_name: ""
+
+    # JSON either from a Google Developers Console client_credentials.json file,
+    # or a Google Developers service account key. Needs to be valid JSON, not a
+    # filesystem path. If empty, fallback to Google default logic:
+    # 1. A JSON file whose path is specified by the
+    # GOOGLE_APPLICATION_CREDENTIALS environment variable. For workload identity
+    # federation, refer to
+    # https://cloud.google.com/iam/docs/how-to#using-workload-identity-federation
+    # on how to generate the JSON configuration file for on-prem/non-Google
+    # cloud platforms.
+    # 2. A JSON file in a location known to the gcloud command-line tool:
+    # $HOME/.config/gcloud/application_default_credentials.json.
+    # 3. On Google Compute Engine it fetches credentials from the metadata
+    # server.
+    # service_account: ""
+
+  azure:
+    # Azure Active Directory tenant ID. If set alongside `client-id` and
+    # `client-secret`, these values will be used for authentication via a client
+    # secret credential.
+    # az_tenant_id: ""
+
+    # Azure Active Directory client ID. If set alongside `az-tenant-id` and
+    # `client-secret`, these values will be used for authentication via a client
+    # secret credential.
+    # client_id: ""
+
+    # Azure Active Directory client secret. If set alongside `az-tenant-id` and
+    # `client-id`, these values will be used for authentication via a client
+    # secret credential.
+    # client_secret: ""
+
+    # Azure storage account name
+    # account_name: ""
+
+    # Azure storage account key. If unset, Azure managed identities will be used
+    # for authentication instead.
+    # account_key: ""
+
+    # If `connection-string` is set, the value of `endpoint-suffix` will not be
+    # used. Use this method over `account-key` if you need to authenticate via a
+    # SAS token. Or if you use the Azurite emulator.
+    # connection_string: ""
+
+    # Azure storage container name
+    # container_name: ""
+
+    # Azure storage endpoint suffix without schema. The account name will be
+    # prefixed to this value to create the FQDN. If set to empty string, default
+    # endpoint suffix is used.
+    # endpoint_suffix: ""
+
+  swift:
+    # OpenStack Swift authentication API version. 0 to autodetect.
+    # auth_version: 0
+
+    # OpenStack Swift authentication URL
+    # auth_url: ""
+
+    # OpenStack Swift username.
+    # username: ""
+
+    # OpenStack Swift user's domain name.
+    # user_domain_name: ""
+
+    # OpenStack Swift user's domain ID.
+    # user_domain_id: ""
+
+    # OpenStack Swift user ID.
+    # user_id: ""
+
+    # OpenStack Swift API key.
+    # password: ""
+
+    # OpenStack Swift user's domain ID.
+    # domain_id: ""
+
+    # OpenStack Swift user's domain name.
+    # domain_name: ""
+
+    # OpenStack Swift project ID (v2,v3 auth only).
+    # project_id: ""
+
+    # OpenStack Swift project name (v2,v3 auth only).
+    # project_name: ""
+
+    # ID of the OpenStack Swift project's domain (v3 auth only), only needed if
+    # it differs the from user domain.
+    # project_domain_id: ""
+
+    # Name of the OpenStack Swift project's domain (v3 auth only), only needed
+    # if it differs from the user domain.
+    # project_domain_name: ""
+
+    # OpenStack Swift Region to use (v2,v3 auth only).
+    # region_name: ""
+
+    # Name of the OpenStack Swift container to put chunks in.
+    # container_name: ""
+
+  cos:
+    # COS bucket name
+    # bucket: ""
+
+    # COS region name
+    # region: ""
+
+    # COS app id
+    # app_id: ""
+
+    # COS storage endpoint
+    # endpoint: ""
+
+    # COS secret key
+    # secret_key: ""
+
+    # COS secret id
+    # secret_id: ""
+
+  filesystem:
+    # Local filesystem storage directory.
+    # dir: "./data/v2/shared"
+
+  # Prefix for all objects stored in the backend storage. For simplicity, it may
+  # only contain digits and English alphabet characters, hyphens, underscores,
+  # dots and forward slashes.
+  # prefix: ""
+
+result_cache:
+  # Backend storage to use. Supported backends are: s3, gcs, azure, swift,
+  # filesystem, cos.
+  # backend: ""
 
   s3:
     # The S3 bucket endpoint. It could be an AWS S3 endpoint listed at

--- a/cmd/pyroscope/pyroscope.yaml
+++ b/cmd/pyroscope/pyroscope.yaml
@@ -491,6 +491,10 @@ limits:
   # overrides.
   # result_cache_generation: 1
 
+  # Comma-separated list of aligned result-cache fragment durations. The
+  # smallest duration is also the minimum cache age.
+  # result_cache_fragment_durations: 24h,2h,15m
+
   # Maximum number of recording rules a tenant can create. 0 to disable.
   # max_recording_rules: 25
 

--- a/docs/design/PYROEP-001-result-cache-label-names.md
+++ b/docs/design/PYROEP-001-result-cache-label-names.md
@@ -93,6 +93,7 @@ overrides:
     result_cache_enabled: true
     result_cache_generation: 1
     result_cache_fragment_durations: [24h, 2h, 15m]
+    result_cache_metadata_service_name_min_query_duration: 7d
 ```
 
 Defaults:
@@ -101,6 +102,7 @@ Defaults:
 result_cache_enabled: false
 result_cache_generation: 1
 result_cache_fragment_durations: [24h, 2h, 15m]
+result_cache_metadata_service_name_min_query_duration: 7d
 ```
 
 Expose these through:

--- a/docs/design/PYROEP-001-result-cache-label-names.md
+++ b/docs/design/PYROEP-001-result-cache-label-names.md
@@ -171,13 +171,13 @@ Block IDs identify immutable block contents and execution-relevant metadata.
 Cache objects use this key layout:
 
 ```text
-result-cache/$tenant-id/$fragment-duration/%04d-$cache-hash
+results-cache/$fragment-duration/$tenant-id/%04d-$cache-hash
 ```
 
 For example:
 
 ```text
-result-cache/tenant-a/24h/0001-d5f3...c02a
+results-cache/24h/tenant-a/0001-d5f3...c02a
 ```
 
 `$cache-hash` is the full lowercase, 64-character SHA-256 digest of a

--- a/docs/design/PYROEP-001-result-cache-label-names.md
+++ b/docs/design/PYROEP-001-result-cache-label-names.md
@@ -1,0 +1,348 @@
+# PYROEP-001: LabelNames result cache
+
+Status: Draft
+
+## Summary
+
+Add a full-result cache for V2 `LabelNames` queries. The first query-backend
+receiving a request coordinates caching: it partitions the request into UTC
+days, reads stable daily results from a dedicated object-storage bucket,
+executes cache misses through the existing query-backend DAG, merges reports,
+and asynchronously schedules cache writes.
+
+The query frontend continues to validate the request, query the metastore, and
+build the full-range plan. It does not read or write cache entries, merge
+cached reports, or publish cache metrics.
+
+Caching is opt-in per tenant. A completed day is cacheable only after twice the
+tenant's ingestion window has elapsed. The initial implementation supports
+`LabelNames`; its components are deliberately query-type-neutral so they can
+later support `Series` and `LabelValues` without redesigning cache
+coordination, storage, tenant controls, or observability.
+
+## Motivation
+
+`LabelNames` queries repeatedly scan TSDB sections from object storage even
+when querying historical data that can no longer change. Caching complete,
+stable daily results reduces object-storage reads and query-backend work.
+
+The cache must preserve current query semantics, fail open when cache storage
+is unavailable, and keep its storage and lifecycle independent from profile
+blocks.
+
+## Goals
+
+- Cache complete `LabelNames` reports for full UTC days.
+- Coordinate cache lookup, execution, merging, and writes in the first
+  query-backend.
+- Store cache entries in a dedicated object-storage bucket.
+- Enable caching per tenant and invalidate entries through tenant generations.
+- Cache only days that are stable with respect to late ingestion.
+- Keep cache writes outside the query result delivery path.
+- Provide global, low-cardinality cache metrics.
+- Provide an extensible design for future `Series` and `LabelValues` result
+  caches.
+
+## Non-goals
+
+- Caching `Series` or `LabelValues` in the initial implementation.
+- Caching partial UTC days, federated requests, or diagnostic requests.
+- Distributed locking or cache-stampede prevention.
+- Application-managed expiration or immediate deletion of old generations.
+- Returning diagnostics from cached execution.
+
+## Architecture
+
+The query frontend keeps its existing responsibilities:
+
+1. Validate and sanitize the query range.
+2. Query the metastore.
+3. Build a full-range query plan.
+4. Send one `InvokeRequest` to the query-backend.
+
+The first query-backend receiving an `InvokeRequest` becomes the cache
+coordinator:
+
+1. Determine whether the request is eligible for result caching.
+2. Split the request into UTC-day fragments.
+3. Look up eligible complete-day fragments in the result-cache bucket.
+4. Create fragment-specific plans for misses and uncached fragments.
+5. Execute those fragments through the normal query-backend DAG.
+6. Merge cached and executed reports.
+7. Enqueue successful eligible misses for asynchronous cache persistence.
+8. Return a normal `InvokeResponse`.
+
+The coordinator runs only on the first backend. Add an internal field to
+`queryv1.InvokeOptions`:
+
+```protobuf
+bool bypass_result_cache = 3;
+```
+
+The frontend leaves the field unset. Before executing or dispatching every
+fragment, the coordinator clones the request and sets it to `true`, preventing
+child query-backends from coordinating the cache a second time.
+
+Requests that are disabled or ineligible still pass through the coordinator
+once. It marks them as bypassed and executes their original plan normally.
+
+## Tenant configuration
+
+Add generic runtime overrides:
+
+```yaml
+overrides:
+  tenant-a:
+    result_cache_enabled: true
+    result_cache_generation: 1
+```
+
+Defaults:
+
+```yaml
+result_cache_enabled: false
+result_cache_generation: 1
+```
+
+Expose these through:
+
+```go
+ResultCacheEnabled(tenantID string) bool
+ResultCacheGeneration(tenantID string) uint32
+```
+
+The enable flag controls participation. Generation is only an invalidation
+namespace and must not double as an enable switch. The overrides are generic,
+but only `LabelNames` uses them initially.
+
+## Dedicated cache bucket
+
+Provision a dedicated result-cache bucket through deployment infrastructure or
+IaC. Add a top-level `result_cache` configuration section with a separate
+object-store client configuration; do not reuse `storage`.
+
+The query-backend owns this client. Query frontends do not need credentials for
+the result-cache bucket.
+
+The separate bucket provides independent lifecycle policies, IAM permissions,
+cost accounting, and retention. Cache storage errors are fail-open: the query
+executes normally if the bucket is unconfigured or unavailable.
+
+The backend requires only read and create-or-replace permissions. Lifecycle
+management owns deletion.
+
+## UTC-day partitioning and stability
+
+Split the sanitized time range at UTC midnight, with inclusive millisecond
+boundaries. A complete day is:
+
+```text
+start_time = YYYY-MM-DDT00:00:00.000Z
+end_time   = YYYY-MM-DDT23:59:59.999Z
+```
+
+Partial first and last days execute normally and are never cached.
+
+For a tenant with ingestion window `RejectOlderThan`, a complete day becomes
+eligible when:
+
+```text
+now >= following UTC midnight + 2 * RejectOlderThan(tenantID)
+```
+
+If `RejectOlderThan` is zero, late ingestion is unbounded and the cache is
+bypassed. Both lookup and write use this same eligibility rule.
+
+For example, with a one-hour ingestion window, the day ending on
+`2026-08-20T23:59:59.999Z` becomes cacheable at `2026-08-21T02:00:00Z`.
+
+## Fragment plans
+
+The initial query plan already includes full-range block metadata. The
+coordinator creates fragment plans without another metastore request:
+
+1. Flatten and deduplicate the blocks in the original plan.
+2. Clone blocks overlapping the fragment.
+3. Remove datasets that do not overlap the fragment.
+4. Remove blocks with no remaining datasets.
+5. Build the fragment plan using `queryplan.Build`.
+
+Dataset filtering is required because `LabelNames` does not independently
+timestamp-filter series within a selected dataset.
+
+Fragments with no matching blocks return empty reports and may be cached when
+otherwise eligible. Fragment execution uses bounded concurrency to avoid
+unbounded fan-out for long permitted query ranges.
+
+## Cache key and format
+
+Cache objects use this key layout:
+
+```text
+result-cache/$tenant-id/%04d-YYYY-MM-DD-$cache-hash
+```
+
+For example:
+
+```text
+result-cache/tenant-a/0001-2026-08-21-d5f3...c02a
+```
+
+`$cache-hash` is the full lowercase, 64-character SHA-256 digest of a
+deterministic protobuf serialization of the `QueryRequest` with `start_time`
+and `end_time` set to zero. It includes the selector, query type, and all
+query-type-specific parameters. Tenant, generation, and UTC day are excluded
+because they already occur in the key path or filename.
+
+Add this protobuf message to `api/query/v1/query.proto`:
+
+```protobuf
+message ResultCacheEntry {
+  QueryRequest query = 1;
+  repeated Report reports = 2;
+}
+```
+
+The stored `QueryRequest` uses the actual complete-day start and end times,
+rather than zero. Reports are stored before public client-capability filtering;
+the query frontend continues to apply UTF-8 label-name filtering after the
+merged result is returned.
+
+Empty report lists are valid cache entries.
+
+## Lookup, validation, and collisions
+
+An entry is served only when it unmarshals successfully and its stored request
+exactly matches the expected complete-day request, including day boundaries.
+
+- Object-not-found is a normal cache miss.
+- A read failure is an `error` outcome. Execute normally and do not enqueue a
+  write because the current object state is unknown.
+- A corrupt protobuf is an `error` outcome. Execute normally; a successful
+  result may replace the corrupt object.
+- A decoded entry whose request does not match is a `collision` outcome.
+  Execute normally and do not overwrite that key, preventing collision
+  ping-pong.
+
+Concurrent writers for the same validated request are not collisions and may
+safely replace one another with equivalent complete results.
+
+## Asynchronous cache writes
+
+Cache persistence must not delay or alter query result delivery. After a
+successful eligible cache miss, the coordinator non-blockingly enqueues an
+immutable write job and returns the query result independently.
+
+A job contains the object key, complete daily request, reports, query type,
+and whether replacing a corrupt entry is allowed. A query-backend-owned worker
+pool then:
+
+1. Builds and marshals `ResultCacheEntry`.
+2. Uses a service-scoped context with a write timeout, never the request
+   context.
+3. Uploads the object to the result-cache bucket.
+4. Records the write outcome.
+
+The queue is bounded. If it is full, the backend drops the write immediately;
+it never blocks query result delivery. A subsequent request can repopulate the
+entry.
+
+Do not enqueue after cache collisions, unknown-state read errors, query errors,
+request cancellation, or for ineligible fragments. Corrupt entries may be
+replaced after a successful execution.
+
+The writer belongs to the query-backend service lifecycle. On startup it
+creates the queue and starts its workers. On shutdown it stops accepting new
+jobs, drains queued jobs best-effort within the normal shutdown deadline, then
+cancels active uploads and discards remaining jobs.
+
+## Report merging and diagnostics
+
+Use the existing query-backend report aggregation framework to merge cached and
+executed fragment responses. `LabelNames` aggregation unions, deduplicates, and
+sorts names.
+
+Cache hits contribute zero object-storage bytes. The coordinator sums bytes
+from executed fragments so existing query-frontend statistics remain accurate.
+
+Requests with `CollectDiagnostics` enabled bypass result caching to avoid
+returning incomplete or misleading execution trees.
+
+Federated requests containing more than one tenant also bypass caching. The
+key format intentionally has a single tenant path component.
+
+## Failure handling
+
+The cache is fail-open. The backend executes normally for disabled tenants,
+unsupported query shapes, federated requests, diagnostic requests, unbounded
+ingestion windows, partial or recent days, cache misses, and cache failures.
+
+Only errors from normal query execution are returned to callers. Cache lookup,
+queueing, marshaling, and upload errors cannot fail a query.
+
+## Metrics and logging
+
+Emit global, low-cardinality query-backend counters:
+
+```text
+pyroscope_query_backend_result_cache_lookups_total{
+  query_type="label_names",
+  outcome="hit|miss|error|collision"
+}
+```
+
+```text
+pyroscope_query_backend_result_cache_writes_total{
+  query_type="label_names",
+  outcome="success|error|dropped"
+}
+```
+
+Metrics count eligible complete-day fragments. Bypassed fragments do not count
+as misses. Do not add tenant IDs, cache keys, dates, generations, or selectors
+as labels.
+
+Logs may include the operation, query type, UTC date, generation, and error
+classification. They must not include selectors, report contents, or sensitive
+tenant identifiers.
+
+## Cleanup
+
+Pyroscope does not delete cache entries. Configure lifecycle expiration on the
+entire dedicated bucket, including version cleanup where the provider supports
+it. AWS S3, Google Cloud Storage, and Azure Blob Storage all support this.
+
+Expired entries become cache misses and are recomputed. Old generations expire
+through the same lifecycle policy.
+
+## Rollout
+
+1. Provision dedicated cache buckets and lifecycle policies.
+2. Deploy the implementation with `result_cache_enabled: false` by default.
+3. Opt in selected tenants through runtime overrides.
+4. Monitor global lookup and write outcomes, storage cost, and backend load.
+5. Expand opt-in gradually.
+6. Increment a tenant generation to invalidate its entries.
+
+Rollback consists of setting `result_cache_enabled: false`; existing objects
+expire through the bucket lifecycle policy.
+
+## Testing
+
+Unit tests must cover:
+
+- UTC splitting and inclusive millisecond boundaries.
+- Partial-day detection and stability boundaries.
+- Zero ingestion-window, diagnostic, and federated bypasses.
+- Tenant enablement and generation selection.
+- Plan flattening and block/dataset overlap filtering.
+- Exact key formatting, generation padding, and deterministic hashing.
+- Hash independence from time fields and sensitivity to all other parameters.
+- Protobuf round trips with real daily boundaries.
+- Hits, misses, corrupt entries, read errors, and collisions.
+- Empty result caching and cached/executed report merging.
+- Non-blocking queueing, dropped writes, worker upload failures, and
+  best-effort shutdown draining.
+- Metric outcomes and the absence of tenant labels.
+
+Integration tests must verify that hits avoid downstream block reads and return

--- a/docs/design/PYROEP-001-result-cache-label-names.md
+++ b/docs/design/PYROEP-001-result-cache-label-names.md
@@ -1,30 +1,29 @@
-# PYROEP-001: LabelNames result cache
+# PYROEP-001: Metadata result cache
 
 Status: Draft
 
 ## Summary
 
-Add a full-result cache for V2 `LabelNames` queries. The first query-backend
-receiving a request coordinates caching: it partitions the request into UTC
-days, reads stable daily results from a dedicated object-storage bucket,
-executes cache misses through the existing query-backend DAG, merges reports,
-and asynchronously schedules cache writes.
+Add a full-result cache for V2 `LabelNames`, `LabelValues`, and `Series` queries.
+The first query-backend receiving a request coordinates caching: it partitions
+the request into aligned, per-tenant duration tiers, reads matching results from
+a dedicated object-storage bucket, executes cache misses through the existing
+query-backend DAG, merges reports, and asynchronously schedules cache writes.
 
 The query frontend continues to validate the request, query the metastore, and
 build the full-range plan. It does not read or write cache entries, merge
 cached reports, or publish cache metrics.
 
-Caching is opt-in per tenant. A completed day is cacheable only after twice the
-tenant's ingestion window has elapsed. The initial implementation supports
-`LabelNames`; its components are deliberately query-type-neutral so they can
-later support `Series` and `LabelValues` without redesigning cache
-coordination, storage, tenant controls, or observability.
+Caching is opt-in per tenant. Cache identities include the exact fragment query
+and sorted block IDs, so late ingestion, compaction, and retention naturally
+select different entries. The smallest configured fragment duration is also
+the minimum cache age.
 
 ## Motivation
 
-`LabelNames` queries repeatedly scan TSDB sections from object storage even
-when querying historical data that can no longer change. Caching complete,
-stable daily results reduces object-storage reads and query-backend work.
+Metadata queries repeatedly scan TSDB sections from object storage. Caching
+results for an exact query and block set reduces object-storage reads and
+query-backend work while allowing recent data to participate safely.
 
 The cache must preserve current query semantics, fail open when cache storage
 is unavailable, and keep its storage and lifecycle independent from profile
@@ -32,21 +31,19 @@ blocks.
 
 ## Goals
 
-- Cache complete `LabelNames` reports for full UTC days.
+- Cache complete metadata-query reports for aligned duration tiers.
 - Coordinate cache lookup, execution, merging, and writes in the first
   query-backend.
 - Store cache entries in a dedicated object-storage bucket.
 - Enable caching per tenant and invalidate entries through tenant generations.
-- Cache only days that are stable with respect to late ingestion.
+- Invalidate entries naturally when the fragment's block set changes.
 - Keep cache writes outside the query result delivery path.
 - Provide global, low-cardinality cache metrics.
-- Provide an extensible design for future `Series` and `LabelValues` result
-  caches.
+- Keep the most recent smallest-duration window uncached.
 
 ## Non-goals
 
-- Caching `Series` or `LabelValues` in the initial implementation.
-- Caching partial UTC days, federated requests, or diagnostic requests.
+- Caching federated requests or diagnostic requests.
 - Distributed locking or cache-stampede prevention.
 - Application-managed expiration or immediate deletion of old generations.
 - Returning diagnostics from cached execution.
@@ -64,8 +61,8 @@ The first query-backend receiving an `InvokeRequest` becomes the cache
 coordinator:
 
 1. Determine whether the request is eligible for result caching.
-2. Split the request into UTC-day fragments.
-3. Look up eligible complete-day fragments in the result-cache bucket.
+2. Split the request into aligned tiered fragments.
+3. Look up eligible fragments in the result-cache bucket.
 4. Create fragment-specific plans for misses and uncached fragments.
 5. Execute those fragments through the normal query-backend DAG.
 6. Merge cached and executed reports.
@@ -95,6 +92,7 @@ overrides:
   tenant-a:
     result_cache_enabled: true
     result_cache_generation: 1
+    result_cache_fragment_durations: [24h, 2h, 15m]
 ```
 
 Defaults:
@@ -102,6 +100,7 @@ Defaults:
 ```yaml
 result_cache_enabled: false
 result_cache_generation: 1
+result_cache_fragment_durations: [24h, 2h, 15m]
 ```
 
 Expose these through:
@@ -109,11 +108,14 @@ Expose these through:
 ```go
 ResultCacheEnabled(tenantID string) bool
 ResultCacheGeneration(tenantID string) uint32
+ResultCacheFragmentDurations(tenantID string) []time.Duration
 ```
 
 The enable flag controls participation. Generation is only an invalidation
-namespace and must not double as an enable switch. The overrides are generic,
-but only `LabelNames` uses them initially.
+namespace and must not double as an enable switch. Fragment durations are
+positive, unique, evenly divisible tiers. Durations must be multiples of 15
+minutes, and at most eight tiers may be configured per tenant. The minimum
+duration and tier-count limit bound request fan-out.
 
 ## Dedicated cache bucket
 
@@ -131,30 +133,18 @@ executes normally if the bucket is unconfigured or unavailable.
 The backend requires only read and create-or-replace permissions. Lifecycle
 management owns deletion.
 
-## UTC-day partitioning and stability
+## Tiered partitioning and recent data
 
-Split the sanitized time range at UTC midnight, with inclusive millisecond
-boundaries. A complete day is:
+Split the sanitized time range into epoch-aligned, inclusive-millisecond
+fragments. At each boundary, choose the largest configured duration that fits,
+then fall back through smaller durations. With the default tiers, this produces
+`24h`, `2h`, and `15m` fragments. Unaligned edge remainders execute normally
+and are not cached.
 
-```text
-start_time = YYYY-MM-DDT00:00:00.000Z
-end_time   = YYYY-MM-DDT23:59:59.999Z
-```
-
-Partial first and last days execute normally and are never cached.
-
-For a tenant with ingestion window `RejectOlderThan`, a complete day becomes
-eligible when:
-
-```text
-now >= following UTC midnight + 2 * RejectOlderThan(tenantID)
-```
-
-If `RejectOlderThan` is zero, late ingestion is unbounded and the cache is
-bypassed. Both lookup and write use this same eligibility rule.
-
-For example, with a one-hour ingestion window, the day ending on
-`2026-08-20T23:59:59.999Z` becomes cacheable at `2026-08-21T02:00:00Z`.
+The smallest configured duration is also the minimum cache age. With the
+default `15m` tier, fragments ending within the latest 15 minutes execute
+normally without a cache lookup or write. This replaces the ingestion-window
+stability delay.
 
 ## Fragment plans
 
@@ -165,7 +155,8 @@ coordinator creates fragment plans without another metastore request:
 2. Clone blocks overlapping the fragment.
 3. Remove datasets that do not overlap the fragment.
 4. Remove blocks with no remaining datasets.
-5. Build the fragment plan using `queryplan.Build`.
+5. Sort blocks by ID.
+6. Build the fragment plan using `queryplan.Build`.
 
 Dataset filtering is required because `LabelNames` does not independently
 timestamp-filter series within a selected dataset.
@@ -173,38 +164,42 @@ timestamp-filter series within a selected dataset.
 Fragments with no matching blocks return empty reports and may be cached when
 otherwise eligible. Cache lookups and fragment execution use a fixed maximum
 concurrency of 64 to avoid unbounded fan-out for long permitted query ranges.
+Block IDs identify immutable block contents and execution-relevant metadata.
 
 ## Cache key and format
 
 Cache objects use this key layout:
 
 ```text
-result-cache/$tenant-id/%04d-YYYY-MM-DD-$cache-hash
+result-cache/$tenant-id/$fragment-duration/%04d-$cache-hash
 ```
 
 For example:
 
 ```text
-result-cache/tenant-a/0001-2026-08-21-d5f3...c02a
+result-cache/tenant-a/24h/0001-d5f3...c02a
 ```
 
 `$cache-hash` is the full lowercase, 64-character SHA-256 digest of a
-deterministic protobuf serialization of the `QueryRequest` with `start_time`
-and `end_time` set to zero. It includes the selector, query type, and all
-query-type-specific parameters. Tenant, generation, and UTC day are excluded
-because they already occur in the key path or filename.
+deterministic protobuf serialization of `ResultCacheKey`. It includes the exact
+fragment boundaries, selector, query parameters, and sorted block IDs. Tenant,
+generation, and fragment duration are excluded because they occur in the path.
 
 Add this protobuf message to `api/query/v1/query.proto`:
 
 ```protobuf
-message ResultCacheEntry {
+message ResultCacheKey {
   QueryRequest query = 1;
+  repeated string block_ids = 2;
+}
+
+message ResultCacheEntry {
+  ResultCacheKey key = 1;
   repeated Report reports = 2;
 }
 ```
 
-The stored `QueryRequest` uses the actual complete-day start and end times,
-rather than zero. Reports are stored before public client-capability filtering;
+Reports are stored before public client-capability filtering;
 the query frontend continues to apply UTF-8 label-name filtering after the
 merged result is returned.
 
@@ -212,15 +207,15 @@ Empty report lists are valid cache entries.
 
 ## Lookup, validation, and collisions
 
-An entry is served only when it unmarshals successfully and its stored request
-exactly matches the expected complete-day request, including day boundaries.
+An entry is served only when it unmarshals successfully and its stored cache
+identity exactly matches the expected query and sorted block list.
 
 - Object-not-found is a normal cache miss.
 - A read failure is an `error` outcome. Execute normally and do not enqueue a
   write because the current object state is unknown.
 - A corrupt protobuf is an `error` outcome. Execute normally; a successful
   result may replace the corrupt object.
-- A decoded entry whose request does not match is a `collision` outcome.
+- A decoded entry whose identity does not match is a `collision` outcome.
   Execute normally and do not overwrite that key, preventing collision
   ping-pong.
 
@@ -233,8 +228,8 @@ Cache persistence must not delay or alter query result delivery. After a
 successful eligible cache miss, the coordinator non-blockingly enqueues an
 immutable write job and returns the query result independently.
 
-A job contains the object key, complete daily request, reports, query type,
-and whether replacing a corrupt entry is allowed. A query-backend-owned worker
+A job contains the object key, cache identity, fragment duration, reports, and
+query type. A query-backend-owned worker
 pool then:
 
 1. Builds and marshals `ResultCacheEntry`.
@@ -274,8 +269,8 @@ key format intentionally has a single tenant path component.
 ## Failure handling
 
 The cache is fail-open. The backend executes normally for disabled tenants,
-unsupported query shapes, federated requests, diagnostic requests, unbounded
-ingestion windows, partial or recent days, cache misses, and cache failures.
+unsupported query shapes, federated requests, diagnostic requests, unaligned
+or recent fragments, cache misses, and cache failures.
 
 Only errors from normal query execution are returned to callers. Cache lookup,
 queueing, marshaling, and upload errors cannot fail a query.
@@ -287,6 +282,7 @@ Emit global, low-cardinality query-backend counters:
 ```text
 pyroscope_query_backend_result_cache_lookups_total{
   query_type="label_names",
+  fragment_duration="24h",
   outcome="hit|miss|error|collision"
 }
 ```
@@ -294,13 +290,15 @@ pyroscope_query_backend_result_cache_lookups_total{
 ```text
 pyroscope_query_backend_result_cache_writes_total{
   query_type="label_names",
+  fragment_duration="24h",
   outcome="success|error|dropped"
 }
 ```
 
-Metrics count eligible complete-day fragments. Bypassed fragments do not count
-as misses. Do not add tenant IDs, cache keys, dates, generations, or selectors
-as labels.
+Metrics count eligible aligned fragments. Bypassed fragments do not count as
+misses. Fragment duration values are canonicalized from the validated tier
+list. Do not add tenant IDs, cache keys, dates, generations, or selectors as
+labels.
 
 Logs may include the operation, query type, UTC date, generation, and error
 classification. They must not include selectors, report contents, or sensitive
@@ -331,18 +329,18 @@ expire through the bucket lifecycle policy.
 
 Unit tests must cover:
 
-- UTC splitting and inclusive millisecond boundaries.
-- Partial-day detection and stability boundaries.
-- Zero ingestion-window, diagnostic, and federated bypasses.
-- Tenant enablement and generation selection.
+- Tiered splitting, alignment, and inclusive millisecond boundaries.
+- Unaligned edge and minimum-cache-age handling.
+- Diagnostic and federated bypasses.
+- Tenant enablement, generation, and duration-tier selection.
 - Plan flattening and block/dataset overlap filtering.
 - Exact key formatting, generation padding, and deterministic hashing.
-- Hash independence from time fields and sensitivity to all other parameters.
-- Protobuf round trips with real daily boundaries.
+- Hash sensitivity to exact time fields, duration, and block-set changes.
+- Protobuf round trips with real fragment boundaries and sorted block IDs.
 - Hits, misses, corrupt entries, read errors, and collisions.
 - Empty result caching and cached/executed report merging.
 - Non-blocking queueing, dropped writes, worker upload failures, and
   best-effort shutdown draining.
-- Metric outcomes and the absence of tenant labels.
+- Metric outcomes, fragment-duration labels, and the absence of tenant labels.
 
 Integration tests must verify that hits avoid downstream block reads and return

--- a/docs/design/PYROEP-001-result-cache-label-names.md
+++ b/docs/design/PYROEP-001-result-cache-label-names.md
@@ -171,8 +171,8 @@ Dataset filtering is required because `LabelNames` does not independently
 timestamp-filter series within a selected dataset.
 
 Fragments with no matching blocks return empty reports and may be cached when
-otherwise eligible. Fragment execution uses bounded concurrency to avoid
-unbounded fan-out for long permitted query ranges.
+otherwise eligible. Cache lookups and fragment execution use a fixed maximum
+concurrency of 64 to avoid unbounded fan-out for long permitted query ranges.
 
 ## Cache key and format
 

--- a/docs/design/PYROEP-001-result-cache-label-names.md
+++ b/docs/design/PYROEP-001-result-cache-label-names.md
@@ -7,7 +7,7 @@ Status: Draft
 Add a full-result cache for V2 `LabelNames`, `LabelValues`, and `Series` queries.
 The first query-backend receiving a request coordinates caching: it partitions
 the request into aligned, per-tenant duration tiers, reads matching results from
-a dedicated object-storage bucket, executes cache misses through the existing
+Redis and a dedicated object-storage bucket, executes cache misses through the existing
 query-backend DAG, merges reports, and asynchronously schedules cache writes.
 
 The query frontend continues to validate the request, query the metastore, and
@@ -34,7 +34,7 @@ blocks.
 - Cache complete metadata-query reports for aligned duration tiers.
 - Coordinate cache lookup, execution, merging, and writes in the first
   query-backend.
-- Store cache entries in a dedicated object-storage bucket.
+- Store cache entries in Redis, with large entries in a dedicated object-storage bucket.
 - Enable caching per tenant and invalidate entries through tenant generations.
 - Invalidate entries naturally when the fragment's block set changes.
 - Keep cache writes outside the query result delivery path.
@@ -62,7 +62,7 @@ coordinator:
 
 1. Determine whether the request is eligible for result caching.
 2. Split the request into aligned tiered fragments.
-3. Look up eligible fragments in the result-cache bucket.
+3. Look up eligible fragments in Redis and, for Redis placeholders, the result-cache bucket.
 4. Create fragment-specific plans for misses and uncached fragments.
 5. Execute those fragments through the normal query-backend DAG.
 6. Merge cached and executed reports.
@@ -92,7 +92,13 @@ overrides:
   tenant-a:
     result_cache_enabled: true
     result_cache_generation: 1
-    result_cache_fragment_durations: [24h, 2h, 15m]
+    result_cache_fragments:
+      - duration: 24h
+        ttl: 48h
+      - duration: 2h
+        ttl: 24h
+      - duration: 15m
+        ttl: 24h
     result_cache_metadata_service_name_min_query_duration: 7d
 ```
 
@@ -101,7 +107,13 @@ Defaults:
 ```yaml
 result_cache_enabled: false
 result_cache_generation: 1
-result_cache_fragment_durations: [24h, 2h, 15m]
+result_cache_fragments:
+  - duration: 24h
+    ttl: 48h
+  - duration: 2h
+    ttl: 24h
+  - duration: 15m
+    ttl: 24h
 result_cache_metadata_service_name_min_query_duration: 7d
 ```
 
@@ -110,27 +122,32 @@ Expose these through:
 ```go
 ResultCacheEnabled(tenantID string) bool
 ResultCacheGeneration(tenantID string) uint32
-ResultCacheFragmentDurations(tenantID string) []time.Duration
+ResultCacheFragments(tenantID string) []ResultCacheFragment
 ```
 
 The enable flag controls participation. Generation is only an invalidation
 namespace and must not double as an enable switch. Fragment durations are
-positive, unique, evenly divisible tiers. Durations must be multiples of 15
-minutes, and at most eight tiers may be configured per tenant. The minimum
-duration and tier-count limit bound request fan-out.
+positive, unique, evenly divisible tiers, and each Redis TTL is positive.
+Durations must be multiples of 15 minutes, and at most eight tiers may be
+configured per tenant. The minimum duration and tier-count limit bound request
+fan-out.
 
-## Dedicated cache bucket
+## Redis and cache bucket
 
-Provision a dedicated result-cache bucket through deployment infrastructure or
-IaC. Add a top-level `result_cache` configuration section with a separate
-object-store client configuration; do not reuse `storage`.
+Provision local Redis and a dedicated result-cache bucket through deployment
+infrastructure or IaC. Add a top-level `result_cache` configuration section
+with Redis and separate object-store client configuration; do not reuse
+`storage`. Both Redis and the bucket are required before result caching is
+enabled.
 
-The query-backend owns this client. Query frontends do not need credentials for
-the result-cache bucket.
+The query-backend owns these clients. Query frontends do not need credentials
+for Redis or the result-cache bucket.
 
-The separate bucket provides independent lifecycle policies, IAM permissions,
-cost accounting, and retention. Cache storage errors are fail-open: the query
-executes normally if the bucket is unconfigured or unavailable.
+Serialized entries smaller than 16 KiB are stored directly in Redis. Larger
+entries are uploaded to the bucket first, then represented in Redis by a
+placeholder with the fragment TTL. A Redis miss is a cache miss; a Redis
+placeholder authorizes the bucket read. Cache storage errors are fail-open: the
+query executes normally if Redis or the bucket is unavailable.
 
 The backend requires only read and create-or-replace permissions. Lifecycle
 management owns deletion.
@@ -212,7 +229,8 @@ Empty report lists are valid cache entries.
 An entry is served only when it unmarshals successfully and its stored cache
 identity exactly matches the expected query and sorted block list.
 
-- Object-not-found is a normal cache miss.
+- A Redis miss is a normal cache miss. A Redis placeholder whose object is
+  absent is also a normal cache miss.
 - A read failure is an `error` outcome. Execute normally and do not enqueue a
   write because the current object state is unknown.
 - A corrupt protobuf is an `error` outcome. Execute normally; a successful
@@ -237,7 +255,8 @@ pool then:
 1. Builds and marshals `ResultCacheEntry`.
 2. Uses a service-scoped context with a write timeout, never the request
    context.
-3. Uploads the object to the result-cache bucket.
+3. Stores entries smaller than 16 KiB directly in Redis; uploads larger
+   entries to the bucket, then writes a Redis placeholder.
 4. Records the write outcome.
 
 The queue is bounded. If it is full, the backend drops the write immediately;
@@ -247,6 +266,12 @@ entry.
 Do not enqueue after cache collisions, unknown-state read errors, query errors,
 request cancellation, or for ineligible fragments. Corrupt entries may be
 replaced after a successful execution.
+
+All fragment lookups share the configured `result_cache.lookup_timeout` budget,
+which defaults to one second. Completed hits are retained when the budget is
+exhausted; outstanding lookups are canceled and their fragments execute
+normally. Confirmed misses may still enqueue asynchronous writes, but timed-out
+or failed lookups never do because their cache state is unknown.
 
 The writer belongs to the query-backend service lifecycle. On startup it
 creates the queue and starts its workers. On shutdown it stops accepting new
@@ -285,7 +310,8 @@ Emit global, low-cardinality query-backend counters:
 pyroscope_query_backend_result_cache_lookups_total{
   query_type="label_names",
   fragment_duration="24h",
-  outcome="hit|miss|error|collision"
+  tier="redis|object|unknown",
+  outcome="hit|miss|error|collision|timeout"
 }
 ```
 
@@ -293,6 +319,7 @@ pyroscope_query_backend_result_cache_lookups_total{
 pyroscope_query_backend_result_cache_writes_total{
   query_type="label_names",
   fragment_duration="24h",
+  tier="redis|object|unknown",
   outcome="success|error|dropped"
 }
 ```

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -401,6 +401,33 @@ result_cache:
   # CLI flag: -result-cache.storage-prefix
   [storage_prefix: <string> | default = ""]
 
+  redis:
+    # Redis server address for the result cache. Result caching requires Redis
+    # and result-cache object storage.
+    # CLI flag: -result-cache.redis.address
+    [address: <string> | default = ""]
+
+    # Redis username for the result cache.
+    # CLI flag: -result-cache.redis.username
+    [username: <string> | default = ""]
+
+    # Redis password for the result cache.
+    # CLI flag: -result-cache.redis.password
+    [password: <string> | default = ""]
+
+    # Redis database for the result cache.
+    # CLI flag: -result-cache.redis.db
+    [db: <int> | default = 0]
+
+    # Use TLS for result-cache Redis connections.
+    # CLI flag: -result-cache.redis.tls-enabled
+    [tls_enabled: <boolean> | default = false]
+
+  # Maximum time a request may spend looking up result-cache entries. 0 disables
+  # the timeout.
+  # CLI flag: -result-cache.lookup-timeout
+  [lookup_timeout: <duration> | default = 1s]
+
 self_profiling:
   # When running in single binary (--target=all) Pyroscope will push (Go SDK)
   # profiles to itself. Set to true to disable self-profiling.
@@ -3523,10 +3550,10 @@ distributor_usage_groups:
 # CLI flag: -result-cache.generation
 [result_cache_generation: <int> | default = 1]
 
-# Comma-separated list of aligned result-cache fragment durations. The smallest
-# duration is also the minimum cache age.
-# CLI flag: -result-cache.fragment-durations
-[result_cache_fragment_durations: <list of durations> | default = 1d,2h,15m]
+# Comma-separated result-cache duration:Redis-TTL pairs. The smallest duration
+# is also the minimum cache age.
+# CLI flag: -result-cache.fragments
+[result_cache_fragments: <list of ResultCacheFragments> | default = 1d:2d,2h:1d,15m:1d]
 
 # Bypass result caching for metadata queries with a service_name matcher below
 # this query duration. 0 disables this bypass.

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -3523,6 +3523,11 @@ distributor_usage_groups:
 # CLI flag: -result-cache.generation
 [result_cache_generation: <int> | default = 1]
 
+# Comma-separated list of aligned result-cache fragment durations. The smallest
+# duration is also the minimum cache age.
+# CLI flag: -result-cache.fragment-durations
+[result_cache_fragment_durations: <list of ints> | default = 24h,2h,15m]
+
 # Maximum number of recording rules a tenant can create. 0 to disable.
 # CLI flag: -recording-rules.max-rules-per-tenant
 [max_recording_rules: <int> | default = 25]

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -3528,6 +3528,11 @@ distributor_usage_groups:
 # CLI flag: -result-cache.fragment-durations
 [result_cache_fragment_durations: <list of ints> | default = 24h,2h,15m]
 
+# Bypass result caching for metadata queries with a service_name matcher below
+# this query duration. 0 disables this bypass.
+# CLI flag: -result-cache.metadata-service-name-min-query-duration
+[result_cache_metadata_service_name_min_query_duration: <duration> | default = 1w]
+
 # Maximum number of recording rules a tenant can create. 0 to disable.
 # CLI flag: -recording-rules.max-rules-per-tenant
 [max_recording_rules: <int> | default = 25]

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -193,18 +193,22 @@ storage:
 
   # The s3_backend block configures the connection to Amazon S3 object storage
   # backend.
+  # The CLI flags prefix for this block configuration is: storage
   [s3: <s3_storage_backend>]
 
   # The gcs_backend block configures the connection to Google Cloud Storage
   # object storage backend.
+  # The CLI flags prefix for this block configuration is: storage
   [gcs: <gcs_storage_backend>]
 
   # The azure_storage_backend block configures the connection to Azure object
   # storage backend.
+  # The CLI flags prefix for this block configuration is: storage
   [azure: <azure_storage_backend>]
 
   # The swift_storage_backend block configures the connection to OpenStack
   # Object Storage (Swift) object storage backend.
+  # The CLI flags prefix for this block configuration is: storage
   [swift: <swift_storage_backend>]
 
   cos:
@@ -273,6 +277,7 @@ storage:
 
   # The filesystem_storage_backend block configures the usage of local file
   # system as object storage backend.
+  # The CLI flags prefix for this block configuration is: storage
   [filesystem: <filesystem_storage_backend>]
 
   # Prefix for all objects stored in the backend storage. For simplicity, it may
@@ -286,6 +291,114 @@ storage:
   # digits and English alphabet characters, hyphens, underscores, dots and
   # forward slashes.
   # CLI flag: -storage.storage-prefix
+  [storage_prefix: <string> | default = ""]
+
+result_cache:
+  # Backend storage to use. Supported backends are: s3, gcs, azure, swift,
+  # filesystem, cos.
+  # CLI flag: -result-cache.backend
+  [backend: <string> | default = ""]
+
+  # The s3_backend block configures the connection to Amazon S3 object storage
+  # backend.
+  # The CLI flags prefix for this block configuration is: result-cache
+  [s3: <s3_storage_backend>]
+
+  # The gcs_backend block configures the connection to Google Cloud Storage
+  # object storage backend.
+  # The CLI flags prefix for this block configuration is: result-cache
+  [gcs: <gcs_storage_backend>]
+
+  # The azure_storage_backend block configures the connection to Azure object
+  # storage backend.
+  # The CLI flags prefix for this block configuration is: result-cache
+  [azure: <azure_storage_backend>]
+
+  # The swift_storage_backend block configures the connection to OpenStack
+  # Object Storage (Swift) object storage backend.
+  # The CLI flags prefix for this block configuration is: result-cache
+  [swift: <swift_storage_backend>]
+
+  cos:
+    # COS bucket name
+    # CLI flag: -result-cache.cos.bucket
+    [bucket: <string> | default = ""]
+
+    # COS region name
+    # CLI flag: -result-cache.cos.region
+    [region: <string> | default = ""]
+
+    # COS app id
+    # CLI flag: -result-cache.cos.app-id
+    [app_id: <string> | default = ""]
+
+    # COS storage endpoint
+    # CLI flag: -result-cache.cos.endpoint
+    [endpoint: <string> | default = ""]
+
+    # COS secret key
+    # CLI flag: -result-cache.cos.secret-key
+    [secret_key: <string> | default = ""]
+
+    # COS secret id
+    # CLI flag: -result-cache.cos.secret-id
+    [secret_id: <string> | default = ""]
+
+    http:
+      # (advanced) The time an idle connection will remain idle before closing.
+      # CLI flag: -result-cache.cos.http.idle-conn-timeout
+      [idle_conn_timeout: <duration> | default = 1m30s]
+
+      # (advanced) The amount of time the client will wait for a servers
+      # response headers.
+      # CLI flag: -result-cache.cos.http.response-header-timeout
+      [response_header_timeout: <duration> | default = 2m]
+
+      # (advanced) If the client connects to COS via HTTPS and this option is
+      # enabled, the client will accept any certificate and hostname.
+      # CLI flag: -result-cache.cos.http.insecure-skip-verify
+      [insecure_skip_verify: <boolean> | default = false]
+
+      # (advanced) Maximum time to wait for a TLS handshake. 0 means no limit.
+      # CLI flag: -result-cache.cos.tls-handshake-timeout
+      [tls_handshake_timeout: <duration> | default = 10s]
+
+      # (advanced) The time to wait for a server's first response headers after
+      # fully writing the request headers if the request has an Expect header. 0
+      # to send the request body immediately.
+      # CLI flag: -result-cache.cos.expect-continue-timeout
+      [expect_continue_timeout: <duration> | default = 1s]
+
+      # (advanced) Maximum number of idle (keep-alive) connections across all
+      # hosts. 0 means no limit.
+      # CLI flag: -result-cache.cos.max-idle-connections
+      [max_idle_connections: <int> | default = 100]
+
+      # (advanced) Maximum number of idle (keep-alive) connections to keep
+      # per-host. If 0, a built-in default value is used.
+      # CLI flag: -result-cache.cos.max-idle-connections-per-host
+      [max_idle_connections_per_host: <int> | default = 100]
+
+      # (advanced) Maximum number of connections per host. 0 means no limit.
+      # CLI flag: -result-cache.cos.max-connections-per-host
+      [max_connections_per_host: <int> | default = 0]
+
+  # The filesystem_storage_backend block configures the usage of local file
+  # system as object storage backend.
+  # The CLI flags prefix for this block configuration is: result-cache
+  [filesystem: <filesystem_storage_backend>]
+
+  # Prefix for all objects stored in the backend storage. For simplicity, it may
+  # only contain digits and English alphabet characters, hyphens, underscores,
+  # dots and forward slashes.
+  # CLI flag: -result-cache.prefix
+  [prefix: <string> | default = ""]
+
+  # (experimental) Deprecated: Use 'result-cache..prefix' instead. Prefix for
+  # all objects stored in the backend storage. For simplicity, it may only
+  # contain digits and English alphabet characters, hyphens, underscores, dots
+  # and forward slashes.
+  # CLI flag: -result-cache.storage-prefix
   [storage_prefix: <string> | default = ""]
 
 self_profiling:
@@ -3401,6 +3514,15 @@ distributor_usage_groups:
 # CLI flag: -retention-period
 [retention_period: <duration> | default = 31d]
 
+# Enable query result caching. This sets the default for tenant overrides.
+# CLI flag: -result-cache.enabled
+[result_cache_enabled: <boolean> | default = false]
+
+# Result-cache invalidation generation. This sets the default for tenant
+# overrides.
+# CLI flag: -result-cache.generation
+[result_cache_generation: <int> | default = 1]
+
 # Maximum number of recording rules a tenant can create. 0 to disable.
 # CLI flag: -recording-rules.max-rules-per-tenant
 [max_recording_rules: <int> | default = 25]
@@ -3408,120 +3530,130 @@ distributor_usage_groups:
 
 ### s3_storage_backend
 
-The s3_backend block configures the connection to Amazon S3 object storage backend.
+The s3_backend block configures the connection to Amazon S3 object storage backend. The supported CLI flags `<prefix>` used to reference this configuration block are:
+
+- `result-cache`
+- `storage`
+
+&nbsp;
 
 ```yaml
 # The S3 bucket endpoint. It could be an AWS S3 endpoint listed at
 # https://docs.aws.amazon.com/general/latest/gr/s3.html or the address of an
 # S3-compatible service in hostname:port format.
-# CLI flag: -storage.s3.endpoint
+# CLI flag: -<prefix>.s3.endpoint
 [endpoint: <string> | default = ""]
 
 # S3 region. If unset, the client will issue a S3 GetBucketLocation API call to
 # autodetect it.
-# CLI flag: -storage.s3.region
+# CLI flag: -<prefix>.s3.region
 [region: <string> | default = ""]
 
 # S3 bucket name
-# CLI flag: -storage.s3.bucket-name
+# CLI flag: -<prefix>.s3.bucket-name
 [bucket_name: <string> | default = ""]
 
 # S3 secret access key
-# CLI flag: -storage.s3.secret-access-key
+# CLI flag: -<prefix>.s3.secret-access-key
 [secret_access_key: <string> | default = ""]
 
 # S3 access key ID
-# CLI flag: -storage.s3.access-key-id
+# CLI flag: -<prefix>.s3.access-key-id
 [access_key_id: <string> | default = ""]
 
 # (advanced) If enabled, use http:// for the S3 endpoint instead of https://.
 # This could be useful in local dev/test environments while using an
 # S3-compatible backend storage, like Minio.
-# CLI flag: -storage.s3.insecure
+# CLI flag: -<prefix>.s3.insecure
 [insecure: <boolean> | default = false]
 
 # (advanced) The signature version to use for authenticating against S3.
 # Supported values are: v4, v2.
-# CLI flag: -storage.s3.signature-version
+# CLI flag: -<prefix>.s3.signature-version
 [signature_version: <string> | default = "v4"]
 
 # (advanced) Deprecated, use s3.bucket-lookup-type instead. Set this to `true`
 # to force the bucket lookup to be using path-style.
-# CLI flag: -storage.s3.force-path-style
+# CLI flag: -<prefix>.s3.force-path-style
 [force_path_style: <boolean> | default = false]
 
 # (advanced) S3 bucket lookup style, use one of: [path-style
 # virtual-hosted-style auto]
-# CLI flag: -storage.s3.bucket-lookup-type
+# CLI flag: -<prefix>.s3.bucket-lookup-type
 [bucket_lookup_type: <string> | default = "auto"]
 
 # (experimental) If enabled, it will use the default authentication methods of
 # the AWS SDK for go based on known environment variables and known AWS config
 # files.
-# CLI flag: -storage.s3.native-aws-auth-enabled
+# CLI flag: -<prefix>.s3.native-aws-auth-enabled
 [native_aws_auth_enabled: <boolean> | default = false]
 
 sse:
   # Enable AWS Server Side Encryption. Supported values: SSE-KMS, SSE-S3.
-  # CLI flag: -storage.s3.sse.type
+  # CLI flag: -<prefix>.s3.sse.type
   [type: <string> | default = ""]
 
   # KMS Key ID used to encrypt objects in S3
-  # CLI flag: -storage.s3.sse.kms-key-id
+  # CLI flag: -<prefix>.s3.sse.kms-key-id
   [kms_key_id: <string> | default = ""]
 
   # KMS Encryption Context used for object encryption. It expects JSON formatted
   # string.
-  # CLI flag: -storage.s3.sse.kms-encryption-context
+  # CLI flag: -<prefix>.s3.sse.kms-encryption-context
   [kms_encryption_context: <string> | default = ""]
 
 http:
   # (advanced) The time an idle connection will remain idle before closing.
-  # CLI flag: -storage.s3.http.idle-conn-timeout
-  [idle_conn_timeout: <duration> | default = 10m]
+  # CLI flag: -<prefix>.s3.http.idle-conn-timeout
+  [idle_conn_timeout: <duration> | default = 1m30s]
 
   # (advanced) The amount of time the client will wait for a servers response
   # headers.
-  # CLI flag: -storage.s3.http.response-header-timeout
+  # CLI flag: -<prefix>.s3.http.response-header-timeout
   [response_header_timeout: <duration> | default = 2m]
 
   # (advanced) If the client connects to S3 via HTTPS and this option is
   # enabled, the client will accept any certificate and hostname.
-  # CLI flag: -storage.s3.http.insecure-skip-verify
+  # CLI flag: -<prefix>.s3.http.insecure-skip-verify
   [insecure_skip_verify: <boolean> | default = false]
 
   # (advanced) Maximum time to wait for a TLS handshake. 0 means no limit.
-  # CLI flag: -storage.s3.tls-handshake-timeout
+  # CLI flag: -<prefix>.s3.tls-handshake-timeout
   [tls_handshake_timeout: <duration> | default = 10s]
 
   # (advanced) The time to wait for a server's first response headers after
   # fully writing the request headers if the request has an Expect header. 0 to
   # send the request body immediately.
-  # CLI flag: -storage.s3.expect-continue-timeout
+  # CLI flag: -<prefix>.s3.expect-continue-timeout
   [expect_continue_timeout: <duration> | default = 1s]
 
   # (advanced) Maximum number of idle (keep-alive) connections across all hosts.
   # 0 means no limit.
-  # CLI flag: -storage.s3.max-idle-connections
+  # CLI flag: -<prefix>.s3.max-idle-connections
   [max_idle_connections: <int> | default = 0]
 
   # (advanced) Maximum number of idle (keep-alive) connections to keep per-host.
   # If 0, a built-in default value is used.
-  # CLI flag: -storage.s3.max-idle-connections-per-host
-  [max_idle_connections_per_host: <int> | default = 1000]
+  # CLI flag: -<prefix>.s3.max-idle-connections-per-host
+  [max_idle_connections_per_host: <int> | default = 100]
 
   # (advanced) Maximum number of connections per host. 0 means no limit.
-  # CLI flag: -storage.s3.max-connections-per-host
+  # CLI flag: -<prefix>.s3.max-connections-per-host
   [max_connections_per_host: <int> | default = 0]
 ```
 
 ### gcs_storage_backend
 
-The gcs_backend block configures the connection to Google Cloud Storage object storage backend.
+The gcs_backend block configures the connection to Google Cloud Storage object storage backend. The supported CLI flags `<prefix>` used to reference this configuration block are:
+
+- `result-cache`
+- `storage`
+
+&nbsp;
 
 ```yaml
 # GCS bucket name
-# CLI flag: -storage.gcs.bucket-name
+# CLI flag: -<prefix>.gcs.bucket-name
 [bucket_name: <string> | default = ""]
 
 # JSON either from a Google Developers Console client_credentials.json file, or
@@ -3535,196 +3667,211 @@ The gcs_backend block configures the connection to Google Cloud Storage object s
 # 2. A JSON file in a location known to the gcloud command-line tool:
 # $HOME/.config/gcloud/application_default_credentials.json.
 # 3. On Google Compute Engine it fetches credentials from the metadata server.
-# CLI flag: -storage.gcs.service-account
+# CLI flag: -<prefix>.gcs.service-account
 [service_account: <string> | default = ""]
 
 http:
   # (advanced) The time an idle connection will remain idle before closing.
-  # CLI flag: -storage.gcs.http.idle-conn-timeout
-  [idle_conn_timeout: <duration> | default = 10m]
+  # CLI flag: -<prefix>.gcs.http.idle-conn-timeout
+  [idle_conn_timeout: <duration> | default = 1m30s]
 
   # (advanced) The amount of time the client will wait for a servers response
   # headers.
-  # CLI flag: -storage.gcs.http.response-header-timeout
+  # CLI flag: -<prefix>.gcs.http.response-header-timeout
   [response_header_timeout: <duration> | default = 2m]
 
   # (advanced) If the client connects to GCS via HTTPS and this option is
   # enabled, the client will accept any certificate and hostname.
-  # CLI flag: -storage.gcs.http.insecure-skip-verify
+  # CLI flag: -<prefix>.gcs.http.insecure-skip-verify
   [insecure_skip_verify: <boolean> | default = false]
 
   # (advanced) Maximum time to wait for a TLS handshake. 0 means no limit.
-  # CLI flag: -storage.gcs.tls-handshake-timeout
+  # CLI flag: -<prefix>.gcs.tls-handshake-timeout
   [tls_handshake_timeout: <duration> | default = 10s]
 
   # (advanced) The time to wait for a server's first response headers after
   # fully writing the request headers if the request has an Expect header. 0 to
   # send the request body immediately.
-  # CLI flag: -storage.gcs.expect-continue-timeout
+  # CLI flag: -<prefix>.gcs.expect-continue-timeout
   [expect_continue_timeout: <duration> | default = 1s]
 
   # (advanced) Maximum number of idle (keep-alive) connections across all hosts.
   # 0 means no limit.
-  # CLI flag: -storage.gcs.max-idle-connections
+  # CLI flag: -<prefix>.gcs.max-idle-connections
   [max_idle_conns: <int> | default = 0]
 
   # (advanced) Maximum number of idle (keep-alive) connections to keep per-host.
   # If 0, a built-in default value is used.
-  # CLI flag: -storage.gcs.max-idle-connections-per-host
-  [max_idle_conns_per_host: <int> | default = 1000]
+  # CLI flag: -<prefix>.gcs.max-idle-connections-per-host
+  [max_idle_conns_per_host: <int> | default = 100]
 
   # (advanced) Maximum number of connections per host. 0 means no limit.
-  # CLI flag: -storage.gcs.max-connections-per-host
+  # CLI flag: -<prefix>.gcs.max-connections-per-host
   [max_conns_per_host: <int> | default = 0]
 ```
 
 ### azure_storage_backend
 
-The `azure_storage_backend` block configures the connection to Azure object storage backend.
+The `azure_storage_backend` block configures the connection to Azure object storage backend. The supported CLI flags `<prefix>` used to reference this configuration block are:
+
+- `result-cache`
+- `storage`
+
+&nbsp;
 
 ```yaml
 # Azure Active Directory tenant ID. If set alongside `client-id` and
 # `client-secret`, these values will be used for authentication via a client
 # secret credential.
-# CLI flag: -storage.azure.az-tenant-id
+# CLI flag: -<prefix>.azure.az-tenant-id
 [az_tenant_id: <string> | default = ""]
 
 # Azure Active Directory client ID. If set alongside `az-tenant-id` and
 # `client-secret`, these values will be used for authentication via a client
 # secret credential.
-# CLI flag: -storage.azure.client-id
+# CLI flag: -<prefix>.azure.client-id
 [client_id: <string> | default = ""]
 
 # Azure Active Directory client secret. If set alongside `az-tenant-id` and
 # `client-id`, these values will be used for authentication via a client secret
 # credential.
-# CLI flag: -storage.azure.client-secret
+# CLI flag: -<prefix>.azure.client-secret
 [client_secret: <string> | default = ""]
 
 # Azure storage account name
-# CLI flag: -storage.azure.account-name
+# CLI flag: -<prefix>.azure.account-name
 [account_name: <string> | default = ""]
 
 # Azure storage account key. If unset, Azure managed identities will be used for
 # authentication instead.
-# CLI flag: -storage.azure.account-key
+# CLI flag: -<prefix>.azure.account-key
 [account_key: <string> | default = ""]
 
 # If `connection-string` is set, the value of `endpoint-suffix` will not be
 # used. Use this method over `account-key` if you need to authenticate via a SAS
 # token. Or if you use the Azurite emulator.
-# CLI flag: -storage.azure.connection-string
+# CLI flag: -<prefix>.azure.connection-string
 [connection_string: <string> | default = ""]
 
 # Azure storage container name
-# CLI flag: -storage.azure.container-name
+# CLI flag: -<prefix>.azure.container-name
 [container_name: <string> | default = ""]
 
 # Azure storage endpoint suffix without schema. The account name will be
 # prefixed to this value to create the FQDN. If set to empty string, default
 # endpoint suffix is used.
-# CLI flag: -storage.azure.endpoint-suffix
+# CLI flag: -<prefix>.azure.endpoint-suffix
 [endpoint_suffix: <string> | default = ""]
 
 # (advanced) Number of retries for recoverable errors
-# CLI flag: -storage.azure.max-retries
+# CLI flag: -<prefix>.azure.max-retries
 [max_retries: <int> | default = 3]
 
 # (advanced) User assigned managed identity. If empty, then System assigned
 # identity is used.
-# CLI flag: -storage.azure.user-assigned-id
+# CLI flag: -<prefix>.azure.user-assigned-id
 [user_assigned_id: <string> | default = ""]
 ```
 
 ### swift_storage_backend
 
-The `swift_storage_backend` block configures the connection to OpenStack Object Storage (Swift) object storage backend.
+The `swift_storage_backend` block configures the connection to OpenStack Object Storage (Swift) object storage backend. The supported CLI flags `<prefix>` used to reference this configuration block are:
+
+- `result-cache`
+- `storage`
+
+&nbsp;
 
 ```yaml
 # OpenStack Swift authentication API version. 0 to autodetect.
-# CLI flag: -storage.swift.auth-version
+# CLI flag: -<prefix>.swift.auth-version
 [auth_version: <int> | default = 0]
 
 # OpenStack Swift authentication URL
-# CLI flag: -storage.swift.auth-url
+# CLI flag: -<prefix>.swift.auth-url
 [auth_url: <string> | default = ""]
 
 # OpenStack Swift username.
-# CLI flag: -storage.swift.username
+# CLI flag: -<prefix>.swift.username
 [username: <string> | default = ""]
 
 # OpenStack Swift user's domain name.
-# CLI flag: -storage.swift.user-domain-name
+# CLI flag: -<prefix>.swift.user-domain-name
 [user_domain_name: <string> | default = ""]
 
 # OpenStack Swift user's domain ID.
-# CLI flag: -storage.swift.user-domain-id
+# CLI flag: -<prefix>.swift.user-domain-id
 [user_domain_id: <string> | default = ""]
 
 # OpenStack Swift user ID.
-# CLI flag: -storage.swift.user-id
+# CLI flag: -<prefix>.swift.user-id
 [user_id: <string> | default = ""]
 
 # OpenStack Swift API key.
-# CLI flag: -storage.swift.password
+# CLI flag: -<prefix>.swift.password
 [password: <string> | default = ""]
 
 # OpenStack Swift user's domain ID.
-# CLI flag: -storage.swift.domain-id
+# CLI flag: -<prefix>.swift.domain-id
 [domain_id: <string> | default = ""]
 
 # OpenStack Swift user's domain name.
-# CLI flag: -storage.swift.domain-name
+# CLI flag: -<prefix>.swift.domain-name
 [domain_name: <string> | default = ""]
 
 # OpenStack Swift project ID (v2,v3 auth only).
-# CLI flag: -storage.swift.project-id
+# CLI flag: -<prefix>.swift.project-id
 [project_id: <string> | default = ""]
 
 # OpenStack Swift project name (v2,v3 auth only).
-# CLI flag: -storage.swift.project-name
+# CLI flag: -<prefix>.swift.project-name
 [project_name: <string> | default = ""]
 
 # ID of the OpenStack Swift project's domain (v3 auth only), only needed if it
 # differs the from user domain.
-# CLI flag: -storage.swift.project-domain-id
+# CLI flag: -<prefix>.swift.project-domain-id
 [project_domain_id: <string> | default = ""]
 
 # Name of the OpenStack Swift project's domain (v3 auth only), only needed if it
 # differs from the user domain.
-# CLI flag: -storage.swift.project-domain-name
+# CLI flag: -<prefix>.swift.project-domain-name
 [project_domain_name: <string> | default = ""]
 
 # OpenStack Swift Region to use (v2,v3 auth only).
-# CLI flag: -storage.swift.region-name
+# CLI flag: -<prefix>.swift.region-name
 [region_name: <string> | default = ""]
 
 # Name of the OpenStack Swift container to put chunks in.
-# CLI flag: -storage.swift.container-name
+# CLI flag: -<prefix>.swift.container-name
 [container_name: <string> | default = ""]
 
 # (advanced) Max retries on requests error.
-# CLI flag: -storage.swift.max-retries
+# CLI flag: -<prefix>.swift.max-retries
 [max_retries: <int> | default = 3]
 
 # (advanced) Time after which a connection attempt is aborted.
-# CLI flag: -storage.swift.connect-timeout
+# CLI flag: -<prefix>.swift.connect-timeout
 [connect_timeout: <duration> | default = 10s]
 
 # (advanced) Time after which an idle request is aborted. The timeout watchdog
 # is reset each time some data is received, so the timeout triggers after X time
 # no data is received on a request.
-# CLI flag: -storage.swift.request-timeout
+# CLI flag: -<prefix>.swift.request-timeout
 [request_timeout: <duration> | default = 5s]
 ```
 
 ### filesystem_storage_backend
 
-The `filesystem_storage_backend` block configures the usage of local file system as object storage backend.
+The `filesystem_storage_backend` block configures the usage of local file system as object storage backend. The supported CLI flags `<prefix>` used to reference this configuration block are:
+
+- `result-cache`
+- `storage`
+
+&nbsp;
 
 ```yaml
 # Local filesystem storage directory.
-# CLI flag: -storage.filesystem.dir
+# CLI flag: -<prefix>.filesystem.dir
 [dir: <string> | default = "./data/v2/shared"]
 ```
 
@@ -3739,4 +3886,3 @@ The `analytics` block configures usage statistics collection. For more details a
 # CLI flag: -usage-stats.enabled
 [reporting_enabled: <boolean> | default = true]
 ```
-

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -3526,7 +3526,7 @@ distributor_usage_groups:
 # Comma-separated list of aligned result-cache fragment durations. The smallest
 # duration is also the minimum cache age.
 # CLI flag: -result-cache.fragment-durations
-[result_cache_fragment_durations: <list of ints> | default = 24h,2h,15m]
+[result_cache_fragment_durations: <list of durations> | default = 1d,2h,15m]
 
 # Bypass result caching for metadata queries with a service_name matcher below
 # this query duration. 0 disables this bypass.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	connectrpc.com/grpchealth v1.4.0
 	github.com/PuerkitoBio/goquery v1.12.0
 	github.com/alecthomas/kingpin/v2 v2.4.0
+	github.com/alicebob/miniredis/v2 v2.37.0
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/colega/zeropool v0.0.0-20230505084239-6fb4a4f75381
 	github.com/dgraph-io/ristretto/v2 v2.4.0
@@ -55,6 +56,7 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5
 	github.com/prometheus/prometheus v0.311.3
+	github.com/redis/go-redis/v9 v9.18.0
 	github.com/samber/lo v1.53.0
 	github.com/simonswine/tempopb v0.2.0
 	github.com/sony/gobreaker/v2 v2.4.0
@@ -91,6 +93,7 @@ require (
 	github.com/basgys/goxml2json v1.1.1-0.20231018121955-e66ee54ceaad // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/dennwc/varint v1.0.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-openapi/swag/cmdutils v0.25.5 // indirect
 	github.com/go-openapi/swag/conv v0.25.5 // indirect
@@ -124,6 +127,7 @@ require (
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/zeebo/xxh3 v1.1.0 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.148.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b h1:mimo19zliBX/vSQ6PWWSL9lK8qwHozUj03+zLoEB8O0=
 github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b/go.mod h1:fvzegU4vN3H1qMT+8wDmzjAcDONcgo2/SZ/TyfdUOFs=
+github.com/alicebob/miniredis/v2 v2.37.0 h1:RheObYW32G1aiJIj81XVt78ZHJpHonHLHW7OLIshq68=
+github.com/alicebob/miniredis/v2 v2.37.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/aliyun/aliyun-oss-go-sdk v2.2.6+incompatible h1:KXeJoM1wo9I/6xPTyt6qCxoSZnmASiAjlrr0dyTUKt8=
 github.com/aliyun/aliyun-oss-go-sdk v2.2.6+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
@@ -147,6 +149,10 @@ github.com/bitly/go-simplejson v0.5.1 h1:xgwPbetQScXt1gh9BmoJ6j9JMr3TElvuIyjR8pg
 github.com/bitly/go-simplejson v0.5.1/go.mod h1:YOPVLzCfwK14b4Sff3oP1AmGhI9T9Vsg84etUnlyp+Q=
 github.com/bluele/gcache v0.0.2 h1:WcbfdXICg7G/DGBh1PFfcirkWOQV+v077yF1pSy3DGw=
 github.com/bluele/gcache v0.0.2/go.mod h1:m15KV+ECjptwSPxKhOhQoAFQVtUFjTVkc3H8o0t/fp0=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
@@ -201,6 +207,8 @@ github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da h1:aIftn67I1fkbMa5
 github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-groupvarint v0.0.0-20230630160417-2bfb7969fb3c h1:cHaw4wmusVzAZLEPWOCCGCfu6UvFXx9UboCHQCnjvxY=
 github.com/dgryski/go-groupvarint v0.0.0-20230630160417-2bfb7969fb3c/go.mod h1:MlkUQveSLEDbIgq2r1e++tSf0zfzU9mQpa9Qkczl+9Y=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/digitalocean/godo v1.178.0 h1:+B4xGOaoFwwwpM7TKhoyGHdmFg5eF9zDB1YfOLvNJ2E=
 github.com/digitalocean/godo v1.178.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
@@ -703,6 +711,8 @@ github.com/prometheus/sigv4 v0.4.1 h1:EIc3j+8NBea9u1iV6O5ZAN8uvPq2xOIUPcqCTivHuX
 github.com/prometheus/sigv4 v0.4.1/go.mod h1:eu+ZbRvsc5TPiHwqh77OWuCnWK73IdkETYY46P4dXOU=
 github.com/puzpuzpuz/xsync/v4 v4.4.0 h1:vlSN6/CkEY0pY8KaB0yqo/pCLZvp9nhdbBdjipT4gWo=
 github.com/puzpuzpuz/xsync/v4 v4.4.0/go.mod h1:VJDmTCJMBt8igNxnkQd86r+8KUeN1quSfNKu5bLYFQo=
+github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
+github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
@@ -784,6 +794,8 @@ github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3i
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=

--- a/pkg/model/result_cache.go
+++ b/pkg/model/result_cache.go
@@ -1,0 +1,10 @@
+package model
+
+import prommodel "github.com/prometheus/common/model"
+
+// ResultCacheFragment configures one aligned result-cache duration and the
+// lifetime of Redis entries for that duration.
+type ResultCacheFragment struct {
+	Duration prommodel.Duration `yaml:"duration" json:"duration"`
+	TTL      prommodel.Duration `yaml:"ttl" json:"ttl"`
+}

--- a/pkg/pyroscope/modules_experimental.go
+++ b/pkg/pyroscope/modules_experimental.go
@@ -30,6 +30,8 @@ import (
 	metastoreclient "github.com/grafana/pyroscope/v2/pkg/metastore/client"
 	"github.com/grafana/pyroscope/v2/pkg/metastore/discovery"
 	"github.com/grafana/pyroscope/v2/pkg/metrics"
+	"github.com/grafana/pyroscope/v2/pkg/objstore"
+	objstoreclient "github.com/grafana/pyroscope/v2/pkg/objstore/client"
 	"github.com/grafana/pyroscope/v2/pkg/operations/v2/querydiagnostics"
 	"github.com/grafana/pyroscope/v2/pkg/querybackend"
 	querybackendclient "github.com/grafana/pyroscope/v2/pkg/querybackend/client"
@@ -383,6 +385,14 @@ func (f *Pyroscope) initQueryBackend() (services.Service, error) {
 		return nil, err
 	}
 	logger := log.With(f.logger, "component", "query-backend")
+	var resultCacheBucket objstore.Bucket
+	if cfg := f.Cfg.ResultCache.Bucket; cfg.Backend != objstoreclient.None {
+		var err error
+		resultCacheBucket, err = objstoreclient.NewBucket(f.context(), cfg, "result-cache")
+		if err != nil {
+			return nil, fmt.Errorf("unable to initialise result-cache bucket: %w", err)
+		}
+	}
 	blockReader := querybackend.NewBlockReader(f.logger, f.storageBucket, f.reg, f.Overrides)
 	b, err := querybackend.New(
 		f.Cfg.QueryBackend,
@@ -390,6 +400,8 @@ func (f *Pyroscope) initQueryBackend() (services.Service, error) {
 		f.reg,
 		f.queryBackendClient,
 		blockReader,
+		resultCacheBucket,
+		f.Overrides,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/pyroscope/modules_experimental.go
+++ b/pkg/pyroscope/modules_experimental.go
@@ -2,6 +2,7 @@ package pyroscope
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"slices"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	grpchealth "google.golang.org/grpc/health"
@@ -30,7 +32,6 @@ import (
 	metastoreclient "github.com/grafana/pyroscope/v2/pkg/metastore/client"
 	"github.com/grafana/pyroscope/v2/pkg/metastore/discovery"
 	"github.com/grafana/pyroscope/v2/pkg/metrics"
-	"github.com/grafana/pyroscope/v2/pkg/objstore"
 	objstoreclient "github.com/grafana/pyroscope/v2/pkg/objstore/client"
 	"github.com/grafana/pyroscope/v2/pkg/operations/v2/querydiagnostics"
 	"github.com/grafana/pyroscope/v2/pkg/querybackend"
@@ -385,13 +386,24 @@ func (f *Pyroscope) initQueryBackend() (services.Service, error) {
 		return nil, err
 	}
 	logger := log.With(f.logger, "component", "query-backend")
-	var resultCacheBucket objstore.Bucket
-	if cfg := f.Cfg.ResultCache.Bucket; cfg.Backend != objstoreclient.None {
+	var resultCacheStore querybackend.ResultCacheStore
+	if f.Cfg.ResultCache.Redis.Enabled() {
+		cfg := f.Cfg.ResultCache.Bucket
 		var err error
-		resultCacheBucket, err = objstoreclient.NewBucket(f.context(), cfg, "result-cache")
+		resultCacheBucket, err := objstoreclient.NewBucket(f.context(), cfg, "result-cache")
 		if err != nil {
 			return nil, fmt.Errorf("unable to initialise result-cache bucket: %w", err)
 		}
+		redisOptions := &redis.Options{
+			Addr:     f.Cfg.ResultCache.Redis.Address,
+			Username: f.Cfg.ResultCache.Redis.Username,
+			Password: f.Cfg.ResultCache.Redis.Password.String(),
+			DB:       f.Cfg.ResultCache.Redis.DB,
+		}
+		if f.Cfg.ResultCache.Redis.TLSEnabled {
+			redisOptions.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+		}
+		resultCacheStore = querybackend.NewResultCacheStore(resultCacheBucket, redis.NewClient(redisOptions))
 	}
 	blockReader := querybackend.NewBlockReader(f.logger, f.storageBucket, f.reg, f.Overrides)
 	b, err := querybackend.New(
@@ -400,8 +412,9 @@ func (f *Pyroscope) initQueryBackend() (services.Service, error) {
 		f.reg,
 		f.queryBackendClient,
 		blockReader,
-		resultCacheBucket,
+		resultCacheStore,
 		f.Overrides,
+		f.Cfg.ResultCache.LookupTimeout,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/pyroscope/pyroscope.go
+++ b/pkg/pyroscope/pyroscope.go
@@ -104,6 +104,7 @@ type Config struct {
 	TenantSettings    settings.Config         `yaml:"tenant_settings"`
 
 	Storage       StorageConfig       `yaml:"storage"`
+	ResultCache   ResultCacheConfig   `yaml:"result_cache"`
 	SelfProfiling SelfProfilingConfig `yaml:"self_profiling,omitempty"`
 
 	MultitenancyEnabled bool              `yaml:"multitenancy_enabled,omitempty"`
@@ -138,6 +139,17 @@ func newDefaultConfig() *Config {
 
 type StorageConfig struct {
 	Bucket objstoreclient.Config `yaml:",inline"`
+}
+
+type ResultCacheConfig struct {
+	Bucket objstoreclient.Config `yaml:",inline"`
+}
+
+func (c *ResultCacheConfig) RegisterFlags(f *flag.FlagSet) {
+	c.Bucket.RegisterFlagsWithPrefix("result-cache.", f)
+	// Unlike primary storage, result-cache storage is opt-in and must not
+	// silently use the local filesystem when no dedicated bucket is configured.
+	c.Bucket.Backend = objstoreclient.None
 }
 
 func (c *StorageConfig) RegisterFlags(f *flag.FlagSet) {
@@ -336,6 +348,7 @@ func (c *Config) registerServerFlagsWithChangedDefaultValues(fs *flag.FlagSet) {
 	// Register to throwaway flags first. Default values are remembered during registration and cannot be changed,
 	// but we can take values from throwaway flag set and reregister into supplied flags with new default values.
 	c.Storage.RegisterFlags(throwaway)
+	c.ResultCache.RegisterFlags(throwaway)
 	c.Server.RegisterFlags(throwaway)
 	c.Distributor.RegisterFlags(throwaway, log.NewLogfmtLogger(os.Stderr))
 	c.Frontend.RegisterFlags(throwaway, log.NewLogfmtLogger(os.Stderr))
@@ -433,6 +446,11 @@ func (c *Config) Validate() error {
 
 	if err := c.Storage.Bucket.Validate(util.Logger); err != nil {
 		return err
+	}
+	if c.ResultCache.Bucket.Backend != objstoreclient.None {
+		if err := c.ResultCache.Bucket.Validate(util.Logger); err != nil {
+			return err
+		}
 	}
 
 	if err := c.TenantSettings.Validate(); err != nil {

--- a/pkg/pyroscope/pyroscope.go
+++ b/pkg/pyroscope/pyroscope.go
@@ -142,7 +142,21 @@ type StorageConfig struct {
 }
 
 type ResultCacheConfig struct {
-	Bucket objstoreclient.Config `yaml:",inline"`
+	Bucket        objstoreclient.Config  `yaml:",inline"`
+	Redis         ResultCacheRedisConfig `yaml:"redis"`
+	LookupTimeout time.Duration          `yaml:"lookup_timeout"`
+}
+
+type ResultCacheRedisConfig struct {
+	Address    string         `yaml:"address"`
+	Username   string         `yaml:"username"`
+	Password   flagext.Secret `yaml:"password"`
+	DB         int            `yaml:"db"`
+	TLSEnabled bool           `yaml:"tls_enabled"`
+}
+
+func (c ResultCacheRedisConfig) Enabled() bool {
+	return c.Address != ""
 }
 
 func (c *ResultCacheConfig) RegisterFlags(f *flag.FlagSet) {
@@ -150,6 +164,12 @@ func (c *ResultCacheConfig) RegisterFlags(f *flag.FlagSet) {
 	// Unlike primary storage, result-cache storage is opt-in and must not
 	// silently use the local filesystem when no dedicated bucket is configured.
 	c.Bucket.Backend = objstoreclient.None
+	f.StringVar(&c.Redis.Address, "result-cache.redis.address", "", "Redis server address for the result cache. Result caching requires Redis and result-cache object storage.")
+	f.StringVar(&c.Redis.Username, "result-cache.redis.username", "", "Redis username for the result cache.")
+	f.Var(&c.Redis.Password, "result-cache.redis.password", "Redis password for the result cache.")
+	f.IntVar(&c.Redis.DB, "result-cache.redis.db", 0, "Redis database for the result cache.")
+	f.BoolVar(&c.Redis.TLSEnabled, "result-cache.redis.tls-enabled", false, "Use TLS for result-cache Redis connections.")
+	f.DurationVar(&c.LookupTimeout, "result-cache.lookup-timeout", time.Second, "Maximum time a request may spend looking up result-cache entries. 0 disables the timeout.")
 }
 
 func (c *StorageConfig) RegisterFlags(f *flag.FlagSet) {
@@ -451,6 +471,12 @@ func (c *Config) Validate() error {
 		if err := c.ResultCache.Bucket.Validate(util.Logger); err != nil {
 			return err
 		}
+	}
+	if c.ResultCache.Redis.Enabled() && c.ResultCache.Bucket.Backend == objstoreclient.None {
+		return fmt.Errorf("result-cache Redis requires result-cache object storage")
+	}
+	if c.ResultCache.LookupTimeout < 0 {
+		return fmt.Errorf("result-cache lookup timeout must not be negative")
 	}
 
 	if err := c.TenantSettings.Validate(); err != nil {

--- a/pkg/pyroscope/pyroscope_test.go
+++ b/pkg/pyroscope/pyroscope_test.go
@@ -62,6 +62,11 @@ func TestFlagDefaults(t *testing.T) {
 	require.Contains(t, gotFlags[flagToCheck], "(default 4040)")
 }
 
+func TestResultCacheRedisRequiresObjectStorage(t *testing.T) {
+	cfg := newTestConfig(t, []string{"-result-cache.redis.address=localhost:6379"})
+	require.ErrorContains(t, cfg.Validate(), "result-cache Redis requires result-cache object storage")
+}
+
 // newTestConfig creates a Config with flags registered and parsed.
 func newTestConfig(t *testing.T, args []string) Config {
 	t.Helper()

--- a/pkg/querybackend/backend.go
+++ b/pkg/querybackend/backend.go
@@ -142,7 +142,7 @@ func (q *QueryBackend) invokeUncached(
 	req *queryv1.InvokeRequest,
 ) (*queryv1.InvokeResponse, error) {
 	if req.GetQueryPlan().GetRoot() == nil {
-		if len(req.Query) == 1 && req.Query[0].QueryType == queryv1.QueryType_QUERY_LABEL_NAMES && req.Query[0].LabelNames != nil {
+		if _, ok := resultCacheQueryType(req.Query); ok {
 			return &queryv1.InvokeResponse{
 				Diagnostics: &queryv1.Diagnostics{ExecutionNode: &queryv1.ExecutionNode{Stats: &queryv1.ExecutionStats{}}},
 			}, nil

--- a/pkg/querybackend/backend.go
+++ b/pkg/querybackend/backend.go
@@ -19,6 +19,7 @@ import (
 
 	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+	"github.com/grafana/pyroscope/v2/pkg/objstore"
 	"github.com/grafana/pyroscope/v2/pkg/util"
 )
 
@@ -56,6 +57,14 @@ type QueryBackend struct {
 	backendClient QueryHandler
 	blockReader   QueryHandler
 	hostname      string
+
+	resultCacheBucket    objstore.Bucket
+	resultCacheOverrides ResultCacheOverrides
+	resultCacheMetrics   *resultCacheMetrics
+	resultCacheWrites    chan resultCacheWriteJob
+	resultCacheWorkers   sync.WaitGroup
+	resultCacheStop      context.CancelFunc
+	now                  func() time.Time
 }
 
 func New(
@@ -64,23 +73,57 @@ func New(
 	reg prometheus.Registerer,
 	backendClient QueryHandler,
 	blockReader QueryHandler,
+	resultCacheBucket objstore.Bucket,
+	resultCacheOverrides ResultCacheOverrides,
 ) (*QueryBackend, error) {
 	hostname, _ := os.Hostname()
 	q := QueryBackend{
-		config:        config,
-		logger:        logger,
-		reg:           reg,
-		backendClient: backendClient,
-		blockReader:   blockReader,
-		hostname:      hostname,
+		config:               config,
+		logger:               logger,
+		reg:                  reg,
+		backendClient:        backendClient,
+		blockReader:          blockReader,
+		hostname:             hostname,
+		resultCacheBucket:    resultCacheBucket,
+		resultCacheOverrides: resultCacheOverrides,
+		resultCacheMetrics:   newResultCacheMetrics(reg),
+		now:                  time.Now,
 	}
-	q.service = services.NewIdleService(q.starting, q.stopping)
+	if resultCacheBucket != nil {
+		q.resultCacheWrites = make(chan resultCacheWriteJob, resultCacheQueueSize)
+	}
+	q.service = services.NewBasicService(q.starting, q.running, q.stopping)
 	return &q, nil
 }
 
-func (q *QueryBackend) Service() services.Service      { return q.service }
-func (q *QueryBackend) starting(context.Context) error { return nil }
-func (q *QueryBackend) stopping(error) error           { return nil }
+func (q *QueryBackend) Service() services.Service { return q.service }
+func (q *QueryBackend) starting(context.Context) error {
+	if q.resultCacheBucket != nil {
+		ctx, cancel := context.WithCancel(context.Background())
+		q.resultCacheStop = cancel
+		q.resultCacheWorkers.Add(resultCacheWorkers)
+		for range resultCacheWorkers {
+			go q.runResultCacheWriter(ctx)
+		}
+	}
+	return nil
+}
+
+func (q *QueryBackend) running(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+func (q *QueryBackend) stopping(error) error {
+	if q.resultCacheStop != nil {
+		q.resultCacheStop()
+		q.resultCacheWorkers.Wait()
+	}
+	if q.resultCacheBucket != nil {
+		return q.resultCacheBucket.Close()
+	}
+	return nil
+}
 
 func (q *QueryBackend) Invoke(
 	ctx context.Context,
@@ -88,6 +131,24 @@ func (q *QueryBackend) Invoke(
 ) (*queryv1.InvokeResponse, error) {
 	span, ctx := tracing.StartSpanFromContext(ctx, "QueryBackend.Invoke")
 	defer span.Finish()
+	if req.GetOptions().GetBypassResultCache() {
+		return q.invokeUncached(ctx, req)
+	}
+	return q.coordinateResultCache(ctx, req)
+}
+
+func (q *QueryBackend) invokeUncached(
+	ctx context.Context,
+	req *queryv1.InvokeRequest,
+) (*queryv1.InvokeResponse, error) {
+	if req.GetQueryPlan().GetRoot() == nil {
+		if len(req.Query) == 1 && req.Query[0].QueryType == queryv1.QueryType_QUERY_LABEL_NAMES && req.Query[0].LabelNames != nil {
+			return &queryv1.InvokeResponse{
+				Diagnostics: &queryv1.Diagnostics{ExecutionNode: &queryv1.ExecutionNode{Stats: &queryv1.ExecutionStats{}}},
+			}, nil
+		}
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("query plan is empty"))
+	}
 
 	collectDiag := req.Options != nil && req.Options.CollectDiagnostics
 	startTime := time.Now()

--- a/pkg/querybackend/backend.go
+++ b/pkg/querybackend/backend.go
@@ -237,7 +237,7 @@ func (q *QueryBackend) merge(
 				childExecNodes[idx] = resp.Diagnostics.ExecutionNode
 				mu.Unlock()
 			}
-			return m.aggregateResponse(resp, nil)
+			return m.aggregateResponse(resp)
 		}))
 	}
 	if err := g.Wait(); err != nil {

--- a/pkg/querybackend/backend.go
+++ b/pkg/querybackend/backend.go
@@ -19,7 +19,6 @@ import (
 
 	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
-	"github.com/grafana/pyroscope/v2/pkg/objstore"
 	"github.com/grafana/pyroscope/v2/pkg/util"
 )
 
@@ -58,13 +57,14 @@ type QueryBackend struct {
 	blockReader   QueryHandler
 	hostname      string
 
-	resultCacheBucket    objstore.Bucket
-	resultCacheOverrides ResultCacheOverrides
-	resultCacheMetrics   *resultCacheMetrics
-	resultCacheWrites    chan resultCacheWriteJob
-	resultCacheWorkers   sync.WaitGroup
-	resultCacheStop      context.CancelFunc
-	now                  func() time.Time
+	resultCacheStore         ResultCacheStore
+	resultCacheOverrides     ResultCacheOverrides
+	resultCacheLookupTimeout time.Duration
+	resultCacheMetrics       *resultCacheMetrics
+	resultCacheWrites        chan resultCacheWriteJob
+	resultCacheWorkers       sync.WaitGroup
+	resultCacheStop          context.CancelFunc
+	now                      func() time.Time
 }
 
 func New(
@@ -73,23 +73,25 @@ func New(
 	reg prometheus.Registerer,
 	backendClient QueryHandler,
 	blockReader QueryHandler,
-	resultCacheBucket objstore.Bucket,
+	resultCacheStore ResultCacheStore,
 	resultCacheOverrides ResultCacheOverrides,
+	resultCacheLookupTimeout time.Duration,
 ) (*QueryBackend, error) {
 	hostname, _ := os.Hostname()
 	q := QueryBackend{
-		config:               config,
-		logger:               logger,
-		reg:                  reg,
-		backendClient:        backendClient,
-		blockReader:          blockReader,
-		hostname:             hostname,
-		resultCacheBucket:    resultCacheBucket,
-		resultCacheOverrides: resultCacheOverrides,
-		resultCacheMetrics:   newResultCacheMetrics(reg),
-		now:                  time.Now,
+		config:                   config,
+		logger:                   logger,
+		reg:                      reg,
+		backendClient:            backendClient,
+		blockReader:              blockReader,
+		hostname:                 hostname,
+		resultCacheStore:         resultCacheStore,
+		resultCacheOverrides:     resultCacheOverrides,
+		resultCacheLookupTimeout: resultCacheLookupTimeout,
+		resultCacheMetrics:       newResultCacheMetrics(reg),
+		now:                      time.Now,
 	}
-	if resultCacheBucket != nil {
+	if resultCacheStore != nil {
 		q.resultCacheWrites = make(chan resultCacheWriteJob, resultCacheQueueSize)
 	}
 	q.service = services.NewBasicService(q.starting, q.running, q.stopping)
@@ -98,7 +100,7 @@ func New(
 
 func (q *QueryBackend) Service() services.Service { return q.service }
 func (q *QueryBackend) starting(context.Context) error {
-	if q.resultCacheBucket != nil {
+	if q.resultCacheStore != nil {
 		ctx, cancel := context.WithCancel(context.Background())
 		q.resultCacheStop = cancel
 		q.resultCacheWorkers.Add(resultCacheWorkers)
@@ -119,8 +121,8 @@ func (q *QueryBackend) stopping(error) error {
 		q.resultCacheStop()
 		q.resultCacheWorkers.Wait()
 	}
-	if q.resultCacheBucket != nil {
-		return q.resultCacheBucket.Close()
+	if q.resultCacheStore != nil {
+		return q.resultCacheStore.Close()
 	}
 	return nil
 }

--- a/pkg/querybackend/client/client_test.go
+++ b/pkg/querybackend/client/client_test.go
@@ -104,7 +104,7 @@ func Test_Concurrency(t *testing.T) {
 		b, err := querybackend.New(querybackend.Config{
 			Address:          backendAddress,
 			GRPCClientConfig: grpcClientCfg,
-		}, test.NewTestingLogger(t), nil, cl, QueryHandler{})
+		}, test.NewTestingLogger(t), nil, cl, QueryHandler{}, nil, nil)
 		require.NoError(t, err)
 
 		grpcOptions := []grpc.ServerOption{

--- a/pkg/querybackend/client/client_test.go
+++ b/pkg/querybackend/client/client_test.go
@@ -104,7 +104,7 @@ func Test_Concurrency(t *testing.T) {
 		b, err := querybackend.New(querybackend.Config{
 			Address:          backendAddress,
 			GRPCClientConfig: grpcClientCfg,
-		}, test.NewTestingLogger(t), nil, cl, QueryHandler{}, nil, nil)
+		}, test.NewTestingLogger(t), nil, cl, QueryHandler{}, nil, nil, 0)
 		require.NoError(t, err)
 
 		grpcOptions := []grpc.ServerOption{

--- a/pkg/querybackend/report_aggregator.go
+++ b/pkg/querybackend/report_aggregator.go
@@ -94,12 +94,9 @@ func newAggregator(request *queryv1.InvokeRequest) *reportAggregator {
 	}
 }
 
-func (ra *reportAggregator) aggregateResponse(resp *queryv1.InvokeResponse, err error) error {
-	if err != nil {
-		return err
-	}
+func (ra *reportAggregator) aggregateResponse(resp *queryv1.InvokeResponse) error {
 	for _, r := range resp.Reports {
-		if err = ra.aggregateReport(r); err != nil {
+		if err := ra.aggregateReport(r); err != nil {
 			return err
 		}
 	}

--- a/pkg/querybackend/report_aggregator_test.go
+++ b/pkg/querybackend/report_aggregator_test.go
@@ -181,7 +181,7 @@ func TestReportAggregator_AggregateResponse(t *testing.T) {
 		},
 	}
 
-	err := ra.aggregateResponse(resp, nil)
+	err := ra.aggregateResponse(resp)
 	require.NoError(t, err)
 
 	assert.Len(t, ra.aggregators, 1)

--- a/pkg/querybackend/result_cache.go
+++ b/pkg/querybackend/result_cache.go
@@ -37,6 +37,7 @@ type ResultCacheOverrides interface {
 	ResultCacheEnabled(tenantID string) bool
 	ResultCacheGeneration(tenantID string) uint32
 	ResultCacheFragmentDurations(tenantID string) []time.Duration
+	ResultCacheMetadataServiceNameMinQueryDuration(tenantID string) time.Duration
 }
 
 type resultCacheMetrics struct {
@@ -328,7 +329,24 @@ func (q *QueryBackend) resultCacheEligible(req *queryv1.InvokeRequest) bool {
 	return q.resultCacheBucket != nil && q.resultCacheOverrides != nil && len(req.Tenant) == 1 &&
 		validQuery &&
 		!req.GetOptions().GetCollectDiagnostics() && q.resultCacheOverrides.ResultCacheEnabled(req.Tenant[0]) &&
-		len(q.resultCacheOverrides.ResultCacheFragmentDurations(req.Tenant[0])) > 0
+		len(q.resultCacheOverrides.ResultCacheFragmentDurations(req.Tenant[0])) > 0 &&
+		!resultCacheMetadataServiceNameShortRange(req, q.resultCacheOverrides.ResultCacheMetadataServiceNameMinQueryDuration(req.Tenant[0]))
+}
+
+func resultCacheMetadataServiceNameShortRange(req *queryv1.InvokeRequest, minQueryDuration time.Duration) bool {
+	if minQueryDuration <= 0 || req.EndTime-req.StartTime >= minQueryDuration.Milliseconds() {
+		return false
+	}
+	matchers, err := phlaremodel.ParseMetricSelector(req.LabelSelector)
+	if err != nil {
+		return false
+	}
+	for _, matcher := range matchers {
+		if matcher.Name == "service_name" {
+			return true
+		}
+	}
+	return false
 }
 
 // readResultCache returns a cache hit. Its error is non-nil only when a read's

--- a/pkg/querybackend/result_cache.go
+++ b/pkg/querybackend/result_cache.go
@@ -24,6 +24,7 @@ import (
 const (
 	resultCacheLabelNames   = "label_names"
 	resultCacheLabelValues  = "label_values"
+	resultCacheSeriesLabels = "series_labels"
 	resultCacheWorkers      = 2
 	resultCacheQueueSize    = 128
 	resultCacheWriteTimeout = 30 * time.Second
@@ -103,9 +104,29 @@ func cacheQuery(req *queryv1.InvokeRequest, start, end int64) (*queryv1.QueryReq
 	if err != nil {
 		return nil, err
 	}
+	queries := cloneQueries(req.Query)
+	normalizeResultCacheQueries(queries)
 	return &queryv1.QueryRequest{
-		StartTime: start, EndTime: end, LabelSelector: selector, Query: req.Query,
+		StartTime: start, EndTime: end, LabelSelector: selector, Query: queries,
 	}, nil
+}
+
+func cloneQueries(queries []*queryv1.Query) []*queryv1.Query {
+	clones := make([]*queryv1.Query, len(queries))
+	for i, query := range queries {
+		if query != nil {
+			clones[i] = query.CloneVT()
+		}
+	}
+	return clones
+}
+
+func normalizeResultCacheQueries(queries []*queryv1.Query) {
+	for _, query := range queries {
+		if query != nil && query.SeriesLabels != nil {
+			sort.Strings(query.SeriesLabels.LabelNames)
+		}
+	}
 }
 
 func canonicalResultCacheSelector(selector string) (string, error) {
@@ -150,6 +171,8 @@ func resultCacheQueryType(queries []*queryv1.Query) (string, bool) {
 		return resultCacheLabelNames, query.LabelNames != nil
 	case queryv1.QueryType_QUERY_LABEL_VALUES:
 		return resultCacheLabelValues, query.LabelValues != nil
+	case queryv1.QueryType_QUERY_SERIES_LABELS:
+		return resultCacheSeriesLabels, query.SeriesLabels != nil
 	default:
 		return "", false
 	}
@@ -182,6 +205,7 @@ func (q *QueryBackend) coordinateResultCache(ctx context.Context, req *queryv1.I
 		fragmentReq := req.CloneVT()
 		fragmentReq.StartTime = fragment.start
 		fragmentReq.EndTime = fragment.end
+		normalizeResultCacheQueries(fragmentReq.Query)
 		fragmentReq.QueryPlan = queryplan.Build(q.filterBlocks(req.QueryPlan.GetRoot(), fragment.start, fragment.end), 4, 20)
 		fragmentReq.Options = fragmentReq.GetOptions().CloneVT()
 		if fragmentReq.Options == nil {

--- a/pkg/querybackend/result_cache.go
+++ b/pkg/querybackend/result_cache.go
@@ -193,7 +193,7 @@ func resultCacheKey(tenant string, generation uint32, duration time.Duration, id
 		return "", fmt.Errorf("marshal result cache identity: %w", err)
 	}
 	digest := sha256.Sum256(b)
-	return fmt.Sprintf("result-cache/%s/%s/%04d-%s", tenant, resultCacheDurationName(duration), generation, hex.EncodeToString(digest[:])), nil
+	return fmt.Sprintf("results-cache/%s/%s/%04d-%s", resultCacheDurationName(duration), tenant, generation, hex.EncodeToString(digest[:])), nil
 }
 
 func resultCacheQueryType(queries []*queryv1.Query) (string, bool) {

--- a/pkg/querybackend/result_cache.go
+++ b/pkg/querybackend/result_cache.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/grafana/dskit/tracing"
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 
 	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
@@ -22,12 +23,13 @@ import (
 )
 
 const (
-	resultCacheLabelNames   = "label_names"
-	resultCacheLabelValues  = "label_values"
-	resultCacheSeriesLabels = "series_labels"
-	resultCacheWorkers      = 2
-	resultCacheQueueSize    = 128
-	resultCacheWriteTimeout = 30 * time.Second
+	resultCacheLabelNames          = "label_names"
+	resultCacheLabelValues         = "label_values"
+	resultCacheSeriesLabels        = "series_labels"
+	resultCacheWorkers             = 2
+	resultCacheQueueSize           = 128
+	resultCacheWriteTimeout        = 30 * time.Second
+	resultCacheFragmentConcurrency = 64
 )
 
 type ResultCacheOverrides interface {
@@ -198,58 +200,75 @@ func (q *QueryBackend) coordinateResultCache(ctx context.Context, req *queryv1.I
 		return q.executeWithResultCacheBypassed(ctx, req)
 	}
 	aggregator := newAggregator(req)
-	var bytesFetched uint64
 	fragments := splitResultCacheFragments(req.StartTime, req.EndTime)
 	span.SetTag("fragments", len(fragments))
-	for _, fragment := range fragments {
-		fragmentReq := req.CloneVT()
-		fragmentReq.StartTime = fragment.start
-		fragmentReq.EndTime = fragment.end
-		normalizeResultCacheQueries(fragmentReq.Query)
-		fragmentReq.QueryPlan = queryplan.Build(q.filterBlocks(req.QueryPlan.GetRoot(), fragment.start, fragment.end), 4, 20)
-		fragmentReq.Options = fragmentReq.GetOptions().CloneVT()
-		if fragmentReq.Options == nil {
-			fragmentReq.Options = &queryv1.InvokeOptions{}
-		}
-		fragmentReq.Options.BypassResultCache = true
+	fragmentResponses := make([]*queryv1.InvokeResponse, len(fragments))
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(resultCacheFragmentConcurrency)
+	for i, fragment := range fragments {
+		idx := i
+		fragment := fragment
+		g.Go(func() error {
+			fragmentReq := req.CloneVT()
+			fragmentReq.StartTime = fragment.start
+			fragmentReq.EndTime = fragment.end
+			normalizeResultCacheQueries(fragmentReq.Query)
+			fragmentReq.QueryPlan = queryplan.Build(q.filterBlocks(req.QueryPlan.GetRoot(), fragment.start, fragment.end), 4, 20)
+			fragmentReq.Options = fragmentReq.GetOptions().CloneVT()
+			if fragmentReq.Options == nil {
+				fragmentReq.Options = &queryv1.InvokeOptions{}
+			}
+			fragmentReq.Options.BypassResultCache = true
 
-		cacheable := fragment.full && stableResultCacheDay(fragment.end, q.now(), q.resultCacheOverrides.RejectOlderThan(tenant))
-		query := &queryv1.QueryRequest{
-			StartTime: fragment.start, EndTime: fragment.end, LabelSelector: selector, Query: fragmentReq.Query,
-		}
-		key := ""
-		writeAllowed := false
-		if cacheable {
-			var hit bool
+			cacheable := fragment.full && stableResultCacheDay(fragment.end, q.now(), q.resultCacheOverrides.RejectOlderThan(tenant))
+			query := &queryv1.QueryRequest{
+				StartTime: fragment.start, EndTime: fragment.end, LabelSelector: selector, Query: fragmentReq.Query,
+			}
+			key := ""
+			writeAllowed := false
+			if cacheable {
+				fragmentAggregator := newAggregator(fragmentReq)
+				var hit bool
+				var err error
+				key, err = resultCacheKey(tenant, generation, query)
+				if err == nil {
+					hit, err = q.readResultCache(ctx, queryType, key, query, fragmentAggregator)
+				}
+				if err == nil && hit {
+					fragmentResponses[idx] = fragmentAggregator.response()
+					return nil
+				}
+				if err == nil {
+					writeAllowed = true
+				}
+			}
+
+			var resp *queryv1.InvokeResponse
 			var err error
-			key, err = resultCacheKey(tenant, generation, query)
-			if err == nil {
-				hit, err = q.readResultCache(ctx, queryType, key, query, aggregator)
+			if fragmentReq.QueryPlan.GetRoot() == nil {
+				resp = &queryv1.InvokeResponse{}
+			} else {
+				resp, err = q.invokeUncached(ctx, fragmentReq)
 			}
-			if err == nil && hit {
-				continue
+			if err != nil {
+				return err
 			}
-			if err == nil {
-				writeAllowed = true
+			if cacheable && writeAllowed && ctx.Err() == nil {
+				q.enqueueResultCacheWrite(resultCacheWriteJob{queryType: queryType, key: key, query: query.CloneVT(), reports: cloneReports(resp.Reports)})
 			}
-		}
+			fragmentResponses[idx] = resp
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
 
-		var resp *queryv1.InvokeResponse
-		var err error
-		if fragmentReq.QueryPlan.GetRoot() == nil {
-			resp = &queryv1.InvokeResponse{}
-		} else {
-			resp, err = q.invokeUncached(ctx, fragmentReq)
-		}
-		if err != nil {
-			return nil, err
-		}
+	var bytesFetched uint64
+	for _, resp := range fragmentResponses {
 		bytesFetched += resp.GetDiagnostics().GetExecutionNode().GetStats().GetBytesFetched()
 		if err := aggregator.aggregateResponse(resp, nil); err != nil {
 			return nil, err
-		}
-		if cacheable && writeAllowed && ctx.Err() == nil {
-			q.enqueueResultCacheWrite(resultCacheWriteJob{queryType: queryType, key: key, query: query.CloneVT(), reports: cloneReports(resp.Reports)})
 		}
 	}
 

--- a/pkg/querybackend/result_cache.go
+++ b/pkg/querybackend/result_cache.go
@@ -303,7 +303,7 @@ func (q *QueryBackend) coordinateResultCache(ctx context.Context, req *queryv1.I
 	var bytesFetched uint64
 	for _, resp := range fragmentResponses {
 		bytesFetched += resp.GetDiagnostics().GetExecutionNode().GetStats().GetBytesFetched()
-		if err := aggregator.aggregateResponse(resp, nil); err != nil {
+		if err := aggregator.aggregateResponse(resp); err != nil {
 			return nil, err
 		}
 	}
@@ -369,7 +369,7 @@ func (q *QueryBackend) readResultCache(ctx context.Context, queryType, duration,
 		q.resultCacheMetrics.lookups.WithLabelValues(queryType, duration, "collision").Inc()
 		return false, fmt.Errorf("result cache collision")
 	}
-	if err := aggregator.aggregateResponse(&queryv1.InvokeResponse{Reports: entry.Reports}, nil); err != nil {
+	if err := aggregator.aggregateResponse(&queryv1.InvokeResponse{Reports: entry.Reports}); err != nil {
 		span.SetTag("outcome", "error")
 		return false, err
 	}

--- a/pkg/querybackend/result_cache.go
+++ b/pkg/querybackend/result_cache.go
@@ -1,0 +1,358 @@
+package querybackend
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/grafana/dskit/tracing"
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/protobuf/proto"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+	phlaremodel "github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/querybackend/queryplan"
+)
+
+const (
+	resultCacheQueryType    = "label_names"
+	resultCacheWorkers      = 2
+	resultCacheQueueSize    = 128
+	resultCacheWriteTimeout = 30 * time.Second
+)
+
+type ResultCacheOverrides interface {
+	RejectOlderThan(tenantID string) time.Duration
+	ResultCacheEnabled(tenantID string) bool
+	ResultCacheGeneration(tenantID string) uint32
+}
+
+type resultCacheMetrics struct {
+	lookups *prometheus.CounterVec
+	writes  *prometheus.CounterVec
+}
+
+func newResultCacheMetrics(reg prometheus.Registerer) *resultCacheMetrics {
+	m := &resultCacheMetrics{
+		lookups: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "pyroscope", Subsystem: "query_backend", Name: "result_cache_lookups_total",
+		}, []string{"query_type", "outcome"}),
+		writes: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "pyroscope", Subsystem: "query_backend", Name: "result_cache_writes_total",
+		}, []string{"query_type", "outcome"}),
+	}
+	if reg != nil {
+		reg.MustRegister(m.lookups, m.writes)
+	}
+	return m
+}
+
+type resultCacheWriteJob struct {
+	key     string
+	query   *queryv1.QueryRequest
+	reports []*queryv1.Report
+}
+
+type resultCacheFragment struct {
+	start int64
+	end   int64
+	full  bool
+}
+
+func splitResultCacheFragments(start, end int64) []resultCacheFragment {
+	if start > end {
+		return nil
+	}
+	fragments := make([]resultCacheFragment, 0, 1)
+	for current := start; current <= end; {
+		dayStart := time.UnixMilli(current).UTC().Truncate(24 * time.Hour)
+		dayEnd := dayStart.Add(24*time.Hour).UnixMilli() - 1
+		fragmentEnd := min(end, dayEnd)
+		fragments = append(fragments, resultCacheFragment{
+			start: current,
+			end:   fragmentEnd,
+			full:  current == dayStart.UnixMilli() && fragmentEnd == dayEnd,
+		})
+		if fragmentEnd == end {
+			break
+		}
+		current = fragmentEnd + 1
+	}
+	return fragments
+}
+
+func stableResultCacheDay(end int64, now time.Time, window time.Duration) bool {
+	if window <= 0 {
+		return false
+	}
+	followingMidnight := time.UnixMilli(end).UTC().Truncate(24 * time.Hour).Add(24 * time.Hour)
+	return !now.Before(followingMidnight.Add(2 * window))
+}
+
+func cacheQuery(req *queryv1.InvokeRequest, start, end int64) (*queryv1.QueryRequest, error) {
+	selector, err := canonicalResultCacheSelector(req.LabelSelector)
+	if err != nil {
+		return nil, err
+	}
+	return &queryv1.QueryRequest{
+		StartTime: start, EndTime: end, LabelSelector: selector, Query: req.Query,
+	}, nil
+}
+
+func canonicalResultCacheSelector(selector string) (string, error) {
+	matchers, err := phlaremodel.ParseMetricSelector(selector)
+	if err != nil {
+		return "", err
+	}
+	sort.Slice(matchers, func(i, j int) bool {
+		return matchers[i].String() < matchers[j].String()
+	})
+	var canonical strings.Builder
+	canonical.WriteByte('{')
+	for i, matcher := range matchers {
+		if i > 0 {
+			canonical.WriteByte(',')
+		}
+		canonical.WriteString(matcher.String())
+	}
+	canonical.WriteByte('}')
+	return canonical.String(), nil
+}
+
+func resultCacheKey(tenant string, generation uint32, query *queryv1.QueryRequest) (string, error) {
+	hashQuery := query.CloneVT()
+	hashQuery.StartTime = 0
+	hashQuery.EndTime = 0
+	b, err := proto.MarshalOptions{Deterministic: true}.Marshal(hashQuery)
+	if err != nil {
+		return "", fmt.Errorf("marshal cache key query: %w", err)
+	}
+	digest := sha256.Sum256(b)
+	date := time.UnixMilli(query.StartTime).UTC().Format("2006-01-02")
+	return fmt.Sprintf("result-cache/%s/%04d-%s-%s", tenant, generation, date, hex.EncodeToString(digest[:])), nil
+}
+
+func (q *QueryBackend) coordinateResultCache(ctx context.Context, req *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error) {
+	span, ctx := tracing.StartSpanFromContext(ctx, "QueryBackend.ResultCache")
+	defer span.Finish()
+	span.SetTag("query_type", resultCacheQueryType)
+	if !q.resultCacheEligible(req) {
+		span.SetTag("outcome", "bypass")
+		return q.executeWithResultCacheBypassed(ctx, req)
+	}
+	span.SetTag("outcome", "enabled")
+
+	tenant := req.Tenant[0]
+	generation := q.resultCacheOverrides.ResultCacheGeneration(tenant)
+	selector, err := canonicalResultCacheSelector(req.LabelSelector)
+	if err != nil {
+		return q.executeWithResultCacheBypassed(ctx, req)
+	}
+	aggregator := newAggregator(req)
+	var bytesFetched uint64
+	fragments := splitResultCacheFragments(req.StartTime, req.EndTime)
+	span.SetTag("fragments", len(fragments))
+	for _, fragment := range fragments {
+		fragmentReq := req.CloneVT()
+		fragmentReq.StartTime = fragment.start
+		fragmentReq.EndTime = fragment.end
+		fragmentReq.QueryPlan = queryplan.Build(q.filterBlocks(req.QueryPlan.GetRoot(), fragment.start, fragment.end), 4, 20)
+		fragmentReq.Options = fragmentReq.GetOptions().CloneVT()
+		if fragmentReq.Options == nil {
+			fragmentReq.Options = &queryv1.InvokeOptions{}
+		}
+		fragmentReq.Options.BypassResultCache = true
+
+		cacheable := fragment.full && stableResultCacheDay(fragment.end, q.now(), q.resultCacheOverrides.RejectOlderThan(tenant))
+		query := &queryv1.QueryRequest{
+			StartTime: fragment.start, EndTime: fragment.end, LabelSelector: selector, Query: fragmentReq.Query,
+		}
+		key := ""
+		writeAllowed := false
+		if cacheable {
+			var hit bool
+			var err error
+			key, err = resultCacheKey(tenant, generation, query)
+			if err == nil {
+				hit, err = q.readResultCache(ctx, key, query, aggregator)
+			}
+			if err == nil && hit {
+				continue
+			}
+			if err == nil {
+				writeAllowed = true
+			}
+		}
+
+		var resp *queryv1.InvokeResponse
+		var err error
+		if fragmentReq.QueryPlan.GetRoot() == nil {
+			resp = &queryv1.InvokeResponse{}
+		} else {
+			resp, err = q.invokeUncached(ctx, fragmentReq)
+		}
+		if err != nil {
+			return nil, err
+		}
+		bytesFetched += resp.GetDiagnostics().GetExecutionNode().GetStats().GetBytesFetched()
+		if err := aggregator.aggregateResponse(resp, nil); err != nil {
+			return nil, err
+		}
+		if cacheable && writeAllowed && ctx.Err() == nil {
+			q.enqueueResultCacheWrite(resultCacheWriteJob{key: key, query: query.CloneVT(), reports: cloneReports(resp.Reports)})
+		}
+	}
+
+	resp := aggregator.response()
+	resp.Diagnostics = &queryv1.Diagnostics{ExecutionNode: &queryv1.ExecutionNode{Stats: &queryv1.ExecutionStats{BytesFetched: bytesFetched}}}
+	return resp, nil
+}
+
+func (q *QueryBackend) executeWithResultCacheBypassed(ctx context.Context, req *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error) {
+	clone := req.CloneVT()
+	clone.Options = clone.GetOptions().CloneVT()
+	if clone.Options == nil {
+		clone.Options = &queryv1.InvokeOptions{}
+	}
+	clone.Options.BypassResultCache = true
+	return q.invokeUncached(ctx, clone)
+}
+
+func (q *QueryBackend) resultCacheEligible(req *queryv1.InvokeRequest) bool {
+	return q.resultCacheBucket != nil && q.resultCacheOverrides != nil && len(req.Tenant) == 1 &&
+		len(req.Query) == 1 && req.Query[0].QueryType == queryv1.QueryType_QUERY_LABEL_NAMES && req.Query[0].LabelNames != nil &&
+		!req.GetOptions().GetCollectDiagnostics() && q.resultCacheOverrides.ResultCacheEnabled(req.Tenant[0]) &&
+		q.resultCacheOverrides.RejectOlderThan(req.Tenant[0]) > 0
+}
+
+// readResultCache returns a cache hit. Its error is non-nil only when a read's
+// object state is unknown; corrupt entries are safe to replace after execution.
+func (q *QueryBackend) readResultCache(ctx context.Context, key string, expected *queryv1.QueryRequest, aggregator *reportAggregator) (bool, error) {
+	span, ctx := tracing.StartSpanFromContext(ctx, "QueryBackend.ResultCacheLookup")
+	defer span.Finish()
+	span.SetTag("query_type", resultCacheQueryType)
+	span.SetTag("utc_day", time.UnixMilli(expected.StartTime).UTC().Format("2006-01-02"))
+
+	r, err := q.resultCacheBucket.Get(ctx, key)
+	if err != nil {
+		if q.resultCacheBucket.IsObjNotFoundErr(err) {
+			span.SetTag("outcome", "miss")
+			q.resultCacheMetrics.lookups.WithLabelValues(resultCacheQueryType, "miss").Inc()
+			return false, nil
+		}
+		span.SetTag("outcome", "error")
+		q.resultCacheMetrics.lookups.WithLabelValues(resultCacheQueryType, "error").Inc()
+		return false, err
+	}
+	defer r.Close()
+	b, err := io.ReadAll(r)
+	if err != nil {
+		span.SetTag("outcome", "error")
+		q.resultCacheMetrics.lookups.WithLabelValues(resultCacheQueryType, "error").Inc()
+		return false, err
+	}
+	entry := new(queryv1.ResultCacheEntry)
+	if err := proto.Unmarshal(b, entry); err != nil {
+		span.SetTag("outcome", "error")
+		q.resultCacheMetrics.lookups.WithLabelValues(resultCacheQueryType, "error").Inc()
+		return false, nil
+	}
+	if !proto.Equal(entry.Query, expected) {
+		span.SetTag("outcome", "collision")
+		q.resultCacheMetrics.lookups.WithLabelValues(resultCacheQueryType, "collision").Inc()
+		return false, fmt.Errorf("result cache collision")
+	}
+	if err := aggregator.aggregateResponse(&queryv1.InvokeResponse{Reports: entry.Reports}, nil); err != nil {
+		span.SetTag("outcome", "error")
+		return false, err
+	}
+	span.SetTag("outcome", "hit")
+	q.resultCacheMetrics.lookups.WithLabelValues(resultCacheQueryType, "hit").Inc()
+	return true, nil
+}
+
+func cloneReports(reports []*queryv1.Report) []*queryv1.Report {
+	result := make([]*queryv1.Report, len(reports))
+	for i, report := range reports {
+		result[i] = report.CloneVT()
+	}
+	return result
+}
+
+func (q *QueryBackend) filterBlocks(root *queryv1.QueryNode, start, end int64) []*metastorev1.BlockMeta {
+	blocks := make(map[string]*metastorev1.BlockMeta)
+	var visit func(*queryv1.QueryNode)
+	visit = func(node *queryv1.QueryNode) {
+		if node == nil {
+			return
+		}
+		for _, block := range node.Blocks {
+			if block.MinTime > end || block.MaxTime < start {
+				continue
+			}
+			clone := block.CloneVT()
+			clone.Datasets = clone.Datasets[:0]
+			for _, dataset := range block.Datasets {
+				if dataset.MinTime <= end && dataset.MaxTime >= start {
+					clone.Datasets = append(clone.Datasets, dataset.CloneVT())
+				}
+			}
+			if len(clone.Datasets) > 0 {
+				blocks[clone.Id] = clone
+			}
+		}
+		for _, child := range node.Children {
+			visit(child)
+		}
+	}
+	visit(root)
+	result := make([]*metastorev1.BlockMeta, 0, len(blocks))
+	for _, block := range blocks {
+		result = append(result, block)
+	}
+	return result
+}
+
+func (q *QueryBackend) enqueueResultCacheWrite(job resultCacheWriteJob) {
+	select {
+	case q.resultCacheWrites <- job:
+	default:
+		q.resultCacheMetrics.writes.WithLabelValues(resultCacheQueryType, "dropped").Inc()
+	}
+}
+
+func (q *QueryBackend) runResultCacheWriter(ctx context.Context) {
+	defer q.resultCacheWorkers.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case job := <-q.resultCacheWrites:
+			span, writeCtx := tracing.StartSpanFromContext(ctx, "QueryBackend.ResultCacheWrite")
+			span.SetTag("query_type", resultCacheQueryType)
+			span.SetTag("utc_day", time.UnixMilli(job.query.StartTime).UTC().Format("2006-01-02"))
+			entry := &queryv1.ResultCacheEntry{Query: job.query, Reports: job.reports}
+			data, err := proto.Marshal(entry)
+			if err == nil {
+				writeCtx, cancel := context.WithTimeout(writeCtx, resultCacheWriteTimeout)
+				err = q.resultCacheBucket.Upload(writeCtx, job.key, bytes.NewReader(data))
+				cancel()
+			}
+			if err != nil {
+				span.SetTag("outcome", "error")
+				q.resultCacheMetrics.writes.WithLabelValues(resultCacheQueryType, "error").Inc()
+			} else {
+				span.SetTag("outcome", "success")
+				q.resultCacheMetrics.writes.WithLabelValues(resultCacheQueryType, "success").Inc()
+			}
+			span.Finish()
+		}
+	}
+}

--- a/pkg/querybackend/result_cache.go
+++ b/pkg/querybackend/result_cache.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -33,9 +34,9 @@ const (
 )
 
 type ResultCacheOverrides interface {
-	RejectOlderThan(tenantID string) time.Duration
 	ResultCacheEnabled(tenantID string) bool
 	ResultCacheGeneration(tenantID string) uint32
+	ResultCacheFragmentDurations(tenantID string) []time.Duration
 }
 
 type resultCacheMetrics struct {
@@ -47,10 +48,10 @@ func newResultCacheMetrics(reg prometheus.Registerer) *resultCacheMetrics {
 	m := &resultCacheMetrics{
 		lookups: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: "pyroscope", Subsystem: "query_backend", Name: "result_cache_lookups_total",
-		}, []string{"query_type", "outcome"}),
+		}, []string{"query_type", "fragment_duration", "outcome"}),
 		writes: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: "pyroscope", Subsystem: "query_backend", Name: "result_cache_writes_total",
-		}, []string{"query_type", "outcome"}),
+		}, []string{"query_type", "fragment_duration", "outcome"}),
 	}
 	if reg != nil {
 		reg.MustRegister(m.lookups, m.writes)
@@ -60,31 +61,49 @@ func newResultCacheMetrics(reg prometheus.Registerer) *resultCacheMetrics {
 
 type resultCacheWriteJob struct {
 	queryType string
+	duration  string
 	key       string
-	query     *queryv1.QueryRequest
+	identity  *queryv1.ResultCacheKey
 	reports   []*queryv1.Report
 }
 
 type resultCacheFragment struct {
-	start int64
-	end   int64
-	full  bool
+	start    int64
+	end      int64
+	duration time.Duration
 }
 
-func splitResultCacheFragments(start, end int64) []resultCacheFragment {
+func splitResultCacheFragments(start, end int64, durations []time.Duration) []resultCacheFragment {
 	if start > end {
 		return nil
 	}
+	durations = append([]time.Duration(nil), durations...)
+	sort.Slice(durations, func(i, j int) bool { return durations[i] > durations[j] })
 	fragments := make([]resultCacheFragment, 0, 1)
-	for current := start; current <= end; {
-		dayStart := time.UnixMilli(current).UTC().Truncate(24 * time.Hour)
-		dayEnd := dayStart.Add(24*time.Hour).UnixMilli() - 1
-		fragmentEnd := min(end, dayEnd)
-		fragments = append(fragments, resultCacheFragment{
-			start: current,
-			end:   fragmentEnd,
-			full:  current == dayStart.UnixMilli() && fragmentEnd == dayEnd,
-		})
+	endExclusive := end + 1
+	for current := start; current < endExclusive; {
+		var selected time.Duration
+		for _, duration := range durations {
+			milliseconds := duration.Milliseconds()
+			if current%milliseconds == 0 && current+milliseconds <= endExclusive {
+				selected = duration
+				break
+			}
+		}
+
+		fragmentEnd := end
+		if selected > 0 {
+			fragmentEnd = current + selected.Milliseconds() - 1
+		} else if len(durations) > 0 {
+			smallest := durations[len(durations)-1].Milliseconds()
+			remainder := current % smallest
+			if remainder < 0 {
+				remainder += smallest
+			}
+			nextBoundary := current + smallest - remainder
+			fragmentEnd = min(end, nextBoundary-1)
+		}
+		fragments = append(fragments, resultCacheFragment{start: current, end: fragmentEnd, duration: selected})
 		if fragmentEnd == end {
 			break
 		}
@@ -93,12 +112,29 @@ func splitResultCacheFragments(start, end int64) []resultCacheFragment {
 	return fragments
 }
 
-func stableResultCacheDay(end int64, now time.Time, window time.Duration) bool {
-	if window <= 0 {
-		return false
+func resultCacheDurationName(duration time.Duration) string {
+	if duration <= 0 {
+		return ""
 	}
-	followingMidnight := time.UnixMilli(end).UTC().Truncate(24 * time.Hour).Add(24 * time.Hour)
-	return !now.Before(followingMidnight.Add(2 * window))
+	if duration%time.Hour == 0 {
+		return strconv.FormatInt(int64(duration/time.Hour), 10) + "h"
+	}
+	if duration%time.Minute == 0 {
+		return strconv.FormatInt(int64(duration/time.Minute), 10) + "m"
+	}
+	if duration%time.Second == 0 {
+		return strconv.FormatInt(int64(duration/time.Second), 10) + "s"
+	}
+	return duration.String()
+}
+
+func resultCacheIdentity(query *queryv1.QueryRequest, blocks []*metastorev1.BlockMeta) *queryv1.ResultCacheKey {
+	blockIDs := make([]string, len(blocks))
+	for i, block := range blocks {
+		blockIDs[i] = block.Id
+	}
+	sort.Strings(blockIDs)
+	return &queryv1.ResultCacheKey{Query: query, BlockIds: blockIDs}
 }
 
 func cacheQuery(req *queryv1.InvokeRequest, start, end int64) (*queryv1.QueryRequest, error) {
@@ -151,17 +187,13 @@ func canonicalResultCacheSelector(selector string) (string, error) {
 	return canonical.String(), nil
 }
 
-func resultCacheKey(tenant string, generation uint32, query *queryv1.QueryRequest) (string, error) {
-	hashQuery := query.CloneVT()
-	hashQuery.StartTime = 0
-	hashQuery.EndTime = 0
-	b, err := proto.MarshalOptions{Deterministic: true}.Marshal(hashQuery)
+func resultCacheKey(tenant string, generation uint32, duration time.Duration, identity *queryv1.ResultCacheKey) (string, error) {
+	b, err := proto.MarshalOptions{Deterministic: true}.Marshal(identity)
 	if err != nil {
-		return "", fmt.Errorf("marshal cache key query: %w", err)
+		return "", fmt.Errorf("marshal result cache identity: %w", err)
 	}
 	digest := sha256.Sum256(b)
-	date := time.UnixMilli(query.StartTime).UTC().Format("2006-01-02")
-	return fmt.Sprintf("result-cache/%s/%04d-%s-%s", tenant, generation, date, hex.EncodeToString(digest[:])), nil
+	return fmt.Sprintf("result-cache/%s/%s/%04d-%s", tenant, resultCacheDurationName(duration), generation, hex.EncodeToString(digest[:])), nil
 }
 
 func resultCacheQueryType(queries []*queryv1.Query) (string, bool) {
@@ -195,12 +227,13 @@ func (q *QueryBackend) coordinateResultCache(ctx context.Context, req *queryv1.I
 
 	tenant := req.Tenant[0]
 	generation := q.resultCacheOverrides.ResultCacheGeneration(tenant)
+	durations := q.resultCacheOverrides.ResultCacheFragmentDurations(tenant)
 	selector, err := canonicalResultCacheSelector(req.LabelSelector)
 	if err != nil {
 		return q.executeWithResultCacheBypassed(ctx, req)
 	}
 	aggregator := newAggregator(req)
-	fragments := splitResultCacheFragments(req.StartTime, req.EndTime)
+	fragments := splitResultCacheFragments(req.StartTime, req.EndTime, durations)
 	span.SetTag("fragments", len(fragments))
 	fragmentResponses := make([]*queryv1.InvokeResponse, len(fragments))
 	g, ctx := errgroup.WithContext(ctx)
@@ -213,26 +246,29 @@ func (q *QueryBackend) coordinateResultCache(ctx context.Context, req *queryv1.I
 			fragmentReq.StartTime = fragment.start
 			fragmentReq.EndTime = fragment.end
 			normalizeResultCacheQueries(fragmentReq.Query)
-			fragmentReq.QueryPlan = queryplan.Build(q.filterBlocks(req.QueryPlan.GetRoot(), fragment.start, fragment.end), 4, 20)
+			blocks := q.filterBlocks(req.QueryPlan.GetRoot(), fragment.start, fragment.end)
+			fragmentReq.QueryPlan = queryplan.Build(blocks, 4, 20)
 			fragmentReq.Options = fragmentReq.GetOptions().CloneVT()
 			if fragmentReq.Options == nil {
 				fragmentReq.Options = &queryv1.InvokeOptions{}
 			}
 			fragmentReq.Options.BypassResultCache = true
 
-			cacheable := fragment.full && stableResultCacheDay(fragment.end, q.now(), q.resultCacheOverrides.RejectOlderThan(tenant))
+			cacheable := fragment.duration > 0 && fragment.end <= q.now().Add(-durations[len(durations)-1]).UnixMilli()
 			query := &queryv1.QueryRequest{
 				StartTime: fragment.start, EndTime: fragment.end, LabelSelector: selector, Query: fragmentReq.Query,
 			}
+			identity := resultCacheIdentity(query, blocks)
+			durationName := resultCacheDurationName(fragment.duration)
 			key := ""
 			writeAllowed := false
 			if cacheable {
 				fragmentAggregator := newAggregator(fragmentReq)
 				var hit bool
 				var err error
-				key, err = resultCacheKey(tenant, generation, query)
+				key, err = resultCacheKey(tenant, generation, fragment.duration, identity)
 				if err == nil {
-					hit, err = q.readResultCache(ctx, queryType, key, query, fragmentAggregator)
+					hit, err = q.readResultCache(ctx, queryType, durationName, key, identity, fragmentAggregator)
 				}
 				if err == nil && hit {
 					fragmentResponses[idx] = fragmentAggregator.response()
@@ -254,7 +290,7 @@ func (q *QueryBackend) coordinateResultCache(ctx context.Context, req *queryv1.I
 				return err
 			}
 			if cacheable && writeAllowed && ctx.Err() == nil {
-				q.enqueueResultCacheWrite(resultCacheWriteJob{queryType: queryType, key: key, query: query.CloneVT(), reports: cloneReports(resp.Reports)})
+				q.enqueueResultCacheWrite(resultCacheWriteJob{queryType: queryType, duration: durationName, key: key, identity: identity.CloneVT(), reports: cloneReports(resp.Reports)})
 			}
 			fragmentResponses[idx] = resp
 			return nil
@@ -292,44 +328,45 @@ func (q *QueryBackend) resultCacheEligible(req *queryv1.InvokeRequest) bool {
 	return q.resultCacheBucket != nil && q.resultCacheOverrides != nil && len(req.Tenant) == 1 &&
 		validQuery &&
 		!req.GetOptions().GetCollectDiagnostics() && q.resultCacheOverrides.ResultCacheEnabled(req.Tenant[0]) &&
-		q.resultCacheOverrides.RejectOlderThan(req.Tenant[0]) > 0
+		len(q.resultCacheOverrides.ResultCacheFragmentDurations(req.Tenant[0])) > 0
 }
 
 // readResultCache returns a cache hit. Its error is non-nil only when a read's
 // object state is unknown; corrupt entries are safe to replace after execution.
-func (q *QueryBackend) readResultCache(ctx context.Context, queryType, key string, expected *queryv1.QueryRequest, aggregator *reportAggregator) (bool, error) {
+func (q *QueryBackend) readResultCache(ctx context.Context, queryType, duration, key string, expected *queryv1.ResultCacheKey, aggregator *reportAggregator) (bool, error) {
 	span, ctx := tracing.StartSpanFromContext(ctx, "QueryBackend.ResultCacheLookup")
 	defer span.Finish()
 	span.SetTag("query_type", queryType)
-	span.SetTag("utc_day", time.UnixMilli(expected.StartTime).UTC().Format("2006-01-02"))
+	span.SetTag("fragment_duration", duration)
+	span.SetTag("fragment_start", time.UnixMilli(expected.GetQuery().GetStartTime()).UTC().Format(time.RFC3339))
 
 	r, err := q.resultCacheBucket.Get(ctx, key)
 	if err != nil {
 		if q.resultCacheBucket.IsObjNotFoundErr(err) {
 			span.SetTag("outcome", "miss")
-			q.resultCacheMetrics.lookups.WithLabelValues(queryType, "miss").Inc()
+			q.resultCacheMetrics.lookups.WithLabelValues(queryType, duration, "miss").Inc()
 			return false, nil
 		}
 		span.SetTag("outcome", "error")
-		q.resultCacheMetrics.lookups.WithLabelValues(queryType, "error").Inc()
+		q.resultCacheMetrics.lookups.WithLabelValues(queryType, duration, "error").Inc()
 		return false, err
 	}
 	defer r.Close()
 	b, err := io.ReadAll(r)
 	if err != nil {
 		span.SetTag("outcome", "error")
-		q.resultCacheMetrics.lookups.WithLabelValues(queryType, "error").Inc()
+		q.resultCacheMetrics.lookups.WithLabelValues(queryType, duration, "error").Inc()
 		return false, err
 	}
 	entry := new(queryv1.ResultCacheEntry)
 	if err := proto.Unmarshal(b, entry); err != nil {
 		span.SetTag("outcome", "error")
-		q.resultCacheMetrics.lookups.WithLabelValues(queryType, "error").Inc()
+		q.resultCacheMetrics.lookups.WithLabelValues(queryType, duration, "error").Inc()
 		return false, nil
 	}
-	if !proto.Equal(entry.Query, expected) {
+	if !proto.Equal(entry.Key, expected) {
 		span.SetTag("outcome", "collision")
-		q.resultCacheMetrics.lookups.WithLabelValues(queryType, "collision").Inc()
+		q.resultCacheMetrics.lookups.WithLabelValues(queryType, duration, "collision").Inc()
 		return false, fmt.Errorf("result cache collision")
 	}
 	if err := aggregator.aggregateResponse(&queryv1.InvokeResponse{Reports: entry.Reports}, nil); err != nil {
@@ -337,7 +374,7 @@ func (q *QueryBackend) readResultCache(ctx context.Context, queryType, key strin
 		return false, err
 	}
 	span.SetTag("outcome", "hit")
-	q.resultCacheMetrics.lookups.WithLabelValues(queryType, "hit").Inc()
+	q.resultCacheMetrics.lookups.WithLabelValues(queryType, duration, "hit").Inc()
 	return true, nil
 }
 
@@ -380,6 +417,7 @@ func (q *QueryBackend) filterBlocks(root *queryv1.QueryNode, start, end int64) [
 	for _, block := range blocks {
 		result = append(result, block)
 	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Id < result[j].Id })
 	return result
 }
 
@@ -387,7 +425,7 @@ func (q *QueryBackend) enqueueResultCacheWrite(job resultCacheWriteJob) {
 	select {
 	case q.resultCacheWrites <- job:
 	default:
-		q.resultCacheMetrics.writes.WithLabelValues(job.queryType, "dropped").Inc()
+		q.resultCacheMetrics.writes.WithLabelValues(job.queryType, job.duration, "dropped").Inc()
 	}
 }
 
@@ -400,8 +438,9 @@ func (q *QueryBackend) runResultCacheWriter(ctx context.Context) {
 		case job := <-q.resultCacheWrites:
 			span, writeCtx := tracing.StartSpanFromContext(ctx, "QueryBackend.ResultCacheWrite")
 			span.SetTag("query_type", job.queryType)
-			span.SetTag("utc_day", time.UnixMilli(job.query.StartTime).UTC().Format("2006-01-02"))
-			entry := &queryv1.ResultCacheEntry{Query: job.query, Reports: job.reports}
+			span.SetTag("fragment_duration", job.duration)
+			span.SetTag("fragment_start", time.UnixMilli(job.identity.GetQuery().GetStartTime()).UTC().Format(time.RFC3339))
+			entry := &queryv1.ResultCacheEntry{Key: job.identity, Reports: job.reports}
 			data, err := proto.Marshal(entry)
 			if err == nil {
 				writeCtx, cancel := context.WithTimeout(writeCtx, resultCacheWriteTimeout)
@@ -410,10 +449,10 @@ func (q *QueryBackend) runResultCacheWriter(ctx context.Context) {
 			}
 			if err != nil {
 				span.SetTag("outcome", "error")
-				q.resultCacheMetrics.writes.WithLabelValues(job.queryType, "error").Inc()
+				q.resultCacheMetrics.writes.WithLabelValues(job.queryType, job.duration, "error").Inc()
 			} else {
 				span.SetTag("outcome", "success")
-				q.resultCacheMetrics.writes.WithLabelValues(job.queryType, "success").Inc()
+				q.resultCacheMetrics.writes.WithLabelValues(job.queryType, job.duration, "success").Inc()
 			}
 			span.Finish()
 		}

--- a/pkg/querybackend/result_cache.go
+++ b/pkg/querybackend/result_cache.go
@@ -22,7 +22,8 @@ import (
 )
 
 const (
-	resultCacheQueryType    = "label_names"
+	resultCacheLabelNames   = "label_names"
+	resultCacheLabelValues  = "label_values"
 	resultCacheWorkers      = 2
 	resultCacheQueueSize    = 128
 	resultCacheWriteTimeout = 30 * time.Second
@@ -55,9 +56,10 @@ func newResultCacheMetrics(reg prometheus.Registerer) *resultCacheMetrics {
 }
 
 type resultCacheWriteJob struct {
-	key     string
-	query   *queryv1.QueryRequest
-	reports []*queryv1.Report
+	queryType string
+	key       string
+	query     *queryv1.QueryRequest
+	reports   []*queryv1.Report
 }
 
 type resultCacheFragment struct {
@@ -139,10 +141,27 @@ func resultCacheKey(tenant string, generation uint32, query *queryv1.QueryReques
 	return fmt.Sprintf("result-cache/%s/%04d-%s-%s", tenant, generation, date, hex.EncodeToString(digest[:])), nil
 }
 
+func resultCacheQueryType(queries []*queryv1.Query) (string, bool) {
+	if len(queries) != 1 || queries[0] == nil {
+		return "", false
+	}
+	switch query := queries[0]; query.QueryType {
+	case queryv1.QueryType_QUERY_LABEL_NAMES:
+		return resultCacheLabelNames, query.LabelNames != nil
+	case queryv1.QueryType_QUERY_LABEL_VALUES:
+		return resultCacheLabelValues, query.LabelValues != nil
+	default:
+		return "", false
+	}
+}
+
 func (q *QueryBackend) coordinateResultCache(ctx context.Context, req *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error) {
 	span, ctx := tracing.StartSpanFromContext(ctx, "QueryBackend.ResultCache")
 	defer span.Finish()
-	span.SetTag("query_type", resultCacheQueryType)
+	queryType, validQuery := resultCacheQueryType(req.Query)
+	if validQuery {
+		span.SetTag("query_type", queryType)
+	}
 	if !q.resultCacheEligible(req) {
 		span.SetTag("outcome", "bypass")
 		return q.executeWithResultCacheBypassed(ctx, req)
@@ -181,7 +200,7 @@ func (q *QueryBackend) coordinateResultCache(ctx context.Context, req *queryv1.I
 			var err error
 			key, err = resultCacheKey(tenant, generation, query)
 			if err == nil {
-				hit, err = q.readResultCache(ctx, key, query, aggregator)
+				hit, err = q.readResultCache(ctx, queryType, key, query, aggregator)
 			}
 			if err == nil && hit {
 				continue
@@ -206,7 +225,7 @@ func (q *QueryBackend) coordinateResultCache(ctx context.Context, req *queryv1.I
 			return nil, err
 		}
 		if cacheable && writeAllowed && ctx.Err() == nil {
-			q.enqueueResultCacheWrite(resultCacheWriteJob{key: key, query: query.CloneVT(), reports: cloneReports(resp.Reports)})
+			q.enqueueResultCacheWrite(resultCacheWriteJob{queryType: queryType, key: key, query: query.CloneVT(), reports: cloneReports(resp.Reports)})
 		}
 	}
 
@@ -226,47 +245,48 @@ func (q *QueryBackend) executeWithResultCacheBypassed(ctx context.Context, req *
 }
 
 func (q *QueryBackend) resultCacheEligible(req *queryv1.InvokeRequest) bool {
+	_, validQuery := resultCacheQueryType(req.Query)
 	return q.resultCacheBucket != nil && q.resultCacheOverrides != nil && len(req.Tenant) == 1 &&
-		len(req.Query) == 1 && req.Query[0].QueryType == queryv1.QueryType_QUERY_LABEL_NAMES && req.Query[0].LabelNames != nil &&
+		validQuery &&
 		!req.GetOptions().GetCollectDiagnostics() && q.resultCacheOverrides.ResultCacheEnabled(req.Tenant[0]) &&
 		q.resultCacheOverrides.RejectOlderThan(req.Tenant[0]) > 0
 }
 
 // readResultCache returns a cache hit. Its error is non-nil only when a read's
 // object state is unknown; corrupt entries are safe to replace after execution.
-func (q *QueryBackend) readResultCache(ctx context.Context, key string, expected *queryv1.QueryRequest, aggregator *reportAggregator) (bool, error) {
+func (q *QueryBackend) readResultCache(ctx context.Context, queryType, key string, expected *queryv1.QueryRequest, aggregator *reportAggregator) (bool, error) {
 	span, ctx := tracing.StartSpanFromContext(ctx, "QueryBackend.ResultCacheLookup")
 	defer span.Finish()
-	span.SetTag("query_type", resultCacheQueryType)
+	span.SetTag("query_type", queryType)
 	span.SetTag("utc_day", time.UnixMilli(expected.StartTime).UTC().Format("2006-01-02"))
 
 	r, err := q.resultCacheBucket.Get(ctx, key)
 	if err != nil {
 		if q.resultCacheBucket.IsObjNotFoundErr(err) {
 			span.SetTag("outcome", "miss")
-			q.resultCacheMetrics.lookups.WithLabelValues(resultCacheQueryType, "miss").Inc()
+			q.resultCacheMetrics.lookups.WithLabelValues(queryType, "miss").Inc()
 			return false, nil
 		}
 		span.SetTag("outcome", "error")
-		q.resultCacheMetrics.lookups.WithLabelValues(resultCacheQueryType, "error").Inc()
+		q.resultCacheMetrics.lookups.WithLabelValues(queryType, "error").Inc()
 		return false, err
 	}
 	defer r.Close()
 	b, err := io.ReadAll(r)
 	if err != nil {
 		span.SetTag("outcome", "error")
-		q.resultCacheMetrics.lookups.WithLabelValues(resultCacheQueryType, "error").Inc()
+		q.resultCacheMetrics.lookups.WithLabelValues(queryType, "error").Inc()
 		return false, err
 	}
 	entry := new(queryv1.ResultCacheEntry)
 	if err := proto.Unmarshal(b, entry); err != nil {
 		span.SetTag("outcome", "error")
-		q.resultCacheMetrics.lookups.WithLabelValues(resultCacheQueryType, "error").Inc()
+		q.resultCacheMetrics.lookups.WithLabelValues(queryType, "error").Inc()
 		return false, nil
 	}
 	if !proto.Equal(entry.Query, expected) {
 		span.SetTag("outcome", "collision")
-		q.resultCacheMetrics.lookups.WithLabelValues(resultCacheQueryType, "collision").Inc()
+		q.resultCacheMetrics.lookups.WithLabelValues(queryType, "collision").Inc()
 		return false, fmt.Errorf("result cache collision")
 	}
 	if err := aggregator.aggregateResponse(&queryv1.InvokeResponse{Reports: entry.Reports}, nil); err != nil {
@@ -274,7 +294,7 @@ func (q *QueryBackend) readResultCache(ctx context.Context, key string, expected
 		return false, err
 	}
 	span.SetTag("outcome", "hit")
-	q.resultCacheMetrics.lookups.WithLabelValues(resultCacheQueryType, "hit").Inc()
+	q.resultCacheMetrics.lookups.WithLabelValues(queryType, "hit").Inc()
 	return true, nil
 }
 
@@ -324,7 +344,7 @@ func (q *QueryBackend) enqueueResultCacheWrite(job resultCacheWriteJob) {
 	select {
 	case q.resultCacheWrites <- job:
 	default:
-		q.resultCacheMetrics.writes.WithLabelValues(resultCacheQueryType, "dropped").Inc()
+		q.resultCacheMetrics.writes.WithLabelValues(job.queryType, "dropped").Inc()
 	}
 }
 
@@ -336,7 +356,7 @@ func (q *QueryBackend) runResultCacheWriter(ctx context.Context) {
 			return
 		case job := <-q.resultCacheWrites:
 			span, writeCtx := tracing.StartSpanFromContext(ctx, "QueryBackend.ResultCacheWrite")
-			span.SetTag("query_type", resultCacheQueryType)
+			span.SetTag("query_type", job.queryType)
 			span.SetTag("utc_day", time.UnixMilli(job.query.StartTime).UTC().Format("2006-01-02"))
 			entry := &queryv1.ResultCacheEntry{Query: job.query, Reports: job.reports}
 			data, err := proto.Marshal(entry)
@@ -347,10 +367,10 @@ func (q *QueryBackend) runResultCacheWriter(ctx context.Context) {
 			}
 			if err != nil {
 				span.SetTag("outcome", "error")
-				q.resultCacheMetrics.writes.WithLabelValues(resultCacheQueryType, "error").Inc()
+				q.resultCacheMetrics.writes.WithLabelValues(job.queryType, "error").Inc()
 			} else {
 				span.SetTag("outcome", "success")
-				q.resultCacheMetrics.writes.WithLabelValues(resultCacheQueryType, "success").Inc()
+				q.resultCacheMetrics.writes.WithLabelValues(job.queryType, "success").Inc()
 			}
 			span.Finish()
 		}

--- a/pkg/querybackend/result_cache.go
+++ b/pkg/querybackend/result_cache.go
@@ -1,12 +1,11 @@
 package querybackend
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
-	"io"
 	"sort"
 	"strconv"
 	"strings"
@@ -36,7 +35,7 @@ const (
 type ResultCacheOverrides interface {
 	ResultCacheEnabled(tenantID string) bool
 	ResultCacheGeneration(tenantID string) uint32
-	ResultCacheFragmentDurations(tenantID string) []time.Duration
+	ResultCacheFragments(tenantID string) []phlaremodel.ResultCacheFragment
 	ResultCacheMetadataServiceNameMinQueryDuration(tenantID string) time.Duration
 }
 
@@ -49,10 +48,10 @@ func newResultCacheMetrics(reg prometheus.Registerer) *resultCacheMetrics {
 	m := &resultCacheMetrics{
 		lookups: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: "pyroscope", Subsystem: "query_backend", Name: "result_cache_lookups_total",
-		}, []string{"query_type", "fragment_duration", "outcome"}),
+		}, []string{"query_type", "fragment_duration", "tier", "outcome"}),
 		writes: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: "pyroscope", Subsystem: "query_backend", Name: "result_cache_writes_total",
-		}, []string{"query_type", "fragment_duration", "outcome"}),
+		}, []string{"query_type", "fragment_duration", "tier", "outcome"}),
 	}
 	if reg != nil {
 		reg.MustRegister(m.lookups, m.writes)
@@ -63,6 +62,7 @@ func newResultCacheMetrics(reg prometheus.Registerer) *resultCacheMetrics {
 type resultCacheWriteJob struct {
 	queryType string
 	duration  string
+	ttl       time.Duration
 	key       string
 	identity  *queryv1.ResultCacheKey
 	reports   []*queryv1.Report
@@ -72,31 +72,32 @@ type resultCacheFragment struct {
 	start    int64
 	end      int64
 	duration time.Duration
+	ttl      time.Duration
 }
 
-func splitResultCacheFragments(start, end int64, durations []time.Duration) []resultCacheFragment {
+func splitResultCacheFragments(start, end int64, configured []phlaremodel.ResultCacheFragment) []resultCacheFragment {
 	if start > end {
 		return nil
 	}
-	durations = append([]time.Duration(nil), durations...)
-	sort.Slice(durations, func(i, j int) bool { return durations[i] > durations[j] })
+	configured = append([]phlaremodel.ResultCacheFragment(nil), configured...)
+	sort.Slice(configured, func(i, j int) bool { return configured[i].Duration > configured[j].Duration })
 	fragments := make([]resultCacheFragment, 0, 1)
 	endExclusive := end + 1
 	for current := start; current < endExclusive; {
-		var selected time.Duration
-		for _, duration := range durations {
-			milliseconds := duration.Milliseconds()
+		var selected phlaremodel.ResultCacheFragment
+		for _, fragment := range configured {
+			milliseconds := time.Duration(fragment.Duration).Milliseconds()
 			if current%milliseconds == 0 && current+milliseconds <= endExclusive {
-				selected = duration
+				selected = fragment
 				break
 			}
 		}
 
 		fragmentEnd := end
-		if selected > 0 {
-			fragmentEnd = current + selected.Milliseconds() - 1
-		} else if len(durations) > 0 {
-			smallest := durations[len(durations)-1].Milliseconds()
+		if selected.Duration > 0 {
+			fragmentEnd = current + time.Duration(selected.Duration).Milliseconds() - 1
+		} else if len(configured) > 0 {
+			smallest := time.Duration(configured[len(configured)-1].Duration).Milliseconds()
 			remainder := current % smallest
 			if remainder < 0 {
 				remainder += smallest
@@ -104,7 +105,7 @@ func splitResultCacheFragments(start, end int64, durations []time.Duration) []re
 			nextBoundary := current + smallest - remainder
 			fragmentEnd = min(end, nextBoundary-1)
 		}
-		fragments = append(fragments, resultCacheFragment{start: current, end: fragmentEnd, duration: selected})
+		fragments = append(fragments, resultCacheFragment{start: current, end: fragmentEnd, duration: time.Duration(selected.Duration), ttl: time.Duration(selected.TTL)})
 		if fragmentEnd == end {
 			break
 		}
@@ -127,6 +128,17 @@ func resultCacheDurationName(duration time.Duration) string {
 		return strconv.FormatInt(int64(duration/time.Second), 10) + "s"
 	}
 	return duration.String()
+}
+
+func smallestResultCacheFragmentDuration(fragments []phlaremodel.ResultCacheFragment) time.Duration {
+	var smallest time.Duration
+	for _, fragment := range fragments {
+		duration := time.Duration(fragment.Duration)
+		if smallest == 0 || duration < smallest {
+			smallest = duration
+		}
+	}
+	return smallest
 }
 
 func resultCacheIdentity(query *queryv1.QueryRequest, blocks []*metastorev1.BlockMeta) *queryv1.ResultCacheKey {
@@ -228,21 +240,32 @@ func (q *QueryBackend) coordinateResultCache(ctx context.Context, req *queryv1.I
 
 	tenant := req.Tenant[0]
 	generation := q.resultCacheOverrides.ResultCacheGeneration(tenant)
-	durations := q.resultCacheOverrides.ResultCacheFragmentDurations(tenant)
+	configured := q.resultCacheOverrides.ResultCacheFragments(tenant)
 	selector, err := canonicalResultCacheSelector(req.LabelSelector)
 	if err != nil {
 		return q.executeWithResultCacheBypassed(ctx, req)
 	}
 	aggregator := newAggregator(req)
-	fragments := splitResultCacheFragments(req.StartTime, req.EndTime, durations)
+	fragments := splitResultCacheFragments(req.StartTime, req.EndTime, configured)
 	span.SetTag("fragments", len(fragments))
 	fragmentResponses := make([]*queryv1.InvokeResponse, len(fragments))
-	g, ctx := errgroup.WithContext(ctx)
-	g.SetLimit(resultCacheFragmentConcurrency)
+	fragmentRequests := make([]*queryv1.InvokeRequest, len(fragments))
+	identities := make([]*queryv1.ResultCacheKey, len(fragments))
+	keys := make([]string, len(fragments))
+	writeAllowed := make([]bool, len(fragments))
+
+	lookupCtx := ctx
+	cancelLookup := func() {}
+	if q.resultCacheLookupTimeout > 0 {
+		lookupCtx, cancelLookup = context.WithTimeout(ctx, q.resultCacheLookupTimeout)
+	}
+	defer cancelLookup()
+	lookupGroup, lookupCtx := errgroup.WithContext(lookupCtx)
+	lookupGroup.SetLimit(resultCacheFragmentConcurrency)
 	for i, fragment := range fragments {
 		idx := i
 		fragment := fragment
-		g.Go(func() error {
+		lookupGroup.Go(func() error {
 			fragmentReq := req.CloneVT()
 			fragmentReq.StartTime = fragment.start
 			fragmentReq.EndTime = fragment.end
@@ -254,50 +277,70 @@ func (q *QueryBackend) coordinateResultCache(ctx context.Context, req *queryv1.I
 				fragmentReq.Options = &queryv1.InvokeOptions{}
 			}
 			fragmentReq.Options.BypassResultCache = true
+			fragmentRequests[idx] = fragmentReq
 
-			cacheable := fragment.duration > 0 && fragment.end <= q.now().Add(-durations[len(durations)-1]).UnixMilli()
+			cacheable := fragment.duration > 0 && fragment.end <= q.now().Add(-smallestResultCacheFragmentDuration(configured)).UnixMilli()
 			query := &queryv1.QueryRequest{
 				StartTime: fragment.start, EndTime: fragment.end, LabelSelector: selector, Query: fragmentReq.Query,
 			}
 			identity := resultCacheIdentity(query, blocks)
+			identities[idx] = identity
 			durationName := resultCacheDurationName(fragment.duration)
-			key := ""
-			writeAllowed := false
 			if cacheable {
 				fragmentAggregator := newAggregator(fragmentReq)
-				var hit bool
-				var err error
-				key, err = resultCacheKey(tenant, generation, fragment.duration, identity)
+				key, err := resultCacheKey(tenant, generation, fragment.duration, identity)
+				keys[idx] = key
 				if err == nil {
-					hit, err = q.readResultCache(ctx, queryType, durationName, key, identity, fragmentAggregator)
-				}
-				if err == nil && hit {
-					fragmentResponses[idx] = fragmentAggregator.response()
-					return nil
-				}
-				if err == nil {
-					writeAllowed = true
+					hit, err := q.readResultCache(lookupCtx, queryType, durationName, key, identity, fragmentAggregator)
+					if err == nil && hit {
+						fragmentResponses[idx] = fragmentAggregator.response()
+						return nil
+					}
+					if err == nil {
+						writeAllowed[idx] = true
+					} else if errors.Is(err, context.DeadlineExceeded) {
+						q.resultCacheMetrics.lookups.WithLabelValues(queryType, durationName, "unknown", "timeout").Inc()
+					}
 				}
 			}
+			return nil
+		})
+	}
+	if err := lookupGroup.Wait(); err != nil {
+		return nil, err
+	}
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 
+	executionGroup, executionCtx := errgroup.WithContext(ctx)
+	executionGroup.SetLimit(resultCacheFragmentConcurrency)
+	for i, fragment := range fragments {
+		if fragmentResponses[i] != nil {
+			continue
+		}
+		idx := i
+		fragment := fragment
+		executionGroup.Go(func() error {
+			fragmentReq := fragmentRequests[idx]
 			var resp *queryv1.InvokeResponse
 			var err error
 			if fragmentReq.QueryPlan.GetRoot() == nil {
 				resp = &queryv1.InvokeResponse{}
 			} else {
-				resp, err = q.invokeUncached(ctx, fragmentReq)
+				resp, err = q.invokeUncached(executionCtx, fragmentReq)
 			}
 			if err != nil {
 				return err
 			}
-			if cacheable && writeAllowed && ctx.Err() == nil {
-				q.enqueueResultCacheWrite(resultCacheWriteJob{queryType: queryType, duration: durationName, key: key, identity: identity.CloneVT(), reports: cloneReports(resp.Reports)})
+			if writeAllowed[idx] && ctx.Err() == nil {
+				q.enqueueResultCacheWrite(resultCacheWriteJob{queryType: queryType, duration: resultCacheDurationName(fragment.duration), ttl: fragment.ttl, key: keys[idx], identity: identities[idx].CloneVT(), reports: cloneReports(resp.Reports)})
 			}
 			fragmentResponses[idx] = resp
 			return nil
 		})
 	}
-	if err := g.Wait(); err != nil {
+	if err := executionGroup.Wait(); err != nil {
 		return nil, err
 	}
 
@@ -326,10 +369,10 @@ func (q *QueryBackend) executeWithResultCacheBypassed(ctx context.Context, req *
 
 func (q *QueryBackend) resultCacheEligible(req *queryv1.InvokeRequest) bool {
 	_, validQuery := resultCacheQueryType(req.Query)
-	return q.resultCacheBucket != nil && q.resultCacheOverrides != nil && len(req.Tenant) == 1 &&
+	return q.resultCacheStore != nil && q.resultCacheOverrides != nil && len(req.Tenant) == 1 &&
 		validQuery &&
 		!req.GetOptions().GetCollectDiagnostics() && q.resultCacheOverrides.ResultCacheEnabled(req.Tenant[0]) &&
-		len(q.resultCacheOverrides.ResultCacheFragmentDurations(req.Tenant[0])) > 0 &&
+		len(q.resultCacheOverrides.ResultCacheFragments(req.Tenant[0])) > 0 &&
 		!resultCacheMetadataServiceNameShortRange(req, q.resultCacheOverrides.ResultCacheMetadataServiceNameMinQueryDuration(req.Tenant[0]))
 }
 
@@ -358,41 +401,47 @@ func (q *QueryBackend) readResultCache(ctx context.Context, queryType, duration,
 	span.SetTag("fragment_duration", duration)
 	span.SetTag("fragment_start", time.UnixMilli(expected.GetQuery().GetStartTime()).UTC().Format(time.RFC3339))
 
-	r, err := q.resultCacheBucket.Get(ctx, key)
+	b, tier, err := q.resultCacheStore.Get(ctx, key)
 	if err != nil {
-		if q.resultCacheBucket.IsObjNotFoundErr(err) {
+		if errors.Is(err, errResultCacheNotFound) {
 			span.SetTag("outcome", "miss")
-			q.resultCacheMetrics.lookups.WithLabelValues(queryType, duration, "miss").Inc()
+			span.SetTag("tier", tier)
+			q.resultCacheMetrics.lookups.WithLabelValues(queryType, duration, tier, "miss").Inc()
+			return false, nil
+		}
+		if errors.Is(err, errResultCacheCorrupt) {
+			span.SetTag("outcome", "error")
+			span.SetTag("tier", tier)
+			q.resultCacheMetrics.lookups.WithLabelValues(queryType, duration, tier, "error").Inc()
 			return false, nil
 		}
 		span.SetTag("outcome", "error")
-		q.resultCacheMetrics.lookups.WithLabelValues(queryType, duration, "error").Inc()
-		return false, err
-	}
-	defer r.Close()
-	b, err := io.ReadAll(r)
-	if err != nil {
-		span.SetTag("outcome", "error")
-		q.resultCacheMetrics.lookups.WithLabelValues(queryType, duration, "error").Inc()
+		span.SetTag("tier", tier)
+		q.resultCacheMetrics.lookups.WithLabelValues(queryType, duration, tier, "error").Inc()
 		return false, err
 	}
 	entry := new(queryv1.ResultCacheEntry)
 	if err := proto.Unmarshal(b, entry); err != nil {
 		span.SetTag("outcome", "error")
-		q.resultCacheMetrics.lookups.WithLabelValues(queryType, duration, "error").Inc()
+		span.SetTag("tier", tier)
+		q.resultCacheMetrics.lookups.WithLabelValues(queryType, duration, tier, "error").Inc()
 		return false, nil
 	}
 	if !proto.Equal(entry.Key, expected) {
 		span.SetTag("outcome", "collision")
-		q.resultCacheMetrics.lookups.WithLabelValues(queryType, duration, "collision").Inc()
+		span.SetTag("tier", tier)
+		q.resultCacheMetrics.lookups.WithLabelValues(queryType, duration, tier, "collision").Inc()
 		return false, fmt.Errorf("result cache collision")
 	}
 	if err := aggregator.aggregateResponse(&queryv1.InvokeResponse{Reports: entry.Reports}); err != nil {
 		span.SetTag("outcome", "error")
+		span.SetTag("tier", tier)
+		q.resultCacheMetrics.lookups.WithLabelValues(queryType, duration, tier, "error").Inc()
 		return false, err
 	}
 	span.SetTag("outcome", "hit")
-	q.resultCacheMetrics.lookups.WithLabelValues(queryType, duration, "hit").Inc()
+	span.SetTag("tier", tier)
+	q.resultCacheMetrics.lookups.WithLabelValues(queryType, duration, tier, "hit").Inc()
 	return true, nil
 }
 
@@ -443,7 +492,7 @@ func (q *QueryBackend) enqueueResultCacheWrite(job resultCacheWriteJob) {
 	select {
 	case q.resultCacheWrites <- job:
 	default:
-		q.resultCacheMetrics.writes.WithLabelValues(job.queryType, job.duration, "dropped").Inc()
+		q.resultCacheMetrics.writes.WithLabelValues(job.queryType, job.duration, "unknown", "dropped").Inc()
 	}
 }
 
@@ -459,18 +508,20 @@ func (q *QueryBackend) runResultCacheWriter(ctx context.Context) {
 			span.SetTag("fragment_duration", job.duration)
 			span.SetTag("fragment_start", time.UnixMilli(job.identity.GetQuery().GetStartTime()).UTC().Format(time.RFC3339))
 			entry := &queryv1.ResultCacheEntry{Key: job.identity, Reports: job.reports}
+			tier := "unknown"
 			data, err := proto.Marshal(entry)
 			if err == nil {
 				writeCtx, cancel := context.WithTimeout(writeCtx, resultCacheWriteTimeout)
-				err = q.resultCacheBucket.Upload(writeCtx, job.key, bytes.NewReader(data))
+				tier, err = q.resultCacheStore.Put(writeCtx, job.key, data, job.ttl)
+				span.SetTag("tier", tier)
 				cancel()
 			}
 			if err != nil {
 				span.SetTag("outcome", "error")
-				q.resultCacheMetrics.writes.WithLabelValues(job.queryType, job.duration, "error").Inc()
+				q.resultCacheMetrics.writes.WithLabelValues(job.queryType, job.duration, tier, "error").Inc()
 			} else {
 				span.SetTag("outcome", "success")
-				q.resultCacheMetrics.writes.WithLabelValues(job.queryType, job.duration, "success").Inc()
+				q.resultCacheMetrics.writes.WithLabelValues(job.queryType, job.duration, tier, "success").Inc()
 			}
 			span.Finish()
 		}

--- a/pkg/querybackend/result_cache_store.go
+++ b/pkg/querybackend/result_cache_store.go
@@ -1,0 +1,112 @@
+package querybackend
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/grafana/pyroscope/v2/pkg/objstore"
+)
+
+const (
+	resultCacheRedisMaxValueSize = 16 * 1024
+	resultCacheRedisKeyPrefix    = "pyroscope:result-cache:"
+	resultCacheRedisRecordInline = byte(1)
+	resultCacheRedisRecordObject = byte(2)
+)
+
+var (
+	errResultCacheNotFound = errors.New("result cache entry not found")
+	errResultCacheUnknown  = errors.New("result cache state unknown")
+	errResultCacheCorrupt  = errors.New("corrupt result cache entry")
+)
+
+type ResultCacheStore interface {
+	Get(context.Context, string) ([]byte, string, error)
+	Put(context.Context, string, []byte, time.Duration) (string, error)
+	Close() error
+}
+
+type redisResultCacheStore struct {
+	bucket objstore.Bucket
+	redis  redis.UniversalClient
+}
+
+func NewResultCacheStore(bucket objstore.Bucket, redisClient redis.UniversalClient) ResultCacheStore {
+	return &redisResultCacheStore{bucket: bucket, redis: redisClient}
+}
+
+func (s *redisResultCacheStore) Get(ctx context.Context, key string) ([]byte, string, error) {
+	record, err := s.redis.Get(ctx, resultCacheRedisKeyPrefix+key).Bytes()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return nil, "redis", errResultCacheNotFound
+		}
+		if ctx.Err() != nil {
+			return nil, "redis", ctx.Err()
+		}
+		data, objectErr := s.getObject(ctx, key)
+		if objectErr == nil {
+			return data, "object", nil
+		}
+		return nil, "redis", fmt.Errorf("%w: Redis: %v; object storage: %v", errResultCacheUnknown, err, objectErr)
+	}
+	if len(record) == 0 {
+		return nil, "redis", errResultCacheCorrupt
+	}
+	switch record[0] {
+	case resultCacheRedisRecordInline:
+		return record[1:], "redis", nil
+	case resultCacheRedisRecordObject:
+		data, err := s.getObject(ctx, key)
+		if ctx.Err() != nil {
+			return nil, "object", ctx.Err()
+		}
+		if errors.Is(err, errResultCacheNotFound) {
+			return nil, "object", errResultCacheNotFound
+		}
+		if err != nil {
+			return nil, "object", fmt.Errorf("%w: %v", errResultCacheUnknown, err)
+		}
+		return data, "object", nil
+	default:
+		return nil, "redis", errResultCacheCorrupt
+	}
+}
+
+func (s *redisResultCacheStore) Put(ctx context.Context, key string, data []byte, ttl time.Duration) (string, error) {
+	if len(data) < resultCacheRedisMaxValueSize {
+		record := append([]byte{resultCacheRedisRecordInline}, data...)
+		return "redis", s.redis.Set(ctx, resultCacheRedisKeyPrefix+key, record, ttl).Err()
+	}
+	if err := s.bucket.Upload(ctx, key, bytes.NewReader(data)); err != nil {
+		return "object", err
+	}
+	if err := s.redis.Set(ctx, resultCacheRedisKeyPrefix+key, []byte{resultCacheRedisRecordObject}, ttl).Err(); err != nil {
+		return "redis", err
+	}
+	return "object", nil
+}
+
+func (s *redisResultCacheStore) getObject(ctx context.Context, key string) ([]byte, error) {
+	r, err := s.bucket.Get(ctx, key)
+	if err != nil {
+		if s.bucket.IsObjNotFoundErr(err) {
+			return nil, errResultCacheNotFound
+		}
+		return nil, err
+	}
+	defer r.Close()
+	return io.ReadAll(r)
+}
+
+func (s *redisResultCacheStore) Close() error {
+	redisErr := s.redis.Close()
+	bucketErr := s.bucket.Close()
+	return errors.Join(redisErr, bucketErr)
+}

--- a/pkg/querybackend/result_cache_test.go
+++ b/pkg/querybackend/result_cache_test.go
@@ -15,6 +15,7 @@ import (
 
 	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	phlareobjstore "github.com/grafana/pyroscope/v2/pkg/objstore"
 )
 
@@ -79,6 +80,25 @@ func TestResultCacheKeyIgnoresTime(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, key, labelValuesKey)
 	require.NotEqual(t, labelValuesKey, otherLabelValuesKey)
+
+	seriesLabels := &queryv1.InvokeRequest{
+		LabelSelector: `{service_name="api"}`,
+		Query: []*queryv1.Query{{
+			QueryType:    queryv1.QueryType_QUERY_SERIES_LABELS,
+			SeriesLabels: &queryv1.SeriesLabelsQuery{LabelNames: []string{"service_name", "cluster"}},
+		}},
+	}
+	seriesLabelsQuery, err := cacheQuery(seriesLabels, query.StartTime, query.EndTime)
+	require.NoError(t, err)
+	require.Equal(t, []string{"cluster", "service_name"}, seriesLabelsQuery.Query[0].SeriesLabels.LabelNames)
+	seriesLabels.Query[0].SeriesLabels.LabelNames = []string{"cluster", "service_name"}
+	otherSeriesLabelsQuery, err := cacheQuery(seriesLabels, query.StartTime, query.EndTime)
+	require.NoError(t, err)
+	seriesLabelsKey, err := resultCacheKey("tenant-a", 1, seriesLabelsQuery)
+	require.NoError(t, err)
+	otherSeriesLabelsKey, err := resultCacheKey("tenant-a", 1, otherSeriesLabelsQuery)
+	require.NoError(t, err)
+	require.Equal(t, seriesLabelsKey, otherSeriesLabelsKey)
 }
 
 func TestCanonicalResultCacheSelector(t *testing.T) {
@@ -194,6 +214,50 @@ func TestCoordinateResultCacheLabelValuesHitDoesNotExecutePlan(t *testing.T) {
 	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelValues, "hit")))
 }
 
+func TestCoordinateResultCacheSeriesLabelsHitDoesNotExecutePlan(t *testing.T) {
+	bucket := phlareobjstore.NewBucket(thanobjstore.NewInMemBucket())
+	q := &QueryBackend{
+		resultCacheBucket:    bucket,
+		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 7, window: time.Hour},
+		resultCacheMetrics:   newResultCacheMetrics(prometheus.NewRegistry()),
+		now:                  func() time.Time { return time.Date(2026, 8, 23, 3, 0, 0, 0, time.UTC) },
+	}
+	start := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC).UnixMilli()
+	end := time.Date(2026, 8, 20, 23, 59, 59, 999000000, time.UTC).UnixMilli()
+	req := &queryv1.InvokeRequest{
+		Tenant:        []string{"tenant-a"},
+		StartTime:     start,
+		EndTime:       end,
+		LabelSelector: "{}",
+		Query: []*queryv1.Query{{
+			QueryType:    queryv1.QueryType_QUERY_SERIES_LABELS,
+			SeriesLabels: &queryv1.SeriesLabelsQuery{LabelNames: []string{"service_name", "cluster"}},
+		}},
+	}
+	query, err := cacheQuery(req, start, end)
+	require.NoError(t, err)
+	key, err := resultCacheKey("tenant-a", 7, query)
+	require.NoError(t, err)
+	data, err := proto.Marshal(&queryv1.ResultCacheEntry{Query: query, Reports: []*queryv1.Report{{
+		ReportType: queryv1.ReportType_REPORT_SERIES_LABELS,
+		SeriesLabels: &queryv1.SeriesLabelsReport{
+			Query: query.Query[0].SeriesLabels,
+			SeriesLabels: []*typesv1.Labels{{Labels: []*typesv1.LabelPair{
+				{Name: "cluster", Value: "prod"},
+				{Name: "service_name", Value: "api"},
+			}}},
+		},
+	}}})
+	require.NoError(t, err)
+	require.NoError(t, bucket.Upload(context.Background(), key, bytes.NewReader(data)))
+
+	resp, err := q.Invoke(context.Background(), req)
+	require.NoError(t, err)
+	require.Len(t, resp.Reports[0].SeriesLabels.SeriesLabels, 1)
+	require.Zero(t, resp.Diagnostics.ExecutionNode.Stats.BytesFetched)
+	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheSeriesLabels, "hit")))
+}
+
 func TestResultCacheEligibility(t *testing.T) {
 	q := &QueryBackend{
 		resultCacheBucket:    phlareobjstore.NewBucket(thanobjstore.NewInMemBucket()),
@@ -207,6 +271,10 @@ func TestResultCacheEligibility(t *testing.T) {
 	req.Query[0] = &queryv1.Query{QueryType: queryv1.QueryType_QUERY_LABEL_VALUES, LabelValues: &queryv1.LabelValuesQuery{LabelName: "service_name"}}
 	require.True(t, q.resultCacheEligible(req))
 	req.Query[0].LabelValues = nil
+	require.False(t, q.resultCacheEligible(req))
+	req.Query[0] = &queryv1.Query{QueryType: queryv1.QueryType_QUERY_SERIES_LABELS, SeriesLabels: &queryv1.SeriesLabelsQuery{}}
+	require.True(t, q.resultCacheEligible(req))
+	req.Query[0].SeriesLabels = nil
 	require.False(t, q.resultCacheEligible(req))
 	req.Query[0] = &queryv1.Query{QueryType: queryv1.QueryType_QUERY_LABEL_NAMES, LabelNames: &queryv1.LabelNamesQuery{}}
 	req.Options = &queryv1.InvokeOptions{CollectDiagnostics: true}

--- a/pkg/querybackend/result_cache_test.go
+++ b/pkg/querybackend/result_cache_test.go
@@ -3,6 +3,7 @@ package querybackend
 import (
 	"bytes"
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -28,6 +29,12 @@ type resultCacheOverrides struct {
 func (o resultCacheOverrides) ResultCacheEnabled(string) bool       { return o.enabled }
 func (o resultCacheOverrides) ResultCacheGeneration(string) uint32  { return o.generation }
 func (o resultCacheOverrides) RejectOlderThan(string) time.Duration { return o.window }
+
+type queryHandlerFunc func(context.Context, *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error)
+
+func (f queryHandlerFunc) Invoke(ctx context.Context, req *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error) {
+	return f(ctx, req)
+}
 
 func TestSplitResultCacheFragments(t *testing.T) {
 	start := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC).UnixMilli()
@@ -256,6 +263,95 @@ func TestCoordinateResultCacheSeriesLabelsHitDoesNotExecutePlan(t *testing.T) {
 	require.Len(t, resp.Reports[0].SeriesLabels.SeriesLabels, 1)
 	require.Zero(t, resp.Diagnostics.ExecutionNode.Stats.BytesFetched)
 	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheSeriesLabels, "hit")))
+}
+
+func TestCoordinateResultCacheLimitsConcurrentColdFragments(t *testing.T) {
+	const fragments = resultCacheFragmentConcurrency + 1
+
+	started := make(chan struct{}, fragments)
+	release := make(chan struct{})
+	var mu sync.Mutex
+	inFlight := 0
+	maxInFlight := 0
+	calls := 0
+
+	blockReader := queryHandlerFunc(func(ctx context.Context, req *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error) {
+		mu.Lock()
+		inFlight++
+		calls++
+		maxInFlight = max(maxInFlight, inFlight)
+		mu.Unlock()
+		started <- struct{}{}
+
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+
+		mu.Lock()
+		inFlight--
+		mu.Unlock()
+		return &queryv1.InvokeResponse{
+			Reports: []*queryv1.Report{{
+				ReportType: queryv1.ReportType_REPORT_LABEL_NAMES,
+				LabelNames: &queryv1.LabelNamesReport{
+					Query:      req.Query[0].LabelNames.CloneVT(),
+					LabelNames: []string{"service_name"},
+				},
+			}},
+			Diagnostics: &queryv1.Diagnostics{ExecutionNode: &queryv1.ExecutionNode{Stats: &queryv1.ExecutionStats{}}},
+		}, nil
+	})
+
+	start := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, fragments).Add(-time.Millisecond)
+	q := &QueryBackend{
+		blockReader:          blockReader,
+		resultCacheBucket:    phlareobjstore.NewBucket(thanobjstore.NewInMemBucket()),
+		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 1, window: time.Hour},
+		resultCacheMetrics:   newResultCacheMetrics(prometheus.NewRegistry()),
+		now:                  func() time.Time { return end.Add(48 * time.Hour) },
+	}
+	req := &queryv1.InvokeRequest{
+		Tenant:        []string{"tenant-a"},
+		StartTime:     start.UnixMilli(),
+		EndTime:       end.UnixMilli(),
+		LabelSelector: "{}",
+		Query:         []*queryv1.Query{{QueryType: queryv1.QueryType_QUERY_LABEL_NAMES, LabelNames: &queryv1.LabelNamesQuery{}}},
+		QueryPlan: &queryv1.QueryPlan{Root: &queryv1.QueryNode{Blocks: []*metastorev1.BlockMeta{{
+			Id: "block", MinTime: start.UnixMilli(), MaxTime: end.UnixMilli(),
+			Datasets: []*metastorev1.Dataset{{MinTime: start.UnixMilli(), MaxTime: end.UnixMilli()}},
+		}}}},
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := q.Invoke(context.Background(), req)
+		result <- err
+	}()
+
+	for range resultCacheFragmentConcurrency {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for concurrent fragment execution")
+		}
+	}
+	mu.Lock()
+	require.Equal(t, resultCacheFragmentConcurrency, maxInFlight)
+	mu.Unlock()
+	select {
+	case <-started:
+		t.Fatal("fragment execution exceeded the concurrency limit")
+	default:
+	}
+
+	close(release)
+	require.NoError(t, <-result)
+	mu.Lock()
+	require.Equal(t, fragments, calls)
+	mu.Unlock()
 }
 
 func TestResultCacheEligibility(t *testing.T) {

--- a/pkg/querybackend/result_cache_test.go
+++ b/pkg/querybackend/result_cache_test.go
@@ -21,9 +21,10 @@ import (
 )
 
 type resultCacheOverrides struct {
-	enabled    bool
-	generation uint32
-	durations  []time.Duration
+	enabled                             bool
+	generation                          uint32
+	durations                           []time.Duration
+	metadataServiceNameMinQueryDuration time.Duration
 }
 
 func (o resultCacheOverrides) ResultCacheEnabled(string) bool      { return o.enabled }
@@ -33,6 +34,9 @@ func (o resultCacheOverrides) ResultCacheFragmentDurations(string) []time.Durati
 		return []time.Duration{24 * time.Hour, 2 * time.Hour, 15 * time.Minute}
 	}
 	return o.durations
+}
+func (o resultCacheOverrides) ResultCacheMetadataServiceNameMinQueryDuration(string) time.Duration {
+	return o.metadataServiceNameMinQueryDuration
 }
 
 type queryHandlerFunc func(context.Context, *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error)
@@ -486,7 +490,7 @@ func TestCoordinateResultCacheLimitsConcurrentColdFragments(t *testing.T) {
 func TestResultCacheEligibility(t *testing.T) {
 	q := &QueryBackend{
 		resultCacheBucket:    phlareobjstore.NewBucket(thanobjstore.NewInMemBucket()),
-		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 1},
+		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 1, metadataServiceNameMinQueryDuration: 7 * 24 * time.Hour},
 	}
 	req := &queryv1.InvokeRequest{
 		Tenant: []string{"tenant-a"},
@@ -502,6 +506,19 @@ func TestResultCacheEligibility(t *testing.T) {
 	req.Query[0].SeriesLabels = nil
 	require.False(t, q.resultCacheEligible(req))
 	req.Query[0] = &queryv1.Query{QueryType: queryv1.QueryType_QUERY_LABEL_NAMES, LabelNames: &queryv1.LabelNamesQuery{}}
+	req.LabelSelector = `{service_name="api"}`
+	req.StartTime = 0
+	req.EndTime = (7 * 24 * time.Hour).Milliseconds() - 1
+	require.False(t, q.resultCacheEligible(req))
+	req.EndTime++
+	require.True(t, q.resultCacheEligible(req))
+	q.resultCacheOverrides = resultCacheOverrides{enabled: true, generation: 1}
+	req.EndTime = 0
+	require.True(t, q.resultCacheEligible(req))
+	q.resultCacheOverrides = resultCacheOverrides{enabled: true, generation: 1, metadataServiceNameMinQueryDuration: 7 * 24 * time.Hour}
+	req.LabelSelector = `{job="api"}`
+	req.EndTime = 0
+	require.True(t, q.resultCacheEligible(req))
 	req.Options = &queryv1.InvokeOptions{CollectDiagnostics: true}
 	require.False(t, q.resultCacheEligible(req))
 	req.Options = nil

--- a/pkg/querybackend/result_cache_test.go
+++ b/pkg/querybackend/result_cache_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/prometheus/client_golang/prometheus"
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	thanobjstore "github.com/thanos-io/objstore"
 	"google.golang.org/protobuf/proto"
@@ -64,6 +66,19 @@ func TestResultCacheKeyIgnoresTime(t *testing.T) {
 	require.Contains(t, key, "result-cache/tenant-a/0001-2026-08-21-")
 	require.NotEqual(t, key, otherDayKey)
 	require.Equal(t, key[len(key)-64:], otherDayKey[len(otherDayKey)-64:])
+
+	labelValues := query.CloneVT()
+	labelValues.Query[0] = &queryv1.Query{
+		QueryType:   queryv1.QueryType_QUERY_LABEL_VALUES,
+		LabelValues: &queryv1.LabelValuesQuery{LabelName: "service_name"},
+	}
+	labelValuesKey, err := resultCacheKey("tenant-a", 1, labelValues)
+	require.NoError(t, err)
+	labelValues.Query[0].LabelValues.LabelName = "cluster"
+	otherLabelValuesKey, err := resultCacheKey("tenant-a", 1, labelValues)
+	require.NoError(t, err)
+	require.NotEqual(t, key, labelValuesKey)
+	require.NotEqual(t, labelValuesKey, otherLabelValuesKey)
 }
 
 func TestCanonicalResultCacheSelector(t *testing.T) {
@@ -89,7 +104,7 @@ func TestReadResultCache(t *testing.T) {
 	require.NoError(t, bucket.Upload(context.Background(), "entry", bytes.NewReader(data)))
 
 	aggregator := newAggregator(request)
-	hit, err := q.readResultCache(context.Background(), "entry", expected, aggregator)
+	hit, err := q.readResultCache(context.Background(), resultCacheLabelNames, "entry", expected, aggregator)
 	require.NoError(t, err)
 	require.True(t, hit)
 	require.Equal(t, []string{"cluster", "service_name"}, aggregator.response().Reports[0].LabelNames.LabelNames)
@@ -98,7 +113,7 @@ func TestReadResultCache(t *testing.T) {
 	data, err = proto.Marshal(entry)
 	require.NoError(t, err)
 	require.NoError(t, bucket.Upload(context.Background(), "collision", bytes.NewReader(data)))
-	hit, err = q.readResultCache(context.Background(), "collision", expected, newAggregator(request))
+	hit, err = q.readResultCache(context.Background(), resultCacheLabelNames, "collision", expected, newAggregator(request))
 	require.Error(t, err)
 	require.False(t, hit)
 }
@@ -135,6 +150,48 @@ func TestCoordinateResultCacheHitDoesNotExecutePlan(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"cluster"}, resp.Reports[0].LabelNames.LabelNames)
 	require.Zero(t, resp.Diagnostics.ExecutionNode.Stats.BytesFetched)
+	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelNames, "hit")))
+}
+
+func TestCoordinateResultCacheLabelValuesHitDoesNotExecutePlan(t *testing.T) {
+	bucket := phlareobjstore.NewBucket(thanobjstore.NewInMemBucket())
+	q := &QueryBackend{
+		resultCacheBucket:    bucket,
+		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 7, window: time.Hour},
+		resultCacheMetrics:   newResultCacheMetrics(prometheus.NewRegistry()),
+		now:                  func() time.Time { return time.Date(2026, 8, 23, 3, 0, 0, 0, time.UTC) },
+	}
+	start := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC).UnixMilli()
+	end := time.Date(2026, 8, 20, 23, 59, 59, 999000000, time.UTC).UnixMilli()
+	req := &queryv1.InvokeRequest{
+		Tenant:        []string{"tenant-a"},
+		StartTime:     start,
+		EndTime:       end,
+		LabelSelector: "{}",
+		Query: []*queryv1.Query{{
+			QueryType:   queryv1.QueryType_QUERY_LABEL_VALUES,
+			LabelValues: &queryv1.LabelValuesQuery{LabelName: "service_name"},
+		}},
+	}
+	query, err := cacheQuery(req, start, end)
+	require.NoError(t, err)
+	key, err := resultCacheKey("tenant-a", 7, query)
+	require.NoError(t, err)
+	data, err := proto.Marshal(&queryv1.ResultCacheEntry{Query: query, Reports: []*queryv1.Report{{
+		ReportType: queryv1.ReportType_REPORT_LABEL_VALUES,
+		LabelValues: &queryv1.LabelValuesReport{
+			Query:       &queryv1.LabelValuesQuery{LabelName: "service_name"},
+			LabelValues: []string{"api", "worker"},
+		},
+	}}})
+	require.NoError(t, err)
+	require.NoError(t, bucket.Upload(context.Background(), key, bytes.NewReader(data)))
+
+	resp, err := q.Invoke(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, []string{"api", "worker"}, resp.Reports[0].LabelValues.LabelValues)
+	require.Zero(t, resp.Diagnostics.ExecutionNode.Stats.BytesFetched)
+	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelValues, "hit")))
 }
 
 func TestResultCacheEligibility(t *testing.T) {
@@ -147,11 +204,49 @@ func TestResultCacheEligibility(t *testing.T) {
 		Query:  []*queryv1.Query{{QueryType: queryv1.QueryType_QUERY_LABEL_NAMES, LabelNames: &queryv1.LabelNamesQuery{}}},
 	}
 	require.True(t, q.resultCacheEligible(req))
+	req.Query[0] = &queryv1.Query{QueryType: queryv1.QueryType_QUERY_LABEL_VALUES, LabelValues: &queryv1.LabelValuesQuery{LabelName: "service_name"}}
+	require.True(t, q.resultCacheEligible(req))
+	req.Query[0].LabelValues = nil
+	require.False(t, q.resultCacheEligible(req))
+	req.Query[0] = &queryv1.Query{QueryType: queryv1.QueryType_QUERY_LABEL_NAMES, LabelNames: &queryv1.LabelNamesQuery{}}
 	req.Options = &queryv1.InvokeOptions{CollectDiagnostics: true}
 	require.False(t, q.resultCacheEligible(req))
 	req.Options = nil
 	req.Tenant = append(req.Tenant, "tenant-b")
 	require.False(t, q.resultCacheEligible(req))
+}
+
+func TestInvokeUncachedEmptyPlanMetadataQuery(t *testing.T) {
+	q := &QueryBackend{}
+	for _, tc := range []struct {
+		name    string
+		query   *queryv1.Query
+		wantErr bool
+	}{
+		{
+			name:  "label names",
+			query: &queryv1.Query{QueryType: queryv1.QueryType_QUERY_LABEL_NAMES, LabelNames: &queryv1.LabelNamesQuery{}},
+		},
+		{
+			name:  "label values",
+			query: &queryv1.Query{QueryType: queryv1.QueryType_QUERY_LABEL_VALUES, LabelValues: &queryv1.LabelValuesQuery{LabelName: "service_name"}},
+		},
+		{
+			name:    "time series",
+			query:   &queryv1.Query{QueryType: queryv1.QueryType_QUERY_TIME_SERIES, TimeSeries: &queryv1.TimeSeriesQuery{}},
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := q.invokeUncached(context.Background(), &queryv1.InvokeRequest{Query: []*queryv1.Query{tc.query}})
+			if !tc.wantErr {
+				require.NoError(t, err)
+				require.Empty(t, resp.Reports)
+				return
+			}
+			require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+		})
+	}
 }
 
 func TestFilterResultCacheBlocks(t *testing.T) {

--- a/pkg/querybackend/result_cache_test.go
+++ b/pkg/querybackend/result_cache_test.go
@@ -1,0 +1,168 @@
+package querybackend
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	thanobjstore "github.com/thanos-io/objstore"
+	"google.golang.org/protobuf/proto"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+	phlareobjstore "github.com/grafana/pyroscope/v2/pkg/objstore"
+)
+
+type resultCacheOverrides struct {
+	enabled    bool
+	generation uint32
+	window     time.Duration
+}
+
+func (o resultCacheOverrides) ResultCacheEnabled(string) bool       { return o.enabled }
+func (o resultCacheOverrides) ResultCacheGeneration(string) uint32  { return o.generation }
+func (o resultCacheOverrides) RejectOlderThan(string) time.Duration { return o.window }
+
+func TestSplitResultCacheFragments(t *testing.T) {
+	start := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC).UnixMilli()
+	end := time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC).UnixMilli()
+
+	fragments := splitResultCacheFragments(start, end)
+	require.Len(t, fragments, 3)
+	require.False(t, fragments[0].full)
+	require.True(t, fragments[1].full)
+	require.False(t, fragments[2].full)
+	require.Equal(t, time.Date(2026, 8, 20, 23, 59, 59, 999000000, time.UTC).UnixMilli(), fragments[0].end)
+	require.Equal(t, time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC).UnixMilli(), fragments[1].start)
+	require.Equal(t, time.Date(2026, 8, 21, 23, 59, 59, 999000000, time.UTC).UnixMilli(), fragments[1].end)
+}
+
+func TestStableResultCacheDay(t *testing.T) {
+	end := time.Date(2026, 8, 20, 23, 59, 59, 999000000, time.UTC).UnixMilli()
+	boundary := time.Date(2026, 8, 21, 2, 0, 0, 0, time.UTC)
+	require.False(t, stableResultCacheDay(end, boundary.Add(-time.Nanosecond), time.Hour))
+	require.True(t, stableResultCacheDay(end, boundary, time.Hour))
+	require.False(t, stableResultCacheDay(end, boundary, 0))
+}
+
+func TestResultCacheKeyIgnoresTime(t *testing.T) {
+	query := &queryv1.QueryRequest{
+		StartTime:     time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC).UnixMilli(),
+		EndTime:       time.Date(2026, 8, 21, 23, 59, 59, 999000000, time.UTC).UnixMilli(),
+		LabelSelector: `{service_name="api"}`,
+		Query:         []*queryv1.Query{{QueryType: queryv1.QueryType_QUERY_LABEL_NAMES, LabelNames: &queryv1.LabelNamesQuery{}}},
+	}
+	key, err := resultCacheKey("tenant-a", 1, query)
+	require.NoError(t, err)
+	query.StartTime += 24 * 60 * 60 * 1000
+	query.EndTime += 24 * 60 * 60 * 1000
+	otherDayKey, err := resultCacheKey("tenant-a", 1, query)
+	require.NoError(t, err)
+	require.Contains(t, key, "result-cache/tenant-a/0001-2026-08-21-")
+	require.NotEqual(t, key, otherDayKey)
+	require.Equal(t, key[len(key)-64:], otherDayKey[len(otherDayKey)-64:])
+}
+
+func TestCanonicalResultCacheSelector(t *testing.T) {
+	first, err := canonicalResultCacheSelector(`{service_name="api",environment="prod"}`)
+	require.NoError(t, err)
+	second, err := canonicalResultCacheSelector(`{ environment = "prod", service_name = "api" }`)
+	require.NoError(t, err)
+	require.Equal(t, `{environment="prod",service_name="api"}`, first)
+	require.Equal(t, first, second)
+}
+
+func TestReadResultCache(t *testing.T) {
+	bucket := phlareobjstore.NewBucket(thanobjstore.NewInMemBucket())
+	q := &QueryBackend{resultCacheBucket: bucket, resultCacheMetrics: newResultCacheMetrics(prometheus.NewRegistry())}
+	request := &queryv1.InvokeRequest{Query: []*queryv1.Query{{QueryType: queryv1.QueryType_QUERY_LABEL_NAMES, LabelNames: &queryv1.LabelNamesQuery{}}}}
+	expected := &queryv1.QueryRequest{StartTime: 1, EndTime: 2, Query: request.Query}
+	entry := &queryv1.ResultCacheEntry{Query: expected.CloneVT(), Reports: []*queryv1.Report{{
+		ReportType: queryv1.ReportType_REPORT_LABEL_NAMES,
+		LabelNames: &queryv1.LabelNamesReport{Query: &queryv1.LabelNamesQuery{}, LabelNames: []string{"cluster", "service_name"}},
+	}}}
+	data, err := proto.Marshal(entry)
+	require.NoError(t, err)
+	require.NoError(t, bucket.Upload(context.Background(), "entry", bytes.NewReader(data)))
+
+	aggregator := newAggregator(request)
+	hit, err := q.readResultCache(context.Background(), "entry", expected, aggregator)
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.Equal(t, []string{"cluster", "service_name"}, aggregator.response().Reports[0].LabelNames.LabelNames)
+
+	entry.Query.EndTime = 3
+	data, err = proto.Marshal(entry)
+	require.NoError(t, err)
+	require.NoError(t, bucket.Upload(context.Background(), "collision", bytes.NewReader(data)))
+	hit, err = q.readResultCache(context.Background(), "collision", expected, newAggregator(request))
+	require.Error(t, err)
+	require.False(t, hit)
+}
+
+func TestCoordinateResultCacheHitDoesNotExecutePlan(t *testing.T) {
+	bucket := phlareobjstore.NewBucket(thanobjstore.NewInMemBucket())
+	q := &QueryBackend{
+		resultCacheBucket:    bucket,
+		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 7, window: time.Hour},
+		resultCacheMetrics:   newResultCacheMetrics(prometheus.NewRegistry()),
+		now:                  func() time.Time { return time.Date(2026, 8, 23, 3, 0, 0, 0, time.UTC) },
+	}
+	start := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC).UnixMilli()
+	end := time.Date(2026, 8, 20, 23, 59, 59, 999000000, time.UTC).UnixMilli()
+	req := &queryv1.InvokeRequest{
+		Tenant:        []string{"tenant-a"},
+		StartTime:     start,
+		EndTime:       end,
+		LabelSelector: "{}",
+		Query:         []*queryv1.Query{{QueryType: queryv1.QueryType_QUERY_LABEL_NAMES, LabelNames: &queryv1.LabelNamesQuery{}}},
+	}
+	query, err := cacheQuery(req, start, end)
+	require.NoError(t, err)
+	key, err := resultCacheKey("tenant-a", 7, query)
+	require.NoError(t, err)
+	data, err := proto.Marshal(&queryv1.ResultCacheEntry{Query: query, Reports: []*queryv1.Report{{
+		ReportType: queryv1.ReportType_REPORT_LABEL_NAMES,
+		LabelNames: &queryv1.LabelNamesReport{Query: &queryv1.LabelNamesQuery{}, LabelNames: []string{"cluster"}},
+	}}})
+	require.NoError(t, err)
+	require.NoError(t, bucket.Upload(context.Background(), key, bytes.NewReader(data)))
+
+	resp, err := q.Invoke(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, []string{"cluster"}, resp.Reports[0].LabelNames.LabelNames)
+	require.Zero(t, resp.Diagnostics.ExecutionNode.Stats.BytesFetched)
+}
+
+func TestResultCacheEligibility(t *testing.T) {
+	q := &QueryBackend{
+		resultCacheBucket:    phlareobjstore.NewBucket(thanobjstore.NewInMemBucket()),
+		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 1, window: time.Hour},
+	}
+	req := &queryv1.InvokeRequest{
+		Tenant: []string{"tenant-a"},
+		Query:  []*queryv1.Query{{QueryType: queryv1.QueryType_QUERY_LABEL_NAMES, LabelNames: &queryv1.LabelNamesQuery{}}},
+	}
+	require.True(t, q.resultCacheEligible(req))
+	req.Options = &queryv1.InvokeOptions{CollectDiagnostics: true}
+	require.False(t, q.resultCacheEligible(req))
+	req.Options = nil
+	req.Tenant = append(req.Tenant, "tenant-b")
+	require.False(t, q.resultCacheEligible(req))
+}
+
+func TestFilterResultCacheBlocks(t *testing.T) {
+	root := &queryv1.QueryNode{Blocks: []*metastorev1.BlockMeta{{
+		Id: "block", MinTime: 0, MaxTime: 100,
+		Datasets: []*metastorev1.Dataset{{MinTime: 0, MaxTime: 49}, {MinTime: 50, MaxTime: 100}},
+	}}}
+	q := &QueryBackend{}
+	blocks := q.filterBlocks(root, 50, 75)
+	require.Len(t, blocks, 1)
+	require.Len(t, blocks[0].Datasets, 1)
+	require.Equal(t, int64(50), blocks[0].Datasets[0].MinTime)
+	require.Len(t, root.Blocks[0].Datasets, 2)
+}

--- a/pkg/querybackend/result_cache_test.go
+++ b/pkg/querybackend/result_cache_test.go
@@ -80,7 +80,7 @@ func TestResultCacheKeyIncludesTimeAndBlocks(t *testing.T) {
 	key, err := resultCacheKey("tenant-a", 1, 24*time.Hour, identity)
 	require.NoError(t, err)
 	require.Equal(t, []string{"block-a", "block-b"}, identity.BlockIds)
-	require.Contains(t, key, "result-cache/tenant-a/24h/0001-")
+	require.Contains(t, key, "results-cache/24h/tenant-a/0001-")
 
 	otherBlocksKey, err := resultCacheKey("tenant-a", 1, 24*time.Hour, resultCacheIdentity(query, []*metastorev1.BlockMeta{{Id: "block-a"}, {Id: "block-c"}}))
 	require.NoError(t, err)
@@ -88,7 +88,7 @@ func TestResultCacheKeyIncludesTimeAndBlocks(t *testing.T) {
 
 	otherDurationKey, err := resultCacheKey("tenant-a", 1, 2*time.Hour, identity)
 	require.NoError(t, err)
-	require.Contains(t, otherDurationKey, "result-cache/tenant-a/2h/0001-")
+	require.Contains(t, otherDurationKey, "results-cache/2h/tenant-a/0001-")
 	require.NotEqual(t, key, otherDurationKey)
 
 	otherDay := query.CloneVT()

--- a/pkg/querybackend/result_cache_test.go
+++ b/pkg/querybackend/result_cache_test.go
@@ -23,12 +23,17 @@ import (
 type resultCacheOverrides struct {
 	enabled    bool
 	generation uint32
-	window     time.Duration
+	durations  []time.Duration
 }
 
-func (o resultCacheOverrides) ResultCacheEnabled(string) bool       { return o.enabled }
-func (o resultCacheOverrides) ResultCacheGeneration(string) uint32  { return o.generation }
-func (o resultCacheOverrides) RejectOlderThan(string) time.Duration { return o.window }
+func (o resultCacheOverrides) ResultCacheEnabled(string) bool      { return o.enabled }
+func (o resultCacheOverrides) ResultCacheGeneration(string) uint32 { return o.generation }
+func (o resultCacheOverrides) ResultCacheFragmentDurations(string) []time.Duration {
+	if o.durations == nil {
+		return []time.Duration{24 * time.Hour, 2 * time.Hour, 15 * time.Minute}
+	}
+	return o.durations
+}
 
 type queryHandlerFunc func(context.Context, *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error)
 
@@ -37,53 +42,74 @@ func (f queryHandlerFunc) Invoke(ctx context.Context, req *queryv1.InvokeRequest
 }
 
 func TestSplitResultCacheFragments(t *testing.T) {
-	start := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC).UnixMilli()
-	end := time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC).UnixMilli()
+	start := time.Date(2026, 8, 20, 1, 45, 0, 0, time.UTC)
+	end := time.Date(2026, 8, 20, 4, 14, 59, 999000000, time.UTC)
 
-	fragments := splitResultCacheFragments(start, end)
+	fragments := splitResultCacheFragments(start.UnixMilli(), end.UnixMilli(), []time.Duration{2 * time.Hour, 15 * time.Minute})
 	require.Len(t, fragments, 3)
-	require.False(t, fragments[0].full)
-	require.True(t, fragments[1].full)
-	require.False(t, fragments[2].full)
-	require.Equal(t, time.Date(2026, 8, 20, 23, 59, 59, 999000000, time.UTC).UnixMilli(), fragments[0].end)
-	require.Equal(t, time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC).UnixMilli(), fragments[1].start)
-	require.Equal(t, time.Date(2026, 8, 21, 23, 59, 59, 999000000, time.UTC).UnixMilli(), fragments[1].end)
+	require.Equal(t, 15*time.Minute, fragments[0].duration)
+	require.Equal(t, 2*time.Hour, fragments[1].duration)
+	require.Equal(t, 15*time.Minute, fragments[2].duration)
+	require.Equal(t, start.UnixMilli(), fragments[0].start)
+	require.Equal(t, time.Date(2026, 8, 20, 2, 0, 0, 0, time.UTC).UnixMilli(), fragments[1].start)
+	require.Equal(t, end.UnixMilli(), fragments[2].end)
+
+	unaligned := splitResultCacheFragments(start.Add(2*time.Minute).UnixMilli(), end.Add(-2*time.Minute).UnixMilli(), []time.Duration{2 * time.Hour, 15 * time.Minute})
+	require.Len(t, unaligned, 3)
+	require.Zero(t, unaligned[0].duration)
+	require.Equal(t, 2*time.Hour, unaligned[1].duration)
+	require.Zero(t, unaligned[2].duration)
+
+	beforeEpoch := splitResultCacheFragments(-time.Millisecond.Milliseconds(), (15*time.Minute - time.Millisecond).Milliseconds(), []time.Duration{15 * time.Minute})
+	require.Len(t, beforeEpoch, 2)
+	require.Equal(t, int64(-1), beforeEpoch[0].start)
+	require.Equal(t, int64(-1), beforeEpoch[0].end)
+	require.Zero(t, beforeEpoch[0].duration)
+	require.Equal(t, int64(0), beforeEpoch[1].start)
+	require.Equal(t, 15*time.Minute, beforeEpoch[1].duration)
 }
 
-func TestStableResultCacheDay(t *testing.T) {
-	end := time.Date(2026, 8, 20, 23, 59, 59, 999000000, time.UTC).UnixMilli()
-	boundary := time.Date(2026, 8, 21, 2, 0, 0, 0, time.UTC)
-	require.False(t, stableResultCacheDay(end, boundary.Add(-time.Nanosecond), time.Hour))
-	require.True(t, stableResultCacheDay(end, boundary, time.Hour))
-	require.False(t, stableResultCacheDay(end, boundary, 0))
-}
-
-func TestResultCacheKeyIgnoresTime(t *testing.T) {
+func TestResultCacheKeyIncludesTimeAndBlocks(t *testing.T) {
 	query := &queryv1.QueryRequest{
 		StartTime:     time.Date(2026, 8, 21, 0, 0, 0, 0, time.UTC).UnixMilli(),
 		EndTime:       time.Date(2026, 8, 21, 23, 59, 59, 999000000, time.UTC).UnixMilli(),
 		LabelSelector: `{service_name="api"}`,
 		Query:         []*queryv1.Query{{QueryType: queryv1.QueryType_QUERY_LABEL_NAMES, LabelNames: &queryv1.LabelNamesQuery{}}},
 	}
-	key, err := resultCacheKey("tenant-a", 1, query)
+	identity := resultCacheIdentity(query, []*metastorev1.BlockMeta{{Id: "block-b"}, {Id: "block-a"}})
+	key, err := resultCacheKey("tenant-a", 1, 24*time.Hour, identity)
 	require.NoError(t, err)
+	require.Equal(t, []string{"block-a", "block-b"}, identity.BlockIds)
+	require.Contains(t, key, "result-cache/tenant-a/24h/0001-")
+
+	otherBlocksKey, err := resultCacheKey("tenant-a", 1, 24*time.Hour, resultCacheIdentity(query, []*metastorev1.BlockMeta{{Id: "block-a"}, {Id: "block-c"}}))
+	require.NoError(t, err)
+	require.NotEqual(t, key, otherBlocksKey)
+
+	otherDurationKey, err := resultCacheKey("tenant-a", 1, 2*time.Hour, identity)
+	require.NoError(t, err)
+	require.Contains(t, otherDurationKey, "result-cache/tenant-a/2h/0001-")
+	require.NotEqual(t, key, otherDurationKey)
+
+	otherDay := query.CloneVT()
+	otherDay.StartTime += 24 * 60 * 60 * 1000
+	otherDay.EndTime += 24 * 60 * 60 * 1000
+	otherDayKey, err := resultCacheKey("tenant-a", 1, 24*time.Hour, resultCacheIdentity(otherDay, []*metastorev1.BlockMeta{{Id: "block-b"}, {Id: "block-a"}}))
+	require.NoError(t, err)
+	require.NotEqual(t, key, otherDayKey)
+
 	query.StartTime += 24 * 60 * 60 * 1000
 	query.EndTime += 24 * 60 * 60 * 1000
-	otherDayKey, err := resultCacheKey("tenant-a", 1, query)
-	require.NoError(t, err)
-	require.Contains(t, key, "result-cache/tenant-a/0001-2026-08-21-")
-	require.NotEqual(t, key, otherDayKey)
-	require.Equal(t, key[len(key)-64:], otherDayKey[len(otherDayKey)-64:])
 
 	labelValues := query.CloneVT()
 	labelValues.Query[0] = &queryv1.Query{
 		QueryType:   queryv1.QueryType_QUERY_LABEL_VALUES,
 		LabelValues: &queryv1.LabelValuesQuery{LabelName: "service_name"},
 	}
-	labelValuesKey, err := resultCacheKey("tenant-a", 1, labelValues)
+	labelValuesKey, err := resultCacheKey("tenant-a", 1, 24*time.Hour, resultCacheIdentity(labelValues, nil))
 	require.NoError(t, err)
 	labelValues.Query[0].LabelValues.LabelName = "cluster"
-	otherLabelValuesKey, err := resultCacheKey("tenant-a", 1, labelValues)
+	otherLabelValuesKey, err := resultCacheKey("tenant-a", 1, 24*time.Hour, resultCacheIdentity(labelValues, nil))
 	require.NoError(t, err)
 	require.NotEqual(t, key, labelValuesKey)
 	require.NotEqual(t, labelValuesKey, otherLabelValuesKey)
@@ -101,9 +127,9 @@ func TestResultCacheKeyIgnoresTime(t *testing.T) {
 	seriesLabels.Query[0].SeriesLabels.LabelNames = []string{"cluster", "service_name"}
 	otherSeriesLabelsQuery, err := cacheQuery(seriesLabels, query.StartTime, query.EndTime)
 	require.NoError(t, err)
-	seriesLabelsKey, err := resultCacheKey("tenant-a", 1, seriesLabelsQuery)
+	seriesLabelsKey, err := resultCacheKey("tenant-a", 1, 24*time.Hour, resultCacheIdentity(seriesLabelsQuery, nil))
 	require.NoError(t, err)
-	otherSeriesLabelsKey, err := resultCacheKey("tenant-a", 1, otherSeriesLabelsQuery)
+	otherSeriesLabelsKey, err := resultCacheKey("tenant-a", 1, 24*time.Hour, resultCacheIdentity(otherSeriesLabelsQuery, nil))
 	require.NoError(t, err)
 	require.Equal(t, seriesLabelsKey, otherSeriesLabelsKey)
 }
@@ -121,8 +147,8 @@ func TestReadResultCache(t *testing.T) {
 	bucket := phlareobjstore.NewBucket(thanobjstore.NewInMemBucket())
 	q := &QueryBackend{resultCacheBucket: bucket, resultCacheMetrics: newResultCacheMetrics(prometheus.NewRegistry())}
 	request := &queryv1.InvokeRequest{Query: []*queryv1.Query{{QueryType: queryv1.QueryType_QUERY_LABEL_NAMES, LabelNames: &queryv1.LabelNamesQuery{}}}}
-	expected := &queryv1.QueryRequest{StartTime: 1, EndTime: 2, Query: request.Query}
-	entry := &queryv1.ResultCacheEntry{Query: expected.CloneVT(), Reports: []*queryv1.Report{{
+	expected := &queryv1.ResultCacheKey{Query: &queryv1.QueryRequest{StartTime: 1, EndTime: 2, Query: request.Query}, BlockIds: []string{"block-a"}}
+	entry := &queryv1.ResultCacheEntry{Key: expected.CloneVT(), Reports: []*queryv1.Report{{
 		ReportType: queryv1.ReportType_REPORT_LABEL_NAMES,
 		LabelNames: &queryv1.LabelNamesReport{Query: &queryv1.LabelNamesQuery{}, LabelNames: []string{"cluster", "service_name"}},
 	}}}
@@ -131,16 +157,16 @@ func TestReadResultCache(t *testing.T) {
 	require.NoError(t, bucket.Upload(context.Background(), "entry", bytes.NewReader(data)))
 
 	aggregator := newAggregator(request)
-	hit, err := q.readResultCache(context.Background(), resultCacheLabelNames, "entry", expected, aggregator)
+	hit, err := q.readResultCache(context.Background(), resultCacheLabelNames, "24h", "entry", expected, aggregator)
 	require.NoError(t, err)
 	require.True(t, hit)
 	require.Equal(t, []string{"cluster", "service_name"}, aggregator.response().Reports[0].LabelNames.LabelNames)
 
-	entry.Query.EndTime = 3
+	entry.Key.BlockIds[0] = "block-b"
 	data, err = proto.Marshal(entry)
 	require.NoError(t, err)
 	require.NoError(t, bucket.Upload(context.Background(), "collision", bytes.NewReader(data)))
-	hit, err = q.readResultCache(context.Background(), resultCacheLabelNames, "collision", expected, newAggregator(request))
+	hit, err = q.readResultCache(context.Background(), resultCacheLabelNames, "24h", "collision", expected, newAggregator(request))
 	require.Error(t, err)
 	require.False(t, hit)
 }
@@ -149,7 +175,7 @@ func TestCoordinateResultCacheHitDoesNotExecutePlan(t *testing.T) {
 	bucket := phlareobjstore.NewBucket(thanobjstore.NewInMemBucket())
 	q := &QueryBackend{
 		resultCacheBucket:    bucket,
-		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 7, window: time.Hour},
+		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 7},
 		resultCacheMetrics:   newResultCacheMetrics(prometheus.NewRegistry()),
 		now:                  func() time.Time { return time.Date(2026, 8, 23, 3, 0, 0, 0, time.UTC) },
 	}
@@ -164,9 +190,10 @@ func TestCoordinateResultCacheHitDoesNotExecutePlan(t *testing.T) {
 	}
 	query, err := cacheQuery(req, start, end)
 	require.NoError(t, err)
-	key, err := resultCacheKey("tenant-a", 7, query)
+	identity := resultCacheIdentity(query, nil)
+	key, err := resultCacheKey("tenant-a", 7, 24*time.Hour, identity)
 	require.NoError(t, err)
-	data, err := proto.Marshal(&queryv1.ResultCacheEntry{Query: query, Reports: []*queryv1.Report{{
+	data, err := proto.Marshal(&queryv1.ResultCacheEntry{Key: identity, Reports: []*queryv1.Report{{
 		ReportType: queryv1.ReportType_REPORT_LABEL_NAMES,
 		LabelNames: &queryv1.LabelNamesReport{Query: &queryv1.LabelNamesQuery{}, LabelNames: []string{"cluster"}},
 	}}})
@@ -177,14 +204,14 @@ func TestCoordinateResultCacheHitDoesNotExecutePlan(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"cluster"}, resp.Reports[0].LabelNames.LabelNames)
 	require.Zero(t, resp.Diagnostics.ExecutionNode.Stats.BytesFetched)
-	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelNames, "hit")))
+	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelNames, "24h", "hit")))
 }
 
 func TestCoordinateResultCacheLabelValuesHitDoesNotExecutePlan(t *testing.T) {
 	bucket := phlareobjstore.NewBucket(thanobjstore.NewInMemBucket())
 	q := &QueryBackend{
 		resultCacheBucket:    bucket,
-		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 7, window: time.Hour},
+		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 7},
 		resultCacheMetrics:   newResultCacheMetrics(prometheus.NewRegistry()),
 		now:                  func() time.Time { return time.Date(2026, 8, 23, 3, 0, 0, 0, time.UTC) },
 	}
@@ -202,9 +229,10 @@ func TestCoordinateResultCacheLabelValuesHitDoesNotExecutePlan(t *testing.T) {
 	}
 	query, err := cacheQuery(req, start, end)
 	require.NoError(t, err)
-	key, err := resultCacheKey("tenant-a", 7, query)
+	identity := resultCacheIdentity(query, nil)
+	key, err := resultCacheKey("tenant-a", 7, 24*time.Hour, identity)
 	require.NoError(t, err)
-	data, err := proto.Marshal(&queryv1.ResultCacheEntry{Query: query, Reports: []*queryv1.Report{{
+	data, err := proto.Marshal(&queryv1.ResultCacheEntry{Key: identity, Reports: []*queryv1.Report{{
 		ReportType: queryv1.ReportType_REPORT_LABEL_VALUES,
 		LabelValues: &queryv1.LabelValuesReport{
 			Query:       &queryv1.LabelValuesQuery{LabelName: "service_name"},
@@ -218,14 +246,14 @@ func TestCoordinateResultCacheLabelValuesHitDoesNotExecutePlan(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"api", "worker"}, resp.Reports[0].LabelValues.LabelValues)
 	require.Zero(t, resp.Diagnostics.ExecutionNode.Stats.BytesFetched)
-	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelValues, "hit")))
+	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelValues, "24h", "hit")))
 }
 
 func TestCoordinateResultCacheSeriesLabelsHitDoesNotExecutePlan(t *testing.T) {
 	bucket := phlareobjstore.NewBucket(thanobjstore.NewInMemBucket())
 	q := &QueryBackend{
 		resultCacheBucket:    bucket,
-		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 7, window: time.Hour},
+		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 7},
 		resultCacheMetrics:   newResultCacheMetrics(prometheus.NewRegistry()),
 		now:                  func() time.Time { return time.Date(2026, 8, 23, 3, 0, 0, 0, time.UTC) },
 	}
@@ -243,9 +271,10 @@ func TestCoordinateResultCacheSeriesLabelsHitDoesNotExecutePlan(t *testing.T) {
 	}
 	query, err := cacheQuery(req, start, end)
 	require.NoError(t, err)
-	key, err := resultCacheKey("tenant-a", 7, query)
+	identity := resultCacheIdentity(query, nil)
+	key, err := resultCacheKey("tenant-a", 7, 24*time.Hour, identity)
 	require.NoError(t, err)
-	data, err := proto.Marshal(&queryv1.ResultCacheEntry{Query: query, Reports: []*queryv1.Report{{
+	data, err := proto.Marshal(&queryv1.ResultCacheEntry{Key: identity, Reports: []*queryv1.Report{{
 		ReportType: queryv1.ReportType_REPORT_SERIES_LABELS,
 		SeriesLabels: &queryv1.SeriesLabelsReport{
 			Query: query.Query[0].SeriesLabels,
@@ -262,7 +291,107 @@ func TestCoordinateResultCacheSeriesLabelsHitDoesNotExecutePlan(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resp.Reports[0].SeriesLabels.SeriesLabels, 1)
 	require.Zero(t, resp.Diagnostics.ExecutionNode.Stats.BytesFetched)
-	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheSeriesLabels, "hit")))
+	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheSeriesLabels, "24h", "hit")))
+}
+
+func TestCoordinateResultCacheDoesNotCacheSmallestRecentFragment(t *testing.T) {
+	bucket := phlareobjstore.NewBucket(thanobjstore.NewInMemBucket())
+	start := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+	end := start.Add(30*time.Minute - time.Millisecond)
+	blockReader := queryHandlerFunc(func(_ context.Context, req *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error) {
+		return &queryv1.InvokeResponse{
+			Reports: []*queryv1.Report{{
+				ReportType: queryv1.ReportType_REPORT_LABEL_NAMES,
+				LabelNames: &queryv1.LabelNamesReport{Query: req.Query[0].LabelNames.CloneVT(), LabelNames: []string{"service_name"}},
+			}},
+			Diagnostics: &queryv1.Diagnostics{ExecutionNode: &queryv1.ExecutionNode{Stats: &queryv1.ExecutionStats{}}},
+		}, nil
+	})
+	q := &QueryBackend{
+		blockReader:          blockReader,
+		resultCacheBucket:    bucket,
+		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 1, durations: []time.Duration{15 * time.Minute}},
+		resultCacheMetrics:   newResultCacheMetrics(prometheus.NewRegistry()),
+		now:                  func() time.Time { return end.Add(time.Millisecond) },
+	}
+	req := &queryv1.InvokeRequest{
+		Tenant:        []string{"tenant-a"},
+		StartTime:     start.UnixMilli(),
+		EndTime:       end.UnixMilli(),
+		LabelSelector: "{}",
+		Query:         []*queryv1.Query{{QueryType: queryv1.QueryType_QUERY_LABEL_NAMES, LabelNames: &queryv1.LabelNamesQuery{}}},
+		QueryPlan: &queryv1.QueryPlan{Root: &queryv1.QueryNode{Blocks: []*metastorev1.BlockMeta{{
+			Id: "block", MinTime: start.UnixMilli(), MaxTime: end.UnixMilli(),
+			Datasets: []*metastorev1.Dataset{{MinTime: start.UnixMilli(), MaxTime: end.UnixMilli()}},
+		}}}},
+	}
+
+	resp, err := q.Invoke(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, []string{"service_name"}, resp.Reports[0].LabelNames.LabelNames)
+	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelNames, "15m", "miss")))
+	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.writes.WithLabelValues(resultCacheLabelNames, "15m", "dropped")))
+}
+
+func TestCoordinateResultCacheBlockSetInvalidatesEntry(t *testing.T) {
+	bucket := phlareobjstore.NewBucket(thanobjstore.NewInMemBucket())
+	start := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+	end := start.Add(15*time.Minute - time.Millisecond)
+	block := func(id string) *metastorev1.BlockMeta {
+		return &metastorev1.BlockMeta{
+			Id: id, MinTime: start.UnixMilli(), MaxTime: end.UnixMilli(),
+			Datasets: []*metastorev1.Dataset{{MinTime: start.UnixMilli(), MaxTime: end.UnixMilli()}},
+		}
+	}
+	query := &queryv1.QueryRequest{
+		StartTime: start.UnixMilli(), EndTime: end.UnixMilli(), LabelSelector: "{}",
+		Query: []*queryv1.Query{{QueryType: queryv1.QueryType_QUERY_LABEL_NAMES, LabelNames: &queryv1.LabelNamesQuery{}}},
+	}
+	identity := resultCacheIdentity(query, []*metastorev1.BlockMeta{block("block-a")})
+	key, err := resultCacheKey("tenant-a", 1, 15*time.Minute, identity)
+	require.NoError(t, err)
+	data, err := proto.Marshal(&queryv1.ResultCacheEntry{Key: identity, Reports: []*queryv1.Report{{
+		ReportType: queryv1.ReportType_REPORT_LABEL_NAMES,
+		LabelNames: &queryv1.LabelNamesReport{Query: &queryv1.LabelNamesQuery{}, LabelNames: []string{"cached"}},
+	}}})
+	require.NoError(t, err)
+	require.NoError(t, bucket.Upload(context.Background(), key, bytes.NewReader(data)))
+
+	calls := 0
+	q := &QueryBackend{
+		blockReader: queryHandlerFunc(func(_ context.Context, req *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error) {
+			calls++
+			return &queryv1.InvokeResponse{
+				Reports: []*queryv1.Report{{
+					ReportType: queryv1.ReportType_REPORT_LABEL_NAMES,
+					LabelNames: &queryv1.LabelNamesReport{Query: req.Query[0].LabelNames.CloneVT(), LabelNames: []string{"fresh"}},
+				}},
+				Diagnostics: &queryv1.Diagnostics{ExecutionNode: &queryv1.ExecutionNode{Stats: &queryv1.ExecutionStats{}}},
+			}, nil
+		}),
+		resultCacheBucket:    bucket,
+		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 1, durations: []time.Duration{15 * time.Minute}},
+		resultCacheMetrics:   newResultCacheMetrics(prometheus.NewRegistry()),
+		now:                  func() time.Time { return end.Add(30 * time.Minute) },
+	}
+	req := &queryv1.InvokeRequest{
+		Tenant: []string{"tenant-a"}, StartTime: start.UnixMilli(), EndTime: end.UnixMilli(), LabelSelector: "{}",
+		Query:     query.Query,
+		QueryPlan: &queryv1.QueryPlan{Root: &queryv1.QueryNode{Blocks: []*metastorev1.BlockMeta{block("block-a")}}},
+	}
+
+	resp, err := q.Invoke(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, []string{"cached"}, resp.Reports[0].LabelNames.LabelNames)
+	require.Zero(t, calls)
+
+	req.QueryPlan.Root.Blocks = append(req.QueryPlan.Root.Blocks, block("block-b"))
+	resp, err = q.Invoke(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, []string{"fresh"}, resp.Reports[0].LabelNames.LabelNames)
+	require.Equal(t, 1, calls)
+	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelNames, "15m", "hit")))
+	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelNames, "15m", "miss")))
 }
 
 func TestCoordinateResultCacheLimitsConcurrentColdFragments(t *testing.T) {
@@ -309,7 +438,7 @@ func TestCoordinateResultCacheLimitsConcurrentColdFragments(t *testing.T) {
 	q := &QueryBackend{
 		blockReader:          blockReader,
 		resultCacheBucket:    phlareobjstore.NewBucket(thanobjstore.NewInMemBucket()),
-		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 1, window: time.Hour},
+		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 1, durations: []time.Duration{24 * time.Hour}},
 		resultCacheMetrics:   newResultCacheMetrics(prometheus.NewRegistry()),
 		now:                  func() time.Time { return end.Add(48 * time.Hour) },
 	}
@@ -357,7 +486,7 @@ func TestCoordinateResultCacheLimitsConcurrentColdFragments(t *testing.T) {
 func TestResultCacheEligibility(t *testing.T) {
 	q := &QueryBackend{
 		resultCacheBucket:    phlareobjstore.NewBucket(thanobjstore.NewInMemBucket()),
-		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 1, window: time.Hour},
+		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 1},
 	}
 	req := &queryv1.InvokeRequest{
 		Tenant: []string{"tenant-a"},

--- a/pkg/querybackend/result_cache_test.go
+++ b/pkg/querybackend/result_cache_test.go
@@ -1,15 +1,17 @@
 package querybackend
 
 import (
-	"bytes"
 	"context"
 	"sync"
 	"testing"
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/alicebob/miniredis/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	promtest "github.com/prometheus/client_golang/prometheus/testutil"
+	prommodel "github.com/prometheus/common/model"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 	thanobjstore "github.com/thanos-io/objstore"
 	"google.golang.org/protobuf/proto"
@@ -17,23 +19,86 @@ import (
 	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	phlaremodel "github.com/grafana/pyroscope/v2/pkg/model"
 	phlareobjstore "github.com/grafana/pyroscope/v2/pkg/objstore"
 )
 
 type resultCacheOverrides struct {
 	enabled                             bool
 	generation                          uint32
-	durations                           []time.Duration
+	fragments                           []phlaremodel.ResultCacheFragment
 	metadataServiceNameMinQueryDuration time.Duration
 }
 
 func (o resultCacheOverrides) ResultCacheEnabled(string) bool      { return o.enabled }
 func (o resultCacheOverrides) ResultCacheGeneration(string) uint32 { return o.generation }
-func (o resultCacheOverrides) ResultCacheFragmentDurations(string) []time.Duration {
-	if o.durations == nil {
-		return []time.Duration{24 * time.Hour, 2 * time.Hour, 15 * time.Minute}
+func (o resultCacheOverrides) ResultCacheFragments(string) []phlaremodel.ResultCacheFragment {
+	if o.fragments == nil {
+		return defaultResultCacheFragments()
 	}
-	return o.durations
+	return o.fragments
+}
+
+func defaultResultCacheFragments() []phlaremodel.ResultCacheFragment {
+	return []phlaremodel.ResultCacheFragment{
+		{Duration: modelDuration(24 * time.Hour), TTL: modelDuration(48 * time.Hour)},
+		{Duration: modelDuration(2 * time.Hour), TTL: modelDuration(24 * time.Hour)},
+		{Duration: modelDuration(15 * time.Minute), TTL: modelDuration(24 * time.Hour)},
+	}
+}
+
+func modelDuration(duration time.Duration) prommodel.Duration {
+	return prommodel.Duration(duration)
+}
+
+func newTestResultCacheStore(t *testing.T) ResultCacheStore {
+	t.Helper()
+	server, err := miniredis.Run()
+	require.NoError(t, err)
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	store := NewResultCacheStore(phlareobjstore.NewBucket(thanobjstore.NewInMemBucket()), client)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+		server.Close()
+	})
+	return store
+}
+
+func TestResultCacheStoreRoutesInlineAndObjectEntries(t *testing.T) {
+	server, err := miniredis.Run()
+	require.NoError(t, err)
+	defer server.Close()
+	client := redis.NewClient(&redis.Options{Addr: server.Addr()})
+	bucket := phlareobjstore.NewBucket(thanobjstore.NewInMemBucket())
+	store := NewResultCacheStore(bucket, client)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	inline := make([]byte, resultCacheRedisMaxValueSize-1)
+	tier, err := store.Put(context.Background(), "inline", inline, 24*time.Hour)
+	require.NoError(t, err)
+	require.Equal(t, "redis", tier)
+	record, err := client.Get(context.Background(), resultCacheRedisKeyPrefix+"inline").Bytes()
+	require.NoError(t, err)
+	require.Equal(t, resultCacheRedisRecordInline, record[0])
+	exists, err := bucket.Exists(context.Background(), "inline")
+	require.NoError(t, err)
+	require.False(t, exists)
+	require.Equal(t, 24*time.Hour, server.TTL(resultCacheRedisKeyPrefix+"inline"))
+
+	object := make([]byte, resultCacheRedisMaxValueSize)
+	tier, err = store.Put(context.Background(), "object", object, 48*time.Hour)
+	require.NoError(t, err)
+	require.Equal(t, "object", tier)
+	record, err = client.Get(context.Background(), resultCacheRedisKeyPrefix+"object").Bytes()
+	require.NoError(t, err)
+	require.Equal(t, []byte{resultCacheRedisRecordObject}, record)
+	exists, err = bucket.Exists(context.Background(), "object")
+	require.NoError(t, err)
+	require.True(t, exists)
+	got, tier, err := store.Get(context.Background(), "object")
+	require.NoError(t, err)
+	require.Equal(t, "object", tier)
+	require.Equal(t, object, got)
 }
 func (o resultCacheOverrides) ResultCacheMetadataServiceNameMinQueryDuration(string) time.Duration {
 	return o.metadataServiceNameMinQueryDuration
@@ -45,11 +110,81 @@ func (f queryHandlerFunc) Invoke(ctx context.Context, req *queryv1.InvokeRequest
 	return f(ctx, req)
 }
 
+type resultCacheStoreFunc struct {
+	get func(context.Context, string) ([]byte, string, error)
+}
+
+func (s resultCacheStoreFunc) Get(ctx context.Context, key string) ([]byte, string, error) {
+	return s.get(ctx, key)
+}
+
+func (resultCacheStoreFunc) Put(context.Context, string, []byte, time.Duration) (string, error) {
+	return "redis", nil
+}
+
+func (resultCacheStoreFunc) Close() error { return nil }
+
+func TestResultCacheLookupBudgetRetainsCompletedHits(t *testing.T) {
+	start := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+	fragmentDuration := 15 * time.Minute
+	block := &metastorev1.BlockMeta{
+		Id: "block", MinTime: start.UnixMilli(), MaxTime: start.Add(2*fragmentDuration - time.Millisecond).UnixMilli(),
+		Datasets: []*metastorev1.Dataset{{MinTime: start.UnixMilli(), MaxTime: start.Add(2*fragmentDuration - time.Millisecond).UnixMilli()}},
+	}
+	query := &queryv1.QueryRequest{
+		StartTime: start.UnixMilli(), EndTime: start.Add(fragmentDuration - time.Millisecond).UnixMilli(), LabelSelector: "{}",
+		Query: []*queryv1.Query{{QueryType: queryv1.QueryType_QUERY_LABEL_NAMES, LabelNames: &queryv1.LabelNamesQuery{}}},
+	}
+	identity := resultCacheIdentity(query, []*metastorev1.BlockMeta{block})
+	hitKey, err := resultCacheKey("tenant-a", 1, fragmentDuration, identity)
+	require.NoError(t, err)
+	hitData, err := proto.Marshal(&queryv1.ResultCacheEntry{Key: identity, Reports: []*queryv1.Report{{
+		ReportType: queryv1.ReportType_REPORT_LABEL_NAMES,
+		LabelNames: &queryv1.LabelNamesReport{Query: &queryv1.LabelNamesQuery{}, LabelNames: []string{"cached"}},
+	}}})
+	require.NoError(t, err)
+
+	calls := 0
+	q := &QueryBackend{
+		blockReader: queryHandlerFunc(func(_ context.Context, req *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error) {
+			calls++
+			return &queryv1.InvokeResponse{Reports: []*queryv1.Report{{
+				ReportType: queryv1.ReportType_REPORT_LABEL_NAMES,
+				LabelNames: &queryv1.LabelNamesReport{Query: req.Query[0].LabelNames.CloneVT(), LabelNames: []string{"fresh"}},
+			}}}, nil
+		}),
+		resultCacheStore: resultCacheStoreFunc{get: func(ctx context.Context, key string) ([]byte, string, error) {
+			if key == hitKey {
+				return hitData, "redis", nil
+			}
+			<-ctx.Done()
+			return nil, "redis", ctx.Err()
+		}},
+		resultCacheOverrides:     resultCacheOverrides{enabled: true, generation: 1, fragments: defaultResultCacheFragments()[2:]},
+		resultCacheLookupTimeout: 25 * time.Millisecond,
+		resultCacheMetrics:       newResultCacheMetrics(prometheus.NewRegistry()),
+		now:                      func() time.Time { return start.Add(24 * time.Hour) },
+	}
+	resp, err := q.Invoke(context.Background(), &queryv1.InvokeRequest{
+		Tenant:        []string{"tenant-a"},
+		StartTime:     start.UnixMilli(),
+		EndTime:       start.Add(2*fragmentDuration - time.Millisecond).UnixMilli(),
+		LabelSelector: "{}",
+		Query:         query.Query,
+		QueryPlan:     &queryv1.QueryPlan{Root: &queryv1.QueryNode{Blocks: []*metastorev1.BlockMeta{block}}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"cached", "fresh"}, resp.Reports[0].LabelNames.LabelNames)
+	require.Equal(t, 1, calls)
+	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelNames, "15m", "redis", "hit")))
+	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelNames, "15m", "unknown", "timeout")))
+}
+
 func TestSplitResultCacheFragments(t *testing.T) {
 	start := time.Date(2026, 8, 20, 1, 45, 0, 0, time.UTC)
 	end := time.Date(2026, 8, 20, 4, 14, 59, 999000000, time.UTC)
 
-	fragments := splitResultCacheFragments(start.UnixMilli(), end.UnixMilli(), []time.Duration{2 * time.Hour, 15 * time.Minute})
+	fragments := splitResultCacheFragments(start.UnixMilli(), end.UnixMilli(), defaultResultCacheFragments()[1:])
 	require.Len(t, fragments, 3)
 	require.Equal(t, 15*time.Minute, fragments[0].duration)
 	require.Equal(t, 2*time.Hour, fragments[1].duration)
@@ -58,13 +193,13 @@ func TestSplitResultCacheFragments(t *testing.T) {
 	require.Equal(t, time.Date(2026, 8, 20, 2, 0, 0, 0, time.UTC).UnixMilli(), fragments[1].start)
 	require.Equal(t, end.UnixMilli(), fragments[2].end)
 
-	unaligned := splitResultCacheFragments(start.Add(2*time.Minute).UnixMilli(), end.Add(-2*time.Minute).UnixMilli(), []time.Duration{2 * time.Hour, 15 * time.Minute})
+	unaligned := splitResultCacheFragments(start.Add(2*time.Minute).UnixMilli(), end.Add(-2*time.Minute).UnixMilli(), defaultResultCacheFragments()[1:])
 	require.Len(t, unaligned, 3)
 	require.Zero(t, unaligned[0].duration)
 	require.Equal(t, 2*time.Hour, unaligned[1].duration)
 	require.Zero(t, unaligned[2].duration)
 
-	beforeEpoch := splitResultCacheFragments(-time.Millisecond.Milliseconds(), (15*time.Minute - time.Millisecond).Milliseconds(), []time.Duration{15 * time.Minute})
+	beforeEpoch := splitResultCacheFragments(-time.Millisecond.Milliseconds(), (15*time.Minute - time.Millisecond).Milliseconds(), defaultResultCacheFragments()[2:])
 	require.Len(t, beforeEpoch, 2)
 	require.Equal(t, int64(-1), beforeEpoch[0].start)
 	require.Equal(t, int64(-1), beforeEpoch[0].end)
@@ -148,8 +283,8 @@ func TestCanonicalResultCacheSelector(t *testing.T) {
 }
 
 func TestReadResultCache(t *testing.T) {
-	bucket := phlareobjstore.NewBucket(thanobjstore.NewInMemBucket())
-	q := &QueryBackend{resultCacheBucket: bucket, resultCacheMetrics: newResultCacheMetrics(prometheus.NewRegistry())}
+	store := newTestResultCacheStore(t)
+	q := &QueryBackend{resultCacheStore: store, resultCacheMetrics: newResultCacheMetrics(prometheus.NewRegistry())}
 	request := &queryv1.InvokeRequest{Query: []*queryv1.Query{{QueryType: queryv1.QueryType_QUERY_LABEL_NAMES, LabelNames: &queryv1.LabelNamesQuery{}}}}
 	expected := &queryv1.ResultCacheKey{Query: &queryv1.QueryRequest{StartTime: 1, EndTime: 2, Query: request.Query}, BlockIds: []string{"block-a"}}
 	entry := &queryv1.ResultCacheEntry{Key: expected.CloneVT(), Reports: []*queryv1.Report{{
@@ -158,7 +293,8 @@ func TestReadResultCache(t *testing.T) {
 	}}}
 	data, err := proto.Marshal(entry)
 	require.NoError(t, err)
-	require.NoError(t, bucket.Upload(context.Background(), "entry", bytes.NewReader(data)))
+	_, err = store.Put(context.Background(), "entry", data, time.Hour)
+	require.NoError(t, err)
 
 	aggregator := newAggregator(request)
 	hit, err := q.readResultCache(context.Background(), resultCacheLabelNames, "24h", "entry", expected, aggregator)
@@ -169,16 +305,17 @@ func TestReadResultCache(t *testing.T) {
 	entry.Key.BlockIds[0] = "block-b"
 	data, err = proto.Marshal(entry)
 	require.NoError(t, err)
-	require.NoError(t, bucket.Upload(context.Background(), "collision", bytes.NewReader(data)))
+	_, err = store.Put(context.Background(), "collision", data, time.Hour)
+	require.NoError(t, err)
 	hit, err = q.readResultCache(context.Background(), resultCacheLabelNames, "24h", "collision", expected, newAggregator(request))
 	require.Error(t, err)
 	require.False(t, hit)
 }
 
 func TestCoordinateResultCacheHitDoesNotExecutePlan(t *testing.T) {
-	bucket := phlareobjstore.NewBucket(thanobjstore.NewInMemBucket())
+	store := newTestResultCacheStore(t)
 	q := &QueryBackend{
-		resultCacheBucket:    bucket,
+		resultCacheStore:     store,
 		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 7},
 		resultCacheMetrics:   newResultCacheMetrics(prometheus.NewRegistry()),
 		now:                  func() time.Time { return time.Date(2026, 8, 23, 3, 0, 0, 0, time.UTC) },
@@ -202,19 +339,20 @@ func TestCoordinateResultCacheHitDoesNotExecutePlan(t *testing.T) {
 		LabelNames: &queryv1.LabelNamesReport{Query: &queryv1.LabelNamesQuery{}, LabelNames: []string{"cluster"}},
 	}}})
 	require.NoError(t, err)
-	require.NoError(t, bucket.Upload(context.Background(), key, bytes.NewReader(data)))
+	_, err = store.Put(context.Background(), key, data, time.Hour)
+	require.NoError(t, err)
 
 	resp, err := q.Invoke(context.Background(), req)
 	require.NoError(t, err)
 	require.Equal(t, []string{"cluster"}, resp.Reports[0].LabelNames.LabelNames)
 	require.Zero(t, resp.Diagnostics.ExecutionNode.Stats.BytesFetched)
-	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelNames, "24h", "hit")))
+	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelNames, "24h", "redis", "hit")))
 }
 
 func TestCoordinateResultCacheLabelValuesHitDoesNotExecutePlan(t *testing.T) {
-	bucket := phlareobjstore.NewBucket(thanobjstore.NewInMemBucket())
+	store := newTestResultCacheStore(t)
 	q := &QueryBackend{
-		resultCacheBucket:    bucket,
+		resultCacheStore:     store,
 		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 7},
 		resultCacheMetrics:   newResultCacheMetrics(prometheus.NewRegistry()),
 		now:                  func() time.Time { return time.Date(2026, 8, 23, 3, 0, 0, 0, time.UTC) },
@@ -244,19 +382,20 @@ func TestCoordinateResultCacheLabelValuesHitDoesNotExecutePlan(t *testing.T) {
 		},
 	}}})
 	require.NoError(t, err)
-	require.NoError(t, bucket.Upload(context.Background(), key, bytes.NewReader(data)))
+	_, err = store.Put(context.Background(), key, data, time.Hour)
+	require.NoError(t, err)
 
 	resp, err := q.Invoke(context.Background(), req)
 	require.NoError(t, err)
 	require.Equal(t, []string{"api", "worker"}, resp.Reports[0].LabelValues.LabelValues)
 	require.Zero(t, resp.Diagnostics.ExecutionNode.Stats.BytesFetched)
-	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelValues, "24h", "hit")))
+	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelValues, "24h", "redis", "hit")))
 }
 
 func TestCoordinateResultCacheSeriesLabelsHitDoesNotExecutePlan(t *testing.T) {
-	bucket := phlareobjstore.NewBucket(thanobjstore.NewInMemBucket())
+	store := newTestResultCacheStore(t)
 	q := &QueryBackend{
-		resultCacheBucket:    bucket,
+		resultCacheStore:     store,
 		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 7},
 		resultCacheMetrics:   newResultCacheMetrics(prometheus.NewRegistry()),
 		now:                  func() time.Time { return time.Date(2026, 8, 23, 3, 0, 0, 0, time.UTC) },
@@ -289,17 +428,18 @@ func TestCoordinateResultCacheSeriesLabelsHitDoesNotExecutePlan(t *testing.T) {
 		},
 	}}})
 	require.NoError(t, err)
-	require.NoError(t, bucket.Upload(context.Background(), key, bytes.NewReader(data)))
+	_, err = store.Put(context.Background(), key, data, time.Hour)
+	require.NoError(t, err)
 
 	resp, err := q.Invoke(context.Background(), req)
 	require.NoError(t, err)
 	require.Len(t, resp.Reports[0].SeriesLabels.SeriesLabels, 1)
 	require.Zero(t, resp.Diagnostics.ExecutionNode.Stats.BytesFetched)
-	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheSeriesLabels, "24h", "hit")))
+	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheSeriesLabels, "24h", "redis", "hit")))
 }
 
 func TestCoordinateResultCacheDoesNotCacheSmallestRecentFragment(t *testing.T) {
-	bucket := phlareobjstore.NewBucket(thanobjstore.NewInMemBucket())
+	store := newTestResultCacheStore(t)
 	start := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
 	end := start.Add(30*time.Minute - time.Millisecond)
 	blockReader := queryHandlerFunc(func(_ context.Context, req *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error) {
@@ -313,8 +453,8 @@ func TestCoordinateResultCacheDoesNotCacheSmallestRecentFragment(t *testing.T) {
 	})
 	q := &QueryBackend{
 		blockReader:          blockReader,
-		resultCacheBucket:    bucket,
-		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 1, durations: []time.Duration{15 * time.Minute}},
+		resultCacheStore:     store,
+		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 1, fragments: defaultResultCacheFragments()[2:]},
 		resultCacheMetrics:   newResultCacheMetrics(prometheus.NewRegistry()),
 		now:                  func() time.Time { return end.Add(time.Millisecond) },
 	}
@@ -333,12 +473,12 @@ func TestCoordinateResultCacheDoesNotCacheSmallestRecentFragment(t *testing.T) {
 	resp, err := q.Invoke(context.Background(), req)
 	require.NoError(t, err)
 	require.Equal(t, []string{"service_name"}, resp.Reports[0].LabelNames.LabelNames)
-	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelNames, "15m", "miss")))
-	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.writes.WithLabelValues(resultCacheLabelNames, "15m", "dropped")))
+	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelNames, "15m", "redis", "miss")))
+	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.writes.WithLabelValues(resultCacheLabelNames, "15m", "unknown", "dropped")))
 }
 
 func TestCoordinateResultCacheBlockSetInvalidatesEntry(t *testing.T) {
-	bucket := phlareobjstore.NewBucket(thanobjstore.NewInMemBucket())
+	store := newTestResultCacheStore(t)
 	start := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
 	end := start.Add(15*time.Minute - time.Millisecond)
 	block := func(id string) *metastorev1.BlockMeta {
@@ -359,7 +499,8 @@ func TestCoordinateResultCacheBlockSetInvalidatesEntry(t *testing.T) {
 		LabelNames: &queryv1.LabelNamesReport{Query: &queryv1.LabelNamesQuery{}, LabelNames: []string{"cached"}},
 	}}})
 	require.NoError(t, err)
-	require.NoError(t, bucket.Upload(context.Background(), key, bytes.NewReader(data)))
+	_, err = store.Put(context.Background(), key, data, time.Hour)
+	require.NoError(t, err)
 
 	calls := 0
 	q := &QueryBackend{
@@ -373,8 +514,8 @@ func TestCoordinateResultCacheBlockSetInvalidatesEntry(t *testing.T) {
 				Diagnostics: &queryv1.Diagnostics{ExecutionNode: &queryv1.ExecutionNode{Stats: &queryv1.ExecutionStats{}}},
 			}, nil
 		}),
-		resultCacheBucket:    bucket,
-		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 1, durations: []time.Duration{15 * time.Minute}},
+		resultCacheStore:     store,
+		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 1, fragments: defaultResultCacheFragments()[2:]},
 		resultCacheMetrics:   newResultCacheMetrics(prometheus.NewRegistry()),
 		now:                  func() time.Time { return end.Add(30 * time.Minute) },
 	}
@@ -394,8 +535,8 @@ func TestCoordinateResultCacheBlockSetInvalidatesEntry(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"fresh"}, resp.Reports[0].LabelNames.LabelNames)
 	require.Equal(t, 1, calls)
-	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelNames, "15m", "hit")))
-	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelNames, "15m", "miss")))
+	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelNames, "15m", "redis", "hit")))
+	require.Equal(t, float64(1), promtest.ToFloat64(q.resultCacheMetrics.lookups.WithLabelValues(resultCacheLabelNames, "15m", "redis", "miss")))
 }
 
 func TestCoordinateResultCacheLimitsConcurrentColdFragments(t *testing.T) {
@@ -441,8 +582,8 @@ func TestCoordinateResultCacheLimitsConcurrentColdFragments(t *testing.T) {
 	end := start.AddDate(0, 0, fragments).Add(-time.Millisecond)
 	q := &QueryBackend{
 		blockReader:          blockReader,
-		resultCacheBucket:    phlareobjstore.NewBucket(thanobjstore.NewInMemBucket()),
-		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 1, durations: []time.Duration{24 * time.Hour}},
+		resultCacheStore:     newTestResultCacheStore(t),
+		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 1, fragments: defaultResultCacheFragments()[:1]},
 		resultCacheMetrics:   newResultCacheMetrics(prometheus.NewRegistry()),
 		now:                  func() time.Time { return end.Add(48 * time.Hour) },
 	}
@@ -489,7 +630,7 @@ func TestCoordinateResultCacheLimitsConcurrentColdFragments(t *testing.T) {
 
 func TestResultCacheEligibility(t *testing.T) {
 	q := &QueryBackend{
-		resultCacheBucket:    phlareobjstore.NewBucket(thanobjstore.NewInMemBucket()),
+		resultCacheStore:     newTestResultCacheStore(t),
 		resultCacheOverrides: resultCacheOverrides{enabled: true, generation: 1, metadataServiceNameMinQueryDuration: 7 * 24 * time.Hour},
 	}
 	req := &queryv1.InvokeRequest{

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/grafana/dskit/flagext"
+	"github.com/prometheus/common/model"
 
 	"github.com/grafana/pyroscope/v2/pkg/util/fieldcategory"
 )
@@ -217,6 +218,9 @@ func getFlagName(fl *flag.Flag) string {
 		case "*model.Duration":
 			return "duration"
 		case "*tsdb.DurationList":
+			return "comma-separated list of durations"
+		}
+		if v.Kind() == reflect.Ptr && v.Elem().Kind() == reflect.Slice && v.Elem().Type().Elem() == reflect.TypeOf(model.Duration(0)) {
 			return "comma-separated list of durations"
 		}
 	}

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -116,8 +116,10 @@ type Limits struct {
 	S3SSEKMSEncryptionContext string `yaml:"s3_sse_kms_encryption_context" json:"s3_sse_kms_encryption_context" doc:"nocli|description=S3 server-side encryption KMS encryption context. If unset and the key ID override is set, the encryption context will not be provided to S3. Ignored if the SSE type override is not set."`
 
 	// Ensure profiles are dated within the IngestionWindow of the distributor.
-	RejectOlderThan model.Duration `yaml:"reject_older_than" json:"reject_older_than"`
-	RejectNewerThan model.Duration `yaml:"reject_newer_than" json:"reject_newer_than"`
+	RejectOlderThan       model.Duration `yaml:"reject_older_than" json:"reject_older_than"`
+	RejectNewerThan       model.Duration `yaml:"reject_newer_than" json:"reject_newer_than"`
+	ResultCacheEnabled    bool           `yaml:"result_cache_enabled" json:"result_cache_enabled"`
+	ResultCacheGeneration uint           `yaml:"result_cache_generation" json:"result_cache_generation"`
 
 	// Write path overrides used in distributor.
 	WritePathOverrides writepath.Config `yaml:",inline" json:",inline"`
@@ -153,6 +155,8 @@ func (e LimitError) Error() string {
 
 // RegisterFlags adds the flags required to config this to the given FlagSet
 func (l *Limits) RegisterFlags(f *flag.FlagSet) {
+	f.BoolVar(&l.ResultCacheEnabled, "result-cache.enabled", false, "Enable query result caching. This sets the default for tenant overrides.")
+	f.UintVar(&l.ResultCacheGeneration, "result-cache.generation", 1, "Result-cache invalidation generation. This sets the default for tenant overrides.")
 	f.Float64Var(&l.IngestionRateMB, "distributor.ingestion-rate-limit-mb", 4, "Per-tenant ingestion rate limit in sample size per second. Units in MB.")
 	f.Float64Var(&l.IngestionBurstSizeMB, "distributor.ingestion-burst-size-mb", 2, "Per-tenant allowed ingestion burst size (in sample size). Units in MB. The burst size refers to the per-distributor local rate limiter, and should be set at least to the maximum profile size expected in a single push request.")
 	f.Float64Var(&l.IngestionBodyLimitMB, "distributor.ingestion-body-limit-mb", 256, "Per-tenant ingestion body size limit in MB, before decompressing. 0 to disable.")
@@ -558,6 +562,14 @@ func (o *Overrides) RejectNewerThan(tenantID string) time.Duration {
 // RejectOlderThan will ensure that profiles that are older than the return value are rejected.
 func (o *Overrides) RejectOlderThan(tenantID string) time.Duration {
 	return time.Duration(o.getOverridesForTenant(tenantID).RejectOlderThan)
+}
+
+func (o *Overrides) ResultCacheEnabled(tenantID string) bool {
+	return o.getOverridesForTenant(tenantID).ResultCacheEnabled
+}
+
+func (o *Overrides) ResultCacheGeneration(tenantID string) uint32 {
+	return uint32(o.getOverridesForTenant(tenantID).ResultCacheGeneration)
 }
 
 // QueryAnalysisEnabled can be used to disable the query analysis endpoint in the query frontend.

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -5,6 +5,9 @@ import (
 	"flag"
 	"fmt"
 	"iter"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/prometheus/common/model"
@@ -21,12 +24,61 @@ import (
 )
 
 const (
-	bytesInMB = 1048576
+	bytesInMB                       = 1048576
+	maxResultCacheFragmentDurations = 8
+	minResultCacheFragmentDuration  = 15 * time.Minute
 
 	// MinCompactorPartialBlockDeletionDelay is the minimum partial blocks deletion delay that can be configured in Mimir.
 	// Partial blocks are blocks that are not having meta file uploaded yet.
 	MinCompactorPartialBlockDeletionDelay = 4 * time.Hour
 )
+
+type DurationList []model.Duration
+
+// String returns a canonical comma-separated representation for flags and docs.
+// Whole hours and minutes omit time.Duration's trailing zero components.
+func (d *DurationList) String() string {
+	values := make([]string, len(*d))
+	for i, value := range *d {
+		duration := time.Duration(value)
+		switch {
+		case duration%time.Hour == 0:
+			values[i] = strconv.FormatInt(int64(duration/time.Hour), 10) + "h"
+		case duration%time.Minute == 0:
+			values[i] = strconv.FormatInt(int64(duration/time.Minute), 10) + "m"
+		default:
+			values[i] = duration.String()
+		}
+	}
+	return strings.Join(values, ",")
+}
+
+func (d *DurationList) Set(value string) error {
+	values := strings.Split(value, ",")
+	result := make(DurationList, 0, len(values))
+	for _, value := range values {
+		parsed, err := time.ParseDuration(strings.TrimSpace(value))
+		if err != nil {
+			return err
+		}
+		result = append(result, model.Duration(parsed))
+	}
+	*d = result
+	return nil
+}
+
+func (d *DurationList) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var values []model.Duration
+	if err := unmarshal(&values); err == nil {
+		*d = values
+		return nil
+	}
+	var value string
+	if err := unmarshal(&value); err != nil {
+		return err
+	}
+	return d.Set(value)
+}
 
 // Limits describe all the limits for tenants; can be used to describe global default
 // limits via flags, or per-tenant limits via yaml config.
@@ -116,10 +168,11 @@ type Limits struct {
 	S3SSEKMSEncryptionContext string `yaml:"s3_sse_kms_encryption_context" json:"s3_sse_kms_encryption_context" doc:"nocli|description=S3 server-side encryption KMS encryption context. If unset and the key ID override is set, the encryption context will not be provided to S3. Ignored if the SSE type override is not set."`
 
 	// Ensure profiles are dated within the IngestionWindow of the distributor.
-	RejectOlderThan       model.Duration `yaml:"reject_older_than" json:"reject_older_than"`
-	RejectNewerThan       model.Duration `yaml:"reject_newer_than" json:"reject_newer_than"`
-	ResultCacheEnabled    bool           `yaml:"result_cache_enabled" json:"result_cache_enabled"`
-	ResultCacheGeneration uint           `yaml:"result_cache_generation" json:"result_cache_generation"`
+	RejectOlderThan              model.Duration `yaml:"reject_older_than" json:"reject_older_than"`
+	RejectNewerThan              model.Duration `yaml:"reject_newer_than" json:"reject_newer_than"`
+	ResultCacheEnabled           bool           `yaml:"result_cache_enabled" json:"result_cache_enabled"`
+	ResultCacheGeneration        uint           `yaml:"result_cache_generation" json:"result_cache_generation"`
+	ResultCacheFragmentDurations DurationList   `yaml:"result_cache_fragment_durations" json:"result_cache_fragment_durations"`
 
 	// Write path overrides used in distributor.
 	WritePathOverrides writepath.Config `yaml:",inline" json:",inline"`
@@ -157,6 +210,8 @@ func (e LimitError) Error() string {
 func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&l.ResultCacheEnabled, "result-cache.enabled", false, "Enable query result caching. This sets the default for tenant overrides.")
 	f.UintVar(&l.ResultCacheGeneration, "result-cache.generation", 1, "Result-cache invalidation generation. This sets the default for tenant overrides.")
+	l.ResultCacheFragmentDurations = DurationList{model.Duration(24 * time.Hour), model.Duration(2 * time.Hour), model.Duration(15 * time.Minute)}
+	f.Var(&l.ResultCacheFragmentDurations, "result-cache.fragment-durations", "Comma-separated list of aligned result-cache fragment durations. The smallest duration is also the minimum cache age.")
 	f.Float64Var(&l.IngestionRateMB, "distributor.ingestion-rate-limit-mb", 4, "Per-tenant ingestion rate limit in sample size per second. Units in MB.")
 	f.Float64Var(&l.IngestionBurstSizeMB, "distributor.ingestion-burst-size-mb", 2, "Per-tenant allowed ingestion burst size (in sample size). Units in MB. The burst size refers to the per-distributor local rate limiter, and should be set at least to the maximum profile size expected in a single push request.")
 	f.Float64Var(&l.IngestionBodyLimitMB, "distributor.ingestion-body-limit-mb", 256, "Per-tenant ingestion body size limit in MB, before decompressing. 0 to disable.")
@@ -257,6 +312,11 @@ func (l *Limits) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // Validate validates that this limits config is valid.
 func (l *Limits) Validate() error {
+	if l.ResultCacheEnabled || len(l.ResultCacheFragmentDurations) > 0 {
+		if err := validateResultCacheFragmentDurations(l.ResultCacheFragmentDurations); err != nil {
+			return err
+		}
+	}
 	if l.IngestionRelabelingDefaultRulesPosition != "" {
 		if err := l.IngestionRelabelingDefaultRulesPosition.Set(string(l.IngestionRelabelingDefaultRulesPosition)); err != nil {
 			return err
@@ -270,6 +330,38 @@ func (l *Limits) Validate() error {
 		}
 	}
 
+	return nil
+}
+
+func validateResultCacheFragmentDurations(values DurationList) error {
+	if len(values) == 0 {
+		return fmt.Errorf("result cache fragment durations must not be empty")
+	}
+	if len(values) > maxResultCacheFragmentDurations {
+		return fmt.Errorf("result cache fragment durations must contain at most %d values", maxResultCacheFragmentDurations)
+	}
+	durations := make([]time.Duration, len(values))
+	for i, value := range values {
+		durations[i] = time.Duration(value)
+		if durations[i] <= 0 || durations[i]%time.Millisecond != 0 {
+			return fmt.Errorf("result cache fragment duration %q must be a positive whole number of milliseconds", durations[i])
+		}
+		if durations[i] < minResultCacheFragmentDuration {
+			return fmt.Errorf("result cache fragment duration %q must be at least %q", durations[i], minResultCacheFragmentDuration)
+		}
+		if durations[i]%minResultCacheFragmentDuration != 0 {
+			return fmt.Errorf("result cache fragment duration %q must be a multiple of %q", durations[i], minResultCacheFragmentDuration)
+		}
+	}
+	sort.Slice(durations, func(i, j int) bool { return durations[i] > durations[j] })
+	for i := 1; i < len(durations); i++ {
+		if durations[i-1] == durations[i] {
+			return fmt.Errorf("result cache fragment duration %q is duplicated", durations[i])
+		}
+		if durations[i-1]%durations[i] != 0 {
+			return fmt.Errorf("result cache fragment duration %q must be evenly divisible by %q", durations[i-1], durations[i])
+		}
+	}
 	return nil
 }
 
@@ -570,6 +662,16 @@ func (o *Overrides) ResultCacheEnabled(tenantID string) bool {
 
 func (o *Overrides) ResultCacheGeneration(tenantID string) uint32 {
 	return uint32(o.getOverridesForTenant(tenantID).ResultCacheGeneration)
+}
+
+func (o *Overrides) ResultCacheFragmentDurations(tenantID string) []time.Duration {
+	configured := o.getOverridesForTenant(tenantID).ResultCacheFragmentDurations
+	durations := make([]time.Duration, len(configured))
+	for i, duration := range configured {
+		durations[i] = time.Duration(duration)
+	}
+	sort.Slice(durations, func(i, j int) bool { return durations[i] > durations[j] })
+	return durations
 }
 
 // QueryAnalysisEnabled can be used to disable the query analysis endpoint in the query frontend.

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"iter"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -33,51 +32,30 @@ const (
 	MinCompactorPartialBlockDeletionDelay = 4 * time.Hour
 )
 
-type DurationList []model.Duration
+// durationListFlag adapts []model.Duration for the comma-separated CLI flag.
+// The Limits field itself remains a plain slice so YAML and JSON use model.Duration.
+type durationListFlag []model.Duration
 
-// String returns a canonical comma-separated representation for flags and docs.
-// Whole hours and minutes omit time.Duration's trailing zero components.
-func (d *DurationList) String() string {
+func (d *durationListFlag) String() string {
 	values := make([]string, len(*d))
 	for i, value := range *d {
-		duration := time.Duration(value)
-		switch {
-		case duration%time.Hour == 0:
-			values[i] = strconv.FormatInt(int64(duration/time.Hour), 10) + "h"
-		case duration%time.Minute == 0:
-			values[i] = strconv.FormatInt(int64(duration/time.Minute), 10) + "m"
-		default:
-			values[i] = duration.String()
-		}
+		values[i] = value.String()
 	}
 	return strings.Join(values, ",")
 }
 
-func (d *DurationList) Set(value string) error {
+func (d *durationListFlag) Set(value string) error {
 	values := strings.Split(value, ",")
-	result := make(DurationList, 0, len(values))
+	result := make([]model.Duration, 0, len(values))
 	for _, value := range values {
-		parsed, err := time.ParseDuration(strings.TrimSpace(value))
+		parsed, err := model.ParseDuration(strings.TrimSpace(value))
 		if err != nil {
 			return err
 		}
-		result = append(result, model.Duration(parsed))
+		result = append(result, parsed)
 	}
-	*d = result
+	*d = durationListFlag(result)
 	return nil
-}
-
-func (d *DurationList) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var values []model.Duration
-	if err := unmarshal(&values); err == nil {
-		*d = values
-		return nil
-	}
-	var value string
-	if err := unmarshal(&value); err != nil {
-		return err
-	}
-	return d.Set(value)
 }
 
 // Limits describe all the limits for tenants; can be used to describe global default
@@ -168,12 +146,12 @@ type Limits struct {
 	S3SSEKMSEncryptionContext string `yaml:"s3_sse_kms_encryption_context" json:"s3_sse_kms_encryption_context" doc:"nocli|description=S3 server-side encryption KMS encryption context. If unset and the key ID override is set, the encryption context will not be provided to S3. Ignored if the SSE type override is not set."`
 
 	// Ensure profiles are dated within the IngestionWindow of the distributor.
-	RejectOlderThan                                model.Duration `yaml:"reject_older_than" json:"reject_older_than"`
-	RejectNewerThan                                model.Duration `yaml:"reject_newer_than" json:"reject_newer_than"`
-	ResultCacheEnabled                             bool           `yaml:"result_cache_enabled" json:"result_cache_enabled"`
-	ResultCacheGeneration                          uint           `yaml:"result_cache_generation" json:"result_cache_generation"`
-	ResultCacheFragmentDurations                   DurationList   `yaml:"result_cache_fragment_durations" json:"result_cache_fragment_durations"`
-	ResultCacheMetadataServiceNameMinQueryDuration model.Duration `yaml:"result_cache_metadata_service_name_min_query_duration" json:"result_cache_metadata_service_name_min_query_duration"`
+	RejectOlderThan                                model.Duration   `yaml:"reject_older_than" json:"reject_older_than"`
+	RejectNewerThan                                model.Duration   `yaml:"reject_newer_than" json:"reject_newer_than"`
+	ResultCacheEnabled                             bool             `yaml:"result_cache_enabled" json:"result_cache_enabled"`
+	ResultCacheGeneration                          uint             `yaml:"result_cache_generation" json:"result_cache_generation"`
+	ResultCacheFragmentDurations                   []model.Duration `yaml:"result_cache_fragment_durations" json:"result_cache_fragment_durations"`
+	ResultCacheMetadataServiceNameMinQueryDuration model.Duration   `yaml:"result_cache_metadata_service_name_min_query_duration" json:"result_cache_metadata_service_name_min_query_duration"`
 
 	// Write path overrides used in distributor.
 	WritePathOverrides writepath.Config `yaml:",inline" json:",inline"`
@@ -211,8 +189,8 @@ func (e LimitError) Error() string {
 func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&l.ResultCacheEnabled, "result-cache.enabled", false, "Enable query result caching. This sets the default for tenant overrides.")
 	f.UintVar(&l.ResultCacheGeneration, "result-cache.generation", 1, "Result-cache invalidation generation. This sets the default for tenant overrides.")
-	l.ResultCacheFragmentDurations = DurationList{model.Duration(24 * time.Hour), model.Duration(2 * time.Hour), model.Duration(15 * time.Minute)}
-	f.Var(&l.ResultCacheFragmentDurations, "result-cache.fragment-durations", "Comma-separated list of aligned result-cache fragment durations. The smallest duration is also the minimum cache age.")
+	l.ResultCacheFragmentDurations = []model.Duration{model.Duration(24 * time.Hour), model.Duration(2 * time.Hour), model.Duration(15 * time.Minute)}
+	f.Var((*durationListFlag)(&l.ResultCacheFragmentDurations), "result-cache.fragment-durations", "Comma-separated list of aligned result-cache fragment durations. The smallest duration is also the minimum cache age.")
 	l.ResultCacheMetadataServiceNameMinQueryDuration = model.Duration(7 * 24 * time.Hour)
 	f.Var(&l.ResultCacheMetadataServiceNameMinQueryDuration, "result-cache.metadata-service-name-min-query-duration", "Bypass result caching for metadata queries with a service_name matcher below this query duration. 0 disables this bypass.")
 	f.Float64Var(&l.IngestionRateMB, "distributor.ingestion-rate-limit-mb", 4, "Per-tenant ingestion rate limit in sample size per second. Units in MB.")
@@ -339,7 +317,7 @@ func (l *Limits) Validate() error {
 	return nil
 }
 
-func validateResultCacheFragmentDurations(values DurationList) error {
+func validateResultCacheFragmentDurations(values []model.Duration) error {
 	if len(values) == 0 {
 		return fmt.Errorf("result cache fragment durations must not be empty")
 	}

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -168,11 +168,12 @@ type Limits struct {
 	S3SSEKMSEncryptionContext string `yaml:"s3_sse_kms_encryption_context" json:"s3_sse_kms_encryption_context" doc:"nocli|description=S3 server-side encryption KMS encryption context. If unset and the key ID override is set, the encryption context will not be provided to S3. Ignored if the SSE type override is not set."`
 
 	// Ensure profiles are dated within the IngestionWindow of the distributor.
-	RejectOlderThan              model.Duration `yaml:"reject_older_than" json:"reject_older_than"`
-	RejectNewerThan              model.Duration `yaml:"reject_newer_than" json:"reject_newer_than"`
-	ResultCacheEnabled           bool           `yaml:"result_cache_enabled" json:"result_cache_enabled"`
-	ResultCacheGeneration        uint           `yaml:"result_cache_generation" json:"result_cache_generation"`
-	ResultCacheFragmentDurations DurationList   `yaml:"result_cache_fragment_durations" json:"result_cache_fragment_durations"`
+	RejectOlderThan                                model.Duration `yaml:"reject_older_than" json:"reject_older_than"`
+	RejectNewerThan                                model.Duration `yaml:"reject_newer_than" json:"reject_newer_than"`
+	ResultCacheEnabled                             bool           `yaml:"result_cache_enabled" json:"result_cache_enabled"`
+	ResultCacheGeneration                          uint           `yaml:"result_cache_generation" json:"result_cache_generation"`
+	ResultCacheFragmentDurations                   DurationList   `yaml:"result_cache_fragment_durations" json:"result_cache_fragment_durations"`
+	ResultCacheMetadataServiceNameMinQueryDuration model.Duration `yaml:"result_cache_metadata_service_name_min_query_duration" json:"result_cache_metadata_service_name_min_query_duration"`
 
 	// Write path overrides used in distributor.
 	WritePathOverrides writepath.Config `yaml:",inline" json:",inline"`
@@ -212,6 +213,8 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.UintVar(&l.ResultCacheGeneration, "result-cache.generation", 1, "Result-cache invalidation generation. This sets the default for tenant overrides.")
 	l.ResultCacheFragmentDurations = DurationList{model.Duration(24 * time.Hour), model.Duration(2 * time.Hour), model.Duration(15 * time.Minute)}
 	f.Var(&l.ResultCacheFragmentDurations, "result-cache.fragment-durations", "Comma-separated list of aligned result-cache fragment durations. The smallest duration is also the minimum cache age.")
+	l.ResultCacheMetadataServiceNameMinQueryDuration = model.Duration(7 * 24 * time.Hour)
+	f.Var(&l.ResultCacheMetadataServiceNameMinQueryDuration, "result-cache.metadata-service-name-min-query-duration", "Bypass result caching for metadata queries with a service_name matcher below this query duration. 0 disables this bypass.")
 	f.Float64Var(&l.IngestionRateMB, "distributor.ingestion-rate-limit-mb", 4, "Per-tenant ingestion rate limit in sample size per second. Units in MB.")
 	f.Float64Var(&l.IngestionBurstSizeMB, "distributor.ingestion-burst-size-mb", 2, "Per-tenant allowed ingestion burst size (in sample size). Units in MB. The burst size refers to the per-distributor local rate limiter, and should be set at least to the maximum profile size expected in a single push request.")
 	f.Float64Var(&l.IngestionBodyLimitMB, "distributor.ingestion-body-limit-mb", 256, "Per-tenant ingestion body size limit in MB, before decompressing. 0 to disable.")
@@ -316,6 +319,9 @@ func (l *Limits) Validate() error {
 		if err := validateResultCacheFragmentDurations(l.ResultCacheFragmentDurations); err != nil {
 			return err
 		}
+	}
+	if l.ResultCacheMetadataServiceNameMinQueryDuration < 0 {
+		return fmt.Errorf("result cache metadata service name minimum query duration must not be negative")
 	}
 	if l.IngestionRelabelingDefaultRulesPosition != "" {
 		if err := l.IngestionRelabelingDefaultRulesPosition.Set(string(l.IngestionRelabelingDefaultRulesPosition)); err != nil {
@@ -672,6 +678,10 @@ func (o *Overrides) ResultCacheFragmentDurations(tenantID string) []time.Duratio
 	}
 	sort.Slice(durations, func(i, j int) bool { return durations[i] > durations[j] })
 	return durations
+}
+
+func (o *Overrides) ResultCacheMetadataServiceNameMinQueryDuration(tenantID string) time.Duration {
+	return time.Duration(o.getOverridesForTenant(tenantID).ResultCacheMetadataServiceNameMinQueryDuration)
 }
 
 // QueryAnalysisEnabled can be used to disable the query analysis endpoint in the query frontend.

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -32,29 +32,37 @@ const (
 	MinCompactorPartialBlockDeletionDelay = 4 * time.Hour
 )
 
-// durationListFlag adapts []model.Duration for the comma-separated CLI flag.
-// The Limits field itself remains a plain slice so YAML and JSON use model.Duration.
-type durationListFlag []model.Duration
+// resultCacheFragmentListFlag adapts result-cache fragments for the
+// comma-separated CLI flag. YAML and JSON use the typed struct directly.
+type resultCacheFragmentListFlag []phlaremodel.ResultCacheFragment
 
-func (d *durationListFlag) String() string {
+func (d *resultCacheFragmentListFlag) String() string {
 	values := make([]string, len(*d))
 	for i, value := range *d {
-		values[i] = value.String()
+		values[i] = value.Duration.String() + ":" + value.TTL.String()
 	}
 	return strings.Join(values, ",")
 }
 
-func (d *durationListFlag) Set(value string) error {
+func (d *resultCacheFragmentListFlag) Set(value string) error {
 	values := strings.Split(value, ",")
-	result := make([]model.Duration, 0, len(values))
+	result := make([]phlaremodel.ResultCacheFragment, 0, len(values))
 	for _, value := range values {
-		parsed, err := model.ParseDuration(strings.TrimSpace(value))
+		parts := strings.Split(strings.TrimSpace(value), ":")
+		if len(parts) != 2 {
+			return fmt.Errorf("result cache fragment %q must be duration:ttl", value)
+		}
+		duration, err := model.ParseDuration(strings.TrimSpace(parts[0]))
 		if err != nil {
 			return err
 		}
-		result = append(result, parsed)
+		ttl, err := model.ParseDuration(strings.TrimSpace(parts[1]))
+		if err != nil {
+			return err
+		}
+		result = append(result, phlaremodel.ResultCacheFragment{Duration: duration, TTL: ttl})
 	}
-	*d = durationListFlag(result)
+	*d = resultCacheFragmentListFlag(result)
 	return nil
 }
 
@@ -146,12 +154,12 @@ type Limits struct {
 	S3SSEKMSEncryptionContext string `yaml:"s3_sse_kms_encryption_context" json:"s3_sse_kms_encryption_context" doc:"nocli|description=S3 server-side encryption KMS encryption context. If unset and the key ID override is set, the encryption context will not be provided to S3. Ignored if the SSE type override is not set."`
 
 	// Ensure profiles are dated within the IngestionWindow of the distributor.
-	RejectOlderThan                                model.Duration   `yaml:"reject_older_than" json:"reject_older_than"`
-	RejectNewerThan                                model.Duration   `yaml:"reject_newer_than" json:"reject_newer_than"`
-	ResultCacheEnabled                             bool             `yaml:"result_cache_enabled" json:"result_cache_enabled"`
-	ResultCacheGeneration                          uint             `yaml:"result_cache_generation" json:"result_cache_generation"`
-	ResultCacheFragmentDurations                   []model.Duration `yaml:"result_cache_fragment_durations" json:"result_cache_fragment_durations"`
-	ResultCacheMetadataServiceNameMinQueryDuration model.Duration   `yaml:"result_cache_metadata_service_name_min_query_duration" json:"result_cache_metadata_service_name_min_query_duration"`
+	RejectOlderThan                                model.Duration                    `yaml:"reject_older_than" json:"reject_older_than"`
+	RejectNewerThan                                model.Duration                    `yaml:"reject_newer_than" json:"reject_newer_than"`
+	ResultCacheEnabled                             bool                              `yaml:"result_cache_enabled" json:"result_cache_enabled"`
+	ResultCacheGeneration                          uint                              `yaml:"result_cache_generation" json:"result_cache_generation"`
+	ResultCacheFragments                           []phlaremodel.ResultCacheFragment `yaml:"result_cache_fragments" json:"result_cache_fragments"`
+	ResultCacheMetadataServiceNameMinQueryDuration model.Duration                    `yaml:"result_cache_metadata_service_name_min_query_duration" json:"result_cache_metadata_service_name_min_query_duration"`
 
 	// Write path overrides used in distributor.
 	WritePathOverrides writepath.Config `yaml:",inline" json:",inline"`
@@ -189,8 +197,12 @@ func (e LimitError) Error() string {
 func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&l.ResultCacheEnabled, "result-cache.enabled", false, "Enable query result caching. This sets the default for tenant overrides.")
 	f.UintVar(&l.ResultCacheGeneration, "result-cache.generation", 1, "Result-cache invalidation generation. This sets the default for tenant overrides.")
-	l.ResultCacheFragmentDurations = []model.Duration{model.Duration(24 * time.Hour), model.Duration(2 * time.Hour), model.Duration(15 * time.Minute)}
-	f.Var((*durationListFlag)(&l.ResultCacheFragmentDurations), "result-cache.fragment-durations", "Comma-separated list of aligned result-cache fragment durations. The smallest duration is also the minimum cache age.")
+	l.ResultCacheFragments = []phlaremodel.ResultCacheFragment{
+		{Duration: model.Duration(24 * time.Hour), TTL: model.Duration(48 * time.Hour)},
+		{Duration: model.Duration(2 * time.Hour), TTL: model.Duration(24 * time.Hour)},
+		{Duration: model.Duration(15 * time.Minute), TTL: model.Duration(24 * time.Hour)},
+	}
+	f.Var((*resultCacheFragmentListFlag)(&l.ResultCacheFragments), "result-cache.fragments", "Comma-separated result-cache duration:Redis-TTL pairs. The smallest duration is also the minimum cache age.")
 	l.ResultCacheMetadataServiceNameMinQueryDuration = model.Duration(7 * 24 * time.Hour)
 	f.Var(&l.ResultCacheMetadataServiceNameMinQueryDuration, "result-cache.metadata-service-name-min-query-duration", "Bypass result caching for metadata queries with a service_name matcher below this query duration. 0 disables this bypass.")
 	f.Float64Var(&l.IngestionRateMB, "distributor.ingestion-rate-limit-mb", 4, "Per-tenant ingestion rate limit in sample size per second. Units in MB.")
@@ -293,8 +305,8 @@ func (l *Limits) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // Validate validates that this limits config is valid.
 func (l *Limits) Validate() error {
-	if l.ResultCacheEnabled || len(l.ResultCacheFragmentDurations) > 0 {
-		if err := validateResultCacheFragmentDurations(l.ResultCacheFragmentDurations); err != nil {
+	if l.ResultCacheEnabled || len(l.ResultCacheFragments) > 0 {
+		if err := validateResultCacheFragments(l.ResultCacheFragments); err != nil {
 			return err
 		}
 	}
@@ -317,7 +329,7 @@ func (l *Limits) Validate() error {
 	return nil
 }
 
-func validateResultCacheFragmentDurations(values []model.Duration) error {
+func validateResultCacheFragments(values []phlaremodel.ResultCacheFragment) error {
 	if len(values) == 0 {
 		return fmt.Errorf("result cache fragment durations must not be empty")
 	}
@@ -326,7 +338,7 @@ func validateResultCacheFragmentDurations(values []model.Duration) error {
 	}
 	durations := make([]time.Duration, len(values))
 	for i, value := range values {
-		durations[i] = time.Duration(value)
+		durations[i] = time.Duration(value.Duration)
 		if durations[i] <= 0 || durations[i]%time.Millisecond != 0 {
 			return fmt.Errorf("result cache fragment duration %q must be a positive whole number of milliseconds", durations[i])
 		}
@@ -335,6 +347,9 @@ func validateResultCacheFragmentDurations(values []model.Duration) error {
 		}
 		if durations[i]%minResultCacheFragmentDuration != 0 {
 			return fmt.Errorf("result cache fragment duration %q must be a multiple of %q", durations[i], minResultCacheFragmentDuration)
+		}
+		if value.TTL <= 0 {
+			return fmt.Errorf("result cache fragment TTL %q must be positive", time.Duration(value.TTL))
 		}
 	}
 	sort.Slice(durations, func(i, j int) bool { return durations[i] > durations[j] })
@@ -648,14 +663,11 @@ func (o *Overrides) ResultCacheGeneration(tenantID string) uint32 {
 	return uint32(o.getOverridesForTenant(tenantID).ResultCacheGeneration)
 }
 
-func (o *Overrides) ResultCacheFragmentDurations(tenantID string) []time.Duration {
-	configured := o.getOverridesForTenant(tenantID).ResultCacheFragmentDurations
-	durations := make([]time.Duration, len(configured))
-	for i, duration := range configured {
-		durations[i] = time.Duration(duration)
-	}
-	sort.Slice(durations, func(i, j int) bool { return durations[i] > durations[j] })
-	return durations
+func (o *Overrides) ResultCacheFragments(tenantID string) []phlaremodel.ResultCacheFragment {
+	configured := o.getOverridesForTenant(tenantID).ResultCacheFragments
+	fragments := append([]phlaremodel.ResultCacheFragment(nil), configured...)
+	sort.Slice(fragments, func(i, j int) bool { return fragments[i].Duration > fragments[j].Duration })
+	return fragments
 }
 
 func (o *Overrides) ResultCacheMetadataServiceNameMinQueryDuration(tenantID string) time.Duration {

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -38,18 +38,18 @@ func TestLimitsTagsYamlMatchJson(t *testing.T) {
 func TestResultCacheFragmentDurations(t *testing.T) {
 	tests := []struct {
 		name    string
-		values  DurationList
+		values  []model.Duration
 		wantErr string
 	}{
-		{name: "valid", values: DurationList{model.Duration(24 * time.Hour), model.Duration(2 * time.Hour), model.Duration(15 * time.Minute)}},
-		{name: "valid unordered", values: DurationList{model.Duration(15 * time.Minute), model.Duration(24 * time.Hour), model.Duration(2 * time.Hour)}},
+		{name: "valid", values: []model.Duration{model.Duration(24 * time.Hour), model.Duration(2 * time.Hour), model.Duration(15 * time.Minute)}},
+		{name: "valid unordered", values: []model.Duration{model.Duration(15 * time.Minute), model.Duration(24 * time.Hour), model.Duration(2 * time.Hour)}},
 		{name: "empty", wantErr: "must not be empty"},
-		{name: "duplicate", values: DurationList{model.Duration(time.Hour), model.Duration(time.Hour)}, wantErr: "duplicated"},
-		{name: "not divisible", values: DurationList{model.Duration(45 * time.Minute), model.Duration(30 * time.Minute)}, wantErr: "evenly divisible"},
-		{name: "sub-millisecond", values: DurationList{model.Duration(time.Microsecond)}, wantErr: "whole number of milliseconds"},
-		{name: "below minimum", values: DurationList{model.Duration(5 * time.Minute)}, wantErr: "must be at least"},
-		{name: "long duration", values: DurationList{model.Duration(7 * 24 * time.Hour), model.Duration(24 * time.Hour), model.Duration(15 * time.Minute)}},
-		{name: "not 15 minute multiple", values: DurationList{model.Duration(20 * time.Minute)}, wantErr: "must be a multiple"},
+		{name: "duplicate", values: []model.Duration{model.Duration(time.Hour), model.Duration(time.Hour)}, wantErr: "duplicated"},
+		{name: "not divisible", values: []model.Duration{model.Duration(45 * time.Minute), model.Duration(30 * time.Minute)}, wantErr: "evenly divisible"},
+		{name: "sub-millisecond", values: []model.Duration{model.Duration(time.Microsecond)}, wantErr: "whole number of milliseconds"},
+		{name: "below minimum", values: []model.Duration{model.Duration(5 * time.Minute)}, wantErr: "must be at least"},
+		{name: "long duration", values: []model.Duration{model.Duration(7 * 24 * time.Hour), model.Duration(24 * time.Hour), model.Duration(15 * time.Minute)}},
+		{name: "not 15 minute multiple", values: []model.Duration{model.Duration(20 * time.Minute)}, wantErr: "must be a multiple"},
 	}
 
 	for _, test := range tests {
@@ -63,20 +63,22 @@ func TestResultCacheFragmentDurations(t *testing.T) {
 		})
 	}
 
-	overrides, err := NewOverrides(Limits{ResultCacheFragmentDurations: DurationList{
+	overrides, err := NewOverrides(Limits{ResultCacheFragmentDurations: []model.Duration{
 		model.Duration(15 * time.Minute), model.Duration(24 * time.Hour), model.Duration(2 * time.Hour),
 	}}, nil)
 	require.NoError(t, err)
 	require.Equal(t, []time.Duration{24 * time.Hour, 2 * time.Hour, 15 * time.Minute}, overrides.ResultCacheFragmentDurations("tenant-a"))
 
-	for _, input := range []string{
-		"result_cache_fragment_durations: [24h, 2h, 15m]",
-		"result_cache_fragment_durations: 24h,2h,15m",
-	} {
-		var limits Limits
-		require.NoError(t, yaml.Unmarshal([]byte(input), &limits))
-		require.Equal(t, DurationList{model.Duration(24 * time.Hour), model.Duration(2 * time.Hour), model.Duration(15 * time.Minute)}, limits.ResultCacheFragmentDurations)
-	}
+	var limits Limits
+	require.NoError(t, yaml.Unmarshal([]byte("result_cache_fragment_durations: [1d, 2h, 15m]"), &limits))
+	require.Equal(t, []model.Duration{model.Duration(24 * time.Hour), model.Duration(2 * time.Hour), model.Duration(15 * time.Minute)}, limits.ResultCacheFragmentDurations)
+	require.Error(t, yaml.Unmarshal([]byte("result_cache_fragment_durations: 1d,2h,15m"), &limits))
+
+	flags := flag.NewFlagSet("test", flag.ContinueOnError)
+	limits.RegisterFlags(flags)
+	require.Equal(t, "1d,2h,15m", flags.Lookup("result-cache.fragment-durations").DefValue)
+	require.NoError(t, flags.Parse([]string{"-result-cache.fragment-durations=1d,2h,15m"}))
+	require.Equal(t, []model.Duration{model.Duration(24 * time.Hour), model.Duration(2 * time.Hour), model.Duration(15 * time.Minute)}, limits.ResultCacheFragmentDurations)
 }
 
 func TestResultCacheMetadataServiceNameMinQueryDuration(t *testing.T) {

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -34,6 +34,50 @@ func TestLimitsTagsYamlMatchJson(t *testing.T) {
 	assert.Empty(t, mismatch, "expected no mismatched JSON and YAML tags")
 }
 
+func TestResultCacheFragmentDurations(t *testing.T) {
+	tests := []struct {
+		name    string
+		values  DurationList
+		wantErr string
+	}{
+		{name: "valid", values: DurationList{model.Duration(24 * time.Hour), model.Duration(2 * time.Hour), model.Duration(15 * time.Minute)}},
+		{name: "valid unordered", values: DurationList{model.Duration(15 * time.Minute), model.Duration(24 * time.Hour), model.Duration(2 * time.Hour)}},
+		{name: "empty", wantErr: "must not be empty"},
+		{name: "duplicate", values: DurationList{model.Duration(time.Hour), model.Duration(time.Hour)}, wantErr: "duplicated"},
+		{name: "not divisible", values: DurationList{model.Duration(45 * time.Minute), model.Duration(30 * time.Minute)}, wantErr: "evenly divisible"},
+		{name: "sub-millisecond", values: DurationList{model.Duration(time.Microsecond)}, wantErr: "whole number of milliseconds"},
+		{name: "below minimum", values: DurationList{model.Duration(5 * time.Minute)}, wantErr: "must be at least"},
+		{name: "long duration", values: DurationList{model.Duration(7 * 24 * time.Hour), model.Duration(24 * time.Hour), model.Duration(15 * time.Minute)}},
+		{name: "not 15 minute multiple", values: DurationList{model.Duration(20 * time.Minute)}, wantErr: "must be a multiple"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateResultCacheFragmentDurations(test.values)
+			if test.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+
+	overrides, err := NewOverrides(Limits{ResultCacheFragmentDurations: DurationList{
+		model.Duration(15 * time.Minute), model.Duration(24 * time.Hour), model.Duration(2 * time.Hour),
+	}}, nil)
+	require.NoError(t, err)
+	require.Equal(t, []time.Duration{24 * time.Hour, 2 * time.Hour, 15 * time.Minute}, overrides.ResultCacheFragmentDurations("tenant-a"))
+
+	for _, input := range []string{
+		"result_cache_fragment_durations: [24h, 2h, 15m]",
+		"result_cache_fragment_durations: 24h,2h,15m",
+	} {
+		var limits Limits
+		require.NoError(t, yaml.Unmarshal([]byte(input), &limits))
+		require.Equal(t, DurationList{model.Duration(24 * time.Hour), model.Duration(2 * time.Hour), model.Duration(15 * time.Minute)}, limits.ResultCacheFragmentDurations)
+	}
+}
+
 func TestLimitsYamlMatchJson(t *testing.T) {
 	inputYAML := `
 ingestion_rate_strategy: "some-strategy"

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"encoding/json"
+	"flag"
 	"reflect"
 	"testing"
 	"time"
@@ -76,6 +77,15 @@ func TestResultCacheFragmentDurations(t *testing.T) {
 		require.NoError(t, yaml.Unmarshal([]byte(input), &limits))
 		require.Equal(t, DurationList{model.Duration(24 * time.Hour), model.Duration(2 * time.Hour), model.Duration(15 * time.Minute)}, limits.ResultCacheFragmentDurations)
 	}
+}
+
+func TestResultCacheMetadataServiceNameMinQueryDuration(t *testing.T) {
+	limits := Limits{}
+	limits.RegisterFlags(flag.NewFlagSet("test", flag.ContinueOnError))
+	require.Equal(t, model.Duration(7*24*time.Hour), limits.ResultCacheMetadataServiceNameMinQueryDuration)
+
+	limits.ResultCacheMetadataServiceNameMinQueryDuration = model.Duration(-time.Hour)
+	require.ErrorContains(t, limits.Validate(), "must not be negative")
 }
 
 func TestLimitsYamlMatchJson(t *testing.T) {

--- a/pkg/validation/limits_test.go
+++ b/pkg/validation/limits_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
+
+	phlaremodel "github.com/grafana/pyroscope/v2/pkg/model"
 )
 
 func TestLimitsTagsYamlMatchJson(t *testing.T) {
@@ -35,26 +37,25 @@ func TestLimitsTagsYamlMatchJson(t *testing.T) {
 	assert.Empty(t, mismatch, "expected no mismatched JSON and YAML tags")
 }
 
-func TestResultCacheFragmentDurations(t *testing.T) {
+func TestResultCacheFragments(t *testing.T) {
 	tests := []struct {
 		name    string
-		values  []model.Duration
+		values  []phlaremodel.ResultCacheFragment
 		wantErr string
 	}{
-		{name: "valid", values: []model.Duration{model.Duration(24 * time.Hour), model.Duration(2 * time.Hour), model.Duration(15 * time.Minute)}},
-		{name: "valid unordered", values: []model.Duration{model.Duration(15 * time.Minute), model.Duration(24 * time.Hour), model.Duration(2 * time.Hour)}},
+		{name: "valid", values: []phlaremodel.ResultCacheFragment{{Duration: model.Duration(24 * time.Hour), TTL: model.Duration(48 * time.Hour)}, {Duration: model.Duration(2 * time.Hour), TTL: model.Duration(24 * time.Hour)}, {Duration: model.Duration(15 * time.Minute), TTL: model.Duration(24 * time.Hour)}}},
+		{name: "valid unordered", values: []phlaremodel.ResultCacheFragment{{Duration: model.Duration(15 * time.Minute), TTL: model.Duration(time.Hour)}, {Duration: model.Duration(24 * time.Hour), TTL: model.Duration(time.Hour)}, {Duration: model.Duration(2 * time.Hour), TTL: model.Duration(time.Hour)}}},
 		{name: "empty", wantErr: "must not be empty"},
-		{name: "duplicate", values: []model.Duration{model.Duration(time.Hour), model.Duration(time.Hour)}, wantErr: "duplicated"},
-		{name: "not divisible", values: []model.Duration{model.Duration(45 * time.Minute), model.Duration(30 * time.Minute)}, wantErr: "evenly divisible"},
-		{name: "sub-millisecond", values: []model.Duration{model.Duration(time.Microsecond)}, wantErr: "whole number of milliseconds"},
-		{name: "below minimum", values: []model.Duration{model.Duration(5 * time.Minute)}, wantErr: "must be at least"},
-		{name: "long duration", values: []model.Duration{model.Duration(7 * 24 * time.Hour), model.Duration(24 * time.Hour), model.Duration(15 * time.Minute)}},
-		{name: "not 15 minute multiple", values: []model.Duration{model.Duration(20 * time.Minute)}, wantErr: "must be a multiple"},
+		{name: "duplicate", values: []phlaremodel.ResultCacheFragment{{Duration: model.Duration(time.Hour), TTL: model.Duration(time.Hour)}, {Duration: model.Duration(time.Hour), TTL: model.Duration(time.Hour)}}, wantErr: "duplicated"},
+		{name: "not divisible", values: []phlaremodel.ResultCacheFragment{{Duration: model.Duration(45 * time.Minute), TTL: model.Duration(time.Hour)}, {Duration: model.Duration(30 * time.Minute), TTL: model.Duration(time.Hour)}}, wantErr: "evenly divisible"},
+		{name: "sub-millisecond", values: []phlaremodel.ResultCacheFragment{{Duration: model.Duration(time.Microsecond), TTL: model.Duration(time.Hour)}}, wantErr: "whole number of milliseconds"},
+		{name: "below minimum", values: []phlaremodel.ResultCacheFragment{{Duration: model.Duration(5 * time.Minute), TTL: model.Duration(time.Hour)}}, wantErr: "must be at least"},
+		{name: "zero TTL", values: []phlaremodel.ResultCacheFragment{{Duration: model.Duration(15 * time.Minute)}}, wantErr: "TTL"},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := validateResultCacheFragmentDurations(test.values)
+			err := validateResultCacheFragments(test.values)
 			if test.wantErr == "" {
 				require.NoError(t, err)
 				return
@@ -63,22 +64,22 @@ func TestResultCacheFragmentDurations(t *testing.T) {
 		})
 	}
 
-	overrides, err := NewOverrides(Limits{ResultCacheFragmentDurations: []model.Duration{
-		model.Duration(15 * time.Minute), model.Duration(24 * time.Hour), model.Duration(2 * time.Hour),
+	overrides, err := NewOverrides(Limits{ResultCacheFragments: []phlaremodel.ResultCacheFragment{
+		{Duration: model.Duration(15 * time.Minute), TTL: model.Duration(24 * time.Hour)}, {Duration: model.Duration(24 * time.Hour), TTL: model.Duration(48 * time.Hour)}, {Duration: model.Duration(2 * time.Hour), TTL: model.Duration(24 * time.Hour)},
 	}}, nil)
 	require.NoError(t, err)
-	require.Equal(t, []time.Duration{24 * time.Hour, 2 * time.Hour, 15 * time.Minute}, overrides.ResultCacheFragmentDurations("tenant-a"))
+	require.Equal(t, []phlaremodel.ResultCacheFragment{{Duration: model.Duration(24 * time.Hour), TTL: model.Duration(48 * time.Hour)}, {Duration: model.Duration(2 * time.Hour), TTL: model.Duration(24 * time.Hour)}, {Duration: model.Duration(15 * time.Minute), TTL: model.Duration(24 * time.Hour)}}, overrides.ResultCacheFragments("tenant-a"))
 
 	var limits Limits
-	require.NoError(t, yaml.Unmarshal([]byte("result_cache_fragment_durations: [1d, 2h, 15m]"), &limits))
-	require.Equal(t, []model.Duration{model.Duration(24 * time.Hour), model.Duration(2 * time.Hour), model.Duration(15 * time.Minute)}, limits.ResultCacheFragmentDurations)
-	require.Error(t, yaml.Unmarshal([]byte("result_cache_fragment_durations: 1d,2h,15m"), &limits))
+	require.NoError(t, yaml.Unmarshal([]byte("result_cache_fragments: [{duration: 1d, ttl: 2d}, {duration: 2h, ttl: 1d}, {duration: 15m, ttl: 1d}]"), &limits))
+	require.Equal(t, []phlaremodel.ResultCacheFragment{{Duration: model.Duration(24 * time.Hour), TTL: model.Duration(48 * time.Hour)}, {Duration: model.Duration(2 * time.Hour), TTL: model.Duration(24 * time.Hour)}, {Duration: model.Duration(15 * time.Minute), TTL: model.Duration(24 * time.Hour)}}, limits.ResultCacheFragments)
+	require.Error(t, yaml.Unmarshal([]byte("result_cache_fragments: 1d,2h,15m"), &limits))
 
 	flags := flag.NewFlagSet("test", flag.ContinueOnError)
 	limits.RegisterFlags(flags)
-	require.Equal(t, "1d,2h,15m", flags.Lookup("result-cache.fragment-durations").DefValue)
-	require.NoError(t, flags.Parse([]string{"-result-cache.fragment-durations=1d,2h,15m"}))
-	require.Equal(t, []model.Duration{model.Duration(24 * time.Hour), model.Duration(2 * time.Hour), model.Duration(15 * time.Minute)}, limits.ResultCacheFragmentDurations)
+	require.Equal(t, "1d:2d,2h:1d,15m:1d", flags.Lookup("result-cache.fragments").DefValue)
+	require.NoError(t, flags.Parse([]string{"-result-cache.fragments=1d:2d,2h:1d,15m:1d"}))
+	require.Equal(t, []phlaremodel.ResultCacheFragment{{Duration: model.Duration(24 * time.Hour), TTL: model.Duration(48 * time.Hour)}, {Duration: model.Duration(2 * time.Hour), TTL: model.Duration(24 * time.Hour)}, {Duration: model.Duration(15 * time.Minute), TTL: model.Duration(24 * time.Hour)}}, limits.ResultCacheFragments)
 }
 
 func TestResultCacheMetadataServiceNameMinQueryDuration(t *testing.T) {

--- a/pkg/validation/testutil.go
+++ b/pkg/validation/testutil.go
@@ -24,8 +24,10 @@ type MockLimits struct {
 	DistributorAggregationWindowValue time.Duration
 	DistributorAggregationPeriodValue time.Duration
 
-	RejectOlderThanValue time.Duration
-	RejectNewerThanValue time.Duration
+	RejectOlderThanValue       time.Duration
+	RejectNewerThanValue       time.Duration
+	ResultCacheEnabledValue    bool
+	ResultCacheGenerationValue uint32
 
 	MaxProfileSizeBytesValue              int
 	MaxProfileStacktraceSamplesValue      int
@@ -106,6 +108,9 @@ func (m MockLimits) RejectOlderThan(userID string) time.Duration {
 func (m MockLimits) RejectNewerThan(userID string) time.Duration {
 	return m.RejectNewerThanValue
 }
+
+func (m MockLimits) ResultCacheEnabled(string) bool      { return m.ResultCacheEnabledValue }
+func (m MockLimits) ResultCacheGeneration(string) uint32 { return m.ResultCacheGenerationValue }
 
 func (m MockLimits) SymbolizerEnabled(s string) bool       { return m.SymbolizerEnabledValue }
 func (m MockLimits) QueryTreeEnabled(s string) bool        { return m.QueryTreeEnabledValue }

--- a/pkg/validation/testutil.go
+++ b/pkg/validation/testutil.go
@@ -24,11 +24,12 @@ type MockLimits struct {
 	DistributorAggregationWindowValue time.Duration
 	DistributorAggregationPeriodValue time.Duration
 
-	RejectOlderThanValue              time.Duration
-	RejectNewerThanValue              time.Duration
-	ResultCacheEnabledValue           bool
-	ResultCacheGenerationValue        uint32
-	ResultCacheFragmentDurationsValue []time.Duration
+	RejectOlderThanValue                                time.Duration
+	RejectNewerThanValue                                time.Duration
+	ResultCacheEnabledValue                             bool
+	ResultCacheGenerationValue                          uint32
+	ResultCacheFragmentDurationsValue                   []time.Duration
+	ResultCacheMetadataServiceNameMinQueryDurationValue time.Duration
 
 	MaxProfileSizeBytesValue              int
 	MaxProfileStacktraceSamplesValue      int
@@ -114,6 +115,9 @@ func (m MockLimits) ResultCacheEnabled(string) bool      { return m.ResultCacheE
 func (m MockLimits) ResultCacheGeneration(string) uint32 { return m.ResultCacheGenerationValue }
 func (m MockLimits) ResultCacheFragmentDurations(string) []time.Duration {
 	return m.ResultCacheFragmentDurationsValue
+}
+func (m MockLimits) ResultCacheMetadataServiceNameMinQueryDuration(string) time.Duration {
+	return m.ResultCacheMetadataServiceNameMinQueryDurationValue
 }
 
 func (m MockLimits) SymbolizerEnabled(s string) bool       { return m.SymbolizerEnabledValue }

--- a/pkg/validation/testutil.go
+++ b/pkg/validation/testutil.go
@@ -24,10 +24,11 @@ type MockLimits struct {
 	DistributorAggregationWindowValue time.Duration
 	DistributorAggregationPeriodValue time.Duration
 
-	RejectOlderThanValue       time.Duration
-	RejectNewerThanValue       time.Duration
-	ResultCacheEnabledValue    bool
-	ResultCacheGenerationValue uint32
+	RejectOlderThanValue              time.Duration
+	RejectNewerThanValue              time.Duration
+	ResultCacheEnabledValue           bool
+	ResultCacheGenerationValue        uint32
+	ResultCacheFragmentDurationsValue []time.Duration
 
 	MaxProfileSizeBytesValue              int
 	MaxProfileStacktraceSamplesValue      int
@@ -111,6 +112,9 @@ func (m MockLimits) RejectNewerThan(userID string) time.Duration {
 
 func (m MockLimits) ResultCacheEnabled(string) bool      { return m.ResultCacheEnabledValue }
 func (m MockLimits) ResultCacheGeneration(string) uint32 { return m.ResultCacheGenerationValue }
+func (m MockLimits) ResultCacheFragmentDurations(string) []time.Duration {
+	return m.ResultCacheFragmentDurationsValue
+}
 
 func (m MockLimits) SymbolizerEnabled(s string) bool       { return m.SymbolizerEnabledValue }
 func (m MockLimits) QueryTreeEnabled(s string) bool        { return m.QueryTreeEnabledValue }

--- a/pkg/validation/testutil.go
+++ b/pkg/validation/testutil.go
@@ -2,6 +2,8 @@ package validation
 
 import (
 	"time"
+
+	phlaremodel "github.com/grafana/pyroscope/v2/pkg/model"
 )
 
 type MockLimits struct {
@@ -28,7 +30,7 @@ type MockLimits struct {
 	RejectNewerThanValue                                time.Duration
 	ResultCacheEnabledValue                             bool
 	ResultCacheGenerationValue                          uint32
-	ResultCacheFragmentDurationsValue                   []time.Duration
+	ResultCacheFragmentsValue                           []phlaremodel.ResultCacheFragment
 	ResultCacheMetadataServiceNameMinQueryDurationValue time.Duration
 
 	MaxProfileSizeBytesValue              int
@@ -113,8 +115,8 @@ func (m MockLimits) RejectNewerThan(userID string) time.Duration {
 
 func (m MockLimits) ResultCacheEnabled(string) bool      { return m.ResultCacheEnabledValue }
 func (m MockLimits) ResultCacheGeneration(string) uint32 { return m.ResultCacheGenerationValue }
-func (m MockLimits) ResultCacheFragmentDurations(string) []time.Duration {
-	return m.ResultCacheFragmentDurationsValue
+func (m MockLimits) ResultCacheFragments(string) []phlaremodel.ResultCacheFragment {
+	return m.ResultCacheFragmentsValue
 }
 func (m MockLimits) ResultCacheMetadataServiceNameMinQueryDuration(string) time.Duration {
 	return m.ResultCacheMetadataServiceNameMinQueryDurationValue

--- a/tools/doc-generator/parse/parser.go
+++ b/tools/doc-generator/parse/parser.go
@@ -346,6 +346,8 @@ func getFieldCustomType(t reflect.Type) (string, bool) {
 		return typeURL, true
 	case reflect.TypeOf(time.Duration(0)).String():
 		return typeDuration, true
+	case reflect.TypeOf(model.Duration(0)).String():
+		return typeDuration, true
 	case reflect.TypeOf(flagext.StringSliceCSV{}).String():
 		return typeString, true
 	case reflect.TypeOf(flagext.CIDRSliceCSV{}).String():
@@ -423,6 +425,8 @@ func getCustomFieldType(t reflect.Type) (string, bool) {
 	case reflect.TypeOf(&url.URL{}).String():
 		return typeURL, true
 	case reflect.TypeOf(time.Duration(0)).String():
+		return typeDuration, true
+	case reflect.TypeOf(model.Duration(0)).String():
 		return typeDuration, true
 	case reflect.TypeOf(flagext.StringSliceCSV{}).String():
 		return typeString, true


### PR DESCRIPTION
Adds an opt-in, per-tenant result cache for V2 `LabelNames`, `LabelValues`, and `SeriesLabels` queries. Eligible ranges are split into aligned duration tiers; cache entries use a canonical query, sorted block IDs, and a tenant generation so block changes and generation bumps invalidate results safely.

The cache is fail-open in a dedicated object-storage bucket, with asynchronous bounded writes and low-cardinality lookup/write metrics. This includes runtime overrides, result-cache configuration and API generation, unit tests, and a draft design with rollout guidance.

## Cache Time Slots

The query range uses inclusive millisecond boundaries. Starting at the query start, the backend chooses the largest aligned tier that fits (`24h`, then `2h`, then `15m`). An unaligned remainder runs normally until the next smallest-tier boundary.

```text
Query range
  start                                                                     end
    |                                                                         |
    +-----------------+------------------------+--------------+--------------+-----------+
    | unaligned edge  |        24h slot        |   2h slot    |   15m slot   |   edge    |
    |    uncached     |       cacheable        |  cacheable   |  cacheable   | uncached  |
    +-----------------+------------------------+--------------+--------------+-----------+
```

## Benchmark

`BenchmarkQueryMetadata` against a six-day query range on macOS/arm64 (Apple M2 Max). Each cached response had the same SHA-256 as its uncached response. Cold-cache results contain one iteration; use the warm-cache measurements for comparison.

| Query | No cache | Cold cache | Warm cache | Warm speedup |
| --- | ---: | ---: | ---: | ---: |
| LabelNames | 8.576s | 11.44s | 1.089s | 7.9x |
| LabelValues (`namespace`) | 8.276s | 8.942s | 0.782s | 10.6x |
| LabelValues (`cluster`) | 8.343s | 8.667s | 0.846s | 9.9x |
| LabelValues (`pod`) | 9.667s | 10.61s | 1.918s | 5.0x |
| Series (`service_name`, `profile_type`) | 12.37s | 13.20s | 0.859s | 14.4x |
| Series (`cluster`, `namespace`, `pod`) | 29.56s | 28.09s | 4.386s | 6.7x |

