### PR TITLE
query-backend: Optimize label names query with selector(s)

### DIFF
--- a/pkg/phlaredb/tsdb/index/index.go
+++ b/pkg/phlaredb/tsdb/index/index.go
@@ -1622,25 +1622,58 @@ func (r *Reader) LabelValues(name string, matchers ...*labels.Matcher) ([]string
 // LabelNamesFor returns all the label names for the series referred to by IDs.
 // The names returned are sorted.
 func (r *Reader) LabelNamesFor(ids ...storage.SeriesRef) ([]string, error) {
+	return r.labelNamesFor(func(yield func(storage.SeriesRef) bool) error {
+		for _, id := range ids {
+			if !yield(id) {
+				break
+			}
+		}
+		return nil
+	})
+}
+
+// LabelNamesForPostings returns all label names used by the series in postings.
+func (r *Reader) LabelNamesForPostings(postings Postings) ([]string, error) {
+	return r.labelNamesFor(func(yield func(storage.SeriesRef) bool) error {
+		for postings.Next() {
+			if !yield(postings.At()) {
+				break
+			}
+		}
+		return postings.Err()
+	})
+}
+
+func (r *Reader) labelNamesFor(iterate func(func(storage.SeriesRef) bool) error) ([]string, error) {
 	// Gather offsetsMap the name offsetsMap in the symbol table first
 	offsetsMap := make(map[uint32]struct{})
-	for _, id := range ids {
+	var decodeErr error
+	err := iterate(func(id storage.SeriesRef) bool {
 		// Series IDs are 16-byte padded; the ID is the multiple of 16 of the actual position.
 		offset := id * 16
 
 		d := encoding.DecWrap(tsdb_enc.NewDecbufUvarintAt(r.b, int(offset), castagnoliTable))
 		buf := d.Get()
 		if d.Err() != nil {
-			return nil, fmt.Errorf("get buffer for series: %w", d.Err())
+			decodeErr = fmt.Errorf("get buffer for series: %w", d.Err())
+			return false
 		}
 
 		offsets, err := r.dec.LabelNamesOffsetsFor(buf)
 		if err != nil {
-			return nil, fmt.Errorf("get label name offsets: %w", err)
+			decodeErr = fmt.Errorf("get label name offsets: %w", err)
+			return false
 		}
 		for _, off := range offsets {
 			offsetsMap[off] = struct{}{}
 		}
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+	if decodeErr != nil {
+		return nil, decodeErr
 	}
 
 	// Lookup the unique symbols.

--- a/pkg/querybackend/query_label_names.go
+++ b/pkg/querybackend/query_label_names.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/pyroscope/v2/pkg/block"
 	"github.com/grafana/pyroscope/v2/pkg/model"
 	"github.com/grafana/pyroscope/v2/pkg/phlaredb"
+	"github.com/grafana/pyroscope/v2/pkg/phlaredb/tsdb/index"
 )
 
 func init() {
@@ -48,6 +49,12 @@ func labelNamesForMatchers(reader phlaredb.IndexReader, matchers []*labels.Match
 	if err != nil {
 		return nil, err
 	}
+	if reader, ok := reader.(interface {
+		LabelNamesForPostings(index.Postings) ([]string, error)
+	}); ok {
+		return reader.LabelNamesForPostings(postings)
+	}
+
 	l := make(map[string]struct{})
 	for postings.Next() {
 		var n []string

--- a/pkg/querybackend/query_label_names_benchmark_test.go
+++ b/pkg/querybackend/query_label_names_benchmark_test.go
@@ -1,0 +1,102 @@
+package querybackend
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	prommodel "github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/stretchr/testify/require"
+
+	phlaremodel "github.com/grafana/pyroscope/v2/pkg/model"
+	"github.com/grafana/pyroscope/v2/pkg/phlaredb"
+	"github.com/grafana/pyroscope/v2/pkg/phlaredb/tsdb/index"
+)
+
+type legacyLabelNamesReader struct {
+	phlaredb.IndexReader
+}
+
+func TestLabelNamesForMatchersBatched(t *testing.T) {
+	reader := buildLabelNamesTestIndex(t, 10)
+	matchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchEqual, "service_name", "api"),
+	}
+
+	got, err := labelNamesForMatchers(reader, matchers)
+	require.NoError(t, err)
+
+	want, err := labelNamesForMatchers(legacyLabelNamesReader{reader}, matchers)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+	require.Equal(t, []string{"instance", "region", "service_name"}, got)
+}
+
+func BenchmarkLabelNamesForMatchers(b *testing.B) {
+	reader := buildLabelNamesTestIndex(b, 50_000)
+	matchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchRegexp, "service_name", ".*"),
+	}
+
+	for _, benchmark := range []struct {
+		name   string
+		reader phlaredb.IndexReader
+	}{
+		{name: "per_series", reader: legacyLabelNamesReader{reader}},
+		{name: "batched", reader: reader},
+	} {
+		b.Run(benchmark.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				_, err := labelNamesForMatchers(benchmark.reader, matchers)
+				require.NoError(b, err)
+			}
+		})
+	}
+}
+
+func buildLabelNamesTestIndex(tb testing.TB, numSeries int) *index.Reader {
+	tb.Helper()
+
+	path := filepath.Join(tb.TempDir(), index.IndexFilename)
+	w, err := index.NewWriter(tb.Context(), path)
+	require.NoError(tb, err)
+
+	symbols := map[string]struct{}{
+		"instance": {}, "region": {}, "service_name": {},
+		"api": {}, "worker": {}, "us-east": {}, "us-west": {},
+	}
+	for i := 0; i < numSeries; i++ {
+		symbols[fmt.Sprintf("instance-%05d", i)] = struct{}{}
+	}
+	orderedSymbols := make([]string, 0, len(symbols))
+	for symbol := range symbols {
+		orderedSymbols = append(orderedSymbols, symbol)
+	}
+	sort.Strings(orderedSymbols)
+	for _, symbol := range orderedSymbols {
+		require.NoError(tb, w.AddSymbol(symbol))
+	}
+
+	for i := 0; i < numSeries; i++ {
+		service := "api"
+		if i%2 == 1 {
+			service = "worker"
+		}
+		series := phlaremodel.LabelsFromStrings(
+			"instance", fmt.Sprintf("instance-%05d", i),
+			"region", []string{"us-east", "us-west"}[i%2],
+			"service_name", service,
+		)
+		require.NoError(tb, w.AddSeries(storage.SeriesRef(i), series, prommodel.Fingerprint(series.Hash())))
+	}
+	require.NoError(tb, w.Close())
+
+	reader, err := index.NewFileReader(path)
+	require.NoError(tb, err)
+	tb.Cleanup(func() { require.NoError(tb, reader.Close()) })
+	return reader
+}


### PR DESCRIPTION
Regression when LabelNames call has a selectors.

<img width="1664" height="524" alt="image" src="https://github.com/user-attachments/assets/53072246-4738-4568-af1e-1637970c4f41" />

# Micro benchmark

```
                                 │ baseline.txt │ pr.txt │
                                 │    sec/op    │ sec/op │ vs base
LabelNamesForMatchers/batched-12   14.615m ± 3%   3.638m ± 0%  -75.11% (p=0.002 n=6)

                                 │ baseline.txt │ pr.txt │
                                 │     B/op     │  B/op  │ vs base
LabelNamesForMatchers/batched-12   12109.6Ki ± 0%  781.6Ki ± 0%  -93.55% (p=0.002 n=6)

                                 │ baseline.txt │ pr.txt │
                                 │  allocs/op   │ allocs/op │ vs base
LabelNamesForMatchers/batched-12   350.01k ± 0%   50.01k ± 0%  -85.71% (p=0.002 n=6)
```

# Macro benchmark in a cell

```
                                                 │  before.txt  │        after-ad790d6cfadb.txt        │
                                                 │    sec/op    │    sec/op     vs base                │
QueryMetadata/LabelNames/service_name!=abc/1h-12   642.3m ± 15%   419.2m ±  8%  -34.73% (p=0.000 n=12)
QueryMetadata/LabelNames/service_name!=abc/1d-12    6.662 ±  1%    2.285 ±  9%  -65.69% (p=0.000 n=12)
QueryMetadata/LabelNames/service_name!=abc/7d-12   [timeout]       13.32 ±  3%
```

