### PR TITLE
chore: Upgrade pyroscope/api to v1.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/grafana/pyroscope-go v1.2.8
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.12
 	github.com/grafana/pyroscope-go/x/k6 v0.0.0-20241003203156-a917cea171d3
-	github.com/grafana/pyroscope/api v1.5.0
+	github.com/grafana/pyroscope/api v1.6.0
 	github.com/grafana/pyroscope/lidia v0.0.2
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0


### PR DESCRIPTION
## api/v1.5.0 -> api/v1.6.0

Releases a new version of the Pyroscope API to make several changes official.

### Query API (`query.v1`)
- Symbol-ref trees: new `SymbolMode` enum and `SymbolRefTable`; `TreeQuery.symbol_mode`, `TreeQuery.max_unresolved_locations`, `TreeReport.symbol_refs`. `full_symbols` deprecated, still honored when `symbol_mode` is unset (#5318)
- `trace_id_selector` on `Query`; `span_selector`, `trace_id_selector`, and per-row `trace_id` on span heatmaps (#5284, #5353)
- `bytes_fetched` on the invoke response: object-storage bytes for the successful call only (#5180)

### Querier API (`querier.v1`)
- Async queries (experimental): `AsyncQueryRequest`/`AsyncQueryResponse`, `AsyncQueryType`/`AsyncQueryStatus`, `async` fields on request and response (#4995)
- Unified merge formats: `PROFILE_FORMAT_PPROF`, `PprofProfile` message, `pprof` response field (#5358)
- `SelectMergeSpanProfile` and `SelectMergeProfile` marked deprecated; both still supported in `querier.v1`
- `trace_id_selector` and `span_selector` on `SelectMergeStacktraces` (#5284, #5273)

### Debuginfo API (`debuginfo.v1alpha1`)
- New `ListDebuginfo` and `DeleteDebuginfo` RPCs; `ObjectMetadata.size_bytes` (#5217)

### Types (`types.v1`)
- `trace_id` on the span type (32 lowercase hex chars)

### Metastore (`raft_log`)
- `reserved 4` on `raft_log.CompactionJobStatusUpdate` for wire compatibility with `metastore.v1.CompactionJobStatusUpdate` (#5465)

### Dependencies
- Security: grpc 1.80.0 -> 1.82.1, x/net 0.52.0 -> 0.56.0, x/text 0.35.0 -> 0.39.0 (#5391, #5380, #5381)
- connect 1.19.1 -> 1.19.2, grpc-gateway 2.28.0 -> 2.29.0, otel 1.43 -> 1.44, genproto refresh, toolchain go1.25.9 -> go1.25.13