### PR TITLE
docs: Include the client flag for utf-8 label names

### DIFF
--- a/docs/sources/reference-server-api/index.md
+++ b/docs/sources/reference-server-api/index.md
@@ -113,7 +113,10 @@ print(resp.content)
 
 ### Querying profiling data
 
-#### UTF-8 label names
+Use the Querier API endpoints to discover profile labels and types, select matching series, and retrieve or compare profiling data. The following sections describe query-specific requirements and the available endpoints.
+
+{{% admonition type="note" %}}
+**UTF-8 label names**
 
 To return UTF-8 label names from the `LabelNames` and `Series` APIs, include the following `Accept` header in the request:
 
@@ -123,8 +126,7 @@ Accept: */*; allow-utf8-labelnames=true
 
 Pyroscope requires an explicit opt-in to preserve compatibility for existing API consumers that expect legacy label-name syntax. Without this client capability, Pyroscope filters label names that do not conform to the legacy label-name format from API responses.
 
-When querying a UTF-8 label name outside the legacy format, quote the name inside the selector (this is following the [Prometheus UTF-8 querying guide](https://prometheus.io/docs/guides/utf8/#querying)). For example:
-
+When querying a UTF-8 label name outside the legacy format, quote the name inside the selector, as described in the [Prometheus UTF-8 querying guide](https://prometheus.io/docs/guides/utf8/#querying). For example:
 
 ```promql
 {"service.name"="checkout"}
@@ -135,9 +137,12 @@ In a JSON request body, escape the selector's quotes:
 
 ```json
 {
-  "labelSelector": "{\"service.name\"=\"checkout\"}"
+  "matchers": [
+    "{\"service.name\"=\"checkout\"}"
+  ]
 }
 ```
+{{% /admonition %}}
 
 #### `/querier.v1.QuerierService/Diff`
 

--- a/docs/sources/reference-server-api/index.md
+++ b/docs/sources/reference-server-api/index.md
@@ -113,6 +113,32 @@ print(resp.content)
 
 ### Querying profiling data
 
+#### UTF-8 label names
+
+To return UTF-8 label names from the `LabelNames` and `Series` APIs, include the following `Accept` header in the request:
+
+```http
+Accept: */*; allow-utf8-labelnames=true
+```
+
+Pyroscope requires an explicit opt-in to preserve compatibility for existing API consumers that expect legacy label-name syntax. Without this client capability, Pyroscope filters label names that do not conform to the legacy label-name format from API responses.
+
+When querying a UTF-8 label name outside the legacy format, quote the name inside the selector (this is following the [Prometheus UTF-8 querying guide](https://prometheus.io/docs/guides/utf8/#querying)). For example:
+
+
+```promql
+{"service.name"="checkout"}
+{"世界"="value"}
+```
+
+In a JSON request body, escape the selector's quotes:
+
+```json
+{
+  "labelSelector": "{\"service.name\"=\"checkout\"}"
+}
+```
+
 #### `/querier.v1.QuerierService/Diff`
 
 Diff returns a diff of two profiles

--- a/docs/sources/reference-server-api/index.template
+++ b/docs/sources/reference-server-api/index.template
@@ -39,7 +39,10 @@ Pyroscope APIs are categorized into two scopes:
 
 ### Querying profiling data
 
-#### UTF-8 label names
+Use the Querier API endpoints to discover profile labels and types, select matching series, and retrieve or compare profiling data. The following sections describe query-specific requirements and the available endpoints.
+
+{{% admonition type="note" %}}
+**UTF-8 label names**
 
 To return UTF-8 label names from the `LabelNames` and `Series` APIs, include the following `Accept` header in the request:
 
@@ -49,8 +52,7 @@ Accept: */*; allow-utf8-labelnames=true
 
 Pyroscope requires an explicit opt-in to preserve compatibility for existing API consumers that expect legacy label-name syntax. Without this client capability, Pyroscope filters label names that do not conform to the legacy label-name format from API responses.
 
-When querying a UTF-8 label name outside the legacy format, quote the name inside the selector (this is following the [Prometheus UTF-8 querying guide](https://prometheus.io/docs/guides/utf8/#querying)). For example:
-
+When querying a UTF-8 label name outside the legacy format, quote the name inside the selector, as described in the [Prometheus UTF-8 querying guide](https://prometheus.io/docs/guides/utf8/#querying). For example:
 
 ```promql
 {"service.name"="checkout"}
@@ -61,9 +63,12 @@ In a JSON request body, escape the selector's quotes:
 
 ```json
 {
-  "labelSelector": "{\"service.name\"=\"checkout\"}"
+  "matchers": [
+    "{\"service.name\"=\"checkout\"}"
+  ]
 }
 ```
+{{% /admonition %}}
 
 {{ .RenderAPIGroup "/querier.v1.QuerierService" }}
 

--- a/docs/sources/reference-server-api/index.template
+++ b/docs/sources/reference-server-api/index.template
@@ -39,6 +39,32 @@ Pyroscope APIs are categorized into two scopes:
 
 ### Querying profiling data
 
+#### UTF-8 label names
+
+To return UTF-8 label names from the `LabelNames` and `Series` APIs, include the following `Accept` header in the request:
+
+```http
+Accept: */*; allow-utf8-labelnames=true
+```
+
+Pyroscope requires an explicit opt-in to preserve compatibility for existing API consumers that expect legacy label-name syntax. Without this client capability, Pyroscope filters label names that do not conform to the legacy label-name format from API responses.
+
+When querying a UTF-8 label name outside the legacy format, quote the name inside the selector (this is following the [Prometheus UTF-8 querying guide](https://prometheus.io/docs/guides/utf8/#querying)). For example:
+
+
+```promql
+{"service.name"="checkout"}
+{"世界"="value"}
+```
+
+In a JSON request body, escape the selector's quotes:
+
+```json
+{
+  "labelSelector": "{\"service.name\"=\"checkout\"}"
+}
+```
+
 {{ .RenderAPIGroup "/querier.v1.QuerierService" }}
 
 

--- a/docs/sources/reference-server-api/index.template
+++ b/docs/sources/reference-server-api/index.template
@@ -41,7 +41,7 @@ Pyroscope APIs are categorized into two scopes:
 
 Use the Querier API endpoints to discover profile labels and types, select matching series, and retrieve or compare profiling data. The following sections describe query-specific requirements and the available endpoints.
 
-{{% admonition type="note" %}}
+{{"{{% admonition type=\"note\" %}}"}}
 **UTF-8 label names**
 
 To return UTF-8 label names from the `LabelNames` and `Series` APIs, include the following `Accept` header in the request:
@@ -68,7 +68,7 @@ In a JSON request body, escape the selector's quotes:
   ]
 }
 ```
-{{% /admonition %}}
+{{"{{% /admonition %}}"}}
 
 {{ .RenderAPIGroup "/querier.v1.QuerierService" }}
 


### PR DESCRIPTION
Was missed when originally implemented
