### PR TITLE
fix(segmentwriter): probe the bucket with Upload instead of Iter

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -1086,7 +1086,7 @@ Usage of ./pyroscope:
   -segment-writer.availability-zone string
     	The availability zone where this instance is running.
   -segment-writer.bucket-health-check-enabled
-    	Enables bucket health check on startup. This both validates credentials and warms up the connection to reduce latency for the first write. If the check fails, the segment writer fails to start. (default true)
+    	Uploads and removes a small object at startup to verify bucket write access. Startup fails if the upload fails; a failed removal is only logged. (default true)
   -segment-writer.bucket-health-check-timeout duration
     	Timeout for bucket health check operations. (default 10s)
   -segment-writer.consul.acl-token string

--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -1086,7 +1086,7 @@ Usage of ./pyroscope:
   -segment-writer.availability-zone string
     	The availability zone where this instance is running.
   -segment-writer.bucket-health-check-enabled
-    	Enables bucket health check on startup. This both validates credentials and warms up the connection to reduce latency for the first write. (default true)
+    	Enables bucket health check on startup. This both validates credentials and warms up the connection to reduce latency for the first write. If the check fails, the segment writer fails to start. (default true)
   -segment-writer.bucket-health-check-timeout duration
     	Timeout for bucket health check operations. (default 10s)
   -segment-writer.consul.acl-token string

--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -1086,7 +1086,7 @@ Usage of ./pyroscope:
   -segment-writer.availability-zone string
     	The availability zone where this instance is running.
   -segment-writer.bucket-health-check-enabled
-    	Uploads and removes a small object at startup to verify bucket write access. Startup fails if the upload fails; a failed removal is only logged. (default true)
+    	Uploads a small object at startup to verify bucket write access. Startup fails if the upload fails. Removal of the object is best effort: it is skipped on filesystem storage, which keeps one object per startup, and a failed removal is only logged. (default true)
   -segment-writer.bucket-health-check-timeout duration
     	Timeout for bucket health check operations. (default 10s)
   -segment-writer.consul.acl-token string

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -1224,9 +1224,10 @@ lifecycler:
 # CLI flag: -segment-writer.metadata-update-timeout
 [metadata_update_timeout: <duration> | default = 2s]
 
-# (advanced) Uploads and removes a small object at startup to verify bucket
-# write access. Startup fails if the upload fails; a failed removal is only
-# logged.
+# (advanced) Uploads a small object at startup to verify bucket write access.
+# Startup fails if the upload fails. Removal of the object is best effort: it is
+# skipped on filesystem storage, which keeps one object per startup, and a
+# failed removal is only logged.
 # CLI flag: -segment-writer.bucket-health-check-enabled
 [bucket_health_check_enabled: <boolean> | default = true]
 

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -1224,9 +1224,9 @@ lifecycler:
 # CLI flag: -segment-writer.metadata-update-timeout
 [metadata_update_timeout: <duration> | default = 2s]
 
-# (advanced) Enables bucket health check on startup. This both validates
-# credentials and warms up the connection to reduce latency for the first write.
-# If the check fails, the segment writer fails to start.
+# (advanced) Uploads and removes a small object at startup to verify bucket
+# write access. Startup fails if the upload fails; a failed removal is only
+# logged.
 # CLI flag: -segment-writer.bucket-health-check-enabled
 [bucket_health_check_enabled: <boolean> | default = true]
 

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -1226,6 +1226,7 @@ lifecycler:
 
 # (advanced) Enables bucket health check on startup. This both validates
 # credentials and warms up the connection to reduce latency for the first write.
+# If the check fails, the segment writer fails to start.
 # CLI flag: -segment-writer.bucket-health-check-enabled
 [bucket_health_check_enabled: <boolean> | default = true]
 

--- a/pkg/segmentwriter/service.go
+++ b/pkg/segmentwriter/service.go
@@ -41,6 +41,11 @@ const (
 	defaultHedgedRequestBurst   = 10 // allow bursts of 10 hedged requests
 )
 
+// errStopIteration aborts the bucket health check iteration: we only care that
+// the bucket is reachable, not about its contents. It is matched with errors.Is
+// so that the check keeps working if a bucket implementation wraps it.
+var errStopIteration = errors.New("stop iteration")
+
 type Config struct {
 	GRPCClientConfig           grpcclient.Config     `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate with the segment writer."`
 	LifecyclerConfig           ring.LifecyclerConfig `yaml:"lifecycler,omitempty"`
@@ -97,7 +102,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.UintVar(&cfg.UploadHedgeRateBurst, prefix+".upload-hedge-rate-burst", defaultHedgedRequestBurst, "Maximum number of hedged requests in a burst.")
 	f.BoolVar(&cfg.MetadataDLQEnabled, prefix+".metadata-dlq-enabled", true, "Enables dead letter queue (DLQ) for metadata. If the metadata update fails, it will be stored and updated asynchronously.")
 	f.DurationVar(&cfg.MetadataUpdateTimeout, prefix+".metadata-update-timeout", 2*time.Second, "Timeout for metadata update requests.")
-	f.BoolVar(&cfg.BucketHealthCheckEnabled, prefix+".bucket-health-check-enabled", true, "Enables bucket health check on startup. This both validates credentials and warms up the connection to reduce latency for the first write.")
+	f.BoolVar(&cfg.BucketHealthCheckEnabled, prefix+".bucket-health-check-enabled", true, "Enables bucket health check on startup. This both validates credentials and warms up the connection to reduce latency for the first write. If the check fails, the segment writer fails to start.")
 	f.DurationVar(&cfg.BucketHealthCheckTimeout, prefix+".bucket-health-check-timeout", 10*time.Second, "Timeout for bucket health check operations.")
 }
 
@@ -194,6 +199,17 @@ func New(
 // performBucketHealthCheck performs a lightweight bucket operation to warm up the connection
 // and detect any object storage issues early. This serves the dual purpose of validating
 // bucket accessibility and reducing latency for the first actual write operation.
+//
+// A failure is fatal: the segment writer cannot serve writes without the bucket, as Push
+// blocks until the segment has been uploaded, and a definitive upload error surfaces as
+// codes.Unknown, which the client does not treat as retryable - so writes routed to a
+// write-broken instance are lost rather than failed over. Returning an error here prevents
+// the instance from starting, instead of letting it report itself ready and silently drop
+// a share of the cell's writes.
+//
+// This completes the plan agreed when the check was introduced in #4453, where warning and
+// continuing was explicitly a staging step until the behaviour had been verified against a
+// live cell.
 func (i *SegmentWriterService) performBucketHealthCheck(ctx context.Context) error {
 	if !i.config.BucketHealthCheckEnabled {
 		return nil
@@ -205,27 +221,35 @@ func (i *SegmentWriterService) performBucketHealthCheck(ctx context.Context) err
 	defer cancel()
 
 	err := i.storageBucket.Iter(healthCheckCtx, "", func(string) error {
-		// We only care about connectivity, not the actual contents
-		// Return an error to stop iteration after first item (if any)
-		return errors.New("stop iteration")
+		// We only care about connectivity, not the actual contents,
+		// so stop the iteration as soon as the bucket yields anything.
+		return errStopIteration
 	})
 
-	// Ignore the "stop iteration" error we intentionally return
-	// and any "object not found" type errors as they indicate the bucket is accessible
-	if err == nil || i.storageBucket.IsObjNotFoundErr(err) || err.Error() == "stop iteration" {
+	// A healthy bucket produces exactly two outcomes: nil when it is empty and the callback
+	// never fires, or the sentinel when it does. Nothing else means the bucket answered - in
+	// particular an "object not found" is not a success here. A list never names a key, so no
+	// healthy bucket can report one; what it can report is a missing *bucket*, and at least
+	// one backend (Tencent COS) classifies any 404 as a not-found, so accepting that class
+	// would let a writer configured with a nonexistent bucket join the ring.
+	if err == nil || errors.Is(err, errStopIteration) {
 		level.Debug(i.logger).Log("msg", "bucket health check succeeded")
 		return nil
 	}
 
-	level.Warn(i.logger).Log("msg", "bucket health check failed", "err", err)
-	return nil // Don't fail startup, just warn
+	level.Error(i.logger).Log("msg", "bucket health check failed", "err", err)
+	return fmt.Errorf("bucket health check failed: %w", err)
 }
 
 func (i *SegmentWriterService) starting(ctx context.Context) error {
 	// Perform bucket health check before ring registration to warm up the connection
-	// and avoid slow first requests affecting p99 latency
-	// On error, will emit a warning but continue startup
-	_ = i.performBucketHealthCheck(ctx)
+	// and avoid slow first requests affecting p99 latency.
+	// On error, the instance fails to start and never registers in the ring, so no
+	// distributor routes writes to it, and the process exits rather than reporting
+	// itself healthy in a state it cannot serve from.
+	if err := i.performBucketHealthCheck(ctx); err != nil {
+		return err
+	}
 
 	if err := services.StartManagerAndAwaitHealthy(ctx, i.subservices); err != nil {
 		return err

--- a/pkg/segmentwriter/service.go
+++ b/pkg/segmentwriter/service.go
@@ -1,6 +1,7 @@
 package segmentwriter
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"flag"
@@ -10,15 +11,18 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/google/uuid"
+	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/multierror"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	segmentwriterv1 "github.com/grafana/pyroscope/api/gen/proto/go/segmentwriter/v1"
+	"github.com/grafana/pyroscope/v2/pkg/block"
 	metastoreclient "github.com/grafana/pyroscope/v2/pkg/metastore/client"
 	"github.com/grafana/pyroscope/v2/pkg/model/relabel"
 	phlareobj "github.com/grafana/pyroscope/v2/pkg/objstore"
@@ -39,12 +43,10 @@ const (
 	defaultSegmentDuration      = 500 * time.Millisecond
 	defaultHedgedRequestMaxRate = 2  // 2 hedged requests per second
 	defaultHedgedRequestBurst   = 10 // allow bursts of 10 hedged requests
-)
 
-// errStopIteration aborts the bucket health check iteration: we only care that
-// the bucket is reachable, not about its contents. It is matched with errors.Is
-// so that the check keeps working if a bucket implementation wraps it.
-var errStopIteration = errors.New("stop iteration")
+	// Shares the segments/ prefix so a segments/* bucket policy covers the probe too.
+	bucketHealthCheckPrefix = block.DirNameSegment + "/_health/"
+)
 
 type Config struct {
 	GRPCClientConfig           grpcclient.Config     `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate with the segment writer."`
@@ -102,7 +104,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.UintVar(&cfg.UploadHedgeRateBurst, prefix+".upload-hedge-rate-burst", defaultHedgedRequestBurst, "Maximum number of hedged requests in a burst.")
 	f.BoolVar(&cfg.MetadataDLQEnabled, prefix+".metadata-dlq-enabled", true, "Enables dead letter queue (DLQ) for metadata. If the metadata update fails, it will be stored and updated asynchronously.")
 	f.DurationVar(&cfg.MetadataUpdateTimeout, prefix+".metadata-update-timeout", 2*time.Second, "Timeout for metadata update requests.")
-	f.BoolVar(&cfg.BucketHealthCheckEnabled, prefix+".bucket-health-check-enabled", true, "Enables bucket health check on startup. This both validates credentials and warms up the connection to reduce latency for the first write. If the check fails, the segment writer fails to start.")
+	f.BoolVar(&cfg.BucketHealthCheckEnabled, prefix+".bucket-health-check-enabled", true, "Uploads and removes a small object at startup to verify bucket write access. Startup fails if the upload fails; a failed removal is only logged.")
 	f.DurationVar(&cfg.BucketHealthCheckTimeout, prefix+".bucket-health-check-timeout", 10*time.Second, "Timeout for bucket health check operations.")
 }
 
@@ -127,6 +129,8 @@ type SegmentWriterService struct {
 
 	storageBucket phlareobj.Bucket
 	segmentWriter *segmentsWriter
+
+	bucketHealthCheckCleanupFailures prometheus.Counter
 }
 
 func New(
@@ -187,6 +191,13 @@ func New(
 	if metastoreClient == nil {
 		return nil, errors.New("metastore client is required for segment writer")
 	}
+	i.bucketHealthCheckCleanupFailures = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Namespace: "pyroscope",
+		Subsystem: "segment_writer",
+		Name:      "bucket_health_check_cleanup_failures_total",
+		Help:      "Times the startup bucket health check could not remove its probe object.",
+	})
+
 	metrics := newSegmentMetrics(i.reg)
 	headMetrics := memdb.NewHeadMetricsWithPrefix(reg, "pyroscope_segment_writer")
 	i.segmentWriter = newSegmentWriter(i.logger, metrics, headMetrics, config, limits, storageBucket, metastoreClient)
@@ -196,57 +207,61 @@ func New(
 	return i, nil
 }
 
-// performBucketHealthCheck performs a lightweight bucket operation to warm up the connection
-// and detect any object storage issues early. This serves the dual purpose of validating
-// bucket accessibility and reducing latency for the first actual write operation.
-//
-// A failure is fatal: the segment writer cannot serve writes without the bucket, as Push
-// blocks until the segment has been uploaded, and a definitive upload error surfaces as
-// codes.Unknown, which the client does not treat as retryable - so writes routed to a
-// write-broken instance are lost rather than failed over. Returning an error here prevents
-// the instance from starting, instead of letting it report itself ready and silently drop
-// a share of the cell's writes.
-//
-// This completes the plan agreed when the check was introduced in #4453, where warning and
-// continuing was explicitly a staging step until the behaviour had been verified against a
-// live cell.
+// performBucketHealthCheck verifies the segment writer can write to object storage before it
+// joins the ring. Failure is fatal: a definitive upload error surfaces as codes.Unknown, which
+// the client does not retry, so writes to a write-broken instance are lost, not failed over.
 func (i *SegmentWriterService) performBucketHealthCheck(ctx context.Context) error {
 	if !i.config.BucketHealthCheckEnabled {
 		return nil
 	}
 
-	level.Debug(i.logger).Log("msg", "starting bucket health check", "timeout", i.config.BucketHealthCheckTimeout.String())
+	name := bucketHealthCheckPrefix + i.config.LifecyclerConfig.ID
+	payload := bucketHealthCheckPayload(i.config.LifecyclerConfig.ID)
+	level.Debug(i.logger).Log("msg", "starting bucket health check", "object", name)
 
-	healthCheckCtx, cancel := context.WithTimeout(ctx, i.config.BucketHealthCheckTimeout)
-	defer cancel()
+	uploadCtx, cancelUpload := context.WithTimeout(ctx, i.config.BucketHealthCheckTimeout)
+	defer cancelUpload()
 
-	err := i.storageBucket.Iter(healthCheckCtx, "", func(string) error {
-		// We only care about connectivity, not the actual contents,
-		// so stop the iteration as soon as the bucket yields anything.
-		return errStopIteration
+	// An already-expired context skips the loop entirely, so err must start out non-nil.
+	err := uploadCtx.Err()
+	retries := backoff.New(uploadCtx, backoff.Config{
+		MinBackoff: i.config.UploadMinBackoff,
+		MaxBackoff: i.config.UploadMaxBackoff,
+		MaxRetries: i.config.UploadMaxRetries,
 	})
-
-	// A healthy bucket produces exactly two outcomes: nil when it is empty and the callback
-	// never fires, or the sentinel when it does. Nothing else means the bucket answered - in
-	// particular an "object not found" is not a success here. A list never names a key, so no
-	// healthy bucket can report one; what it can report is a missing *bucket*, and at least
-	// one backend (Tencent COS) classifies any 404 as a not-found, so accepting that class
-	// would let a writer configured with a nonexistent bucket join the ring.
-	if err == nil || errors.Is(err, errStopIteration) {
-		level.Debug(i.logger).Log("msg", "bucket health check succeeded")
-		return nil
+	for retries.Ongoing() {
+		if err = i.storageBucket.Upload(uploadCtx, name, bytes.NewReader(payload)); err == nil {
+			break
+		}
+		retries.Wait()
+	}
+	if err != nil {
+		level.Error(i.logger).Log("msg", "bucket health check failed", "object", name, "err", err)
+		return fmt.Errorf("bucket health check failed: %w", err)
 	}
 
-	level.Error(i.logger).Log("msg", "bucket health check failed", "err", err)
-	return fmt.Errorf("bucket health check failed: %w", err)
+	// Best effort: the key is per instance, so a bucket denying deletes keeps one object per
+	// replica, not one per restart.
+	deleteCtx, cancelDelete := context.WithTimeout(ctx, i.config.BucketHealthCheckTimeout)
+	defer cancelDelete()
+	if err := i.storageBucket.Delete(deleteCtx, name); err != nil {
+		i.bucketHealthCheckCleanupFailures.Inc()
+		level.Warn(i.logger).Log("msg", "failed to remove bucket health check object", "object", name, "err", err)
+	}
+
+	level.Debug(i.logger).Log("msg", "bucket health check succeeded")
+	return nil
+}
+
+func bucketHealthCheckPayload(instanceID string) []byte {
+	return []byte(fmt.Sprintf(
+		"pyroscope segment-writer bucket health check\ninstance: %s\nwritten: %s\n"+
+			"Written at startup to verify write access to the bucket. Safe to delete.\n",
+		instanceID, time.Now().UTC().Format(time.RFC3339),
+	))
 }
 
 func (i *SegmentWriterService) starting(ctx context.Context) error {
-	// Perform bucket health check before ring registration to warm up the connection
-	// and avoid slow first requests affecting p99 latency.
-	// On error, the instance fails to start and never registers in the ring, so no
-	// distributor routes writes to it, and the process exits rather than reporting
-	// itself healthy in a state it cannot serve from.
 	if err := i.performBucketHealthCheck(ctx); err != nil {
 		return err
 	}

--- a/pkg/segmentwriter/service.go
+++ b/pkg/segmentwriter/service.go
@@ -11,13 +11,13 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/google/uuid"
-	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/multierror"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/thanos-io/objstore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -44,7 +44,8 @@ const (
 	defaultHedgedRequestMaxRate = 2  // 2 hedged requests per second
 	defaultHedgedRequestBurst   = 10 // allow bursts of 10 hedged requests
 
-	// Shares the segments/ prefix so a segments/* bucket policy covers the probe too.
+	// The probe has to exercise the prefix the write path itself uses: a policy that grants
+	// another prefix while denying this one would pass the check and fail every real write.
 	bucketHealthCheckPrefix = block.DirNameSegment + "/_health/"
 )
 
@@ -104,7 +105,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.UintVar(&cfg.UploadHedgeRateBurst, prefix+".upload-hedge-rate-burst", defaultHedgedRequestBurst, "Maximum number of hedged requests in a burst.")
 	f.BoolVar(&cfg.MetadataDLQEnabled, prefix+".metadata-dlq-enabled", true, "Enables dead letter queue (DLQ) for metadata. If the metadata update fails, it will be stored and updated asynchronously.")
 	f.DurationVar(&cfg.MetadataUpdateTimeout, prefix+".metadata-update-timeout", 2*time.Second, "Timeout for metadata update requests.")
-	f.BoolVar(&cfg.BucketHealthCheckEnabled, prefix+".bucket-health-check-enabled", true, "Uploads and removes a small object at startup to verify bucket write access. Startup fails if the upload fails; a failed removal is only logged.")
+	f.BoolVar(&cfg.BucketHealthCheckEnabled, prefix+".bucket-health-check-enabled", true, "Uploads a small object at startup to verify bucket write access. Startup fails if the upload fails. Removal of the object is best effort: it is skipped on filesystem storage, which keeps one object per startup, and a failed removal is only logged.")
 	f.DurationVar(&cfg.BucketHealthCheckTimeout, prefix+".bucket-health-check-timeout", 10*time.Second, "Timeout for bucket health check operations.")
 }
 
@@ -210,47 +211,55 @@ func New(
 // performBucketHealthCheck verifies the segment writer can write to object storage before it
 // joins the ring. Failure is fatal: a definitive upload error surfaces as codes.Unknown, which
 // the client does not retry, so writes to a write-broken instance are lost, not failed over.
+// One attempt is enough, as the restart is the retry and the supervisor backs it off.
 func (i *SegmentWriterService) performBucketHealthCheck(ctx context.Context) error {
 	if !i.config.BucketHealthCheckEnabled {
 		return nil
 	}
 
-	name := bucketHealthCheckPrefix + i.config.LifecyclerConfig.ID
+	name := bucketHealthCheckKey(i.config.LifecyclerConfig.ID)
 	payload := bucketHealthCheckPayload(i.config.LifecyclerConfig.ID)
 	level.Debug(i.logger).Log("msg", "starting bucket health check", "object", name)
 
-	uploadCtx, cancelUpload := context.WithTimeout(ctx, i.config.BucketHealthCheckTimeout)
-	defer cancelUpload()
-
-	// An already-expired context skips the loop entirely, so err must start out non-nil.
-	err := uploadCtx.Err()
-	retries := backoff.New(uploadCtx, backoff.Config{
-		MinBackoff: i.config.UploadMinBackoff,
-		MaxBackoff: i.config.UploadMaxBackoff,
-		MaxRetries: i.config.UploadMaxRetries,
-	})
-	for retries.Ongoing() {
-		if err = i.storageBucket.Upload(uploadCtx, name, bytes.NewReader(payload)); err == nil {
-			break
-		}
-		retries.Wait()
-	}
-	if err != nil {
+	uploadCtx, cancel := context.WithTimeout(ctx, i.config.BucketHealthCheckTimeout)
+	defer cancel()
+	if err := i.storageBucket.Upload(uploadCtx, name, bytes.NewReader(payload)); err != nil {
 		level.Error(i.logger).Log("msg", "bucket health check failed", "object", name, "err", err)
 		return fmt.Errorf("bucket health check failed: %w", err)
 	}
 
-	// Best effort: the key is per instance, so a bucket denying deletes keeps one object per
-	// replica, not one per restart.
-	deleteCtx, cancelDelete := context.WithTimeout(ctx, i.config.BucketHealthCheckTimeout)
-	defer cancelDelete()
+	i.removeBucketHealthCheckObject(ctx, name)
+	level.Debug(i.logger).Log("msg", "bucket health check succeeded")
+	return nil
+}
+
+// removeBucketHealthCheckObject clears the probe away again, best effort: a bucket that grants
+// writes but not deletes is still serviceable, and keeping one small object per start is the
+// price of a probe the bucket cannot refuse to create. Those leftovers can be expired with a
+// lifecycle rule scoped to the probe prefix, never to segments/ itself.
+func (i *SegmentWriterService) removeBucketHealthCheckObject(ctx context.Context, name string) {
+	// The filesystem bucket deletes by walking up and removing parents it has just found empty.
+	// A writer creating the first real segment inside that window would lose it, so the probe
+	// stays: on this backend it is a stray file, not lost data.
+	if i.storageBucket.Provider() == objstore.FILESYSTEM {
+		level.Debug(i.logger).Log("msg", "keeping bucket health check object", "object", name,
+			"reason", "deleting it on the filesystem backend can remove concurrently written segments")
+		return
+	}
+
+	deleteCtx, cancel := context.WithTimeout(ctx, i.config.BucketHealthCheckTimeout)
+	defer cancel()
 	if err := i.storageBucket.Delete(deleteCtx, name); err != nil {
 		i.bucketHealthCheckCleanupFailures.Inc()
 		level.Warn(i.logger).Log("msg", "failed to remove bucket health check object", "object", name, "err", err)
 	}
+}
 
-	level.Debug(i.logger).Log("msg", "bucket health check succeeded")
-	return nil
+// bucketHealthCheckKey is unique per start, which keeps the probe a create rather than an
+// overwrite. The distinction matters: GCS grants such as roles/storage.objectCreator allow
+// creating an object and deny replacing one, and the write path only ever creates.
+func bucketHealthCheckKey(instanceID string) string {
+	return bucketHealthCheckPrefix + instanceID + "/" + uuid.New().String()
 }
 
 func bucketHealthCheckPayload(instanceID string) []byte {

--- a/pkg/segmentwriter/service_test.go
+++ b/pkg/segmentwriter/service_test.go
@@ -1,0 +1,169 @@
+package segmentwriter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+
+	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockobjstore"
+)
+
+func TestSegmentWriterService_performBucketHealthCheck(t *testing.T) {
+	t.Parallel()
+
+	const timeout = 100 * time.Millisecond
+
+	// iterCalledWith returns a mock expectation for Iter at the bucket root, invoking
+	// visit with the callback the health check passed in.
+	iterCalledWith := func(visit func(f func(string) error) error) func(*mockobjstore.MockBucket) {
+		return func(bucket *mockobjstore.MockBucket) {
+			bucket.On("Iter", mock.Anything, "", mock.Anything).
+				Return(func(_ context.Context, _ string, f func(string) error, _ ...objstore.IterOption) error {
+					return visit(f)
+				})
+		}
+	}
+
+	// iterFailsWith makes Iter return err without invoking the callback.
+	iterFailsWith := func(err error) func(*mockobjstore.MockBucket) {
+		return iterCalledWith(func(func(string) error) error { return err })
+	}
+
+	unreachable := errors.New("dial tcp: connection refused")
+	noSuchBucket := errors.New("NoSuchBucket: the specified bucket does not exist")
+
+	for _, tc := range []struct {
+		name    string
+		enabled bool
+		setup   func(*mockobjstore.MockBucket)
+		assert  func(*testing.T, error)
+	}{
+		{
+			// The check is skipped entirely: the bucket must not be touched.
+			name:    "disabled",
+			enabled: false,
+			setup:   func(*mockobjstore.MockBucket) {},
+			assert:  func(t *testing.T, err error) { require.NoError(t, err) },
+		},
+		{
+			// One of only two healthy outcomes: an empty bucket never invokes the
+			// callback, so Iter returns nil.
+			name:    "empty bucket",
+			enabled: true,
+			setup:   iterCalledWith(func(func(string) error) error { return nil }),
+			assert:  func(t *testing.T, err error) { require.NoError(t, err) },
+		},
+		{
+			// The other healthy outcome, and the production shape: the callback fires and
+			// its sentinel comes back out of Iter. Treating that as a failure would stop
+			// the segment writer starting against a perfectly healthy bucket.
+			name:    "non-empty bucket",
+			enabled: true,
+			setup: iterCalledWith(func(f func(string) error) error {
+				return f("some/object/path")
+			}),
+			assert: func(t *testing.T, err error) { require.NoError(t, err) },
+		},
+		{
+			// The sentinel must be recognised even if a bucket implementation wraps it.
+			// This is what errors.Is buys over comparing the message.
+			name:    "non-empty bucket with wrapped sentinel",
+			enabled: true,
+			setup: iterCalledWith(func(f func(string) error) error {
+				return fmt.Errorf("iter some/prefix: %w", f("some/object/path"))
+			}),
+			assert: func(t *testing.T, err error) { require.NoError(t, err) },
+		},
+		{
+			// A nonexistent bucket must not start. This is why the success condition
+			// cannot accept "object not found": a list never names a key, so that class
+			// only ever arrives from a missing bucket, and Tencent COS reports any 404 -
+			// NoSuchBucket included - as a not-found.
+			name:    "missing bucket is fatal",
+			enabled: true,
+			setup:   iterFailsWith(noSuchBucket),
+			assert: func(t *testing.T, err error) {
+				require.ErrorIs(t, err, noSuchBucket)
+				require.ErrorContains(t, err, "bucket health check failed")
+			},
+		},
+		{
+			// Anything else stops the segment writer starting too, rather than letting it
+			// report itself healthy and drop writes it cannot fulfil. The cause is wrapped
+			// so operators can see it.
+			name:    "bucket unreachable is fatal",
+			enabled: true,
+			setup:   iterFailsWith(unreachable),
+			assert: func(t *testing.T, err error) {
+				require.ErrorIs(t, err, unreachable)
+				require.ErrorContains(t, err, "bucket health check failed")
+			},
+		},
+		{
+			// Exercised through a real expiring context rather than a synthetic error,
+			// so the timeout plumbing itself is covered.
+			name:    "timeout is fatal",
+			enabled: true,
+			setup: func(bucket *mockobjstore.MockBucket) {
+				bucket.On("Iter", mock.Anything, "", mock.Anything).
+					Return(func(ctx context.Context, _ string, _ func(string) error, _ ...objstore.IterOption) error {
+						<-ctx.Done()
+						return ctx.Err()
+					})
+			},
+			assert: func(t *testing.T, err error) {
+				require.ErrorIs(t, err, context.DeadlineExceeded)
+				require.ErrorContains(t, err, "bucket health check failed")
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			bucket := mockobjstore.NewMockBucket(t)
+			tc.setup(bucket)
+
+			svc := &SegmentWriterService{
+				logger:        log.NewNopLogger(),
+				storageBucket: bucket,
+				config: Config{
+					BucketHealthCheckEnabled: tc.enabled,
+					BucketHealthCheckTimeout: timeout,
+				},
+			}
+
+			tc.assert(t, svc.performBucketHealthCheck(context.Background()))
+		})
+	}
+}
+
+// The failure has to reach the caller so the dskit service transitions to Failed, which is
+// what stops the instance registering in the ring and ultimately exits the process.
+func TestSegmentWriterService_starting_bucketHealthCheckFailure(t *testing.T) {
+	t.Parallel()
+
+	unreachable := errors.New("dial tcp: connection refused")
+	bucket := mockobjstore.NewMockBucket(t)
+	bucket.On("Iter", mock.Anything, "", mock.Anything).Return(unreachable)
+
+	svc := &SegmentWriterService{
+		logger:        log.NewNopLogger(),
+		storageBucket: bucket,
+		config: Config{
+			BucketHealthCheckEnabled: true,
+			BucketHealthCheckTimeout: time.Second,
+		},
+	}
+
+	// subservices is deliberately left nil: StartManagerAndAwaitHealthy would panic on
+	// it, so returning an error instead proves starting bailed out before the ring.
+	err := svc.starting(context.Background())
+	require.ErrorIs(t, err, unreachable)
+}

--- a/pkg/segmentwriter/service_test.go
+++ b/pkg/segmentwriter/service_test.go
@@ -3,117 +3,139 @@ package segmentwriter
 import (
 	"context"
 	"errors"
-	"fmt"
+	"io"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/ring"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/objstore"
 
+	"github.com/grafana/pyroscope/v2/pkg/block"
 	"github.com/grafana/pyroscope/v2/pkg/test/mocks/mockobjstore"
 )
+
+const testInstanceID = "segment-writer-7"
+
+// Asserted literally rather than rebuilt from the constants, so moving the probe is deliberate.
+const expectedHealthCheckKey = "segments/_health/" + testInstanceID
 
 func TestSegmentWriterService_performBucketHealthCheck(t *testing.T) {
 	t.Parallel()
 
-	const timeout = 100 * time.Millisecond
+	const timeout = time.Second
 
-	// iterCalledWith returns a mock expectation for Iter at the bucket root, invoking
-	// visit with the callback the health check passed in.
-	iterCalledWith := func(visit func(f func(string) error) error) func(*mockobjstore.MockBucket) {
+	uploadReturns := func(errs ...error) func(*mockobjstore.MockBucket) {
 		return func(bucket *mockobjstore.MockBucket) {
-			bucket.On("Iter", mock.Anything, "", mock.Anything).
-				Return(func(_ context.Context, _ string, f func(string) error, _ ...objstore.IterOption) error {
-					return visit(f)
+			var attempt int
+			bucket.On("Upload", mock.Anything, expectedHealthCheckKey, mock.Anything).
+				Return(func(_ context.Context, _ string, r io.Reader, _ ...objstore.ObjectUploadOption) error {
+					// A reader shared across retries would be drained after the first.
+					body, err := io.ReadAll(r)
+					require.NoError(t, err)
+					require.Contains(t, string(body), testInstanceID)
+
+					err = errs[min(attempt, len(errs)-1)]
+					attempt++
+					return err
 				})
 		}
 	}
 
-	// iterFailsWith makes Iter return err without invoking the callback.
-	iterFailsWith := func(err error) func(*mockobjstore.MockBucket) {
-		return iterCalledWith(func(func(string) error) error { return err })
+	uploadThenDelete := func(deleteErr error) func(*mockobjstore.MockBucket) {
+		return func(bucket *mockobjstore.MockBucket) {
+			uploadReturns(nil)(bucket)
+			bucket.On("Delete", mock.Anything, expectedHealthCheckKey).Return(deleteErr)
+		}
 	}
 
 	unreachable := errors.New("dial tcp: connection refused")
 	noSuchBucket := errors.New("NoSuchBucket: the specified bucket does not exist")
+	accessDenied := errors.New("AccessDenied: not authorized to perform s3:DeleteObject")
 
 	for _, tc := range []struct {
-		name    string
-		enabled bool
-		setup   func(*mockobjstore.MockBucket)
-		assert  func(*testing.T, error)
+		name            string
+		enabled         bool
+		setup           func(*mockobjstore.MockBucket)
+		assert          func(*testing.T, error)
+		wantCleanupFail int
 	}{
 		{
-			// The check is skipped entirely: the bucket must not be touched.
+			// Skipped entirely: the bucket must not be touched.
 			name:    "disabled",
 			enabled: false,
 			setup:   func(*mockobjstore.MockBucket) {},
 			assert:  func(t *testing.T, err error) { require.NoError(t, err) },
 		},
 		{
-			// One of only two healthy outcomes: an empty bucket never invokes the
-			// callback, so Iter returns nil.
-			name:    "empty bucket",
+			name:    "upload and delete succeed",
 			enabled: true,
-			setup:   iterCalledWith(func(func(string) error) error { return nil }),
+			setup:   uploadThenDelete(nil),
 			assert:  func(t *testing.T, err error) { require.NoError(t, err) },
 		},
 		{
-			// The other healthy outcome, and the production shape: the callback fires and
-			// its sentinel comes back out of Iter. Treating that as a failure would stop
-			// the segment writer starting against a perfectly healthy bucket.
-			name:    "non-empty bucket",
+			// A blip must not crash-loop an instance the write path would have tolerated.
+			name:    "transient upload failure is retried",
 			enabled: true,
-			setup: iterCalledWith(func(f func(string) error) error {
-				return f("some/object/path")
-			}),
+			setup: func(bucket *mockobjstore.MockBucket) {
+				uploadReturns(unreachable, unreachable, nil)(bucket)
+				bucket.On("Delete", mock.Anything, expectedHealthCheckKey).Return(nil)
+			},
 			assert: func(t *testing.T, err error) { require.NoError(t, err) },
 		},
 		{
-			// The sentinel must be recognised even if a bucket implementation wraps it.
-			// This is what errors.Is buys over comparing the message.
-			name:    "non-empty bucket with wrapped sentinel",
-			enabled: true,
-			setup: iterCalledWith(func(f func(string) error) error {
-				return fmt.Errorf("iter some/prefix: %w", f("some/object/path"))
-			}),
-			assert: func(t *testing.T, err error) { require.NoError(t, err) },
+			// A bucket granting writes but not deletes is still serviceable.
+			name:            "delete permission denied is not fatal",
+			enabled:         true,
+			setup:           uploadThenDelete(accessDenied),
+			assert:          func(t *testing.T, err error) { require.NoError(t, err) },
+			wantCleanupFail: 1,
 		},
 		{
-			// A nonexistent bucket must not start. This is why the success condition
-			// cannot accept "object not found": a list never names a key, so that class
-			// only ever arrives from a missing bucket, and Tencent COS reports any 404 -
-			// NoSuchBucket included - as a not-found.
-			name:    "missing bucket is fatal",
+			name:    "delete timeout is not fatal",
 			enabled: true,
-			setup:   iterFailsWith(noSuchBucket),
+			setup: func(bucket *mockobjstore.MockBucket) {
+				uploadReturns(nil)(bucket)
+				bucket.On("Delete", mock.Anything, expectedHealthCheckKey).
+					Return(func(ctx context.Context, _ string) error {
+						<-ctx.Done()
+						return ctx.Err()
+					})
+			},
+			assert:          func(t *testing.T, err error) { require.NoError(t, err) },
+			wantCleanupFail: 1,
+		},
+		{
+			name:    "missing bucket is fatal once retries are exhausted",
+			enabled: true,
+			setup:   uploadReturns(noSuchBucket),
 			assert: func(t *testing.T, err error) {
 				require.ErrorIs(t, err, noSuchBucket)
 				require.ErrorContains(t, err, "bucket health check failed")
 			},
 		},
 		{
-			// Anything else stops the segment writer starting too, rather than letting it
-			// report itself healthy and drop writes it cannot fulfil. The cause is wrapped
-			// so operators can see it.
-			name:    "bucket unreachable is fatal",
+			name:    "bucket unreachable is fatal once retries are exhausted",
 			enabled: true,
-			setup:   iterFailsWith(unreachable),
+			setup:   uploadReturns(unreachable),
 			assert: func(t *testing.T, err error) {
 				require.ErrorIs(t, err, unreachable)
 				require.ErrorContains(t, err, "bucket health check failed")
 			},
 		},
 		{
-			// Exercised through a real expiring context rather than a synthetic error,
-			// so the timeout plumbing itself is covered.
-			name:    "timeout is fatal",
+			// A real expiring context, so the timeout plumbing itself is covered.
+			name:    "upload timeout is fatal",
 			enabled: true,
 			setup: func(bucket *mockobjstore.MockBucket) {
-				bucket.On("Iter", mock.Anything, "", mock.Anything).
-					Return(func(ctx context.Context, _ string, _ func(string) error, _ ...objstore.IterOption) error {
+				bucket.On("Upload", mock.Anything, expectedHealthCheckKey, mock.Anything).
+					Return(func(ctx context.Context, _ string, _ io.Reader, _ ...objstore.ObjectUploadOption) error {
 						<-ctx.Done()
 						return ctx.Err()
 					})
@@ -130,40 +152,57 @@ func TestSegmentWriterService_performBucketHealthCheck(t *testing.T) {
 			bucket := mockobjstore.NewMockBucket(t)
 			tc.setup(bucket)
 
-			svc := &SegmentWriterService{
-				logger:        log.NewNopLogger(),
-				storageBucket: bucket,
-				config: Config{
-					BucketHealthCheckEnabled: tc.enabled,
-					BucketHealthCheckTimeout: timeout,
-				},
-			}
-
+			svc := newTestServiceForHealthCheck(bucket, tc.enabled, timeout)
 			tc.assert(t, svc.performBucketHealthCheck(context.Background()))
+
+			require.Equal(t, float64(tc.wantCleanupFail),
+				testutil.ToFloat64(svc.bucketHealthCheckCleanupFailures))
 		})
 	}
 }
 
-// The failure has to reach the caller so the dskit service transitions to Failed, which is
-// what stops the instance registering in the ring and ultimately exits the process.
+// The failure must reach the caller: that is what moves the dskit service to Failed, so the
+// instance never registers in the ring.
 func TestSegmentWriterService_starting_bucketHealthCheckFailure(t *testing.T) {
 	t.Parallel()
 
 	unreachable := errors.New("dial tcp: connection refused")
 	bucket := mockobjstore.NewMockBucket(t)
-	bucket.On("Iter", mock.Anything, "", mock.Anything).Return(unreachable)
-
-	svc := &SegmentWriterService{
-		logger:        log.NewNopLogger(),
-		storageBucket: bucket,
-		config: Config{
-			BucketHealthCheckEnabled: true,
-			BucketHealthCheckTimeout: time.Second,
-		},
-	}
+	bucket.On("Upload", mock.Anything, expectedHealthCheckKey, mock.Anything).Return(unreachable)
 
 	// subservices is deliberately left nil: StartManagerAndAwaitHealthy would panic on
 	// it, so returning an error instead proves starting bailed out before the ring.
-	err := svc.starting(context.Background())
+	err := newTestServiceForHealthCheck(bucket, true, time.Second).starting(context.Background())
 	require.ErrorIs(t, err, unreachable)
+}
+
+func newTestServiceForHealthCheck(bucket *mockobjstore.MockBucket, enabled bool, timeout time.Duration) *SegmentWriterService {
+	return &SegmentWriterService{
+		logger:        log.NewNopLogger(),
+		storageBucket: bucket,
+		config: Config{
+			LifecyclerConfig:         ring.LifecyclerConfig{ID: testInstanceID},
+			BucketHealthCheckEnabled: enabled,
+			BucketHealthCheckTimeout: timeout,
+			UploadMaxRetries:         3,
+			UploadMinBackoff:         time.Millisecond,
+			UploadMaxBackoff:         5 * time.Millisecond,
+		},
+		bucketHealthCheckCleanupFailures: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "bucket_health_check_cleanup_failures_total",
+		}),
+	}
+}
+
+// The probe shares segments/ with real block data, so it must never parse as a block: the
+// compaction worker deletes keys that resolve to a ULID older than a tombstone's cut-off.
+func TestBucketHealthCheckKeyIsNotABlockPath(t *testing.T) {
+	t.Parallel()
+
+	_, err := block.ParseBlockIDFromPath(expectedHealthCheckKey)
+	require.Error(t, err, "probe key must not parse as a block path")
+
+	// The shard element is a uint32, which is what keeps _health out of any scanned directory.
+	_, err = strconv.ParseUint(strings.TrimSuffix(strings.TrimPrefix(bucketHealthCheckPrefix, block.DirNameSegment+"/"), "/"), 10, 32)
+	require.Error(t, err, "probe directory must not be parseable as a shard")
 }

--- a/pkg/segmentwriter/service_test.go
+++ b/pkg/segmentwriter/service_test.go
@@ -23,119 +23,148 @@ import (
 
 const testInstanceID = "segment-writer-7"
 
-// Asserted literally rather than rebuilt from the constants, so moving the probe is deliberate.
-const expectedHealthCheckKey = "segments/_health/" + testInstanceID
+// Asserted literally rather than rebuilt from the constants, so moving the probe is deliberate:
+// it has to stay on the prefix real writes use, or a prefix-scoped policy could pass the check
+// and deny every write.
+const testHealthCheckPrefix = "segments/_health/" + testInstanceID + "/"
+
+// probe records the keys the health check touched, which lets every case assert both how many
+// attempts it made and that the cleanup targeted the object it had just uploaded.
+type probe struct {
+	uploaded []string
+	deleted  []string
+}
+
+func (p *probe) onUpload(t *testing.T, bucket *mockobjstore.MockBucket, err error) {
+	bucket.On("Upload", mock.Anything, healthCheckKey(), mock.Anything).
+		Return(func(_ context.Context, name string, r io.Reader, _ ...objstore.ObjectUploadOption) error {
+			body, readErr := io.ReadAll(r)
+			require.NoError(t, readErr)
+			require.Contains(t, string(body), testInstanceID)
+			p.uploaded = append(p.uploaded, name)
+			return err
+		})
+}
+
+func (p *probe) onDelete(bucket *mockobjstore.MockBucket, fn func(context.Context) error) {
+	bucket.On("Delete", mock.Anything, healthCheckKey()).
+		Return(func(ctx context.Context, name string) error {
+			p.deleted = append(p.deleted, name)
+			return fn(ctx)
+		})
+}
+
+func healthCheckKey() interface{} {
+	return mock.MatchedBy(func(name string) bool {
+		return strings.HasPrefix(name, testHealthCheckPrefix) && len(name) > len(testHealthCheckPrefix)
+	})
+}
 
 func TestSegmentWriterService_performBucketHealthCheck(t *testing.T) {
 	t.Parallel()
 
-	const timeout = time.Second
-
-	uploadReturns := func(errs ...error) func(*mockobjstore.MockBucket) {
-		return func(bucket *mockobjstore.MockBucket) {
-			var attempt int
-			bucket.On("Upload", mock.Anything, expectedHealthCheckKey, mock.Anything).
-				Return(func(_ context.Context, _ string, r io.Reader, _ ...objstore.ObjectUploadOption) error {
-					// A reader shared across retries would be drained after the first.
-					body, err := io.ReadAll(r)
-					require.NoError(t, err)
-					require.Contains(t, string(body), testInstanceID)
-
-					err = errs[min(attempt, len(errs)-1)]
-					attempt++
-					return err
-				})
-		}
-	}
-
-	uploadThenDelete := func(deleteErr error) func(*mockobjstore.MockBucket) {
-		return func(bucket *mockobjstore.MockBucket) {
-			uploadReturns(nil)(bucket)
-			bucket.On("Delete", mock.Anything, expectedHealthCheckKey).Return(deleteErr)
-		}
-	}
+	const timeout = 100 * time.Millisecond
 
 	unreachable := errors.New("dial tcp: connection refused")
 	noSuchBucket := errors.New("NoSuchBucket: the specified bucket does not exist")
 	accessDenied := errors.New("AccessDenied: not authorized to perform s3:DeleteObject")
+	succeeds := func(context.Context) error { return nil }
+	fails := func(err error) func(context.Context) error {
+		return func(context.Context) error { return err }
+	}
+	blocksUntilCancelled := func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
 
 	for _, tc := range []struct {
 		name            string
 		enabled         bool
-		setup           func(*mockobjstore.MockBucket)
+		setup           func(*testing.T, *mockobjstore.MockBucket, *probe)
 		assert          func(*testing.T, error)
+		wantUploads     int
+		wantDeletes     int
 		wantCleanupFail int
 	}{
 		{
 			// Skipped entirely: the bucket must not be touched.
 			name:    "disabled",
 			enabled: false,
-			setup:   func(*mockobjstore.MockBucket) {},
+			setup:   func(*testing.T, *mockobjstore.MockBucket, *probe) {},
 			assert:  func(t *testing.T, err error) { require.NoError(t, err) },
 		},
 		{
 			name:    "upload and delete succeed",
 			enabled: true,
-			setup:   uploadThenDelete(nil),
-			assert:  func(t *testing.T, err error) { require.NoError(t, err) },
-		},
-		{
-			// A blip must not crash-loop an instance the write path would have tolerated.
-			name:    "transient upload failure is retried",
-			enabled: true,
-			setup: func(bucket *mockobjstore.MockBucket) {
-				uploadReturns(unreachable, unreachable, nil)(bucket)
-				bucket.On("Delete", mock.Anything, expectedHealthCheckKey).Return(nil)
+			setup: func(t *testing.T, bucket *mockobjstore.MockBucket, p *probe) {
+				p.onUpload(t, bucket, nil)
+				bucket.On("Provider").Return(objstore.S3)
+				p.onDelete(bucket, succeeds)
 			},
-			assert: func(t *testing.T, err error) { require.NoError(t, err) },
+			assert:      func(t *testing.T, err error) { require.NoError(t, err) },
+			wantUploads: 1,
+			wantDeletes: 1,
 		},
 		{
 			// A bucket granting writes but not deletes is still serviceable.
-			name:            "delete permission denied is not fatal",
-			enabled:         true,
-			setup:           uploadThenDelete(accessDenied),
+			name:    "delete permission denied is not fatal",
+			enabled: true,
+			setup: func(t *testing.T, bucket *mockobjstore.MockBucket, p *probe) {
+				p.onUpload(t, bucket, nil)
+				bucket.On("Provider").Return(objstore.S3)
+				p.onDelete(bucket, fails(accessDenied))
+			},
 			assert:          func(t *testing.T, err error) { require.NoError(t, err) },
+			wantUploads:     1,
+			wantDeletes:     1,
 			wantCleanupFail: 1,
 		},
 		{
 			name:    "delete timeout is not fatal",
 			enabled: true,
-			setup: func(bucket *mockobjstore.MockBucket) {
-				uploadReturns(nil)(bucket)
-				bucket.On("Delete", mock.Anything, expectedHealthCheckKey).
-					Return(func(ctx context.Context, _ string) error {
-						<-ctx.Done()
-						return ctx.Err()
-					})
+			setup: func(t *testing.T, bucket *mockobjstore.MockBucket, p *probe) {
+				p.onUpload(t, bucket, nil)
+				bucket.On("Provider").Return(objstore.S3)
+				p.onDelete(bucket, blocksUntilCancelled)
 			},
 			assert:          func(t *testing.T, err error) { require.NoError(t, err) },
+			wantUploads:     1,
+			wantDeletes:     1,
 			wantCleanupFail: 1,
 		},
 		{
-			name:    "missing bucket is fatal once retries are exhausted",
+			// One attempt only: the restart is the retry, and the supervisor backs it off.
+			name:    "bucket unreachable is fatal and not retried",
 			enabled: true,
-			setup:   uploadReturns(noSuchBucket),
-			assert: func(t *testing.T, err error) {
-				require.ErrorIs(t, err, noSuchBucket)
-				require.ErrorContains(t, err, "bucket health check failed")
+			setup: func(t *testing.T, bucket *mockobjstore.MockBucket, p *probe) {
+				p.onUpload(t, bucket, unreachable)
 			},
-		},
-		{
-			name:    "bucket unreachable is fatal once retries are exhausted",
-			enabled: true,
-			setup:   uploadReturns(unreachable),
 			assert: func(t *testing.T, err error) {
 				require.ErrorIs(t, err, unreachable)
 				require.ErrorContains(t, err, "bucket health check failed")
 			},
+			wantUploads: 1,
+		},
+		{
+			name:    "missing bucket is fatal",
+			enabled: true,
+			setup: func(t *testing.T, bucket *mockobjstore.MockBucket, p *probe) {
+				p.onUpload(t, bucket, noSuchBucket)
+			},
+			assert: func(t *testing.T, err error) {
+				require.ErrorIs(t, err, noSuchBucket)
+				require.ErrorContains(t, err, "bucket health check failed")
+			},
+			wantUploads: 1,
 		},
 		{
 			// A real expiring context, so the timeout plumbing itself is covered.
 			name:    "upload timeout is fatal",
 			enabled: true,
-			setup: func(bucket *mockobjstore.MockBucket) {
-				bucket.On("Upload", mock.Anything, expectedHealthCheckKey, mock.Anything).
-					Return(func(ctx context.Context, _ string, _ io.Reader, _ ...objstore.ObjectUploadOption) error {
+			setup: func(t *testing.T, bucket *mockobjstore.MockBucket, p *probe) {
+				bucket.On("Upload", mock.Anything, healthCheckKey(), mock.Anything).
+					Return(func(ctx context.Context, name string, _ io.Reader, _ ...objstore.ObjectUploadOption) error {
+						p.uploaded = append(p.uploaded, name)
 						<-ctx.Done()
 						return ctx.Err()
 					})
@@ -144,21 +173,81 @@ func TestSegmentWriterService_performBucketHealthCheck(t *testing.T) {
 				require.ErrorIs(t, err, context.DeadlineExceeded)
 				require.ErrorContains(t, err, "bucket health check failed")
 			},
+			wantUploads: 1,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			bucket := mockobjstore.NewMockBucket(t)
-			tc.setup(bucket)
+			var p probe
+			tc.setup(t, bucket, &p)
 
 			svc := newTestServiceForHealthCheck(bucket, tc.enabled, timeout)
 			tc.assert(t, svc.performBucketHealthCheck(context.Background()))
 
+			require.Len(t, p.uploaded, tc.wantUploads)
+			require.Len(t, p.deleted, tc.wantDeletes)
+			if len(p.deleted) > 0 {
+				require.Equal(t, p.uploaded, p.deleted, "cleanup must target the object just uploaded")
+			}
 			require.Equal(t, float64(tc.wantCleanupFail),
 				testutil.ToFloat64(svc.bucketHealthCheckCleanupFailures))
 		})
 	}
+}
+
+// The filesystem bucket deletes an object by walking up and removing each parent it has just
+// found empty, so the cleanup could take out a segment another writer created in that window.
+// Leaving a stray file behind is the cheaper trade. No Delete expectation is registered, so
+// the mock fails the test if the check attempts one.
+func TestSegmentWriterService_performBucketHealthCheck_filesystemKeepsProbe(t *testing.T) {
+	t.Parallel()
+
+	bucket := mockobjstore.NewMockBucket(t)
+	var p probe
+	p.onUpload(t, bucket, nil)
+	bucket.On("Provider").Return(objstore.FILESYSTEM)
+
+	svc := newTestServiceForHealthCheck(bucket, true, time.Second)
+	require.NoError(t, svc.performBucketHealthCheck(context.Background()))
+
+	require.Len(t, p.uploaded, 1)
+	require.Empty(t, p.deleted)
+	require.Zero(t, testutil.ToFloat64(svc.bucketHealthCheckCleanupFailures))
+}
+
+// A grant such as GCS roles/storage.objectCreator can create an object and not replace one, so
+// a probe key that repeated across restarts would fail every start after the first. Real writes
+// only ever create, so the check must not need more than that.
+func TestSegmentWriterService_performBucketHealthCheck_createOnlyBucket(t *testing.T) {
+	t.Parallel()
+
+	overwriteDenied := errors.New("AccessDenied: replacing an object requires storage.objects.delete")
+	seen := make(map[string]struct{})
+
+	var uploaded []string
+	bucket := mockobjstore.NewMockBucket(t)
+	bucket.On("Upload", mock.Anything, healthCheckKey(), mock.Anything).
+		Return(func(_ context.Context, name string, _ io.Reader, _ ...objstore.ObjectUploadOption) error {
+			if _, ok := seen[name]; ok {
+				return overwriteDenied
+			}
+			seen[name] = struct{}{}
+			uploaded = append(uploaded, name)
+			return nil
+		})
+	// A bucket that refuses overwrites refuses deletes too: both need the same permission.
+	bucket.On("Provider").Return(objstore.GCS)
+	bucket.On("Delete", mock.Anything, healthCheckKey()).Return(overwriteDenied)
+
+	svc := newTestServiceForHealthCheck(bucket, true, time.Second)
+	require.NoError(t, svc.performBucketHealthCheck(context.Background()))
+	require.NoError(t, svc.performBucketHealthCheck(context.Background()))
+
+	require.Len(t, uploaded, 2)
+	require.NotEqual(t, uploaded[0], uploaded[1], "each start must use a fresh key")
+	require.Equal(t, float64(2), testutil.ToFloat64(svc.bucketHealthCheckCleanupFailures))
 }
 
 // The failure must reach the caller: that is what moves the dskit service to Failed, so the
@@ -168,7 +257,7 @@ func TestSegmentWriterService_starting_bucketHealthCheckFailure(t *testing.T) {
 
 	unreachable := errors.New("dial tcp: connection refused")
 	bucket := mockobjstore.NewMockBucket(t)
-	bucket.On("Upload", mock.Anything, expectedHealthCheckKey, mock.Anything).Return(unreachable)
+	bucket.On("Upload", mock.Anything, healthCheckKey(), mock.Anything).Return(unreachable)
 
 	// subservices is deliberately left nil: StartManagerAndAwaitHealthy would panic on
 	// it, so returning an error instead proves starting bailed out before the ring.
@@ -184,9 +273,6 @@ func newTestServiceForHealthCheck(bucket *mockobjstore.MockBucket, enabled bool,
 			LifecyclerConfig:         ring.LifecyclerConfig{ID: testInstanceID},
 			BucketHealthCheckEnabled: enabled,
 			BucketHealthCheckTimeout: timeout,
-			UploadMaxRetries:         3,
-			UploadMinBackoff:         time.Millisecond,
-			UploadMaxBackoff:         5 * time.Millisecond,
 		},
 		bucketHealthCheckCleanupFailures: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "bucket_health_check_cleanup_failures_total",
@@ -199,7 +285,10 @@ func newTestServiceForHealthCheck(bucket *mockobjstore.MockBucket, enabled bool,
 func TestBucketHealthCheckKeyIsNotABlockPath(t *testing.T) {
 	t.Parallel()
 
-	_, err := block.ParseBlockIDFromPath(expectedHealthCheckKey)
+	key := bucketHealthCheckKey(testInstanceID)
+	require.True(t, strings.HasPrefix(key, testHealthCheckPrefix))
+
+	_, err := block.ParseBlockIDFromPath(key)
 	require.Error(t, err, "probe key must not parse as a block path")
 
 	// The shard element is a uint32, which is what keeps _health out of any scanned directory.


### PR DESCRIPTION
Follow-up to [#4453](https://github.com/grafana/pyroscope/pull/4453), which added the bucket health check but only warned when it failed. Ref [grafana/pyroscope-squad#587](https://github.com/grafana/pyroscope-squad/issues/587).

## Changes

- **Probe with `Upload` instead of `Iter`.** `Iter` tested LIST, which the write path never uses, so a list-only credential passed the check and then failed every write. `Upload` tests the permission `Push` needs, at the cost of one small PUT.
- **A failed upload prevents startup** instead of logging a warning. One attempt only: a restart is the retry, and the supervisor backs it off.
- **A fresh key per start**, `segments/_health/<instance-id>/<uuid>`. GCS grants such as `roles/storage.objectCreator` permit creating an object and deny replacing one, so a fixed key would fail every start after the first. It stays on `segments/` because a policy granting some other prefix while denying this one would pass the check and fail every real write.
- **Cleanup is best effort**, warning and incrementing `pyroscope_segment_writer_bucket_health_check_cleanup_failures_total`. It is skipped on the filesystem backend, whose `Delete` prunes empty parents and can race a concurrently written segment. A bucket denying deletes keeps one small object per start; expire those with a lifecycle rule scoped to `segments/_health/`.

## Testing

Unit tests cover the disabled short-circuit, a successful probe, exactly one upload attempt on failure, three fatal cases, two non-fatal cleanup failures, the filesystem backend skipping cleanup, two checks producing distinct keys, and the startup error reaching the caller.

Live on `fire-dev-001` (GCS), canaried onto one pod behind a Flux ignore:

- The probe ran in 146ms and 191ms, a single attempt each, uploading and removing its object. `..._cleanup_failures_total` stayed 0 across three starts.
- Two restarts produced two distinct keys under the same instance prefix, confirming each probe creates rather than replaces.
- Zero upload errors, and all four distributors held `ACTIVE=6, Unhealthy=0` throughout.