### PR TITLE
docs: explain what a span profile is

### DIFF
--- a/docs/sources/configure-client/trace-span-profiles/_index.md
+++ b/docs/sources/configure-client/trace-span-profiles/_index.md
@@ -10,6 +10,12 @@ weight: 400
 Span Profiles link tracing and profiling data, so that you can look at the profile of a single request or trace span instead of an aggregate of everything a service did.
 This makes it possible to move from a high-level trace view to the code that made one particular span slow.
 
+Key benefits and features:
+
+- Deep analysis: Understand the specifics of code execution within particular time frames, offering granular insights into application performance
+- Seamless integration: Smoothly transition from a high-level trace overview to detailed profiling of specific trace spans within Grafana’s trace view
+- Efficiency and cost savings: Quickly identify and address performance issues, reducing troubleshooting time and operational costs
+
 ## How span profiles work
 
 A span profile is not a separate kind of profile.
@@ -31,21 +37,15 @@ The Go and Java integrations can be configured to label every span instead.
 Spans that can have a profile are marked with the `pyroscope.profile.id` span attribute, whose value is the span ID despite the name.
 Grafana uses that attribute to offer a link from a span to its profile.
 
-Key benefits and features:
-
-- Deep analysis: Understand the specifics of code execution within particular time frames, offering granular insights into application performance
-- Seamless integration: Smoothly transition from a high-level trace overview to detailed profiling of specific trace spans within Grafana’s trace view
-- Efficiency and cost savings: Quickly identify and address performance issues, reducing troubleshooting time and operational costs
-
 ## What to expect
 
 - The `pyroscope.profile.id` attribute marks spans that *can* have a profile. It does not guarantee that any samples were collected for that span.
-- A span shorter than the profiler's sample interval may produce no samples at all. The CPU profiler collects stack traces 100 times per second by default, so spans shorter than roughly 10ms often have nothing to show.
 - The profile types available for span profiles depend on the language and the profiler it uses. Refer to the page for your language.
 - If your instrumentation records span names, avoid dynamic names that embed per-request identifiers such as URLs or SQL queries, because those can significantly degrade performance.
 
 {{< admonition type="note">}}
-Span profiling is only effective on spans longer than 20ms to ensure statistical accuracy.
+Profilers take samples periodically, so a short span can produce no samples at all, and a span with only a handful of samples doesn't show a realistic picture of where its time went.
+How short is too short depends on the profiler's sampling rate, which differs between languages and is often configurable.
 {{< /admonition >}}
 
 ## Get started

--- a/docs/sources/configure-client/trace-span-profiles/_index.md
+++ b/docs/sources/configure-client/trace-span-profiles/_index.md
@@ -22,9 +22,9 @@ Pyroscope recognizes two labels for this:
 Integrations may attach the span name as well, as an ordinary label.
 
 Because the labels are attached per sample, a single profile contains samples belonging to many different spans.
-Querying by span ID returns the samples of that span rather than a whole profile, which is what makes it possible to profile one request.
+Querying by span ID returns the samples of that span rather than a whole profile. This makes it possible to profile one request.
 
-By default, the integrations label only the local root span, meaning the first span created inside the process.
+By default, the integrations label only the local root span, the first span created inside the process.
 Samples collected while its child spans run are included in the root span's profile.
 The Go and Java integrations can be configured to label every span instead.
 

--- a/docs/sources/configure-client/trace-span-profiles/_index.md
+++ b/docs/sources/configure-client/trace-span-profiles/_index.md
@@ -7,10 +7,29 @@ weight: 400
 
 # Link tracing and profiling with Span Profiles
 
-Span Profiles are a powerful feature that further enhances the value of continuous profiling.
-Span Profiles offer a novel approach to profiling by providing detailed insights into specific execution scopes of applications, moving beyond the traditional system-wide analysis to offer a more dynamic, focused analysis of individual requests or trace spans.
+Span Profiles link tracing and profiling data, so that you can look at the profile of a single request or trace span instead of an aggregate of everything a service did.
+This makes it possible to move from a high-level trace view to the code that made one particular span slow.
 
-This method enhances understanding of application behavior by directly linking traces with profiling data, enabling engineering teams to pinpoint and resolve performance bottlenecks with precision.
+## How span profiles work
+
+A span profile is not a separate kind of profile.
+Span-aware instrumentation records which trace span is active as the profiler takes each sample, and tags that sample with the span's identity.
+Pyroscope recognizes two labels for this:
+
+- `span_id`: the ID of the span the sample was taken during. Some integrations send this as `profile_id`, which Pyroscope accepts as a legacy alias.
+- `trace_id`: the ID of the trace that span belongs to.
+
+Integrations may attach the span name as well, as an ordinary label.
+
+Because the labels are attached per sample, a single profile contains samples belonging to many different spans.
+Querying by span ID returns the samples of that span rather than a whole profile, which is what makes it possible to profile one request.
+
+By default, the integrations label only the local root span, meaning the first span created inside the process.
+Samples collected while its child spans run are included in the root span's profile.
+The Go and Java integrations can be configured to label every span instead.
+
+Spans that can have a profile are marked with the `pyroscope.profile.id` span attribute, whose value is the span ID despite the name.
+Grafana uses that attribute to offer a link from a span to its profile.
 
 Key benefits and features:
 
@@ -18,8 +37,15 @@ Key benefits and features:
 - Seamless integration: Smoothly transition from a high-level trace overview to detailed profiling of specific trace spans within Grafana’s trace view
 - Efficiency and cost savings: Quickly identify and address performance issues, reducing troubleshooting time and operational costs
 
+## What to expect
+
+- The `pyroscope.profile.id` attribute marks spans that *can* have a profile. It does not guarantee that any samples were collected for that span.
+- A span shorter than the profiler's sample interval may produce no samples at all. The CPU profiler collects stack traces 100 times per second by default, so spans shorter than roughly 10ms often have nothing to show.
+- The profile types available for span profiles depend on the language and the profiler it uses. Refer to the page for your language.
+- If your instrumentation records span names, avoid dynamic names that embed per-request identifiers such as URLs or SQL queries, because those can significantly degrade performance.
+
 {{< admonition type="note">}}
-Span profiling is only effective on spans longer than 20ms to ensure statistical accuracy. 
+Span profiling is only effective on spans longer than 20ms to ensure statistical accuracy.
 {{< /admonition >}}
 
 ## Get started


### PR DESCRIPTION
Adds a mechanism-level explanation of span profiles to the Span Profiles landing page, which previously only described the benefits.