### PR TITLE
fix(examples): drop the build toolchain from the ruby rideshare image

### DIFF
--- a/examples/language-sdk-instrumentation/ruby/rideshare_rails/Dockerfile
+++ b/examples/language-sdk-instrumentation/ruby/rideshare_rails/Dockerfile
@@ -1,15 +1,5 @@
 FROM ruby:3.3.9-slim
 
-# Install runtime and build dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libsqlite3-0 \
-    libyaml-0-2 \
-    build-essential \
-    libsqlite3-dev \
-    libyaml-dev \
-    pkg-config \
-    && rm -rf /var/lib/apt/lists/*
-
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
@@ -21,8 +11,25 @@ ENV SECRET_KEY_BASE=demo-secret-key-base-not-for-production
 COPY Gemfile /usr/src/app/
 COPY Gemfile.lock /usr/src/app/
 
-RUN bundle config --global frozen 1
-RUN bundle install --without development test
+# Build deps are installed, used and purged in one layer so the compiler and
+# linux-libc-dev never reach the runtime image.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libsqlite3-0 \
+        libyaml-0-2 \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libsqlite3-dev \
+        libyaml-dev \
+        pkg-config \
+    && bundle config --global frozen 1 \
+    && bundle install --without development test \
+    && apt-get purge -y --auto-remove \
+        build-essential \
+        libsqlite3-dev \
+        libyaml-dev \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY app /usr/src/app/app
 COPY bin /usr/src/app/bin


### PR DESCRIPTION
The `sqlite3` and `psych` gems have native extensions, so `bundle install` needs a C compiler. The image installed one and then kept it — along with `linux-libc-dev`, the Linux kernel headers that `libc6-dev` depends on.

That last package is why this matters more than it looks: Trivy matches its version (`6.12.101-1`) against every Linux 6.12 kernel CVE, even though a container has no kernel of its own and uses the host's. It accounted for 631 of the image's findings on its own.

Installing, using and purging the build deps in a single layer:

| Trivy | before | after |
|---|---|---|
| critical | 20 | 10 |
| high | 186 | 87 |
| medium | 710 | 126 |
| packages | 141 | 82 |

`libsqlite3-0` and `libyaml-0-2` are installed as their own step so apt marks them manually requested and `--auto-remove` leaves them in place — the compiled gems link against those at runtime.

The 10 remaining criticals are `perl-base` with no upstream fix (Debian Essential, so it can't be removed either), plus a stale `openssl` and three outdated gems. Those are separate changes.

Verified on linux/amd64: Rails boots, `/bike`, `/car` and `/scooter` return 200, and `sqlite3`, `psych` and `pyroscope` native extensions all still load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
