### PR TITLE
fix(examples): clear the remaining java rideshare CVEs

### DIFF
--- a/examples/language-sdk-instrumentation/java/rideshare/Dockerfile
+++ b/examples/language-sdk-instrumentation/java/rideshare/Dockerfile
@@ -19,7 +19,7 @@ RUN ./gradlew assemble --no-daemon
 
 FROM sapmachine:21-jdk-headless
 
-RUN apt-get update && apt-get install ca-certificates -y && update-ca-certificates
+RUN apt-get update && apt-get upgrade -y && apt-get install ca-certificates -y && update-ca-certificates
 
 ENV PYROSCOPE_APPLICATION_NAME=rideshare.java.push.app
 ENV PYROSCOPE_FORMAT=jfr

--- a/examples/language-sdk-instrumentation/java/rideshare/build.gradle.kts
+++ b/examples/language-sdk-instrumentation/java/rideshare/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java")
-    id("org.springframework.boot") version "3.3.13"
+    id("org.springframework.boot") version "3.5.16"
     id("io.spring.dependency-management") version "1.1.6"
 }
 
@@ -10,9 +10,6 @@ version = "1.0-SNAPSHOT"
 repositories {
     mavenCentral()
 }
-
-ext["tomcat.version"] = "10.1.55"
-ext["jackson-bom.version"] = "2.21.4"
 
 dependencies {
     implementation("io.pyroscope:agent:2.9.1")

--- a/examples/language-sdk-instrumentation/java/rideshare/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/language-sdk-instrumentation/java/rideshare/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The java image had two independent sources of findings and needs both fixed.

**Spring jars.** `spring-boot 3.5.16` is the first release managing `spring-framework 6.2.19`, which the `spring-webmvc` and `spring-expression` advisories require — 3.5.14 only reaches 6.2.18. It also manages `tomcat 10.1.55` and `jackson 2.21.4`, exactly the versions pinned by hand in #5541, so those two `ext[...]` lines are removed. Spring Boot 3.4+ requires Gradle 8.4 or later, hence the wrapper bump.

**The base image.** `sapmachine:21-jdk-headless` still ships `perl-base 5.38.2-3.2ubuntu0.3` and `openssl 3.0.13-0ubuntu3.12` although Ubuntu has published `...0.4` and `...3.15`. Since the staleness is upstream, a rebuild would not have picked these up.

Measured with Trivy:

| | before | after |
|---|---|---|
| high | 5 | 0 |
| medium | 38 | 16 |
| total | 56 | 22 |
| perl-base findings | 9 | 0 |

Verified with both changes applied together, on linux/amd64: builds, app starts on Spring Boot 3.5.16 with no exceptions, `/bike`, `/car` and `/scooter` return 200, and profiles reach a live Pyroscope with 3347 frames including `RideShareController.orderScooter` and `OrderService.findNearestVehicle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
