### PR TITLE
fix(segmentwriter): delete client metrics for removed segment writer addresses

### DIFF
--- a/pkg/segmentwriter/client/client.go
+++ b/pkg/segmentwriter/client/client.go
@@ -160,13 +160,14 @@ func NewSegmentWriterClient(
 	placement placement.Placement,
 	dialOpts ...grpc.DialOption,
 ) (*Client, error) {
-	pool, err := newConnPool(ring, logger, grpcClientConfig, dialOpts...)
+	m := newMetrics(registry)
+	pool, err := newConnPool(ring, logger, grpcClientConfig, m, dialOpts...)
 	if err != nil {
 		return nil, err
 	}
 	c := &Client{
 		logger:      logger,
-		metrics:     newMetrics(registry),
+		metrics:     m,
 		distributor: distributor.NewDistributor(placement, ring),
 		pool:        pool,
 		ring:        ring,
@@ -318,6 +319,7 @@ func newConnPool(
 	rring ring.ReadRing,
 	logger log.Logger,
 	grpcClientConfig grpcclient.Config,
+	m *metrics,
 	dialOpts ...grpc.DialOption,
 ) (*connpool.Pool, error) {
 	options, err := grpcClientConfig.DialOption(nil, nil, nil)
@@ -335,10 +337,19 @@ func newConnPool(
 	)
 
 	// Note that circuit breaker must be created per client conn.
-	factory := connpool.NewConnPoolFactory(func(ring.InstanceDesc) []grpc.DialOption {
-		cb := circuitbreaker.UnaryClientInterceptor(gobreaker.NewCircuitBreaker[any](circuitBreakerConfig))
-		return append(options, grpc.WithUnaryInterceptor(cb))
-	})
+	factory := connpool.NewConnPoolFactory(
+		func(ring.InstanceDesc) []grpc.DialOption {
+			cb := circuitbreaker.UnaryClientInterceptor(gobreaker.NewCircuitBreaker[any](circuitBreakerConfig))
+			return append(options, grpc.WithUnaryInterceptor(cb))
+		},
+		// Segment writer addresses churn with pod IPs, so every address that
+		// ever received a push would keep its (shard, tenant, addr) series
+		// forever. Drop them once the pool has retired the connection, i.e.
+		// the instance is no longer in the ring (grafana/pyroscope#5517).
+		func(addr string) {
+			m.sentBytes.DeletePartialMatch(prometheus.Labels{"addr": addr})
+		},
+	)
 
 	p := ring_client.NewPool(
 		"segment-writer",

--- a/pkg/segmentwriter/client/client_test.go
+++ b/pkg/segmentwriter/client/client_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
@@ -141,6 +142,23 @@ func (s *segwriterClientSuite) Test_Push_HappyPath() {
 
 	_, err := s.client.Push(context.Background(), &segmentwriterv1.PushRequest{})
 	s.Assert().NoError(err)
+}
+
+func (s *segwriterClientSuite) Test_Push_MetricsDeletedOnConnRemoval() {
+	s.service.On("Push", mock.Anything, mock.Anything).
+		Return(&segmentwriterv1.PushResponse{}, nil).
+		Once()
+
+	_, err := s.client.Push(context.Background(), &segmentwriterv1.PushRequest{})
+	s.Require().NoError(err)
+	s.Require().Equal(1, testutil.CollectAndCount(s.client.metrics.sentBytes))
+
+	// This is what the pool does with instances that left the ring;
+	// the connection is closed asynchronously.
+	s.client.pool.RemoveClientFor("localhost")
+	s.Require().Eventually(func() bool {
+		return testutil.CollectAndCount(s.client.metrics.sentBytes) == 0
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 func (s *segwriterClientSuite) Test_Push_EmptyRing() {

--- a/pkg/segmentwriter/client/connpool/conn_pool_ring.go
+++ b/pkg/segmentwriter/client/connpool/conn_pool_ring.go
@@ -34,10 +34,17 @@ func (p *Pool) GetConnFor(addr string) (grpc.ClientConnInterface, error) {
 
 type ConnFactory struct {
 	options func(ring.InstanceDesc) []grpc.DialOption
+	onClose func(addr string)
 }
 
-func NewConnPoolFactory(options func(ring.InstanceDesc) []grpc.DialOption) ring_client.PoolFactory {
-	return &ConnFactory{options: options}
+// NewConnPoolFactory creates a factory of pool clients. The optional onClose
+// hook is called with the instance address after the pool closes the client
+// connection, which happens when the instance is no longer found in the ring.
+func NewConnPoolFactory(
+	options func(ring.InstanceDesc) []grpc.DialOption,
+	onClose func(addr string),
+) ring_client.PoolFactory {
+	return &ConnFactory{options: options, onClose: onClose}
 }
 
 func (f *ConnFactory) FromInstance(inst ring.InstanceDesc) (ring_client.PoolClient, error) {
@@ -49,6 +56,8 @@ func (f *ConnFactory) FromInstance(inst ring.InstanceDesc) (ring_client.PoolClie
 		ClientConnInterface: conn,
 		HealthClient:        health.NoOpClient,
 		Closer:              conn,
+		addr:                inst.Addr,
+		onClose:             f.onClose,
 	}, nil
 }
 
@@ -56,4 +65,14 @@ type poolConn struct {
 	grpc.ClientConnInterface
 	grpc_health_v1.HealthClient
 	io.Closer
+	addr    string
+	onClose func(addr string)
+}
+
+func (c *poolConn) Close() error {
+	err := c.Closer.Close()
+	if c.onClose != nil {
+		c.onClose(c.addr)
+	}
+	return err
 }

--- a/pkg/segmentwriter/client/connpool/conn_pool_ring_test.go
+++ b/pkg/segmentwriter/client/connpool/conn_pool_ring_test.go
@@ -1,0 +1,40 @@
+package connpool
+
+import (
+	"testing"
+
+	"github.com/grafana/dskit/ring"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func TestConnFactory_Close(t *testing.T) {
+	options := func(ring.InstanceDesc) []grpc.DialOption {
+		return []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	}
+	inst := ring.InstanceDesc{Addr: "localhost:0"}
+
+	tests := []struct {
+		name     string
+		withHook bool
+		want     []string
+	}{
+		{name: "onClose receives the instance address", withHook: true, want: []string{"localhost:0"}},
+		{name: "nil onClose is safe", withHook: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var closed []string
+			var onClose func(addr string)
+			if tc.withHook {
+				onClose = func(addr string) { closed = append(closed, addr) }
+			}
+			c, err := NewConnPoolFactory(options, onClose).FromInstance(inst)
+			require.NoError(t, err)
+			require.Empty(t, closed)
+			require.NoError(t, c.Close())
+			require.Equal(t, tc.want, closed)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #5517

## Problem
`pyroscope_segment_writer_client_sent_bytes` is a histogram labelled by `shard`, `tenant` and
`addr`. Segment writer addresses churn with pod IPs and shard relocation, and nothing ever removed
the series of an address that stopped being used, so the number of series exposed by the distributor
grows without bound (every restarted segment writer pod adds a new set of `addr` series).

## Solution
The ring client pool already closes an instance's connection once the instance is no longer in the
ring (`removeStaleClients`, every 15s). This change hooks into that: `connpool.NewConnPoolFactory`
takes an `onClose(addr)` callback which the segment writer client uses to delete all series of the
retired address with `DeletePartialMatch`. No new state, goroutines or configuration.

Notes:
- Deletion runs in the pool's asynchronous `Close`. A push whose response lands just before the
  close can observe after the deletion, leaving at most one set of series for that address until
  it is dialled and retired again, so growth stays bounded.
- An instance that leaves the ring transiently (rollout, unhealthy) has its series deleted and
  re-created on the next push, i.e. a histogram reset; the hook also fires when the pool shuts
  down. Dashboards use `rate()` / `histogram_sum(rate())` by `shard`, which absorb resets.
- The dashboards in `operations/monitoring` group this metric by `shard` only, so they are unaffected.
- Pruning by `tenant` (on tenant deletion) is not covered here; `tenant` and `shard` are bounded
  per live address.

## Tests
- `Test_Push_MetricsDeletedOnConnRemoval`: push, assert one series, remove the client for the
  address from the pool (what `removeStaleClients` calls), assert the series is gone.
- `TestConnFactory_Close`: the hook receives the instance address after `Close`; a nil hook is safe.
