### PR TITLE
fix(querybackend): do not retry responses gRPC cannot deliver

### DIFF
--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -1744,8 +1744,9 @@ The `query_backend` block configures the query-backend (V2 read path).
 # CLI flag: -query-backend.address
 [address: <string> | default = "localhost:9095"]
 
-# Configures the gRPC client used to communicate between the query-frontends and
-# the query-schedulers.
+# Configures the gRPC client used to communicate with query-backends.
+# backoff_on_ratelimits must be disabled: its retries ignore the server's
+# pushback.
 # The CLI flags prefix for this block configuration is:
 # query-backend.grpc-client-config
 [grpc_client_config: <grpc_client>]

--- a/docs/sources/configure-server/reference-configuration-parameters/index.md
+++ b/docs/sources/configure-server/reference-configuration-parameters/index.md
@@ -1745,8 +1745,7 @@ The `query_backend` block configures the query-backend (V2 read path).
 [address: <string> | default = "localhost:9095"]
 
 # Configures the gRPC client used to communicate with query-backends.
-# backoff_on_ratelimits must be disabled: its retries ignore the server's
-# pushback.
+# backoff_on_ratelimits is ignored: its retries ignore the server's pushback.
 # The CLI flags prefix for this block configuration is:
 # query-backend.grpc-client-config
 [grpc_client_config: <grpc_client>]

--- a/pkg/pyroscope/modules_experimental.go
+++ b/pkg/pyroscope/modules_experimental.go
@@ -402,6 +402,7 @@ func (f *Pyroscope) initQueryBackendClient() (services.Service, error) {
 	if err := f.Cfg.QueryBackend.Validate(); err != nil {
 		return nil, err
 	}
+	f.Cfg.QueryBackend.DisableClientRateLimitRetries(f.logger)
 	f.Cfg.QueryBackend.GRPCClientConfig.Middleware = f.grpcClientInterceptors()
 	c, err := querybackendclient.New(
 		f.Cfg.QueryBackend.Address,

--- a/pkg/querybackend/backend.go
+++ b/pkg/querybackend/backend.go
@@ -19,12 +19,13 @@ import (
 
 	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+	"github.com/grafana/pyroscope/v2/pkg/querybackend/internal/pushback"
 	"github.com/grafana/pyroscope/v2/pkg/util"
 )
 
 type Config struct {
 	Address          string            `yaml:"address" category:"advanced"`
-	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate between the query-frontends and the query-schedulers."`
+	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate with query-backends. backoff_on_ratelimits must be disabled: its retries ignore the server's pushback."`
 	ClientTimeout    time.Duration     `yaml:"client_timeout" category:"advanced"`
 }
 
@@ -37,6 +38,11 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 func (cfg *Config) Validate() error {
 	if cfg.Address == "" {
 		return fmt.Errorf("query-backend.address is required")
+	}
+	// dskit's rate-limit retrier retries every RESOURCE_EXHAUSTED error without
+	// honoring grpc-retry-pushback-ms, which would retry oversized responses.
+	if cfg.GRPCClientConfig.BackoffOnRatelimits {
+		return fmt.Errorf("query-backend.grpc-client-config.backoff-on-ratelimits must be disabled: its retries ignore grpc-retry-pushback-ms")
 	}
 	return cfg.GRPCClientConfig.Validate()
 }
@@ -111,6 +117,10 @@ func (q *QueryBackend) Invoke(
 	}
 
 	if err != nil {
+		// A child cannot deliver its response; neither can we.
+		if pushback.IsMarked(err) {
+			pushback.SetNoRetry(ctx)
+		}
 		return nil, err
 	}
 
@@ -139,6 +149,11 @@ func (q *QueryBackend) Invoke(
 		}
 	}
 
+	// The response is complete: all that remains is encoding and the size check in
+	// grpc-go's Server.sendResponse, so a failure there recurs on every attempt.
+	// Queries that failed return above, still retryable.
+	pushback.SetNoRetry(ctx)
+
 	return resp, nil
 }
 
@@ -155,6 +170,7 @@ func (q *QueryBackend) merge(
 	childExecNodes := make([]*queryv1.ExecutionNode, len(children))
 	var mu sync.Mutex
 	var totalBytesFetched atomic.Uint64
+	var noRetry atomic.Bool
 
 	for i, child := range children {
 		idx := i
@@ -166,6 +182,9 @@ func (q *QueryBackend) merge(
 			// TODO: Speculative retry.
 			resp, err := q.backendClient.Invoke(ctx, req)
 			if err != nil {
+				if pushback.IsMarked(err) {
+					noRetry.Store(true)
+				}
 				return err
 			}
 			// Always accumulate bytes regardless of collectDiag so the
@@ -180,6 +199,10 @@ func (q *QueryBackend) merge(
 		}))
 	}
 	if err := g.Wait(); err != nil {
+		// errgroup keeps one error; a sibling's verdict must not be lost with it.
+		if noRetry.Load() {
+			err = pushback.Mark(err)
+		}
 		return nil, nil, 0, err
 	}
 

--- a/pkg/querybackend/backend.go
+++ b/pkg/querybackend/backend.go
@@ -11,6 +11,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/tracing"
@@ -25,7 +26,7 @@ import (
 
 type Config struct {
 	Address          string            `yaml:"address" category:"advanced"`
-	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate with query-backends. backoff_on_ratelimits must be disabled: its retries ignore the server's pushback."`
+	GRPCClientConfig grpcclient.Config `yaml:"grpc_client_config" doc:"description=Configures the gRPC client used to communicate with query-backends. backoff_on_ratelimits is ignored: its retries ignore the server's pushback."`
 	ClientTimeout    time.Duration     `yaml:"client_timeout" category:"advanced"`
 }
 
@@ -39,12 +40,16 @@ func (cfg *Config) Validate() error {
 	if cfg.Address == "" {
 		return fmt.Errorf("query-backend.address is required")
 	}
-	// dskit's rate-limit retrier retries every RESOURCE_EXHAUSTED error without
-	// honoring grpc-retry-pushback-ms, which would retry oversized responses.
-	if cfg.GRPCClientConfig.BackoffOnRatelimits {
-		return fmt.Errorf("query-backend.grpc-client-config.backoff-on-ratelimits must be disabled: its retries ignore grpc-retry-pushback-ms")
-	}
 	return cfg.GRPCClientConfig.Validate()
+}
+
+// DisableClientRateLimitRetries turns off dskit's retrier, which ignores grpc-retry-pushback-ms.
+func (cfg *Config) DisableClientRateLimitRetries(logger log.Logger) {
+	if !cfg.GRPCClientConfig.BackoffOnRatelimits {
+		return
+	}
+	level.Warn(logger).Log("msg", "ignoring query-backend.grpc-client-config.backoff-on-ratelimits: its retries ignore grpc-retry-pushback-ms")
+	cfg.GRPCClientConfig.BackoffOnRatelimits = false
 }
 
 type QueryHandler interface {

--- a/pkg/querybackend/backend_test.go
+++ b/pkg/querybackend/backend_test.go
@@ -1,0 +1,147 @@
+package querybackend
+
+import (
+	"context"
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+	"github.com/grafana/pyroscope/v2/pkg/querybackend/internal/pushback"
+)
+
+type testQueryHandler struct {
+	invoke func(context.Context, *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error)
+}
+
+func (h *testQueryHandler) Invoke(ctx context.Context, req *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error) {
+	return h.invoke(ctx, req)
+}
+
+type testServerStream struct {
+	trailer metadata.MD
+}
+
+func (*testServerStream) Method() string               { return "" }
+func (*testServerStream) SetHeader(metadata.MD) error  { return nil }
+func (*testServerStream) SendHeader(metadata.MD) error { return nil }
+
+func (s *testServerStream) SetTrailer(md metadata.MD) error {
+	s.trailer = metadata.Join(s.trailer, md)
+	return nil
+}
+
+func TestQueryBackend_NoRetrySignal(t *testing.T) {
+	readPlan := &queryv1.QueryPlan{Root: &queryv1.QueryNode{Type: queryv1.QueryNode_READ}}
+	mergePlan := &queryv1.QueryPlan{Root: &queryv1.QueryNode{
+		Type:     queryv1.QueryNode_MERGE,
+		Children: []*queryv1.QueryNode{{Type: queryv1.QueryNode_READ}, {Type: queryv1.QueryNode_READ}},
+	}}
+
+	tests := []struct {
+		name   string
+		plan   *queryv1.QueryPlan
+		invoke func(context.Context, *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error)
+		merge  bool
+		want   bool
+	}{
+		{
+			name: "response built",
+			plan: readPlan,
+			invoke: func(context.Context, *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error) {
+				return &queryv1.InvokeResponse{}, nil
+			},
+			want: true,
+		},
+		{
+			// Load shedding reports the same code as an undeliverable response.
+			name: "query exhausted a resource",
+			plan: readPlan,
+			invoke: func(context.Context, *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error) {
+				return nil, status.Error(codes.ResourceExhausted, "concurrency limit exceeded")
+			},
+		},
+		{
+			name: "query failed",
+			plan: readPlan,
+			invoke: func(context.Context, *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error) {
+				return nil, status.Error(codes.Unavailable, "block reader unavailable")
+			},
+		},
+		{
+			name:  "every child failed",
+			plan:  mergePlan,
+			merge: true,
+			invoke: func(context.Context, *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error) {
+				return nil, status.Error(codes.Unavailable, "backend unavailable")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := &testQueryHandler{invoke: tt.invoke}
+			var backendClient, blockReader QueryHandler = nil, handler
+			if tt.merge {
+				backendClient, blockReader = handler, nil
+			}
+			q, err := New(Config{}, log.NewNopLogger(), nil, backendClient, blockReader)
+			require.NoError(t, err)
+
+			stream := &testServerStream{}
+			ctx := grpc.NewContextWithServerTransportStream(context.Background(), stream)
+			_, _ = q.Invoke(ctx, &queryv1.InvokeRequest{QueryPlan: tt.plan})
+
+			require.Equal(t, tt.want, pushback.IsNoRetry(stream.trailer))
+		})
+	}
+}
+
+// The child that cannot deliver may not be the one errgroup reports.
+func TestQueryBackend_NoRetrySignal_SiblingErrorWins(t *testing.T) {
+	first := status.Error(codes.Unavailable, "fast failure")
+	undeliverable := pushback.Mark(status.Error(codes.ResourceExhausted, "trying to send message larger than max"))
+	scheduled := make(chan struct{}, 1)
+
+	handler := &testQueryHandler{
+		invoke: func(context.Context, *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error) {
+			select {
+			case scheduled <- struct{}{}:
+				return nil, first
+			default:
+				time.Sleep(50 * time.Millisecond)
+				return nil, undeliverable
+			}
+		},
+	}
+	q, err := New(Config{}, log.NewNopLogger(), nil, handler, nil)
+	require.NoError(t, err)
+
+	stream := &testServerStream{}
+	ctx := grpc.NewContextWithServerTransportStream(context.Background(), stream)
+	_, err = q.Invoke(ctx, &queryv1.InvokeRequest{QueryPlan: &queryv1.QueryPlan{
+		Root: &queryv1.QueryNode{
+			Type:     queryv1.QueryNode_MERGE,
+			Children: []*queryv1.QueryNode{{Type: queryv1.QueryNode_READ}, {Type: queryv1.QueryNode_READ}},
+		},
+	}})
+
+	require.ErrorIs(t, err, first)
+	require.True(t, pushback.IsNoRetry(stream.trailer))
+}
+
+func TestConfig_Validate(t *testing.T) {
+	var cfg Config
+	cfg.RegisterFlags(flag.NewFlagSet("", flag.PanicOnError))
+	require.NoError(t, cfg.Validate())
+
+	cfg.GRPCClientConfig.BackoffOnRatelimits = true
+	require.ErrorContains(t, cfg.Validate(), "backoff-on-ratelimits")
+}

--- a/pkg/querybackend/backend_test.go
+++ b/pkg/querybackend/backend_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"testing"
-	"time"
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
@@ -111,12 +110,12 @@ func TestQueryBackend_NoRetrySignal_SiblingErrorWins(t *testing.T) {
 	scheduled := make(chan struct{}, 1)
 
 	handler := &testQueryHandler{
-		invoke: func(context.Context, *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error) {
+		invoke: func(ctx context.Context, _ *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error) {
 			select {
 			case scheduled <- struct{}{}:
 				return nil, first
 			default:
-				time.Sleep(50 * time.Millisecond)
+				<-ctx.Done()
 				return nil, undeliverable
 			}
 		},
@@ -137,11 +136,12 @@ func TestQueryBackend_NoRetrySignal_SiblingErrorWins(t *testing.T) {
 	require.True(t, pushback.IsNoRetry(stream.trailer))
 }
 
-func TestConfig_Validate(t *testing.T) {
+func TestConfig_DisableClientRateLimitRetries(t *testing.T) {
 	var cfg Config
 	cfg.RegisterFlags(flag.NewFlagSet("", flag.PanicOnError))
 	require.NoError(t, cfg.Validate())
 
 	cfg.GRPCClientConfig.BackoffOnRatelimits = true
-	require.ErrorContains(t, cfg.Validate(), "backoff-on-ratelimits")
+	cfg.DisableClientRateLimitRetries(log.NewNopLogger())
+	require.False(t, cfg.GRPCClientConfig.BackoffOnRatelimits)
 }

--- a/pkg/querybackend/client/client.go
+++ b/pkg/querybackend/client/client.go
@@ -8,8 +8,10 @@ import (
 	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/dskit/services"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
+	"github.com/grafana/pyroscope/v2/pkg/querybackend/internal/pushback"
 )
 
 type Client struct {
@@ -48,7 +50,12 @@ func (b *Client) starting(context.Context) error { return nil }
 func (b *Client) stopping(error) error           { return nil }
 
 func (b *Client) Invoke(ctx context.Context, req *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error) {
-	return b.grpcClient.Invoke(ctx, req)
+	var trailer metadata.MD
+	resp, err := b.grpcClient.Invoke(ctx, req, grpc.Trailer(&trailer))
+	if err != nil && pushback.IsNoRetry(trailer) {
+		err = pushback.Mark(err)
+	}
+	return resp, err
 }
 
 const grpcServiceConfigTemplate = `{

--- a/pkg/querybackend/client/client_test.go
+++ b/pkg/querybackend/client/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -12,7 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/status"
 
 	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
 	queryv1 "github.com/grafana/pyroscope/api/gen/proto/go/query/v1"
@@ -35,6 +39,16 @@ type QueryHandler struct {
 func (q QueryHandler) Invoke(ctx context.Context, request *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error) {
 	time.Sleep(nServerResponseTime)
 	return &queryv1.InvokeResponse{}, nil
+}
+
+type testQueryBackendServer struct {
+	queryv1.UnimplementedQueryBackendServiceServer
+	invoke func(context.Context, int32) (*queryv1.InvokeResponse, error)
+	calls  atomic.Int32
+}
+
+func (s *testQueryBackendServer) Invoke(ctx context.Context, _ *queryv1.InvokeRequest) (*queryv1.InvokeResponse, error) {
+	return s.invoke(ctx, s.calls.Add(1))
 }
 
 type multiResolverBuilder struct {
@@ -73,6 +87,147 @@ func (r *multiResolver) updateState() {
 func (r *multiResolver) ResolveNow(resolver.ResolveNowOptions) {}
 
 func (r *multiResolver) Close() {}
+
+// oversizedReader answers the first query with a response too large to send and
+// any retry with an empty one, so a retry would look like a success.
+func oversizedReader(size int) *testQueryBackendServer {
+	return &testQueryBackendServer{
+		invoke: func(ctx context.Context, call int32) (*queryv1.InvokeResponse, error) {
+			if call > 1 {
+				return &queryv1.InvokeResponse{}, nil
+			}
+			return &queryv1.InvokeResponse{
+				Reports: []*queryv1.Report{{
+					ReportType: queryv1.ReportType_REPORT_PPROF,
+					Pprof: &queryv1.PprofReport{
+						Pprof: make([]byte, size),
+					},
+				}},
+			}, nil
+		},
+	}
+}
+
+func TestClient_DoesNotRetryOversizedResponse(t *testing.T) {
+	const maxSendMessageSize = 1024
+
+	reader := oversizedReader(2 * maxSendMessageSize)
+	backend, err := querybackend.New(querybackend.Config{}, log.NewNopLogger(), nil, nil, reader)
+	require.NoError(t, err)
+	client := newTestClient(t, backend, grpc.MaxSendMsgSize(maxSendMessageSize))
+
+	_, err = client.Invoke(context.Background(), &queryv1.InvokeRequest{
+		QueryPlan: &queryv1.QueryPlan{
+			Root: &queryv1.QueryNode{Type: queryv1.QueryNode_READ},
+		},
+	})
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+	require.ErrorContains(t, err, "trying to send message larger than max")
+	require.Equal(t, int32(1), reader.calls.Load())
+}
+
+func TestClient_DoesNotRetryOversizedChildResponse(t *testing.T) {
+	const maxSendMessageSize = 1024
+
+	reader := oversizedReader(2 * maxSendMessageSize)
+	leafBackend, err := querybackend.New(querybackend.Config{}, log.NewNopLogger(), nil, nil, reader)
+	require.NoError(t, err)
+	leafClient := newTestClient(t, leafBackend, grpc.MaxSendMsgSize(maxSendMessageSize))
+	rootBackend, err := querybackend.New(querybackend.Config{}, log.NewNopLogger(), nil, leafClient, nil)
+	require.NoError(t, err)
+	client := newTestClient(t, rootBackend)
+
+	_, err = client.Invoke(context.Background(), &queryv1.InvokeRequest{
+		QueryPlan: &queryv1.QueryPlan{
+			Root: &queryv1.QueryNode{
+				Type: queryv1.QueryNode_MERGE,
+				Children: []*queryv1.QueryNode{{
+					Type: queryv1.QueryNode_READ,
+				}},
+			},
+		},
+	})
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+	require.ErrorContains(t, err, "trying to send message larger than max")
+	require.Equal(t, int32(1), reader.calls.Load())
+}
+
+// The concurrency limiter rejects with the status an undeliverable response
+// also carries, and no pushback.
+func TestClient_RetriesLoadShedding(t *testing.T) {
+	reader := &testQueryBackendServer{
+		invoke: func(ctx context.Context, call int32) (*queryv1.InvokeResponse, error) {
+			if call == 1 {
+				return nil, status.Error(codes.ResourceExhausted, "concurrency limit exceeded")
+			}
+			return &queryv1.InvokeResponse{}, nil
+		},
+	}
+	backend, err := querybackend.New(querybackend.Config{}, log.NewNopLogger(), nil, nil, reader)
+	require.NoError(t, err)
+	client := newTestClient(t, backend)
+
+	resp, err := client.Invoke(context.Background(), &queryv1.InvokeRequest{
+		QueryPlan: &queryv1.QueryPlan{
+			Root: &queryv1.QueryNode{Type: queryv1.QueryNode_READ},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, int32(2), reader.calls.Load())
+}
+
+func TestClient_RetriesRetryableStatus(t *testing.T) {
+	for _, code := range []codes.Code{codes.Unavailable, codes.ResourceExhausted} {
+		t.Run(code.String(), func(t *testing.T) {
+			reader := &testQueryBackendServer{
+				invoke: func(ctx context.Context, call int32) (*queryv1.InvokeResponse, error) {
+					if call == 1 {
+						if err := grpc.SetTrailer(ctx, metadata.Pairs("grpc-retry-pushback-ms", "0")); err != nil {
+							return nil, status.Error(codes.Internal, err.Error())
+						}
+						return nil, status.Error(code, "try again")
+					}
+					return &queryv1.InvokeResponse{}, nil
+				},
+			}
+			backend, err := querybackend.New(querybackend.Config{}, log.NewNopLogger(), nil, nil, reader)
+			require.NoError(t, err)
+			client := newTestClient(t, backend)
+
+			resp, err := client.Invoke(context.Background(), &queryv1.InvokeRequest{
+				QueryPlan: &queryv1.QueryPlan{
+					Root: &queryv1.QueryNode{Type: queryv1.QueryNode_READ},
+				},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.Equal(t, int32(2), reader.calls.Load())
+		})
+	}
+}
+
+func newTestClient(t *testing.T, backend queryv1.QueryBackendServiceServer, serverOptions ...grpc.ServerOption) *Client {
+	t.Helper()
+
+	const address = "localhost:10003"
+	listeners, dialOption := test.CreateInMemoryListeners([]string{address})
+	server := grpc.NewServer(serverOptions...)
+	queryv1.RegisterQueryBackendServiceServer(server, backend)
+	go func() {
+		_ = server.Serve(listeners[address])
+	}()
+	t.Cleanup(server.Stop)
+
+	grpcClientConfig := grpcclient.Config{}
+	grpcClientConfig.RegisterFlags(flag.NewFlagSet("", flag.PanicOnError))
+	conn, err := dial("passthrough:///"+address, grpcClientConfig, 5*time.Second, dialOption)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+	return &Client{grpcClient: queryv1.NewQueryBackendServiceClient(conn)}
+}
 
 // Test_Concurrency tests the concurrent invocation of queries against multiple backend servers.
 //

--- a/pkg/querybackend/internal/pushback/pushback.go
+++ b/pkg/querybackend/internal/pushback/pushback.go
@@ -1,0 +1,67 @@
+// Package pushback carries the gRPC retry pushback signal between a
+// query-backend server and its clients.
+//
+// The client retries RESOURCE_EXHAUSTED, which the server returns when shedding
+// load. gRPC returns the same code when a response exceeds the send limit, which
+// no retry can fix, so the verdict travels out of band, in the trailer gRPC
+// reserves for it (gRFC A6).
+package pushback
+
+import (
+	"context"
+	"errors"
+	"strconv"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	metadataKey = "grpc-retry-pushback-ms"
+	noRetry     = "-1"
+)
+
+var noRetryTrailer = metadata.Pairs(metadataKey, noRetry)
+
+type noRetryError struct{ err error }
+
+func (e *noRetryError) Error() string              { return e.err.Error() }
+func (e *noRetryError) Unwrap() error              { return e.err }
+func (e *noRetryError) GRPCStatus() *status.Status { return status.Convert(e.err) }
+func (e *noRetryError) noRetry()                   {}
+
+// Mark records that retrying err cannot succeed, preserving its gRPC status.
+func Mark(err error) error {
+	if err == nil || IsMarked(err) {
+		return err
+	}
+	return &noRetryError{err: err}
+}
+
+// IsMarked reports whether err, or any error it wraps, is marked.
+func IsMarked(err error) bool {
+	var marker interface{ noRetry() }
+	return errors.As(err, &marker)
+}
+
+// SetNoRetry tells the client that repeating this request cannot succeed.
+// Errors are dropped: a lost signal costs a retry, never a response.
+func SetNoRetry(ctx context.Context) {
+	_ = grpc.SetTrailer(ctx, noRetryTrailer)
+}
+
+// IsNoRetry reports whether md carries a pushback value that stops gRPC from
+// retrying: a single negative or unparsable value, or any count but one.
+func IsNoRetry(md metadata.MD) bool {
+	values := md.Get(metadataKey)
+	switch len(values) {
+	case 0:
+		return false
+	case 1:
+		ms, err := strconv.Atoi(values[0])
+		return err != nil || ms < 0
+	default:
+		return true
+	}
+}

--- a/pkg/querybackend/internal/pushback/pushback_test.go
+++ b/pkg/querybackend/internal/pushback/pushback_test.go
@@ -1,0 +1,76 @@
+package pushback
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func TestMark(t *testing.T) {
+	original := status.Error(codes.ResourceExhausted, "response too large")
+	marked := Mark(original)
+
+	require.ErrorIs(t, marked, original)
+	require.True(t, IsMarked(marked))
+	require.Equal(t, marked, Mark(marked), "marking twice must not nest")
+	require.Nil(t, Mark(nil))
+
+	// Without the status, the caller sees codes.Unknown instead of the failure.
+	require.Equal(t, codes.ResourceExhausted, status.Code(marked))
+	wrapped := fmt.Errorf("merge query: %w", marked)
+	require.True(t, IsMarked(wrapped))
+	require.Equal(t, codes.ResourceExhausted, status.Code(wrapped))
+
+	require.False(t, IsMarked(original))
+	require.False(t, IsMarked(nil))
+}
+
+func TestIsNoRetry(t *testing.T) {
+	tests := []struct {
+		name string
+		md   metadata.MD
+		want bool
+	}{
+		{name: "missing"},
+		{name: "retry now", md: metadata.Pairs(metadataKey, "0")},
+		{name: "retry later", md: metadata.Pairs(metadataKey, "100")},
+		{name: "do not retry", md: metadata.Pairs(metadataKey, noRetry), want: true},
+		{name: "unparsable", md: metadata.Pairs(metadataKey, "soon"), want: true},
+		// grpc-go does not retry on multiple values, whatever they say.
+		{name: "multiple values", md: metadata.Pairs(metadataKey, "0", metadataKey, "0"), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IsNoRetry(tt.md))
+		})
+	}
+}
+
+type fakeStream struct{ trailer metadata.MD }
+
+func (*fakeStream) Method() string               { return "" }
+func (*fakeStream) SetHeader(metadata.MD) error  { return nil }
+func (*fakeStream) SendHeader(metadata.MD) error { return nil }
+func (s *fakeStream) SetTrailer(md metadata.MD) error {
+	s.trailer = metadata.Join(s.trailer, md)
+	return nil
+}
+
+func TestSetNoRetry(t *testing.T) {
+	stream := &fakeStream{}
+	SetNoRetry(grpc.NewContextWithServerTransportStream(context.Background(), stream))
+
+	// The wire format grpc-go reads; only a negative value stops a retry.
+	require.Equal(t, []string{"-1"}, stream.trailer.Get("grpc-retry-pushback-ms"))
+	require.True(t, IsNoRetry(stream.trailer))
+
+	// Outside a gRPC handler there is no client to inform.
+	require.NotPanics(t, func() { SetNoRetry(context.Background()) })
+}


### PR DESCRIPTION
Closes grafana/pyroscope-squad#911.

The query-backend client retries RESOURCE_EXHAUSTED, which the server returns when shedding load. Grpc-go uses the same code when a response exceeds the message size limit, and that failure is deterministic: the query is re-run until the 30s deadline and the caller sees a 504 instead of the real error.

The status code cannot tell the two apart, so the verdict travels out of band. Once a handler has built a response it sets `grpc-retry-pushback-ms: -1`, the trailer gRPC reserves for this. Grpc-go reads it only when deciding a retry, so it is inert on success and only takes effect when the send fails. Queries that fail return before that point and keep the retry policy, load shedding included. Clients forward the verdict up the query plan, so the frontend does not retry a subtree that cannot deliver.

The **trade-off** is that the scope is positional rather than by error identity: any retryable failure raised between the handler returning and the first byte on the wire counts as permanent. That window holds only encoding and the size check (grpc-go `Server.sendResponse`), so nothing transient can occur there, and it is worth re-checking on a major grpc-go bump. Doing the size check ourselves would name the case explicitly, but it duplicates grpc-go, needs the server message size limit plumbed into the module, and over-rejects when compression is enabled.

`backoff_on_ratelimits` is now rejected for this client, since dskit's retrier retries every `RESOURCE_EXHAUSTED` without honoring the pushback.