### PR TITLE
fix(profilecli): stop replay dump from closing the dataset twice

### DIFF
--- a/cmd/profilecli/replay_dump.go
+++ b/cmd/profilecli/replay_dump.go
@@ -236,12 +236,13 @@ func dumpDataset(
 	if err := ds.Open(ctx, block.SectionTSDB, block.SectionProfiles, block.SectionSymbols); err != nil {
 		return 0, fmt.Errorf("failed to open dataset: %w", err)
 	}
-	defer ds.Close()
 
 	it, err := block.NewProfileRowIterator(ds)
 	if err != nil {
+		_ = ds.Close()
 		return 0, fmt.Errorf("failed to create profile row iterator: %w", err)
 	}
+	// The iterator takes ownership of the dataset and closes it.
 	defer it.Close()
 
 	var count int

--- a/cmd/profilecli/replay_dump.go
+++ b/cmd/profilecli/replay_dump.go
@@ -242,7 +242,6 @@ func dumpDataset(
 		_ = ds.Close()
 		return 0, fmt.Errorf("failed to create profile row iterator: %w", err)
 	}
-	// The iterator takes ownership of the dataset and closes it.
 	defer it.Close()
 
 	var count int

--- a/cmd/profilecli/replay_dump_test.go
+++ b/cmd/profilecli/replay_dump_test.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	"github.com/grafana/pyroscope/v2/pkg/block"
 	"github.com/grafana/pyroscope/v2/pkg/objstore/testutil"
 )
 
@@ -28,12 +29,18 @@ func TestDumpBlock_MultipleDatasets(t *testing.T) {
 
 	var md *metastorev1.BlockMeta
 	for _, b := range resp.Blocks {
-		if len(b.Datasets) > 1 {
+		var n int
+		for _, ds := range b.Datasets {
+			if block.DatasetFormat(ds.Format) == block.DatasetFormat0 {
+				n++
+			}
+		}
+		if n > 1 {
 			md = b
 			break
 		}
 	}
-	require.NotNil(t, md, "test data must contain a block with more than one dataset")
+	require.NotNil(t, md, "test data must contain a block with more than one profile dataset")
 
 	var buf bytes.Buffer
 	rw, err := newReplayWriter(&buf, replayHeader{})

--- a/cmd/profilecli/replay_dump_test.go
+++ b/cmd/profilecli/replay_dump_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"math"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	"github.com/grafana/pyroscope/v2/pkg/objstore/testutil"
+)
+
+func TestDumpBlock_MultipleDatasets(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	bucket, _ := testutil.NewFilesystemBucket(t, ctx, "../../pkg/block/testdata")
+
+	raw, err := os.ReadFile("../../pkg/block/testdata/block-metas.json")
+	require.NoError(t, err)
+	var resp metastorev1.GetBlockMetadataResponse
+	require.NoError(t, protojson.Unmarshal(raw, &resp))
+
+	var md *metastorev1.BlockMeta
+	for _, b := range resp.Blocks {
+		if len(b.Datasets) > 1 {
+			md = b
+			break
+		}
+	}
+	require.NotNil(t, md, "test data must contain a block with more than one dataset")
+
+	var buf bytes.Buffer
+	rw, err := newReplayWriter(&buf, replayHeader{})
+	require.NoError(t, err)
+
+	count, err := dumpBlock(ctx, bucket, md, nil, 0, math.MaxInt64, rw)
+	require.NoError(t, err)
+	assert.NotZero(t, count)
+	require.NoError(t, rw.Flush())
+}

--- a/pkg/block/section_profiles.go
+++ b/pkg/block/section_profiles.go
@@ -378,8 +378,9 @@ type profileRowIterator struct {
 	labels           immutableLabels
 }
 
-// NewProfileRowIterator takes ownership of the dataset: closing the
-// iterator closes it. The caller must not close the dataset itself.
+// NewProfileRowIterator takes ownership of one open dataset reference on
+// success. Closing the iterator releases that reference. On error, ownership
+// remains with the caller.
 func NewProfileRowIterator(s *Dataset) (iter.Iterator[ProfileEntry], error) {
 	k, v := index.AllPostingsKey()
 	tsdb := s.Index()

--- a/pkg/block/section_profiles.go
+++ b/pkg/block/section_profiles.go
@@ -378,6 +378,8 @@ type profileRowIterator struct {
 	labels           immutableLabels
 }
 
+// NewProfileRowIterator takes ownership of the dataset: closing the
+// iterator closes it. The caller must not close the dataset itself.
 func NewProfileRowIterator(s *Dataset) (iter.Iterator[ProfileEntry], error) {
 	k, v := index.AllPostingsKey()
 	tsdb := s.Index()


### PR DESCRIPTION
`dumpDataset` deferred `ds.Close()` and then `it.Close()`, but `profileRowIterator.Close` closes its reader, which is that same dataset. Defers run LIFO, so every successful dump closed the dataset twice and released the shared block `Object` one time too many. With a second matching dataset in the block, the next open/close cycle finds a negative refcounter and panics.

The iterator owns the dataset once it exists, so the unconditional defer is gone and `ds.Close()` now only runs on the iterator-construction error path. I put that contract in a doc comment on `NewProfileRowIterator` too, since it wasn't written down anywhere.

`readProfilesFromDataset` and `resolveProfile` in `pkg/operations/v2/blocks/profile_handlers.go` have the same pattern. They keep their own reference on the `Object`, so the counter goes negative without anything panicking today. Happy to fix those here as well if you'd prefer it in one change.

Fixes #5585
