### PR TITLE
fix(blocks): close profile datasets through iterators

### DIFF
--- a/pkg/operations/v2/blocks/profile_handlers.go
+++ b/pkg/operations/v2/blocks/profile_handlers.go
@@ -98,10 +98,10 @@ func (h *Handlers) readProfilesFromDataset(ctx context.Context, blockMeta *metas
 	if err := ds.Open(ctx, block.SectionProfiles, block.SectionTSDB); err != nil {
 		return nil, 0, fmt.Errorf("failed to open dataset: %w", err)
 	}
-	defer ds.Close()
 
 	it, err := block.NewProfileRowIterator(ds)
 	if err != nil {
+		_ = ds.Close()
 		return nil, 0, fmt.Errorf("failed to create profile iterator: %w", err)
 	}
 	defer it.Close()
@@ -167,13 +167,7 @@ func (h *Handlers) CreateDatasetProfileDownloadHandler() func(http.ResponseWrite
 			return
 		}
 
-		_, _, profileMeta, err := h.buildProfileResolver(r.Context(), blockMeta, foundDataset, rowNum)
-		if err != nil {
-			httputil.Error(w, fmt.Errorf("failed to get profile metadata: %w", err))
-			return
-		}
-
-		profile, err := h.retrieveProfile(r.Context(), blockMeta, foundDataset, rowNum)
+		profile, profileMeta, err := h.retrieveProfile(r.Context(), blockMeta, foundDataset, rowNum)
 		if err != nil {
 			httputil.Error(w, fmt.Errorf("failed to download profile: %w", err))
 			return
@@ -194,23 +188,17 @@ func (h *Handlers) retrieveProfile(
 	blockMeta *metastorev1.BlockMeta,
 	dataset *metastorev1.Dataset,
 	rowNum int64,
-) (*googlev1.Profile, error) {
-	resolver, timestamp, meta, err := h.buildProfileResolver(ctx, blockMeta, dataset, rowNum)
+) (*googlev1.Profile, *profileMetadata, error) {
+	profile, timestamp, meta, err := h.buildProfile(ctx, blockMeta, dataset, rowNum)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build profile resolver: %w", err)
-	}
-	defer resolver.Release()
-
-	profile, err := resolver.Pprof()
-	if err != nil {
-		return nil, fmt.Errorf("failed to build pprof profile: %w", err)
+		return nil, nil, fmt.Errorf("failed to build profile: %w", err)
 	}
 
 	if t, err := phlaremodel.ParseProfileTypeSelector(meta.ProfileType); err == nil {
 		pprof.SetProfileMetadata(profile, t, timestamp, 0)
 	}
 
-	return profile, nil
+	return profile, meta, nil
 }
 
 func (h *Handlers) writeProfile(w http.ResponseWriter, profile *googlev1.Profile, filename string) {
@@ -298,15 +286,9 @@ func (h *Handlers) buildProfileTree(
 	dataset *metastorev1.Dataset,
 	rowNum int64,
 ) (*treeNode, int64, *profileMetadata, error) {
-	resolver, timestamp, profileMeta, err := h.buildProfileResolver(ctx, blockMeta, dataset, rowNum)
+	profile, timestamp, profileMeta, err := h.buildProfile(ctx, blockMeta, dataset, rowNum)
 	if err != nil {
-		return nil, 0, nil, fmt.Errorf("failed to build profile resolver: %w", err)
-	}
-	defer resolver.Release()
-
-	profile, err := resolver.Pprof()
-	if err != nil {
-		return nil, 0, nil, fmt.Errorf("failed to build pprof profile: %w", err)
+		return nil, 0, nil, fmt.Errorf("failed to build profile: %w", err)
 	}
 
 	tree := buildTreeFromPprof(profile, profileMeta.Unit)
@@ -314,12 +296,12 @@ func (h *Handlers) buildProfileTree(
 	return tree, timestamp, profileMeta, nil
 }
 
-func (h *Handlers) buildProfileResolver(
+func (h *Handlers) buildProfile(
 	ctx context.Context,
 	blockMeta *metastorev1.BlockMeta,
 	dataset *metastorev1.Dataset,
 	rowNum int64,
-) (*symdb.Resolver, int64, *profileMetadata, error) {
+) (*googlev1.Profile, int64, *profileMetadata, error) {
 	obj := block.NewObject(h.Bucket, blockMeta)
 	if err := obj.Open(ctx); err != nil {
 		return nil, 0, nil, fmt.Errorf("failed to open block object: %w", err)
@@ -330,10 +312,10 @@ func (h *Handlers) buildProfileResolver(
 	if err := ds.Open(ctx, block.SectionProfiles, block.SectionTSDB, block.SectionSymbols); err != nil {
 		return nil, 0, nil, fmt.Errorf("failed to open dataset: %w", err)
 	}
-	defer ds.Close()
 
 	it, err := block.NewProfileRowIterator(ds)
 	if err != nil {
+		_ = ds.Close()
 		return nil, 0, nil, fmt.Errorf("failed to create profile iterator: %w", err)
 	}
 	defer it.Close()
@@ -380,6 +362,7 @@ func (h *Handlers) buildProfileResolver(
 	}
 
 	resolver := symdb.NewResolver(ctx, ds.Symbols())
+	defer resolver.Release()
 
 	partitionID := targetEntry.Row.StacktracePartitionID()
 	var stacktraceIDs []uint32
@@ -402,7 +385,12 @@ func (h *Handlers) buildProfileResolver(
 	}
 	resolver.AddSamples(partitionID, samples)
 
-	return resolver, targetEntry.Timestamp, profileMeta, nil
+	profile, err := resolver.Pprof()
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("failed to build pprof profile: %w", err)
+	}
+
+	return profile, targetEntry.Timestamp, profileMeta, nil
 }
 
 // formatValue formats a value according to the pprof unit specification

--- a/pkg/operations/v2/blocks/profile_handlers_test.go
+++ b/pkg/operations/v2/blocks/profile_handlers_test.go
@@ -1,0 +1,81 @@
+package blocks
+
+import (
+	"context"
+	"math"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	"github.com/grafana/pyroscope/v2/pkg/block"
+	"github.com/grafana/pyroscope/v2/pkg/objstore"
+	"github.com/grafana/pyroscope/v2/pkg/objstore/testutil"
+)
+
+func TestProfileHandlers_CloseDatasetOnce(t *testing.T) {
+	ctx := context.Background()
+	bucket, _ := testutil.NewFilesystemBucket(t, ctx, "../../../block/testdata")
+	blockMeta, dataset := profileDataset(t)
+	blockMeta.Size = math.MaxUint64 // Force each section to use the wrapped bucket reader.
+
+	h := Handlers{Bucket: &singleCloseBucket{Bucket: bucket}}
+	profiles, total, err := h.readProfilesFromDataset(ctx, blockMeta, dataset, 1, 10)
+	require.NoError(t, err)
+	require.NotZero(t, total)
+	require.NotEmpty(t, profiles)
+
+	profile, _, err := h.retrieveProfile(ctx, blockMeta, dataset, 0)
+	require.NoError(t, err)
+	require.NotNil(t, profile)
+}
+
+func profileDataset(t *testing.T) (*metastorev1.BlockMeta, *metastorev1.Dataset) {
+	t.Helper()
+
+	raw, err := os.ReadFile("../../../block/testdata/block-metas.json")
+	require.NoError(t, err)
+	var resp metastorev1.GetBlockMetadataResponse
+	require.NoError(t, protojson.Unmarshal(raw, &resp))
+
+	for _, blockMeta := range resp.Blocks {
+		for _, dataset := range blockMeta.Datasets {
+			if block.DatasetFormat(dataset.Format) == block.DatasetFormat0 {
+				return blockMeta, dataset
+			}
+		}
+	}
+	t.Fatal("test data must contain a profile dataset")
+	return nil, nil
+}
+
+type singleCloseBucket struct {
+	objstore.Bucket
+}
+
+func (b *singleCloseBucket) ReaderAt(ctx context.Context, filename string) (objstore.ReaderAtCloser, error) {
+	r, err := b.Bucket.ReaderAt(ctx, filename)
+	if err != nil {
+		return nil, err
+	}
+	return &singleCloseReader{ReaderAtCloser: r}, nil
+}
+
+type singleCloseReader struct {
+	objstore.ReaderAtCloser
+	mu     sync.Mutex
+	closed bool
+}
+
+func (r *singleCloseReader) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		panic("reader closed more than once")
+	}
+	r.closed = true
+	return r.ReaderAtCloser.Close()
+}


### PR DESCRIPTION
## Summary
- let profile row iterators own the dataset lifetime
- materialize pprof profiles before releasing their symbol resolver
- add a regression test that detects double-close reader calls

## Related
- #5591
