### PR TITLE
fix(profilecli): anchor replay batch windows to due time

### DIFF
--- a/cmd/profilecli/replay_push.go
+++ b/cmd/profilecli/replay_push.go
@@ -199,6 +199,20 @@ func runReplayCycle(
 	cycleStart time.Time,
 	params *replayPushParams,
 ) (pushed, failed int, interrupted bool) {
+	return runReplayCycleWithWait(ctx, pc, records, minTs, cycleStart, params, waitUntil)
+}
+
+type replayWaitFunc func(context.Context, time.Time) bool
+
+func runReplayCycleWithWait(
+	ctx context.Context,
+	pc pushv1connect.PusherServiceClient,
+	records []replayRecord,
+	minTs int64,
+	cycleStart time.Time,
+	params *replayPushParams,
+	wait replayWaitFunc,
+) (pushed, failed int, interrupted bool) {
 	scheduledTarget := func(rec replayRecord) time.Time {
 		offset := time.Duration(float64(rec.TimestampNanos-minTs) / params.Speed)
 		return cycleStart.Add(offset)
@@ -216,7 +230,7 @@ func runReplayCycle(
 
 		first := records[i]
 		firstTarget := scheduledTarget(first)
-		if !waitUntil(ctx, firstTarget) {
+		if !wait(ctx, firstTarget) {
 			interrupted = true
 			break
 		}
@@ -231,14 +245,14 @@ func runReplayCycle(
 		}
 		i++
 
-		deadline := time.Now().Add(params.BatchWait)
+		deadline := firstTarget.Add(params.BatchWait)
 		for i < total && len(batch) < params.BatchSize {
 			next := records[i]
 			nextTarget := scheduledTarget(next)
 			if nextTarget.After(deadline) {
 				break
 			}
-			if !waitUntil(ctx, nextTarget) {
+			if !wait(ctx, nextTarget) {
 				interrupted = true
 				break
 			}

--- a/cmd/profilecli/replay_push_test.go
+++ b/cmd/profilecli/replay_push_test.go
@@ -27,6 +27,22 @@ type fakePusherClient struct {
 	requests []*pushv1.PushRequest
 }
 
+type fakeReplayWaiter struct {
+	now   time.Time
+	waits []time.Time
+}
+
+func (w *fakeReplayWaiter) waitUntil(ctx context.Context, target time.Time) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	w.waits = append(w.waits, target)
+	if target.After(w.now) {
+		w.now = target
+	}
+	return true
+}
+
 func (f *fakePusherClient) Push(_ context.Context, req *connect.Request[pushv1.PushRequest]) (*connect.Response[pushv1.PushResponse], error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -103,18 +119,17 @@ func TestRunReplayCycle_Batching(t *testing.T) {
 		BatchWait: 500 * time.Millisecond,
 	}
 
-	cycleStart := time.Now()
-	pushed, failed, interrupted := runReplayCycle(context.Background(), fake, records, records[0].TimestampNanos, cycleStart, params)
+	cycleStart := time.Unix(0, 0)
+	waiter := &fakeReplayWaiter{now: cycleStart}
+	pushed, failed, interrupted := runReplayCycleWithWait(context.Background(), fake, records, records[0].TimestampNanos, cycleStart, params, waiter.waitUntil)
 
 	require.False(t, interrupted)
 	assert.Equal(t, 0, failed)
 	assert.Equal(t, n, pushed)
 	assert.Equal(t, n, fake.totalSeries())
 
-	// 500 records batched at up to 50 per request should take far fewer
-	// than 500 push RPCs.
-	assert.LessOrEqual(t, fake.requestCount(), n/10)
-	assert.LessOrEqual(t, fake.maxBatchSize(), params.BatchSize)
+	assert.Equal(t, n/params.BatchSize, fake.requestCount())
+	assert.Equal(t, params.BatchSize, fake.maxBatchSize())
 }
 
 // TestRunReplayCycle_SparseRecordsAreNotOverBatched verifies that records
@@ -124,21 +139,23 @@ func TestRunReplayCycle_SparseRecordsAreNotOverBatched(t *testing.T) {
 	t.Parallel()
 
 	pprofBytes := testPprofBytes(t)
+	batchWait := 10 * time.Millisecond
 
 	records := []replayRecord{
 		{Labels: []*typesv1.LabelPair{{Name: "service_name", Value: "svc"}}, TimestampNanos: 0, Pprof: pprofBytes},
-		{Labels: []*typesv1.LabelPair{{Name: "service_name", Value: "svc"}}, TimestampNanos: int64(2 * time.Second), Pprof: pprofBytes},
+		{Labels: []*typesv1.LabelPair{{Name: "service_name", Value: "svc"}}, TimestampNanos: int64(batchWait + time.Nanosecond), Pprof: pprofBytes},
 	}
 
 	fake := &fakePusherClient{}
 	params := &replayPushParams{
-		Speed:     50, // 2s apart in recorded time -> 40ms apart in wall time, still > batch-wait
+		Speed:     1,
 		BatchSize: 50,
-		BatchWait: 10 * time.Millisecond,
+		BatchWait: batchWait,
 	}
 
-	cycleStart := time.Now()
-	pushed, failed, interrupted := runReplayCycle(context.Background(), fake, records, records[0].TimestampNanos, cycleStart, params)
+	cycleStart := time.Unix(0, 0)
+	waiter := &fakeReplayWaiter{now: cycleStart}
+	pushed, failed, interrupted := runReplayCycleWithWait(context.Background(), fake, records, records[0].TimestampNanos, cycleStart, params, waiter.waitUntil)
 
 	require.False(t, interrupted)
 	assert.Equal(t, 0, failed)
@@ -146,6 +163,43 @@ func TestRunReplayCycle_SparseRecordsAreNotOverBatched(t *testing.T) {
 	// Each record should have been flushed in its own batch since they are
 	// scheduled further apart than --batch-wait.
 	assert.Equal(t, 2, fake.requestCount())
+}
+
+func TestRunReplayCycle_BatchWaitBoundary(t *testing.T) {
+	t.Parallel()
+
+	pprofBytes := testPprofBytes(t)
+	batchWait := 10 * time.Millisecond
+	cycleStart := time.Unix(0, 0)
+
+	tests := []struct {
+		name         string
+		gap          time.Duration
+		requestCount int
+	}{
+		{name: "before deadline", gap: batchWait - time.Nanosecond, requestCount: 1},
+		{name: "at deadline", gap: batchWait, requestCount: 1},
+		{name: "after deadline", gap: batchWait + time.Nanosecond, requestCount: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			records := []replayRecord{
+				{Labels: []*typesv1.LabelPair{{Name: "service_name", Value: "svc"}}, TimestampNanos: 0, Pprof: pprofBytes},
+				{Labels: []*typesv1.LabelPair{{Name: "service_name", Value: "svc"}}, TimestampNanos: int64(tt.gap), Pprof: pprofBytes},
+			}
+			fake := &fakePusherClient{}
+			waiter := &fakeReplayWaiter{now: cycleStart}
+			params := &replayPushParams{Speed: 1, BatchSize: 50, BatchWait: batchWait}
+
+			pushed, failed, interrupted := runReplayCycleWithWait(context.Background(), fake, records, 0, cycleStart, params, waiter.waitUntil)
+
+			assert.False(t, interrupted)
+			assert.Zero(t, failed)
+			assert.Equal(t, len(records), pushed)
+			assert.Equal(t, tt.requestCount, fake.requestCount())
+		})
+	}
 }
 
 func TestRunReplayCycle_ContextCancellation(t *testing.T) {
@@ -169,6 +223,15 @@ func TestRunReplayCycle_ContextCancellation(t *testing.T) {
 
 	_, _, interrupted := runReplayCycle(ctx, fake, records, records[0].TimestampNanos, time.Now().Add(20*time.Second), params)
 	assert.True(t, interrupted)
+}
+
+func TestWaitUntil_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	assert.False(t, waitUntil(ctx, time.Now().Add(time.Hour)))
 }
 
 func TestBuildSeries_RewritesTimestamp(t *testing.T) {


### PR DESCRIPTION
Fix replay batching so `--batch-wait` is measured from when the first profile becomes due, rather than from when it is processed.

Previously, scheduler delays or race instrumentation could move the batch deadline forward and cause sparse records to join the same push request. This made `TestRunReplayCycle_SparseRecordsAreNotOverBatched` flaky in the arm64 `-race -cover` job.