### PR TITLE
feat(otlp): detect profile language from telemetry.sdk.language resource attribute

### DIFF
--- a/pkg/ingester/otlp/ingest_handler.go
+++ b/pkg/ingester/otlp/ingest_handler.go
@@ -269,6 +269,7 @@ func (h *ingestHandler) export(ctx context.Context, er *pprofileotlp.ExportProfi
 
 	for _, rp := range rps {
 		serviceName := getServiceNameFromAttributes(rp.Resource.GetAttributes())
+		language := getLanguageFromAttributes(rp.Resource.GetAttributes())
 		for _, sp := range rp.ScopeProfiles {
 			for _, p := range sp.Profiles {
 				sz := proto.Size(p)
@@ -301,6 +302,7 @@ func (h *ingestHandler) export(ctx context.Context, er *pprofileotlp.ExportProfi
 						RawProfile: nil,
 						Profile:    pprof.RawFromProto(pprofProfile.profile),
 						ID:         uuid.New().String(),
+						Language:   language,
 					}
 					req.Series = append(req.Series, s)
 				}
@@ -342,6 +344,18 @@ func getServiceNameFromAttributes(attrs []*v1.KeyValue) string {
 
 	}
 	return fallback
+}
+
+// getLanguageFromAttributes extracts the profile language from the OTLP
+// resource attribute "telemetry.sdk.language", as defined by the semantic
+// conventions: https://opentelemetry.io/docs/specs/semconv/resource/#telemetry-sdk
+func getLanguageFromAttributes(attrs []*v1.KeyValue) string {
+	for _, attr := range attrs {
+		if attr.Key == string(model.AttrTelemetrySDKLanguage) {
+			return stringValueFromAnyValue(attr.GetValue())
+		}
+	}
+	return ""
 }
 
 // getDefaultLabels returns the required base labels for Pyroscope profiles

--- a/pkg/ingester/otlp/ingest_handler_test.go
+++ b/pkg/ingester/otlp/ingest_handler_test.go
@@ -27,6 +27,7 @@ import (
 	v1experimental2 "go.opentelemetry.io/proto/otlp/collector/profiles/v1development"
 	v1 "go.opentelemetry.io/proto/otlp/common/v1"
 	v1experimental "go.opentelemetry.io/proto/otlp/profiles/v1development"
+	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
 
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
 	"github.com/grafana/pyroscope/v2/pkg/distributor/model"
@@ -914,6 +915,86 @@ func TestDifferentServiceNames(t *testing.T) {
 		assert.NotContains(t, jsonStr, "service.name")
 
 	}
+}
+
+func TestCustomProfileTypeLanguageLabeling(t *testing.T) {
+	svc := mockotlp.NewMockPushService(t)
+	var profiles []*model.PushRequest
+	svc.On("PushBatch", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		c := (args.Get(1)).(*model.PushRequest)
+		profiles = append(profiles, c)
+	}).Return(nil, nil)
+
+	otlpb := new(otlpbuilder)
+	otlpb.dictionary.MappingTable = []*v1experimental.Mapping{{
+		MemoryStart:      0x1000,
+		MemoryLimit:      0x2000,
+		FilenameStrindex: otlpb.addstr("app"),
+	}}
+	otlpb.dictionary.LocationTable = []*v1experimental.Location{{
+		MappingIndex: 0,
+		Address:      0x1100,
+	}}
+	otlpb.dictionary.StackTable = []*v1experimental.Stack{{
+		LocationIndices: []int32{0},
+	}}
+	otlpb.profile.Samples = []*v1experimental.Sample{{
+		StackIndex: 0,
+		Values:     []int64{42},
+	}}
+	// Matches the cpp-ld-preload-memory-profiling demo: a custom sample
+	// type with a "space"/"bytes" period type (Go heap-profile convention).
+	otlpb.profile.SampleType = &v1experimental.ValueType{
+		TypeStrindex: otlpb.addstr("alloc_objects"),
+		UnitStrindex: otlpb.addstr("count"),
+	}
+	otlpb.profile.PeriodType = &v1experimental.ValueType{
+		TypeStrindex: otlpb.addstr("space"),
+		UnitStrindex: otlpb.addstr("bytes"),
+	}
+	otlpb.profile.Period = 16
+	otlpb.profile.TimeUnixNano = 239
+
+	req := &v1experimental2.ExportProfilesServiceRequest{
+		ResourceProfiles: []*v1experimental.ResourceProfiles{{
+			Resource: &resourcev1.Resource{
+				Attributes: []*v1.KeyValue{
+					{
+						Key: "service.name",
+						Value: &v1.AnyValue{
+							Value: &v1.AnyValue_StringValue{StringValue: "cpp.ld-preload.memory"},
+						},
+					},
+					{
+						Key: "telemetry.sdk.language",
+						Value: &v1.AnyValue{
+							Value: &v1.AnyValue_StringValue{StringValue: "cpp"},
+						},
+					},
+				},
+			},
+			ScopeProfiles: []*v1experimental.ScopeProfiles{{
+				Profiles: []*v1experimental.Profile{
+					&otlpb.profile,
+				}}}}},
+		Dictionary: &otlpb.dictionary}
+
+	logger := test.NewTestingLogger(t)
+	h := NewOTLPIngestHandler(testConfig(), svc, logger, defaultLimits())
+	_, err := h.Export(user.InjectOrgID(context.Background(), tenant.DefaultTenantID), req)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(profiles))
+	require.Equal(t, 1, len(profiles[0].Series))
+
+	series := profiles[0].Series[0]
+	labelsMap := make(map[string]string)
+	for _, label := range series.Labels {
+		labelsMap[label.Name] = label.Value
+	}
+
+	assert.Equal(t, "cpp.ld-preload.memory", labelsMap[phlaremodel.LabelNameServiceName])
+	assert.Equal(t, "cpp", labelsMap["telemetry.sdk.language"])
+	assert.Equal(t, "cpp", series.Language, "Language must be read from telemetry.sdk.language, not guessed from symbols")
 }
 
 type otlpbuilder struct {

--- a/pkg/model/labels.go
+++ b/pkg/model/labels.go
@@ -61,6 +61,8 @@ const (
 	AttrServiceName         = semconv.ServiceNameKey
 	AttrServiceNameFallback = "unknown_service"
 
+	AttrTelemetrySDKLanguage = semconv.TelemetrySDKLanguageKey
+
 	labelSep = '\xfe'
 
 	ProfileNameOffCpu = "off_cpu" // todo better name?


### PR DESCRIPTION
## Summary

OTLP profiles should report their language via the `telemetry.sdk.language` resource attribute (per [OTel resource semconv](https://opentelemetry.io/docs/specs/semconv/resource/#telemetry-sdk)). Today that attribute isn't used for language detection, instead, `pprof.GetLanguage` is used, which matches known filename prefixes/suffixes (`.go`, `.py`, `java/`, etc.) in the profile's string table and silently returns `unknown` when none match

## Changes

The idea is to use the predefined OpenTelemetry semantic convention directly, avoiding the string-table lookup and giving an accurate language 

- `pkg/model/labels.go`: add `AttrTelemetrySDKLanguage` constant
- `pkg/ingester/otlp/ingest_handler.go`: extract `telemetry.sdk.language` per `ResourceProfiles`, set on each resulting `ProfileSeries.Language` 
- `pkg/ingester/otlp/ingest_handler_test.go`: new test covering a custom (non-CPU/off-CPU) profile with the attribute set
