### PR TITLE
docs: Expand recording rules CLI, add Rust jemalloc profiling, fix profile types, add v2.0 upgrade guide

### DIFF
--- a/docs/sources/configure-client/language-sdks/rust.md
+++ b/docs/sources/configure-client/language-sdks/rust.md
@@ -84,7 +84,73 @@ You can start profiling by invoking the following code:
 let agent_running = agent.start().unwrap();
 ```
 
-The agent can be stopped at any point, and it'll send a last report to the server. The agent can be restarted at a later point.
+## Add memory profiling with jemalloc
+
+The Pyroscope Rust SDK supports memory profiling through the [jemalloc](https://jemalloc.net/) allocator.
+With jemalloc memory profiling, you can identify memory leaks, excessive allocations, and heap growth in your Rust applications the same way you would for Python, Java, or .NET services.
+
+### Before you begin
+
+Memory profiling requires:
+
+- The `jemalloc` allocator configured as the global allocator in your application
+- The `tikv-jemallocator` crate with the `profiling` feature enabled
+- jemalloc profiling activated at runtime through environment variables
+
+### Configure jemalloc memory profiling
+
+1. Add the required dependencies to your `Cargo.toml`:
+
+   ```toml
+   [dependencies]
+   pyroscope = { version = "2.0.0", features = ["backend-jemalloc"] }
+   tikv-jemallocator = { version = "0.7", features = ["profiling"] }
+   ```
+
+1. Set jemalloc as the global allocator in your application:
+
+   ```rust
+   #[global_allocator]
+   static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+   ```
+
+1. Configure the Pyroscope agent to use the jemalloc backend:
+
+   ```rust
+   use pyroscope::pyroscope::PyroscopeAgentBuilder;
+   use pyroscope::backend::jemalloc::jemalloc_backend;
+
+   let agent = PyroscopeAgentBuilder::new(
+       "http://localhost:4040",
+       "myapp",
+       100,
+       "pyroscope-rs",
+       env!("CARGO_PKG_VERSION"),
+       jemalloc_backend(),
+   )
+   .build()?;
+
+   let agent_running = agent.start()?;
+   ```
+
+1. Enable jemalloc profiling at runtime. Set the `_RJEM_MALLOC_CONF` environment variable before starting your application:
+
+   ```bash
+   _RJEM_MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:19 \
+       cargo run --features backend-jemalloc
+   ```
+
+   - `prof:true` enables the profiling infrastructure.
+   - `prof_active:true` starts collecting allocation samples immediately.
+   - `lg_prof_sample:19` sets the sampling interval to every 512 KB (2^19 bytes). Lower values produce more detailed profiles but increase overhead.
+
+The jemalloc backend reports `memory` profile types (`inuse_objects` and `inuse_space`), which appear alongside CPU profiles in Pyroscope.
+
+## Stop profiling
+
+## Stop profiling
+
+The agent can be stopped at any point, and it sends a last report to the server. The agent can be restarted at a later point.
 
 ```rust
 let agent_ready = agent_running.stop().unwrap();

--- a/docs/sources/configure-client/profile-types.md
+++ b/docs/sources/configure-client/profile-types.md
@@ -76,8 +76,8 @@ This table lists the available profile types based on the language SDK.
 | CPU            | Yes       | Yes  | Yes        | Yes  | Yes    | Yes  | Yes     |
 | Alloc Objects  | Yes       | Yes  | Yes        |      | Yes    |      |         |
 | Alloc Space    | Yes       | Yes  | Yes        |      | Yes    |      |         |
-| Inuse Objects  | Yes       |      | Yes (7.0+) |      | Yes    |      |         |
-| Inuse Space    | Yes       |      | Yes (7.0+) |      | Yes    |      |         |
+| Inuse Objects  | Yes       |      | Yes (7.0+) |      | Yes    | Yes  |         |
+| Inuse Space    | Yes       |      | Yes (7.0+) |      | Yes    | Yes  |         |
 | Goroutines     | Yes       |      |            |      |        |      |         |
 | Mutex Count    | Yes       |      | Yes        |      |        |      |         |
 | Mutex Duration | Yes       |      | Yes        |      |        |      |         |

--- a/docs/sources/upgrade-guide/_index.md
+++ b/docs/sources/upgrade-guide/_index.md
@@ -23,7 +23,8 @@ This upgrade guide applies to on-premise installations and not for Grafana Cloud
 
 Version 2.0 introduces a redesigned storage architecture that replaces the v1 write and read paths with new components. If you run Pyroscope on-premises and want to take advantage of improved write throughput, simplified operations, and better compaction, you need to migrate from v1 to v2 storage.
 
-The v2 architecture replaces ingesters with **segment writers** that write directly to object storage, adds a **metastore** for block metadata, and introduces **compaction workers** and a **query backend**. Because the storage format and component topology are different, upgrading to v2 is a migration rather than a configuration change.
+The v2 architecture replaces ingesters with segment writers that write directly to object storage, adds a metastore for block metadata, and introduces compaction workers and a query backend.
+Because the storage format and component topology are different, upgrading to v2 is a migration rather than a configuration change.
 
 For a full description of what changed and why, refer to [About the v2 architecture](../reference-pyroscope-v2-architecture/about-pyroscope-v2-architecture/).
 

--- a/docs/sources/upgrade-guide/_index.md
+++ b/docs/sources/upgrade-guide/_index.md
@@ -19,6 +19,18 @@ The upgrade process changes for each version, depending upon the changes made fo
 
 This upgrade guide applies to on-premise installations and not for Grafana Cloud.
 
+## Upgrade to Pyroscope 2.0
+
+Version 2.0 introduces a redesigned storage architecture that replaces the v1 write and read paths with new components. If you run Pyroscope on-premises and want to take advantage of improved write throughput, simplified operations, and better compaction, you need to migrate from v1 to v2 storage.
+
+The v2 architecture replaces ingesters with **segment writers** that write directly to object storage, adds a **metastore** for block metadata, and introduces **compaction workers** and a **query backend**. Because the storage format and component topology are different, upgrading to v2 is a migration rather than a configuration change.
+
+For a full description of what changed and why, refer to [About the v2 architecture](../reference-pyroscope-v2-architecture/about-pyroscope-v2-architecture/).
+
+For step-by-step migration instructions using Helm, refer to [Migrate from v1 to v2 storage using Helm](../reference-pyroscope-v2-architecture/migrate-from-v1/).
+
+For a list of all changes in the 2.0 release, refer to the [v2.0 release notes](../release-notes/v2-0/).
+
 ## Upgrade to Pyroscope 1.0
 
 Version 1.0 of Pyroscope is a major release that includes breaking changes.

--- a/docs/sources/view-and-analyze-profile-data/profile-cli.md
+++ b/docs/sources/view-and-analyze-profile-data/profile-cli.md
@@ -630,11 +630,120 @@ profilecli ready --url=http://localhost:4040
 
 ### Manage recording rules from the CLI
 
-Use `profilecli recording-rules` commands to list, create, get, and delete recording rules without leaving your terminal.
-This is useful for GitOps-style workflows and automated rollout validation.
+Recording rules let you pre-aggregate profiling data into Prometheus-compatible metrics.
+You can then set alerts, build dashboards, and track function-level costs over time without running ad-hoc queries.
+Use `profilecli recording-rules` commands to list, create, get, and delete recording rules from your terminal so you can manage rules in GitOps workflows and automated rollout validation.
+
+{{< admonition type="note" >}}
+When you connect to a Grafana Cloud data source, the `recording-rules` commands require a token with the `profiles-config:read` scope (for `list` and `get`) or the `profiles-config:write` scope (for `create` and `delete`).
+{{< /admonition >}}
+
+For a conceptual overview of recording rules and the Cloud UI wizard, refer to [Use recording rules](https://grafana.com/docs/grafana-cloud/observe-and-act/send-data/profiles/recording-rules/).
+
+#### List recording rules
+
+Use `profilecli recording-rules list` to view all recording rules for the current tenant.
+Rules that were provisioned through server configuration are marked as read-only.
 
 ```bash
 profilecli recording-rules list
+```
+
+Example output:
+
+```
+Rule with Id nEiOJaMEBL (backend provisioned - read only)
+matchers:
+    - '{__profile_type__="process_cpu:cpu:nanoseconds:cpu:nanoseconds"}'
+metric_name: profiles_recorded_cpu_usage_function_total_x509_certificate_verify_nanoseconds
+group_by:
+    - service_name
+function_name: crypto/x509.(*Certificate).Verify
+```
+
+#### Get a recording rule
+
+Use `profilecli recording-rules get` to retrieve a single recording rule by its ID.
+Use the `-o` flag to save the rule to a file, which is useful for editing and re-creating.
+
+```bash
+profilecli recording-rules get <RULE_ID>
+```
+
+To save the rule to a file:
+
+```bash
+profilecli recording-rules get <RULE_ID> -o rule.yaml
+```
+
+Replace the following:
+
+- `<RULE_ID>`: the ID of the rule, for example `wUkyJdAuRq`
+
+#### Create a recording rule
+
+Use `profilecli recording-rules create` to create a new recording rule from a YAML or JSON file.
+
+1. Create a rule definition file. The file must contain the following fields:
+
+   ```yaml
+   matchers:
+     - '{__profile_type__="process_cpu:cpu:nanoseconds:cpu:nanoseconds", region="emea"}'
+   metric_name: profiles_recorded_cpu_usage_function_total_gc_nanoseconds
+   group_by:
+     - service_name
+   function_name: runtime.gcBgMarkWorker
+   ```
+
+   | Field | Required | Description |
+   | --- | --- | --- |
+   | `matchers` | Yes | Label selectors that filter the profiles to aggregate. Must contain exactly one `__profile_type__` matcher with an equality match. |
+   | `metric_name` | Yes | The Prometheus metric name for the resulting time series. |
+   | `group_by` | No | Label names to group by. Each unique combination of values produces a separate time series. |
+   | `function_name` | No | A function name to filter stack traces. Only samples that include this function contribute to the metric. |
+   | `external_labels` | No | Extra label pairs to attach to every time series the rule produces. Useful for adding environment or team identifiers. |
+
+   An example with `external_labels`:
+
+   ```yaml
+   matchers:
+     - '{__profile_type__="process_cpu:cpu:nanoseconds:cpu:nanoseconds"}'
+   metric_name: profiles_recorded_cpu_usage_total_nanoseconds
+   group_by:
+     - service_name
+   external_labels:
+     - name: env
+       value: production
+   ```
+
+1. Run the create command:
+
+   ```bash
+   profilecli recording-rules create -f rule.yaml
+   ```
+
+   Example output:
+
+   ```
+   New recorded rule created with id: YLKtohSNyV
+   ```
+
+#### Delete a recording rule
+
+Use `profilecli recording-rules delete` to remove a recording rule by its ID.
+
+```bash
+profilecli recording-rules delete <RULE_ID>
+```
+
+Replace the following:
+
+- `<RULE_ID>`: the ID of the rule to delete
+
+Example output:
+
+```
+Deleted recording rule with id: YLKtohSNyV
 ```
 
 ### Validate source mapping coverage


### PR DESCRIPTION
Fills documentation gaps for recording rules CLI usage, Rust memory profiling with jemalloc, profile type support for Rust, and adds a v2.0 signpost to the upgrade guide.

Source PRs:
- https://github.com/grafana/pyroscope/pull/4823 (recording rules CLI)
- https://github.com/grafana/pyroscope-rs/pull/378 (jemalloc memory profiling for Rust)