### PR TITLE
docs: Add info about call tree view

### DIFF
--- a/docs/sources/shared/use-explore-profiles.md
+++ b/docs/sources/shared/use-explore-profiles.md
@@ -57,3 +57,6 @@ Flame graphs help you visualize resource allocation and performance bottlenecks,
 
 On views with a flame graph, you can use **Explain flame graph** to provide an AI flame graph analysis that explains the performance bottleneck, root cause, and recommended fix.
 For more information, refer to [Flame graph AI](https://grafana.com/docs/grafana-cloud/monitor-applications/profiles/flamegraph-ai/).
+
+The flame graph view offers **Top table**, **Flame graph**, and **Call tree** views of your profiling data.
+For details about each view, refer to [Flame graph visualization panel](https://grafana.com/docs/grafana-cloud/visualizations/panels-visualizations/visualizations/flame-graph/).


### PR DESCRIPTION
This adds a brief note to the shared "Use Profiles Drilldown" content pointing out that the flame graph view offers **Top table**, **Flame graph**, and **Call tree** views, and links to the Flame graph visualization panel documentation for details on each view.

- `docs/sources/shared/use-explore-profiles.md`: added a two-line note about the Top table / Flame graph / Call tree views with a link to the Flame graph visualization panel page.

### Related
- Companion Grafana docs PR adding the `## Call tree mode` section to the flame graph panel page: https://github.com/grafana/grafana/pull/132227