### PR TITLE
docs: Add write-path sampling monitoring guide

### DIFF
--- a/docs/sources/configure-server/monitor-sampling.md
+++ b/docs/sources/configure-server/monitor-sampling.md
@@ -15,13 +15,13 @@ keywords:
 
 After you configure write-path sampling, you use Pyroscope's own metrics to confirm that sampling is active and to measure how much data it drops. This page describes the metrics to watch and shows example queries, broken down by tenant and usage group.
 
-To configure sampling, refer to [Configure write-path sampling](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-server/configure-sampling/). 
+To configure sampling, refer to [Configure write-path sampling](/docs/pyroscope/<PYROSCOPE_VERSION>/configure-server/configure-sampling/). 
 
-For how sampling works and what happens to sampled-out profiles, refer to [Write-path sampling](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/reference-pyroscope-v2-architecture/sampling/) in the v2 architecture reference.
+For how sampling works and what happens to sampled-out profiles, refer to [Write-path sampling](/docs/pyroscope/<PYROSCOPE_VERSION>/reference-pyroscope-v2-architecture/sampling/) in the v2 architecture reference.
 
 ## Before you begin
 
-- Run the Pyroscope v2 architecture with sampling configured for at least one tenant. Refer to [Configure write-path sampling](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-server/configure-sampling/).
+- Run the Pyroscope v2 architecture with sampling configured for at least one tenant. Refer to [Configure write-path sampling](/docs/pyroscope/<PYROSCOPE_VERSION>/configure-server/configure-sampling/).
 - Scrape Pyroscope's own metrics with Prometheus or a compatible agent. Pyroscope exposes metrics at the `/metrics` endpoint on the HTTP listen port, `4040` by default.
 - The distributor makes the sampling decision, so these metrics come from the distributor. In microservices mode, aggregate the metrics across all distributor instances.
 
@@ -48,10 +48,10 @@ sum(rate(pyroscope_discarded_samples_total{reason="dropped_by_sampling_rules"}[5
 
 The result is the number of profiles per second that sampling drops across all tenants. A value above zero confirms that sampling is active.
 
-If the query returns no data or stays at zero when you expect drops, then sampling isn't matching any profiles. Confirm that your usage groups and probabilities are correct. Refer to [Troubleshoot sampling](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-server/configure-sampling/#troubleshoot-sampling).
+If the query returns no data or stays at zero when you expect drops, then sampling isn't matching any profiles. Confirm that your usage groups and probabilities are correct. Refer to [Troubleshoot sampling](/docs/pyroscope/<PYROSCOPE_VERSION>/configure-server/configure-sampling/#troubleshoot-sampling).
 
 {{< admonition type="note" >}}
-When `keep_stripped_profiles` is enabled, `pyroscope_discarded_bytes_total` can stay low even though sampling is active, because Pyroscope retains the profile totals and only the stripped stack-trace bytes count as discarded. Use `pyroscope_discarded_samples_total` to confirm sampling in that case. Pyroscope also marks the retained series with the `__sampled__="true"` label. For details, refer to [Retain sampled-out profiles](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/reference-pyroscope-v2-architecture/sampling/#retain-sampled-out-profiles).
+When `keep_stripped_profiles` is enabled, `pyroscope_discarded_bytes_total` can stay low even though sampling is active, because Pyroscope retains the profile totals and only the stripped stack-trace bytes count as discarded. Use `pyroscope_discarded_samples_total` to confirm sampling in that case. Pyroscope also marks the retained series with the `__sampled__="true"` label. For details, refer to [Retain sampled-out profiles](/pyroscope/<PYROSCOPE_VERSION>/reference-pyroscope-v2-architecture/sampling/#retain-sampled-out-profiles).
 {{< /admonition >}}
 
 ## Measure the volume that sampling drops
@@ -110,7 +110,7 @@ sum by (tenant, usage_group) (rate(pyroscope_usage_group_discarded_bytes_total{r
 )
 ```
 
-The result is one series per tenant and usage group, giving the fraction of that group's ingested bytes that sampling drops. Compare this value against the probability that you set for the group in [Configure write-path sampling](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-server/configure-sampling/). A group with probability `0.1` keeps about 10% of its profiles, so it drops close to 90% of the matching volume.
+The result is one series per tenant and usage group, giving the fraction of that group's ingested bytes that sampling drops. Compare this value against the probability that you set for the group in [Configure write-path sampling](/docs/pyroscope/<PYROSCOPE_VERSION>/configure-server/configure-sampling/). A group with probability `0.1` keeps about 10% of its profiles, so it drops close to 90% of the matching volume.
 
 ## Alert on dropped volume
 
@@ -143,5 +143,5 @@ Set the threshold to match the probabilities that you configure. A group with a 
 
 ## Next steps
 
-- Adjust per-group probabilities. Refer to [Configure write-path sampling](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-server/configure-sampling/).
-- Retain totals for sampled-out profiles. Refer to [Retain sampled-out profiles](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/reference-pyroscope-v2-architecture/sampling/#retain-sampled-out-profiles).
+- Adjust per-group probabilities. Refer to [Configure write-path sampling](/docs/pyroscope/<PYROSCOPE_VERSION>/configure-server/configure-sampling/).
+- Retain totals for sampled-out profiles. Refer to [Retain sampled-out profiles](/docs/pyroscope/<PYROSCOPE_VERSION>/reference-pyroscope-v2-architecture/sampling/#retain-sampled-out-profiles).

--- a/docs/sources/configure-server/monitor-sampling.md
+++ b/docs/sources/configure-server/monitor-sampling.md
@@ -1,0 +1,147 @@
+---
+description: Use Pyroscope metrics to confirm that write-path sampling is active and to measure how much data it drops, by tenant and usage group.
+menuTitle: Monitor sampling
+title: Monitor write-path sampling
+weight: 350
+keywords:
+  - Pyroscope
+  - sampling
+  - metrics
+  - monitoring
+  - usage groups
+---
+
+# Monitor write-path sampling
+
+After you configure write-path sampling, you use Pyroscope's own metrics to confirm that sampling is active and to measure how much data it drops. This page describes the metrics to watch and shows example queries, broken down by tenant and usage group.
+
+To configure sampling, refer to [Configure write-path sampling](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-server/configure-sampling/). 
+
+For how sampling works and what happens to sampled-out profiles, refer to [Write-path sampling](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/reference-pyroscope-v2-architecture/sampling/) in the v2 architecture reference.
+
+## Before you begin
+
+- Run the Pyroscope v2 architecture with sampling configured for at least one tenant. Refer to [Configure write-path sampling](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-server/configure-sampling/).
+- Scrape Pyroscope's own metrics with Prometheus or a compatible agent. Pyroscope exposes metrics at the `/metrics` endpoint on the HTTP listen port, `4040` by default.
+- The distributor makes the sampling decision, so these metrics come from the distributor. In microservices mode, aggregate the metrics across all distributor instances.
+
+The example queries use PromQL and assume that Pyroscope's metrics carry the `pyroscope_` prefix from the source code. Your deployment might add labels such as `job`, `namespace`, or `pod`. Add those labels to the queries to scope results to one Pyroscope cluster.
+
+## Sampling metrics
+
+Sampling reuses the distributor's discard metrics with the `reason` label value `dropped_by_sampling_rules`.
+
+| Metric | Labels | Description |
+| --- | --- | --- |
+| `pyroscope_discarded_samples_total` | `reason`, `tenant` | Counts discarded profiles. Increments for every sampled-out profile, even when `keep_stripped_profiles` is enabled. |
+| `pyroscope_discarded_bytes_total` | `reason`, `tenant` | Counts discarded uncompressed bytes. With `keep_stripped_profiles` disabled, this is the full profile size. With `keep_stripped_profiles` enabled, this is only the stripped stack-trace bytes, because Pyroscope retains the totals. |
+| `pyroscope_usage_group_discarded_bytes_total` | `reason`, `tenant`, `usage_group` | Same as `pyroscope_discarded_bytes_total`, broken down by usage group. Profiles that don't match a usage group use `usage_group="other"`. |
+| `pyroscope_usage_group_received_decompressed_total` | `type`, `tenant`, `usage_group` | Counts received uncompressed bytes that Pyroscope keeps, by profile type, tenant, and usage group. Use it as the denominator when you calculate the fraction of data that sampling drops. |
+
+## Confirm that sampling is active
+
+The clearest signal that sampling drops data is a nonzero rate of `pyroscope_discarded_samples_total` for the `dropped_by_sampling_rules` reason. This counter increments for every sampled-out profile, whether or not you retain totals with `keep_stripped_profiles`.
+
+```promql
+sum(rate(pyroscope_discarded_samples_total{reason="dropped_by_sampling_rules"}[5m]))
+```
+
+The result is the number of profiles per second that sampling drops across all tenants. A value above zero confirms that sampling is active.
+
+If the query returns no data or stays at zero when you expect drops, then sampling isn't matching any profiles. Confirm that your usage groups and probabilities are correct. Refer to [Troubleshoot sampling](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-server/configure-sampling/#troubleshoot-sampling).
+
+{{< admonition type="note" >}}
+When `keep_stripped_profiles` is enabled, `pyroscope_discarded_bytes_total` can stay low even though sampling is active, because Pyroscope retains the profile totals and only the stripped stack-trace bytes count as discarded. Use `pyroscope_discarded_samples_total` to confirm sampling in that case. Pyroscope also marks the retained series with the `__sampled__="true"` label. For details, refer to [Retain sampled-out profiles](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/reference-pyroscope-v2-architecture/sampling/#retain-sampled-out-profiles).
+{{< /admonition >}}
+
+## Measure the volume that sampling drops
+
+To measure how much data sampling removes, use `pyroscope_discarded_bytes_total` for the `dropped_by_sampling_rules` reason.
+
+```promql
+sum(rate(pyroscope_discarded_bytes_total{reason="dropped_by_sampling_rules"}[5m]))
+```
+
+The result is the number of uncompressed bytes per second that sampling drops across all tenants.
+
+To express the drop as a fraction of the data that Pyroscope receives, compare the discarded bytes against the received bytes. Because `pyroscope_usage_group_received_decompressed_total` counts only the bytes that Pyroscope keeps, add the discarded bytes back to get the total that reached the sampling stage.
+
+```promql
+sum(rate(pyroscope_usage_group_discarded_bytes_total{reason="dropped_by_sampling_rules"}[5m]))
+/
+(
+  sum(rate(pyroscope_usage_group_received_decompressed_total[5m]))
+  +
+  sum(rate(pyroscope_usage_group_discarded_bytes_total{reason="dropped_by_sampling_rules"}[5m]))
+)
+```
+
+The result is the fraction of ingested bytes that sampling drops, from `0` (nothing dropped) to `1` (everything dropped).
+
+### Break down by tenant
+
+Add `sum by (tenant)` to attribute dropped volume to each tenant.
+
+```promql
+sum by (tenant) (rate(pyroscope_discarded_bytes_total{reason="dropped_by_sampling_rules"}[5m]))
+```
+
+The result is one series per tenant, giving the uncompressed bytes per second that sampling drops for that tenant.
+
+### Break down by usage group
+
+Use `pyroscope_usage_group_discarded_bytes_total` to attribute dropped volume to each usage group within a tenant.
+
+```promql
+sum by (tenant, usage_group) (rate(pyroscope_usage_group_discarded_bytes_total{reason="dropped_by_sampling_rules"}[5m]))
+```
+
+The result is one series per tenant and usage group, giving the uncompressed bytes per second that sampling drops for that group.
+
+To calculate the fraction of each usage group's data that sampling drops, divide the discarded bytes by the total that reached the sampling stage for the same group.
+
+```promql
+sum by (tenant, usage_group) (rate(pyroscope_usage_group_discarded_bytes_total{reason="dropped_by_sampling_rules"}[5m]))
+/
+(
+  sum by (tenant, usage_group) (rate(pyroscope_usage_group_received_decompressed_total[5m]))
+  +
+  sum by (tenant, usage_group) (rate(pyroscope_usage_group_discarded_bytes_total{reason="dropped_by_sampling_rules"}[5m]))
+)
+```
+
+The result is one series per tenant and usage group, giving the fraction of that group's ingested bytes that sampling drops. Compare this value against the probability that you set for the group in [Configure write-path sampling](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-server/configure-sampling/). A group with probability `0.1` keeps about 10% of its profiles, so it drops close to 90% of the matching volume.
+
+## Alert on dropped volume
+
+Sampling behavior changes as your traffic and probabilities change, so monitor it continuously instead of checking once. Turn the drop-fraction query into a Prometheus alerting rule and alert when a group drops more or less data than you expect.
+
+The following example alerts when a tenant and usage group drops more than 95% of its ingested bytes over 10 minutes, which can indicate a probability that's set too low:
+
+```yaml
+groups:
+  - name: pyroscope-sampling
+    rules:
+      - alert: PyroscopeSamplingDropHigh
+        expr: |
+          sum by (tenant, usage_group) (rate(pyroscope_usage_group_discarded_bytes_total{reason="dropped_by_sampling_rules"}[10m]))
+          /
+          (
+            sum by (tenant, usage_group) (rate(pyroscope_usage_group_received_decompressed_total[10m]))
+            +
+            sum by (tenant, usage_group) (rate(pyroscope_usage_group_discarded_bytes_total{reason="dropped_by_sampling_rules"}[10m]))
+          )
+          > 0.95
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Write-path sampling drops over 95% of usage group {{ $labels.usage_group }} for tenant {{ $labels.tenant }}"
+```
+
+Set the threshold to match the probabilities that you configure. A group with a low probability is expected to drop most of its volume, so alert only when the fraction moves outside the range that you plan for.
+
+## Next steps
+
+- Adjust per-group probabilities. Refer to [Configure write-path sampling](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/configure-server/configure-sampling/).
+- Retain totals for sampled-out profiles. Refer to [Retain sampled-out profiles](https://grafana.com/docs/pyroscope/<PYROSCOPE_VERSION>/reference-pyroscope-v2-architecture/sampling/#retain-sampled-out-profiles).


### PR DESCRIPTION
Adds `configure-server/monitor-sampling.md`, a monitoring guide for self-managed operators to confirm write-path sampling is active and measure how much data it drops, broken down by tenant and usage group. This fills the observability gap deferred from #5623.

The guide documents the distributor discard metrics that sampling reuses — `pyroscope_discarded_samples_total`, `pyroscope_discarded_bytes_total`, and the per-usage-group counters — with the `dropped_by_sampling_rules` reason, and explains how `keep_stripped_profiles` changes what `discarded_bytes_total` counts. It includes example PromQL for confirming sampling, measuring dropped volume and fraction, per-tenant and per-usage-group breakdowns, and a Prometheus alerting rule. Metric names and labels are verified against `pkg/validation` and `pkg/distributor`.

> [!WARNING]
> **Merge order:** Depends on the write-path sampling docs in #5623. Merge this **after** #5623 so the cross-links to `configure-sampling` and the sampling reference resolve.

Follow-up: a reverse link from the "Troubleshoot sampling" section of `configure-sampling.md` back to this page should be added in #5623 (that file lives on that branch).
